### PR TITLE
chore: add missing generated artifact entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 /coverage/
 /coverage-frontend/
+
+.phpunit.cache/
+phpmetrics/


### PR DESCRIPTION
Adds `.phpunit.cache/` and `phpmetrics/` to `.gitignore` to prevent generated test and quality tool artifacts from being tracked. These cause unnecessary dirty-submodule noise in the parent repo.

Already present: `/coverage/`, `/tests/.phpunit.cache`