### PR TITLE
Harmonize .gitignore with shared template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,34 @@
+# IDE
 /.idea/
 /*.iml
 *.Identifier
 
+# Dependencies
 /vendor/
 /vendor-bin/*/vendor/
-
-/.php-cs-fixer.cache
-/tests/.phpunit.cache
-
 /node_modules/
-/js
 
+# Build artifacts
+/js/
+
+# Documentation
 /docs/node_modules/
 /docs/build/
 /docs/.docusaurus/
-/custom_apps/
-/config/
+/website/node_modules/
+/website/.docusaurus/
 
+# Testing & Quality
+/.php-cs-fixer.cache
+/tests/.phpunit.cache
+/.phpunit.cache/
+.phpunit.cache/
+.phpunit.result.cache
 /coverage/
 /coverage-frontend/
+/phpmetrics/
+/quality-reports/
+/phpqa/
 
 # Test/build artifacts
 .phpunit.cache/
@@ -36,3 +46,14 @@ bom-npm.cdx.json
 /tests/e2e/test-results/
 /test-results/
 /playwright-report/
+
+# Nextcloud
+/custom_apps/
+/config/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Claude Code
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Harmonizes `.gitignore` with the shared Conduction template
- Adds website documentation, OS files, quality reports, and Claude Code patterns

Closes #100