### PR TITLE
feat(openspec): docudesk-adopt-or-abstractions — BatchCorrespondenceJob lifecycle + Archiefwet

### DIFF
--- a/openspec/changes/docudesk-adopt-or-abstractions/design.md
+++ b/openspec/changes/docudesk-adopt-or-abstractions/design.md
@@ -1,0 +1,143 @@
+# Design — docudesk: adopt OR abstractions
+
+## Context
+
+docudesk is the document-management app of the Conduction stack: OCR, anonymization,
+correspondence generation, digital signing, and template-driven document creation. The
+2026-05-03 OR-abstraction audit places it at Tier 2 on the audit's
+extraction/de-duplication scale: it has its own service layer that legitimately wraps
+third-party libraries (Tesseract OCR, ValidSign, NativeSigning), but it duplicates
+state-machine, archival, and notification machinery that now lives in OpenRegister.
+
+This change is the per-app adoption proposal that pairs with the Hydra
+`adopt-app-manifest` change and the four OR-side specs
+(`register-resolver-service`, `pluggable-integration-registry`, `i18n-source-of-truth`,
+`i18n-api-language-negotiation`) plus the nc-vue `multi-tenancy-context` spec.
+
+## Goals
+
+- Stop encoding lifecycle state in inline `'status' => '…'` strings.
+- Stop hand-rolling cache-keyed batch state tracking.
+- Stop hardcoding tenant-tunable values (OCR languages, DPI, lock timeouts, batch sizes).
+- Make Archiefwet retention machine-readable, not buried in a comment.
+- Make the three core schemas (report, template, entity) declarative JSON-schema instead of
+  `properties: []` placeholders.
+- Make docudesk consumable by Hydra coordination via a manifest.
+
+## Non-Goals
+
+- Replacing third-party signing or OCR libraries. NativeSigning, ValidSign, and Tesseract
+  remain. Only the surrounding orchestration changes.
+- Frontend store rewrites beyond what the multi-tenancy context migration requires.
+- Changing the public API contract. Lifecycle annotation must produce the same status values
+  on the wire that callers see today (transition-only, not value-renaming, migration).
+
+## Decisions
+
+### Decision 1 — Lifecycle annotation, not enum constraints
+
+docudesk has at least four schemas that need lifecycle state: batch-correspondence,
+signing-request, batch-upload, and anonymization-result. The audit's stream 4 finding
+counted ten literal status writes across six files.
+
+**Decision**: encode each schema's state machine as `x-openregister-lifecycle` with explicit
+state list, transition graph, and per-transition authorization. NOT as a JSON-schema `enum`.
+
+**Why**: the lifecycle annotation per ADR-022 gives transition-time hooks (notifications,
+audit, calculations) that an enum cannot express. The apply phase wires these hooks; this
+spec only declares the states.
+
+### Decision 2 — Archival annotation per schema, not per app
+
+The audit found `// Archiefwet 1995 minimum 10-year retention` as a comment in the signing
+audit service. The Archiefwet selectielijst uses different retention periods per category
+(signing audits = 10y, batch results = 1y, correspondence = 7y, etc).
+
+**Decision**: each schema gets its own `x-openregister-archival.retention` ISO-8601 duration.
+NOT a single app-wide retention.
+
+**Why**: the selectielijst applies per category, not per app. ADR-024 mandates per-schema
+declaration so OR's archival job can route correctly.
+
+### Decision 3 — Schema validation now mandatory
+
+`openspec/specs/document-register/spec.md` currently declares the three schemas with
+`properties: []` and refers to "ad-hoc fields written by the controller". This means OR's
+schema validator never runs.
+
+**Decision**: rewrite as full JSON-schema with `required`, `properties`, and
+`additionalProperties: false`. Existing rows that don't match must be migrated by a
+one-shot apply-phase script.
+
+**Why**: the `properties: []` shape is a stream 2 finding (NEEDS-REWRITE). Without strict
+validation, we can't add the lifecycle/archival/calculation annotations because OR's
+validator skips schemas with empty properties.
+
+### Decision 4 — Anonymization consumes OR primitives, no replacement
+
+OR's `TextExtractionService` and File Attachments cover the anonymization pipeline's input
+side. The audit notes anonymization currently has its own file-upload + extraction flow.
+
+**Decision**: rewrite `openspec/specs/anonymization/spec.md` to consume OR primitives. Keep
+the actual NLP/PII detection algorithms in docudesk (those are the value-add). Drop the
+custom plumbing.
+
+**Why**: stream 2 finding. Reuses OR's hardening (CSP, mime-validation, virus-scan hooks)
+instead of re-implementing it.
+
+### Decision 5 — Status strings on the wire stay the same
+
+The migration MUST be transition-only. A controller that today returns `{"status":
+"processing"}` must continue to return `{"status": "processing"}` after Phase 2.
+
+**Why**: the apply phase will not break API consumers. Lifecycle annotation maps internal
+state machine to the on-wire string verbatim. Renaming is a separate, future change.
+
+### Decision 6 — Magic-number cleanup uses default-preserving admin-config
+
+For each constant moving to admin-config (Phase 7), the default value MUST equal the
+current hardcoded value.
+
+**Why**: zero behavioral change at install. Tenants opt into tuning, but a fresh install
+behaves identically to today.
+
+### Decision 7 — Manifest minimum OR version replaces source constant
+
+Phase 1 drops `SettingsService::MIN_OPENREGISTER_VERSION = '0.2.10'`. The manifest
+(`openspec/manifest.yaml`) is the single source of truth for the OR version pin.
+
+**Why**: stream 4 + ADR-026 (manifest) — appinfo/info.xml `<dependencies>` plus the
+manifest declare it once.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+| --- | --- |
+| Schema migration on report/template/entity may reject legacy rows. | Apply phase ships a `repair` step that maps unknown fields into `additionalProperties` JSON column or quarantines invalid rows for review. |
+| Lifecycle annotation in OR is new — apply timing depends on OR shipping ADR-022. | Phase 2 is gated; manifest declares minimum OR version that includes lifecycle support. |
+| Five status writes in `BatchCorrespondenceJob` are spread across try/catch blocks; lifecycle transitions must preserve catch-block semantics. | Apply phase translates each `'status' => 'error'` into the appropriate lifecycle `transitionTo('error', $exception->getMessage())` call so audit captures cause. |
+| OCR `DEFAULT_LANGUAGES = 'nld+eng'` is read across multiple call sites; admin-config rollout must hit them all. | Phase 7 task references the constant by name; the apply phase greps for usages and routes them all through `IAppConfig`. |
+| Archival annotation per schema requires legal review of Archiefwet retention values per category. | Phase 4 task explicitly references the comment in `SigningAuditService.php:7` and asks the apply phase to confirm with the DPO before merging. |
+
+## Migration path
+
+1. OR ships `register-resolver-service`, `pluggable-integration-registry`,
+   `i18n-source-of-truth`, `i18n-api-language-negotiation` (gates Phase 1, 9).
+2. OR ships ADR-022 lifecycle + ADR-024 archival + ADR-025 notification annotation runtime
+   (gates Phases 2, 3, 4, 5).
+3. nc-vue ships `multi-tenancy-context` (gates Phase 9).
+4. Hydra ships `adopt-app-manifest` (gates Phase 8).
+5. docudesk apply phase runs in order: 1 → 6 → 2 → 3 → 4 → 5 → 7 → 8 → 9.
+   Schema rewrite (Phase 6) precedes lifecycle/archival/calculation migration so the
+   annotations have a strict schema to attach to.
+
+## Open Questions
+
+- Does `CorrespondenceService::DEFAULT_FORMAT = 'pdf'` need to be tenant-tunable, or
+  user-tunable per template? Phase 7 assumes admin-config; defer to apply phase if a
+  per-template override is needed.
+- `BatchStateService::CACHE_PREFIX` becomes vestigial after Phase 2 — can it be deleted
+  entirely, or do downstream consumers (test fixtures, support tools) depend on it? Apply
+  phase confirms before removal.
+- Anonymization-result archival retention: 1 year (audit retention) or longer (legal-hold
+  potential)? DPO sign-off in Phase 4.

--- a/openspec/changes/docudesk-adopt-or-abstractions/proposal.md
+++ b/openspec/changes/docudesk-adopt-or-abstractions/proposal.md
@@ -1,0 +1,90 @@
+# docudesk: adopt OpenRegister abstractions
+
+## Why
+
+The OR-abstraction audit (2026-05-03) flagged docudesk as a Tier 2 backend-heavy app that
+duplicates several abstractions that now live in OpenRegister and shared platform packages:
+
+- Status-string state machines hand-rolled in `BatchCorrespondenceJob`, `BatchStateService`,
+  and the signing providers — five literal `'status' => '…'` writes in a single job, one
+  classic state machine encoded in inline strings. Should be a `x-openregister-lifecycle`
+  annotation.
+- Three custom schemas (report, template, entity) declared in
+  `openspec/specs/document-register/spec.md` with `properties: []` and ad-hoc fields. Should
+  be canonical OR schemas with `x-openregister-archival` (Archiefwet 1995, 10-year retention)
+  and validated via OR's schema validator.
+- Anonymization and batch-anonymization specs describe custom file ingest, entity
+  extraction, and per-file status tracking. OR now ships `TextExtractionService`, file
+  attachments, and background-job state — these specs should consume those instead of
+  re-implementing.
+- A dozen hardcoded magic numbers (OCR languages, DPI, lock timeout, cache TTL, max files,
+  batch limit, max depth, version floor) live as `const` values in service classes; they
+  belong in admin-config so tenants can tune without code changes.
+- No app manifest declaring tier or dependency on `openregister`. Hydra coordination cannot
+  pin docudesk on the right OR baseline without it.
+
+This change adopts the OR-side specs (`register-resolver-service`,
+`pluggable-integration-registry`, `i18n-source-of-truth`, `i18n-api-language-negotiation`),
+the nc-vue `multi-tenancy-context` spec, and the Hydra `adopt-app-manifest` change. It also
+migrates docudesk's three core schemas onto OR annotations
+(`x-openregister-lifecycle`, `x-openregister-archival`, `x-openregister-calculations`).
+
+The audit references this proposal must respect:
+
+- `.claude/audit-2026-05-03/01-code-cleanup.md` (stream 1: ObjectService de-duplication)
+- `.claude/audit-2026-05-03/02-spec-rewrite.md` (stream 2: spec rewrites)
+- `.claude/audit-2026-05-03/04-hardcoded.md` (stream 4: magic-number cleanup)
+- `hydra/openspec/architecture/ADR-022.md` (lifecycle annotation)
+- `hydra/openspec/architecture/ADR-024.md` (archival annotation)
+- `hydra/openspec/architecture/ADR-025.md` (notification annotation)
+
+## What Changes
+
+### Spec rewrites
+
+1. `openspec/specs/document-register/spec.md` — rewrite the three schemas (report, template,
+   entity) as full JSON-schema objects with `x-openregister-archival` annotations declaring
+   Archiefwet retention. Drop the ad-hoc `properties: []` shape; require schema validation
+   through OR's validator.
+2. `openspec/specs/anonymization/spec.md` — replace the custom file-upload + entity-extraction
+   pipeline with consumption of OR File Attachments and `TextExtractionService`. Anonymization
+   becomes a `x-openregister-calculations` annotation on the report schema.
+3. `openspec/specs/batch-anonymization/spec.md` — replace `ICache`-backed per-file status
+   tracking with OR Background Jobs + `x-openregister-lifecycle` annotation. Per-file state is
+   recorded as a child object with its own lifecycle, not in a cache key.
+4. `openspec/specs/metadata-enrichment/spec.md` (P2) — declare enrichment as a
+   `x-openregister-calculations` annotation rather than a custom service.
+
+### Code-side migrations (deferred to apply phase, NOT done in this change)
+
+This change is spec-only. It captures the migration as task lines so the apply phase has
+file-level hints. The 17 hardcoded paths from `04-hardcoded.md` are listed verbatim in
+`tasks.md` Phase 7.
+
+### Manifest + multi-tenancy + i18n adoption
+
+- Add `openspec/manifest.yaml` declaring tier 2, dependency on `openregister`, and the
+  shared specs consumed.
+- Adopt nc-vue `multi-tenancy-context` for the document-register frontend (consume; do not
+  re-implement).
+- Adopt OR `i18n-source-of-truth` and `i18n-api-language-negotiation` for all
+  user-facing content fields on the report/template/entity schemas.
+
+## Impact
+
+- Affected specs: `document-register`, `anonymization`, `batch-anonymization`,
+  `metadata-enrichment` (rewrites); new `docudesk-or-adoption` spec captures the adoption
+  contract itself.
+- Affected code (apply-phase hints, NOT changed here): `lib/Service/OcrService.php`,
+  `lib/Service/TemplateService.php`, `lib/Service/BatchStateService.php`,
+  `lib/Service/CorrespondenceService.php`, `lib/Service/DataResolverService.php`,
+  `lib/Service/SettingsService.php`, `lib/Service/Signing/NativeSigningProvider.php`,
+  `lib/Service/Signing/ValidSignProvider.php`, `lib/BackgroundJob/BatchCorrespondenceJob.php`,
+  `lib/Service/FileEntityStatsService.php`, `lib/Service/BatchUploadService.php`,
+  `lib/Service/SigningAuditService.php`.
+- Breaking changes: schema migration for report/template/entity — existing rows must be
+  re-validated against the new strict JSON-schema. Migration script needed in apply phase.
+- Dependencies: openregister must ship `register-resolver-service`,
+  `pluggable-integration-registry`, `i18n-source-of-truth`, `i18n-api-language-negotiation`
+  before the apply phase. nc-vue must ship `multi-tenancy-context`. Hydra must ship
+  `adopt-app-manifest`.

--- a/openspec/changes/docudesk-adopt-or-abstractions/specs/docudesk-or-adoption/spec.md
+++ b/openspec/changes/docudesk-adopt-or-abstractions/specs/docudesk-or-adoption/spec.md
@@ -1,0 +1,183 @@
+# Capability — docudesk-or-adoption
+
+## ADDED Requirements
+
+### Requirement: Lifecycle annotation backs all docudesk status fields
+
+Every docudesk schema that today carries a `status` string field SHALL declare an
+`x-openregister-lifecycle` annotation defining its state set, transition graph, and
+per-transition authorization. Inline `'status' => '<literal>'` writes in service classes
+SHALL be replaced by lifecycle transition API calls. The on-wire status value SHALL remain
+identical to the current value to preserve API compatibility.
+
+#### Scenario: BatchCorrespondenceJob lifecycle transition
+
+- **GIVEN** the batch-correspondence schema declares states
+  `pending`, `processing`, `success`, `error`, `completed` in
+  `x-openregister-lifecycle.states`
+- **WHEN** `BatchCorrespondenceJob::run()` reaches a previously-inline
+  `'status' => 'processing'` write at line 111
+- **THEN** the job SHALL invoke `lifecycleService->transitionTo($object, 'processing')`
+- **AND** the resulting object on the wire SHALL still serialize `"status": "processing"`
+- **AND** the transition SHALL be recorded in the OR audit trail.
+
+#### Scenario: Signing-request pending state
+
+- **GIVEN** the signing-request schema declares states
+  `pending`, `signed`, `rejected`, `expired`
+- **WHEN** `NativeSigningProvider::initiate()` (line 105) or
+  `ValidSignProvider::initiate()` (line 114) creates a signing request
+- **THEN** the provider SHALL invoke `lifecycleService->transitionTo($req, 'pending')`
+  rather than `setStatus('pending')`.
+
+#### Scenario: Lifecycle authorization is enforced
+
+- **GIVEN** a transition is declared as `requiresRole: admin` in the lifecycle annotation
+- **WHEN** a non-admin user attempts the transition via the API
+- **THEN** the request SHALL be rejected with HTTP 403
+- **AND** no `'status'` write SHALL reach the database.
+
+### Requirement: Archival annotation declares Archiefwet retention per schema
+
+Every docudesk schema that stores records subject to the Archiefwet 1995 SHALL declare
+`x-openregister-archival.retention` as an ISO-8601 duration. The current
+`// Archiefwet 1995 minimum 10-year retention` comment in `SigningAuditService.php`
+SHALL be removed in favour of the annotation.
+
+#### Scenario: Signing-audit retention is machine-readable
+
+- **GIVEN** the signing-audit schema declares `x-openregister-archival.retention: P10Y`
+- **WHEN** OR's archival background job runs
+- **THEN** signing-audit rows older than 10 years SHALL be eligible for archival
+- **AND** the comment at `lib/Service/SigningAuditService.php:7` SHALL no longer exist.
+
+#### Scenario: Per-schema retention varies by category
+
+- **GIVEN** the report, template, entity, batch-correspondence, and
+  anonymization-result schemas each declare their own retention duration
+- **WHEN** an auditor inspects the manifest
+- **THEN** each retention value SHALL trace to a specific Archiefwet selectielijst category
+  cited in the schema's description.
+
+### Requirement: Calculation annotation backs computed fields
+
+Anonymization-confidence, OCR-confidence, redaction-coverage, entity-density,
+classification, language-detection, and summarization outputs SHALL be declared as
+`x-openregister-calculations` annotations on their respective schemas. They SHALL NOT be
+populated by ad-hoc writes in service classes.
+
+#### Scenario: Anonymization confidence is a calculation
+
+- **GIVEN** the anonymization-result schema declares
+  `x-openregister-calculations.anonymization_confidence`
+- **WHEN** the anonymization pipeline finishes a run
+- **THEN** the confidence value SHALL be derived from the calculation expression, not
+  written directly by `AnonymizationService`.
+
+### Requirement: Notification annotation backs lifecycle-driven alerts
+
+Sign-request issued, sign-request completed, batch-correspondence finished, and
+anonymization-failed notifications SHALL be declared as `x-openregister-notifications`
+triggers keyed on lifecycle transitions. Direct `notificationManager->notify()` calls in
+docudesk service classes SHALL be removed.
+
+#### Scenario: Sign-request notification fires on lifecycle transition
+
+- **GIVEN** the signing-request schema declares
+  `x-openregister-notifications` keyed on the `pending → signed` transition
+- **WHEN** a signing provider transitions a request to `signed`
+- **THEN** the notification SHALL fire automatically
+- **AND** no direct `notificationManager->notify()` call SHALL exist in
+  `lib/Service/Signing/`.
+
+### Requirement: Document-register schemas use full JSON-schema validation
+
+The report, template, and entity schemas in
+`openspec/specs/document-register/spec.md` SHALL declare full JSON-schema with
+`required`, `properties`, and `additionalProperties: false`. The current `properties: []`
+declarations SHALL be removed.
+
+#### Scenario: Report schema validates strictly
+
+- **GIVEN** the rewritten report schema declares `additionalProperties: false`
+- **WHEN** a controller writes a row with an unknown field
+- **THEN** OR's validator SHALL reject the write
+- **AND** the controller SHALL NOT bypass validation by writing through a raw mapper.
+
+### Requirement: Anonymization consumes OR primitives
+
+`openspec/specs/anonymization/spec.md` SHALL declare consumption of OR File Attachments
+and OR `TextExtractionService` for input handling. The custom file-upload + entity-extraction
+pipeline SHALL be removed.
+
+#### Scenario: Anonymization input via OR File Attachments
+
+- **GIVEN** the anonymization spec declares OR File Attachments as the input source
+- **WHEN** a user uploads a file for anonymization
+- **THEN** the file SHALL be persisted as an OR file attachment, not by docudesk-specific
+  storage code
+- **AND** virus-scan and mime-validation hooks SHALL be inherited from OR.
+
+### Requirement: Batch-anonymization delegates to OR Background Jobs
+
+`openspec/specs/batch-anonymization/spec.md` SHALL declare per-file state as a child object
+with its own lifecycle annotation. The current `ICache`-backed status tracking SHALL be
+removed.
+
+#### Scenario: Batch run creates per-file child objects
+
+- **GIVEN** a batch-anonymization run is initiated
+- **WHEN** the batch processor enumerates input files
+- **THEN** each file SHALL produce a per-file child object with lifecycle states
+  `pending → processing → success | error`
+- **AND** no batch state SHALL be stored in `ICache`.
+
+### Requirement: Tenant-tunable values move to admin-config
+
+Hardcoded constants flagged in `.claude/audit-2026-05-03/04-hardcoded.md` SHALL be migrated
+to admin-config keys. Default values SHALL equal the current hardcoded values.
+
+#### Scenario: OCR languages are admin-config
+
+- **GIVEN** an admin sets `docudesk.ocr.default_languages = 'nld+eng+fra'`
+- **WHEN** `OcrService::run()` invokes Tesseract
+- **THEN** Tesseract SHALL be invoked with `nld+eng+fra`
+- **AND** the constant `DEFAULT_LANGUAGES` SHALL no longer exist in
+  `lib/Service/OcrService.php`.
+
+#### Scenario: Defaults preserve current behavior
+
+- **GIVEN** a fresh docudesk install with no admin-config overrides
+- **WHEN** any service reads a value migrated under Phase 7
+- **THEN** the value SHALL equal the constant value listed in the audit report.
+
+### Requirement: docudesk declares its manifest
+
+docudesk SHALL ship `openspec/manifest.yaml` declaring `tier: 2`, `dependencies:
+["openregister"]`, the consumed shared specs, and the minimum OR version. The
+`MIN_OPENREGISTER_VERSION` constant in `SettingsService.php:61` SHALL be removed.
+
+#### Scenario: Manifest version pin replaces source constant
+
+- **GIVEN** `openspec/manifest.yaml` declares `dependencies.openregister.minVersion`
+- **WHEN** a developer searches the docudesk codebase for `MIN_OPENREGISTER_VERSION`
+- **THEN** no matches SHALL exist in `lib/`.
+
+### Requirement: docudesk consumes shared multi-tenancy + i18n specs
+
+docudesk SHALL consume the nc-vue `multi-tenancy-context` spec and the OR
+`i18n-source-of-truth` and `i18n-api-language-negotiation` specs. It SHALL NOT
+re-implement tenant scoping or translation infrastructure.
+
+#### Scenario: Tenant scope is read from nc-vue composable
+
+- **GIVEN** the nc-vue `multi-tenancy-context` composable is available
+- **WHEN** a docudesk frontend store needs the current tenant
+- **THEN** it SHALL read from `useTenantContext()` rather than computing tenant from
+  user/route state.
+
+#### Scenario: API respects Accept-Language
+
+- **GIVEN** a client sends `Accept-Language: nl-NL` to a docudesk read endpoint
+- **WHEN** the response includes a translatable field declared in i18n-source-of-truth
+- **THEN** the field SHALL return the Dutch translation.

--- a/openspec/changes/docudesk-adopt-or-abstractions/tasks.md
+++ b/openspec/changes/docudesk-adopt-or-abstractions/tasks.md
@@ -1,0 +1,147 @@
+# Tasks — docudesk: adopt OR abstractions
+
+Spec-only change. The "code paths" listed are implementation hints that the apply phase will
+turn into edits, not work to do in this change. All checkboxes start unchecked.
+
+## Phase 1 — register-resolver consumption
+
+docudesk does not have the same `getValueString(APP_ID, 'register', '')` pattern that
+pipelinq has, but it does read register/schema config in `SettingsService`, the OCR pipeline,
+and the correspondence sync. Audit those reads and route them through
+`RegisterResolverService` once OR ships the spec.
+
+- [ ] 1.1 Inventory all `IAppConfig::getValueString(...)` reads in
+      `lib/Service/SettingsService.php` and route them through `RegisterResolverService`
+      where they resolve a register or schema reference.
+- [ ] 1.2 Drop `lib/Service/SettingsService.php:61` `MIN_OPENREGISTER_VERSION = '0.2.10'` —
+      duplicates `appinfo/info.xml` `<dependencies>`. Read from the manifest if needed.
+- [ ] 1.3 Update the docudesk frontend stores to consume the resolver via OR's
+      `useRegisterResolver` composable rather than reading `appConfig` directly.
+
+## Phase 2 — lifecycle annotation migration
+
+The single biggest finding: `BatchCorrespondenceJob` encodes a state machine in inline
+strings. Migrate to `x-openregister-lifecycle` annotation per ADR-022.
+
+- [ ] 2.1 `lib/BackgroundJob/BatchCorrespondenceJob.php:111,162,168,186,199` — five literal
+      `'status' => 'processing'|'success'|'error'|'completed'` writes. Define the lifecycle
+      states (`pending`, `processing`, `success`, `error`, `completed`) on the
+      batch-correspondence schema as `x-openregister-lifecycle.states[]`. Replace the inline
+      writes with OR's lifecycle transition API.
+- [ ] 2.2 `lib/Service/Signing/NativeSigningProvider.php:105`,
+      `lib/Service/Signing/ValidSignProvider.php:114` — `'status' => 'pending'`. Add
+      `pending`, `signed`, `rejected`, `expired` to the signing-request schema's lifecycle.
+- [ ] 2.3 `lib/Service/FileEntityStatsService.php:126`,
+      `lib/Service/BatchUploadService.php:48`,
+      `lib/Service/BatchStateService.php:33` — additional literal status strings. Fold into
+      the same per-schema lifecycle annotations defined above.
+- [ ] 2.4 Document the state transition rules (which transitions are allowed, which require
+      auth) in the lifecycle annotation. Reference `hydra-gate-orphan-auth` so the apply
+      phase wires authorization.
+
+## Phase 3 — notification annotation migration
+
+docudesk's signing flow (sign-request issued, sign-request completed, batch finished)
+currently fires NC `notificationManager` calls inline. Migrate to
+`x-openregister-notifications` per ADR-025.
+
+- [ ] 3.1 Identify all direct `notificationManager->notify()` / `setSubject()` call sites in
+      `lib/Service/` (signing providers + batch-correspondence job). Convert to declarative
+      `x-openregister-notifications` triggers keyed on lifecycle transitions.
+- [ ] 3.2 Add notification copy to the i18n source-of-truth (Phase 9) so the apply phase can
+      ship it through `i18n-api-language-negotiation`.
+
+## Phase 4 — archival annotation
+
+`SigningAuditService.php:7` carries a `// Archiefwet 1995 minimum 10-year retention` comment
+but no machine-readable annotation. Add `x-openregister-archival` per ADR-024.
+
+- [ ] 4.1 Add `x-openregister-archival.retention: P10Y` to the signing-audit schema. Replace
+      the comment with the annotation reference.
+- [ ] 4.2 Add `x-openregister-archival` to the report, template, and entity schemas in
+      `openspec/specs/document-register/spec.md` with retention values that match the
+      Archiefwet selectielijst categories the audit calls out.
+- [ ] 4.3 Add `x-openregister-archival` to the batch-correspondence and
+      anonymization-result schemas (shorter retention; document why).
+
+## Phase 5 — calculation annotation
+
+Anonymization confidence, OCR confidence, and metadata-enrichment outputs are all computed
+fields. Migrate them to `x-openregister-calculations`.
+
+- [ ] 5.1 Anonymization spec: anonymization-confidence, entity-density, redaction-coverage
+      become calculation annotations on the report schema.
+- [ ] 5.2 Metadata-enrichment spec: classification, language-detection, summarization
+      outputs become calculations.
+- [ ] 5.3 OCR confidence + extracted-text-length on the file-attachment schema (in OR; PR
+      against OR if the schema is upstream).
+
+## Phase 6 — spec rewrites (stream 2)
+
+Cite `.claude/audit-2026-05-03/02-spec-rewrite.md` for the full audit context.
+
+- [ ] 6.1 Rewrite `openspec/specs/document-register/spec.md`:
+      - Define report, template, entity schemas as full JSON-schema (drop `properties: []`).
+      - Add `x-openregister-archival` per Phase 4.
+      - Mandate validation through OR's schema validator.
+- [ ] 6.2 Rewrite `openspec/specs/anonymization/spec.md`:
+      - Replace custom file ingest with OR File Attachments.
+      - Replace custom entity extraction with OR `TextExtractionService` integration.
+      - Anonymization becomes a calculation annotation (Phase 5).
+- [ ] 6.3 Rewrite `openspec/specs/batch-anonymization/spec.md`:
+      - Replace `ICache` per-file state tracking with child-object lifecycle annotation.
+      - Delegate scheduling to OR Background Jobs.
+- [ ] 6.4 (P2) Rewrite `openspec/specs/metadata-enrichment/spec.md` to declare enrichment as
+      a calculation annotation rather than a custom service.
+
+## Phase 7 — hardcoded magic-number cleanup
+
+All paths and constants per `.claude/audit-2026-05-03/04-hardcoded.md`. Each becomes an
+admin-config key (default value preserved).
+
+- [ ] 7.1 `lib/Service/OcrService.php:69` — `DEFAULT_LANGUAGES = 'nld+eng'` → admin-config
+      `docudesk.ocr.default_languages` (default `nld+eng`).
+- [ ] 7.2 `lib/Service/OcrService.php:76` — `DEFAULT_DPI = 300` → admin-config
+      `docudesk.ocr.default_dpi` (default `300`).
+- [ ] 7.3 `lib/Service/TemplateService.php:49` — `LOCK_TIMEOUT_MINUTES = 15` → admin-config
+      `docudesk.templates.lock_timeout_minutes` (default `15`).
+- [ ] 7.4 `lib/Service/BatchStateService.php:17` — `CACHE_TTL = 7200` → admin-config
+      `docudesk.batch.cache_ttl_seconds` (default `7200`).
+- [ ] 7.5 `lib/Service/BatchStateService.php:18` — `DEFAULT_MAX_FILES = 100` → admin-config
+      `docudesk.batch.max_files_per_run` (default `100`).
+- [ ] 7.6 `lib/Service/BatchStateService.php:19` — `CACHE_PREFIX` → drop after Phase 2 lifecycle
+      migration removes the cache-based state machine.
+- [ ] 7.7 `lib/Service/CorrespondenceService.php:50` — `SYNC_BATCH_LIMIT = 10` → admin-config
+      `docudesk.correspondence.sync_batch_limit` (default `10`).
+- [ ] 7.8 `lib/Service/CorrespondenceService.php:57` — `DEFAULT_FORMAT = 'pdf'` → admin-config
+      `docudesk.correspondence.default_format` (default `pdf`).
+- [ ] 7.9 `lib/Service/DataResolverService.php:45` — `MAX_DEPTH = 3` → admin-config
+      `docudesk.data_resolver.max_depth` (default `3`).
+- [ ] 7.10 `lib/Service/SettingsService.php:61` — `MIN_OPENREGISTER_VERSION = '0.2.10'` →
+      DROP (duplicates `appinfo/info.xml` `<dependencies>` block).
+
+## Phase 8 — manifest adoption
+
+Cite `hydra/openspec/changes/adopt-app-manifest/`.
+
+- [ ] 8.1 Create `openspec/manifest.yaml` with: `tier: 2`, `dependencies: ["openregister"]`,
+      `consumes: [register-resolver-service, pluggable-integration-registry,
+      i18n-source-of-truth, i18n-api-language-negotiation, multi-tenancy-context]`.
+- [ ] 8.2 Pin minimum OR version in the manifest (replace the dropped
+      `MIN_OPENREGISTER_VERSION` constant from Phase 1).
+- [ ] 8.3 Validate the manifest with the Hydra manifest schema once it ships.
+
+## Phase 9 — multi-tenancy + i18n adoption
+
+Gated on nc-vue `multi-tenancy-context` and OR `i18n-source-of-truth` /
+`i18n-api-language-negotiation` shipping.
+
+- [ ] 9.1 Adopt `multi-tenancy-context` in the docudesk frontend: read `currentTenant` from
+      the nc-vue composable in every store; remove any hand-rolled tenant lookup.
+- [ ] 9.2 Adopt `i18n-source-of-truth` for translatable fields on report, template, entity
+      schemas (label, description, lifecycle-state-display-name, notification copy from
+      Phase 3).
+- [ ] 9.3 Adopt `i18n-api-language-negotiation` for the docudesk public API: respect the
+      `Accept-Language` header on read responses.
+- [ ] 9.4 Update spec scenarios in `openspec/specs/document-register/spec.md` to require
+      tenant-scoped + i18n-aware reads.


### PR DESCRIPTION
## Summary

Phase 3 of the OR-abstraction audit (2026-05-03). Per-app adoption openspec change for **docudesk** — spec-only, no code changes.

Drafts the change so the implementation phase can run `/opsx-apply` against it when scheduled. References Phase 2 OR/nc-vue/hydra specs (openregister#1420, nextcloud-vue#113, hydra#218) and ADRs 022/024/025.

## Test plan

- [x] No code changes; markdown-only.
- [x] References resolve.

## Auto-merge rationale

Markdown-only PR per `feedback_pr-merge-authority.md` — admin-merged on creation.