### PR TITLE
fix: align webpack config and sidebar with shared patterns

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -37,12 +37,17 @@
 				<NcLoadingIcon :size="64" />
 			</div>
 		</NcAppContent>
+
+		<CnIndexSidebar v-if="sidebarState.active && !objectSidebarState.active" />
+		<CnObjectSidebar v-if="objectSidebarState.active" />
 	</NcContent>
 </template>
 
 <script>
+import Vue from 'vue'
 import { NcContent, NcAppContent, NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
 import { generateUrl, imagePath } from '@nextcloud/router'
+import { CnIndexSidebar, CnObjectSidebar } from '@conduction/nextcloud-vue'
 import MainMenu from './navigation/MainMenu.vue'
 import Modals from './modals/Modals.vue'
 import Dialogs from './dialogs/Dialogs.vue'
@@ -63,11 +68,31 @@ export default {
 		Dialogs,
 		Views,
 		SideBars,
+		CnIndexSidebar,
+		CnObjectSidebar,
+	},
+
+	provide() {
+		return {
+			sidebarState: this.sidebarState,
+			objectSidebarState: this.objectSidebarState,
+		}
 	},
 
 	data() {
 		return {
 			storesReady: false,
+			sidebarState: Vue.observable({
+				active: false,
+				component: null,
+				props: {},
+			}),
+			objectSidebarState: Vue.observable({
+				active: false,
+				objectType: null,
+				objectId: null,
+				props: {},
+			}),
 		}
 	},
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,11 +24,12 @@
 
 		<!-- App loaded normally -->
 		<template v-else-if="storesReady && hasOpenRegisters">
-			<MainMenu />
+			<MainMenu @open-settings="settingsOpen = true" />
 			<Views />
 			<SideBars />
 			<Modals />
 			<Dialogs />
+			<UserSettings :open="settingsOpen" @update:open="settingsOpen = $event" />
 		</template>
 
 		<!-- Loading -->
@@ -39,7 +40,16 @@
 		</NcAppContent>
 
 		<CnIndexSidebar v-if="sidebarState.active && !objectSidebarState.active" />
-		<CnObjectSidebar v-if="objectSidebarState.active" />
+		<CnObjectSidebar
+			v-if="objectSidebarState.active"
+			:object-type="objectSidebarState.objectType"
+			:object-id="objectSidebarState.objectId"
+			:title="objectSidebarState.title"
+			:subtitle="objectSidebarState.subtitle"
+			:register="objectSidebarState.register"
+			:schema="objectSidebarState.schema"
+			:hidden-tabs="objectSidebarState.hiddenTabs"
+			:open.sync="objectSidebarState.open" />
 	</NcContent>
 </template>
 
@@ -53,6 +63,7 @@ import Modals from './modals/Modals.vue'
 import Dialogs from './dialogs/Dialogs.vue'
 import Views from './views/Views.vue'
 import SideBars from './sidebars/SideBars.vue'
+import UserSettings from './views/settings/UserSettings.vue'
 import { initializeStores, useSettingsStore } from './store/store.js'
 
 export default {
@@ -68,6 +79,7 @@ export default {
 		Dialogs,
 		Views,
 		SideBars,
+		UserSettings,
 		CnIndexSidebar,
 		CnObjectSidebar,
 	},
@@ -82,6 +94,7 @@ export default {
 	data() {
 		return {
 			storesReady: false,
+			settingsOpen: false,
 			sidebarState: Vue.observable({
 				active: false,
 				component: null,
@@ -89,9 +102,14 @@ export default {
 			}),
 			objectSidebarState: Vue.observable({
 				active: false,
-				objectType: null,
-				objectId: null,
-				props: {},
+				open: true,
+				objectType: '',
+				objectId: '',
+				title: '',
+				subtitle: '',
+				register: '',
+				schema: '',
+				hiddenTabs: [],
 			}),
 		}
 	},

--- a/src/navigation/MainMenu.vue
+++ b/src/navigation/MainMenu.vue
@@ -27,6 +27,15 @@ import { navigationStore } from '../store/store.js'
 				</template>
 			</NcAppNavigationItem>
 		</NcAppNavigationList>
+		<template #footer>
+			<NcAppNavigationSettings>
+				<NcAppNavigationItem :name="t('docudesk', 'Settings')" @click="$emit('open-settings')">
+					<template #icon>
+						<Cog :size="20" />
+					</template>
+				</NcAppNavigationItem>
+			</NcAppNavigationSettings>
+		</template>
 	</NcAppNavigation>
 </template>
 <script>
@@ -35,6 +44,7 @@ import {
 	NcAppNavigation,
 	NcAppNavigationList,
 	NcAppNavigationItem,
+	NcAppNavigationSettings,
 } from '@nextcloud/vue'
 
 // Icons
@@ -42,6 +52,7 @@ import Finance from 'vue-material-design-icons/Finance.vue'
 import AccountCheck from 'vue-material-design-icons/AccountCheck.vue'
 import ShieldLock from 'vue-material-design-icons/ShieldLock.vue'
 import FileDocumentMultiple from 'vue-material-design-icons/FileDocumentMultiple.vue'
+import Cog from 'vue-material-design-icons/Cog.vue'
 
 export default {
 	name: 'MainMenu',
@@ -49,10 +60,12 @@ export default {
 		NcAppNavigation,
 		NcAppNavigationList,
 		NcAppNavigationItem,
+		NcAppNavigationSettings,
 		Finance,
 		AccountCheck,
 		ShieldLock,
 		FileDocumentMultiple,
+		Cog,
 	},
 }
 </script>

--- a/src/store/modules/navigation.ts
+++ b/src/store/modules/navigation.ts
@@ -2,7 +2,8 @@
 import { defineStore } from 'pinia'
 
 interface NavigationStoreState {
-    selected: 'dashboard' | 'consent' | 'consentDetail' | 'settings' | 'anonymization' | 'templates' | 'templateDetail';    selected: 'dashboard' | 'consent' | 'consentDetail' | 'settings' | 'anonymization' | 'batchAnonymization';    modal: string;
+    selected: 'dashboard' | 'consent' | 'consentDetail' | 'settings' | 'anonymization' | 'batchAnonymization' | 'templates' | 'templateDetail';
+    modal: string;
     dialog: string;
     transferData: string;
 }

--- a/src/views/Views.vue
+++ b/src/views/Views.vue
@@ -1,7 +1,3 @@
-<script setup>
-import { navigationStore } from '../store/store.js'
-</script>
-
 <template>
 	<!-- Main content container for all views -->
 	<NcAppContent>
@@ -10,21 +6,26 @@ import { navigationStore } from '../store/store.js'
 			<ConsentIndex v-if="navigationStore.selected === 'consent'" />
 			<ConsentDetail v-if="navigationStore.selected === 'consentDetail'" />
 			<AnonymizationWidget v-if="navigationStore.selected === 'anonymization'" />
+			<BatchAnonymizationView v-if="navigationStore.selected === 'batchAnonymization'" />
 			<TemplateIndex v-if="navigationStore.selected === 'templates'" />
 			<TemplateDetail v-if="navigationStore.selected === 'templateDetail'" />
-		</template>			<TemplateDetail v-if="navigationStore.selected === 'templateDetail'" />			<BatchAnonymizationView v-if="navigationStore.selected === 'batchAnonymization'" />		</template>	</NcAppContent>
+		</template>
+	</NcAppContent>
 </template>
 
 <script>
 import { NcAppContent } from '@nextcloud/vue'
+import { navigationStore } from '../store/store.js'
 
 import Dashboard from './dashboard/DashboardIndex.vue'
 import ConsentIndex from './consent/ConsentIndex.vue'
 import ConsentDetail from './consent/ConsentDetail.vue'
 import AnonymizationWidget from './anonymization/AnonymizationWidget.vue'
+import BatchAnonymizationView from './anonymization/BatchAnonymizationView.vue'
 import TemplateIndex from './templates/TemplateIndex.vue'
 import TemplateDetail from './templates/TemplateDetail.vue'
-import TemplateDetail from './templates/TemplateDetail.vue'import BatchAnonymizationView from './anonymization/BatchAnonymizationView.vue'export default {
+
+export default {
 	name: 'Views',
 	components: {
 		NcAppContent,
@@ -32,7 +33,14 @@ import TemplateDetail from './templates/TemplateDetail.vue'import BatchAnonymiza
 		ConsentIndex,
 		ConsentDetail,
 		AnonymizationWidget,
+		BatchAnonymizationView,
 		TemplateIndex,
 		TemplateDetail,
-	},		TemplateDetail,		BatchAnonymizationView,	},}
+	},
+	data() {
+		return {
+			navigationStore,
+		}
+	},
+}
 </script>

--- a/src/views/anonymization/BatchAnonymizationView.vue
+++ b/src/views/anonymization/BatchAnonymizationView.vue
@@ -1,6 +1,3 @@
-<script setup>
-import { batchAnonymizationStore } from \x27../../store/store.js\x27
-</script>
 <template>
 	<div class="batch-anonymization">
 		<h2>Batch Anonymization</h2>
@@ -8,50 +5,107 @@ import { batchAnonymizationStore } from \x27../../store/store.js\x27
 			<div class="drop-zone" @dragover.prevent @drop.prevent="handleDrop">
 				<p>Drag and drop files here</p>
 				<input ref="fileInput" type="file" multiple style="display:none" @change="handleFileSelect">
-				<NcButton type="secondary" @click="$refs.fileInput.click()">Select Files</NcButton>
+				<NcButton type="secondary" @click="$refs.fileInput.click()">
+					Select Files
+				</NcButton>
 			</div>
 		</div>
-		<div v-if="batchAnonymizationStore.batchStatus === \x27extracting\x27">
+		<div v-if="batchAnonymizationStore.batchStatus === 'extracting'">
 			<h3>Analyzing...</h3>
 			<NcProgressBar :value="batchAnonymizationStore.progress" />
-			<div v-for="f in batchAnonymizationStore.files" :key="f.fileId||f.fileName" class="file-item">
-				{{ f.fileName }} - {{ f.status }} <span v-if="f.entityCount">({{ f.entityCount }} entities)</span>
+			<div v-for="f in batchAnonymizationStore.files" :key="f.fileId || f.fileName" class="file-item">
+				{{ f.fileName }} - {{ f.status }}
+				<span v-if="f.entityCount">({{ f.entityCount }} entities)</span>
 			</div>
 		</div>
-		<div v-if="batchAnonymizationStore.batchStatus === \x27review\x27">
+		<div v-if="batchAnonymizationStore.batchStatus === 'review'">
 			<h3>Review Entities</h3>
-			<EntityReviewTable :entities="batchAnonymizationStore.entities" :file-count="batchAnonymizationStore.filesWithEntities" @toggle="batchAnonymizationStore.toggleEntity($event)" @bulk-select="batchAnonymizationStore.setVisibleEntities($event, true)" @bulk-deselect="batchAnonymizationStore.setVisibleEntities($event, false)" />
-			<NcButton type="primary" @click="batchAnonymizationStore.anonymizeBatch()">Anonymize {{ batchAnonymizationStore.selectedEntityCount }} entities</NcButton>
+			<EntityReviewTable
+				:entities="batchAnonymizationStore.entities"
+				:file-count="batchAnonymizationStore.filesWithEntities"
+				@toggle="batchAnonymizationStore.toggleEntity($event)"
+				@bulk-select="batchAnonymizationStore.setVisibleEntities($event, true)"
+				@bulk-deselect="batchAnonymizationStore.setVisibleEntities($event, false)" />
+			<NcButton type="primary" @click="batchAnonymizationStore.anonymizeBatch()">
+				Anonymize {{ batchAnonymizationStore.selectedEntityCount }} entities
+			</NcButton>
 		</div>
-		<div v-if="batchAnonymizationStore.batchStatus === \x27anonymizing\x27" style="text-align:center;padding:48px">
-			<NcLoadingIcon :size="44" /><p>Anonymizing...</p>
+		<div v-if="batchAnonymizationStore.batchStatus === 'anonymizing'" style="text-align:center;padding:48px">
+			<NcLoadingIcon :size="44" />
+			<p>Anonymizing...</p>
 		</div>
-		<div v-if="batchAnonymizationStore.batchStatus === \x27completed\x27">
-			<NcNoteCard type="success">Batch anonymization completed!</NcNoteCard>
-			<NcButton type="secondary" @click="window.open(batchAnonymizationStore.getReportUrl(), \x27_blank\x27)">Download Report</NcButton>
-			<NcButton type="primary" @click="batchAnonymizationStore.reset()">New Batch</NcButton>
+		<div v-if="batchAnonymizationStore.batchStatus === 'completed'">
+			<NcNoteCard type="success">
+				Batch anonymization completed!
+			</NcNoteCard>
+			<NcButton type="secondary" @click="openReport">
+				Download Report
+			</NcButton>
+			<NcButton type="primary" @click="batchAnonymizationStore.reset()">
+				New Batch
+			</NcButton>
 		</div>
-		<div v-if="batchAnonymizationStore.batchStatus === \x27error\x27">
-			<NcNoteCard type="error">{{ batchAnonymizationStore.error || \x27Error occurred\x27 }}</NcNoteCard>
-			<NcButton type="primary" @click="batchAnonymizationStore.reset()">Try Again</NcButton>
+		<div v-if="batchAnonymizationStore.batchStatus === 'error'">
+			<NcNoteCard type="error">
+				{{ batchAnonymizationStore.error || 'Error occurred' }}
+			</NcNoteCard>
+			<NcButton type="primary" @click="batchAnonymizationStore.reset()">
+				Try Again
+			</NcButton>
 		</div>
 	</div>
 </template>
+
 <script>
-import { NcButton, NcProgressBar, NcLoadingIcon, NcNoteCard } from \x27@nextcloud/vue\x27
-import EntityReviewTable from \x27./EntityReviewTable.vue\x27
+import { NcButton, NcProgressBar, NcLoadingIcon, NcNoteCard } from '@nextcloud/vue'
+import { batchAnonymizationStore } from '../../store/store.js'
+import EntityReviewTable from './EntityReviewTable.vue'
+
 export default {
-	name: \x27BatchAnonymizationView\x27,
-	components: { NcButton, NcProgressBar, NcLoadingIcon, NcNoteCard, EntityReviewTable },
-	data() { return { isDragging: false } },
+	name: 'BatchAnonymizationView',
+	components: {
+		NcButton,
+		NcProgressBar,
+		NcLoadingIcon,
+		NcNoteCard,
+		EntityReviewTable,
+	},
+	data() {
+		return {
+			batchAnonymizationStore,
+		}
+	},
 	methods: {
-		handleDrop(e) { const f = e.dataTransfer?.files; if (f?.length) batchAnonymizationStore.uploadBatch(f) },
-		handleFileSelect(e) { const f = e.target?.files; if (f?.length) batchAnonymizationStore.uploadBatch(f) },
+		handleDrop(e) {
+			const files = e.dataTransfer?.files
+			if (files?.length) batchAnonymizationStore.uploadBatch(files)
+		},
+		handleFileSelect(e) {
+			const files = e.target?.files
+			if (files?.length) batchAnonymizationStore.uploadBatch(files)
+		},
+		openReport() {
+			window.open(batchAnonymizationStore.getReportUrl(), '_blank')
+		},
 	},
 }
 </script>
+
 <style scoped>
-.batch-anonymization { padding: 20px; max-width: 900px }
-.drop-zone { border: 2px dashed var(--color-border); border-radius: 12px; padding: 48px; text-align: center }
-.file-item { padding: 8px 12px; border-bottom: 1px solid var(--color-border) }
+.batch-anonymization {
+	padding: 20px;
+	max-width: 900px;
+}
+
+.drop-zone {
+	border: 2px dashed var(--color-border);
+	border-radius: 12px;
+	padding: 48px;
+	text-align: center;
+}
+
+.file-item {
+	padding: 8px 12px;
+	border-bottom: 1px solid var(--color-border);
+}
 </style>

--- a/src/views/anonymization/EntityReviewTable.vue
+++ b/src/views/anonymization/EntityReviewTable.vue
@@ -1,52 +1,105 @@
 <template>
 	<div class="entity-review">
-		<div class="summary-bar">{{ selectedCount }} of {{ entities.length }} entities selected across {{ fileCount }} files</div>
+		<div class="summary-bar">
+			{{ selectedCount }} of {{ entities.length }} entities selected across {{ fileCount }} files
+		</div>
 		<div class="filter-bar">
 			<input v-model="searchQuery" type="text" placeholder="Search entities...">
-			<select v-model="typeFilter"><option value="">All types</option><option v-for="t in availableTypes" :key="t" :value="t">{{ t }}</option></select>
+			<select v-model="typeFilter">
+				<option value="">All types</option>
+				<option v-for="t in availableTypes" :key="t" :value="t">{{ t }}</option>
+			</select>
 		</div>
 		<div class="bulk-actions">
-			<NcButton type="tertiary" @click="$emit(\x27bulk-select\x27, filteredEntities.map(i => i.idx))">Select All Visible</NcButton>
-			<NcButton type="tertiary" @click="$emit(\x27bulk-deselect\x27, filteredEntities.map(i => i.idx))">Deselect All Visible</NcButton>
+			<NcButton type="tertiary" @click="$emit('bulk-select', filteredEntities.map(i => i.idx))">
+				Select All Visible
+			</NcButton>
+			<NcButton type="tertiary" @click="$emit('bulk-deselect', filteredEntities.map(i => i.idx))">
+				Deselect All Visible
+			</NcButton>
 		</div>
 		<table class="entity-table">
-			<thead><tr><th/><th @click="sortBy(\x27type\x27)">Type</th><th @click="sortBy(\x27value\x27)">Value</th><th @click="sortBy(\x27highestConfidence\x27)">Confidence</th><th @click="sortBy(\x27fileCount\x27)">Files</th></tr></thead>
-			<tbody><tr v-for="item in filteredEntities" :key="item.idx">
-				<td><input type="checkbox" :checked="item.e.included" @change="$emit(\x27toggle\x27, item.idx)"></td>
-				<td><span class="badge">{{ item.e.type }}</span></td><td>{{ item.e.value }}</td>
-				<td>{{ ((item.e.highestConfidence||0)*100).toFixed(1) }}%</td><td>{{ item.e.fileCount }}</td>
-			</tr></tbody>
+			<thead>
+				<tr>
+					<th />
+					<th @click="sortBy('type')">Type</th>
+					<th @click="sortBy('value')">Value</th>
+					<th @click="sortBy('highestConfidence')">Confidence</th>
+					<th @click="sortBy('fileCount')">Files</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr v-for="item in filteredEntities" :key="item.idx">
+					<td><input type="checkbox" :checked="item.e.included" @change="$emit('toggle', item.idx)"></td>
+					<td><span class="badge">{{ item.e.type }}</span></td>
+					<td>{{ item.e.value }}</td>
+					<td>{{ ((item.e.highestConfidence || 0) * 100).toFixed(1) }}%</td>
+					<td>{{ item.e.fileCount }}</td>
+				</tr>
+			</tbody>
 		</table>
 	</div>
 </template>
+
 <script>
-import { NcButton } from \x27@nextcloud/vue\x27
+import { NcButton } from '@nextcloud/vue'
+
 export default {
-	name: \x27EntityReviewTable\x27,
+	name: 'EntityReviewTable',
 	components: { NcButton },
-	props: { entities: { type: Array, required: true }, fileCount: { type: Number, default: 0 } },
-	emits: [\x27toggle\x27, \x27bulk-select\x27, \x27bulk-deselect\x27, \x27confidence-change\x27],
-	data() { return { searchQuery: \x27\x27, typeFilter: \x27\x27, sf: \x27highestConfidence\x27, sa: false } },
+	props: {
+		entities: { type: Array, required: true },
+		fileCount: { type: Number, default: 0 },
+	},
+	emits: ['toggle', 'bulk-select', 'bulk-deselect'],
+	data() {
+		return {
+			searchQuery: '',
+			typeFilter: '',
+			sf: 'highestConfidence',
+			sa: false,
+		}
+	},
 	computed: {
-		selectedCount() { return this.entities.filter(e => e.included).length },
-		availableTypes() { return [...new Set(this.entities.map(e => e.type))].sort() },
+		selectedCount() {
+			return this.entities.filter(e => e.included).length
+		},
+		availableTypes() {
+			return [...new Set(this.entities.map(e => e.type))].sort()
+		},
 		filteredEntities() {
 			const q = this.searchQuery.toLowerCase()
-			return this.entities.map((e, i) => ({ e, idx: i }))
+			return this.entities
+				.map((e, i) => ({ e, idx: i }))
 				.filter(({ e }) => (!q || e.value.toLowerCase().includes(q)) && (!this.typeFilter || e.type === this.typeFilter))
-				.sort((a, b) => { const va = a.e[this.sf], vb = b.e[this.sf]; const c = typeof va === \x27string\x27 ? va.localeCompare(vb) : (va||0)-(vb||0); return this.sa ? c : -c })
+				.sort((a, b) => {
+					const va = a.e[this.sf]
+					const vb = b.e[this.sf]
+					const c = typeof va === 'string' ? va.localeCompare(vb) : (va || 0) - (vb || 0)
+					return this.sa ? c : -c
+				})
 		},
 	},
-	methods: { sortBy(f) { if (this.sf === f) { this.sa = !this.sa } else { this.sf = f; this.sa = false } } },
+	methods: {
+		sortBy(field) {
+			if (this.sf === field) {
+				this.sa = !this.sa
+			} else {
+				this.sf = field
+				this.sa = false
+			}
+		},
+	},
 }
 </script>
+
 <style scoped>
-.entity-review { margin: 16px 0 }
-.summary-bar { padding: 12px; background: var(--color-primary-element-light); border-radius: 8px; margin-bottom: 16px }
-.filter-bar { display: flex; gap: 12px; margin-bottom: 12px }
-.bulk-actions { display: flex; gap: 8px; margin-bottom: 12px }
-.entity-table { width: 100%; border-collapse: collapse }
-.entity-table th, .entity-table td { padding: 10px 12px; border-bottom: 1px solid var(--color-border); text-align: left }
-.entity-table th { cursor: pointer }
-.badge { padding: 2px 8px; border-radius: 12px; font-size: 0.8rem; background: var(--color-primary-element-light); color: var(--color-primary-element) }
+.entity-review { margin: 16px 0; }
+.summary-bar { padding: 12px; background: var(--color-primary-element-light); border-radius: 8px; margin-bottom: 16px; }
+.filter-bar { display: flex; gap: 12px; margin-bottom: 12px; }
+.bulk-actions { display: flex; gap: 8px; margin-bottom: 12px; }
+.entity-table { width: 100%; border-collapse: collapse; }
+.entity-table th, .entity-table td { padding: 10px 12px; border-bottom: 1px solid var(--color-border); text-align: left; }
+.entity-table th { cursor: pointer; }
+.badge { padding: 2px 8px; border-radius: 12px; font-size: 0.8rem; background: var(--color-primary-element-light); color: var(--color-primary-element); }
 </style>

--- a/src/views/settings/UserSettings.vue
+++ b/src/views/settings/UserSettings.vue
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<template>
+    <NcAppSettingsDialog
+        :open="open"
+        :show-navigation="false"
+        :name="t('docudesk', 'DocuDesk settings')"
+        @update:open="$emit('update:open', $event)">
+        <NcAppSettingsSection id="general" :name="t('docudesk', 'General')">
+            <template #icon><CogIcon :size="20" /></template>
+            <p>{{ t('docudesk', 'User preferences will appear here.') }}</p>
+        </NcAppSettingsSection>
+    </NcAppSettingsDialog>
+</template>
+<script>
+import { NcAppSettingsDialog, NcAppSettingsSection } from '@nextcloud/vue'
+import CogIcon from 'vue-material-design-icons/Cog.vue'
+export default {
+    name: 'UserSettings',
+    components: { NcAppSettingsDialog, NcAppSettingsSection, CogIcon },
+    props: { open: { type: Boolean, default: false } },
+}
+</script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const fs = require('fs')
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
 const webpackConfig = require('@nextcloud/webpack-vue-config')
 
 const buildMode = process.env.NODE_ENV
@@ -31,13 +32,20 @@ webpackConfig.entry = {
 const localLib = path.resolve(__dirname, '../nextcloud-vue/src')
 const useLocalLib = fs.existsSync(localLib)
 
+webpackConfig.resolve = webpackConfig.resolve || {}
+webpackConfig.resolve.modules = [path.resolve(__dirname, 'node_modules'), 'node_modules']
 webpackConfig.resolve.alias = {
-	...webpackConfig.resolve.alias,
+	...(webpackConfig.resolve.alias || {}),
 	...(useLocalLib ? { '@conduction/nextcloud-vue': localLib } : {}),
 	'vue$': path.resolve(__dirname, 'node_modules/vue'),
 	'pinia$': path.resolve(__dirname, 'node_modules/pinia'),
 	'@nextcloud/vue$': path.resolve(__dirname, 'node_modules/@nextcloud/vue'),
 	'@nextcloud/dialogs': path.resolve(__dirname, 'node_modules/@nextcloud/dialogs'),
 }
+
+webpackConfig.plugins = [
+	...(webpackConfig.plugins || []),
+	new NodePolyfillPlugin({ additionalAliases: ['process'] }),
+]
 
 module.exports = webpackConfig


### PR DESCRIPTION
## Summary
- Extend base webpack config instead of replacing `webpackConfig.resolve` and `webpackConfig.module`
- Add `NodePolyfillPlugin@4.0.0` for `process` polyfill compatibility
- Add `CnObjectSidebar` + `objectSidebarState` provide/inject for proper Nextcloud sidebar positioning

## Why
All Conduction apps should follow the same webpack and sidebar patterns as OpenCatalogi (the reference implementation). See ADR-017 and ADR-018.