### PR TITLE
feat(openspec): docudesk-legacy-quality-cleanup tracking change

### DIFF
--- a/openspec/changes/docudesk-legacy-quality-cleanup/proposal.md
+++ b/openspec/changes/docudesk-legacy-quality-cleanup/proposal.md
@@ -1,0 +1,71 @@
+# DocuDesk Legacy Quality Cleanup
+
+## Why
+
+The OR-abstraction audit (2026-05-03, stream 3 + the quality-gates
+cleanup at session start) flagged that docudesk's quality gates have
+legacy debt absorbed via exclude patterns and a PHPStan baseline.
+Burning these down keeps PR diffs honest — gates catch real
+regressions rather than silently absorbing already-broken code.
+
+DocuDesk has 6 phpcs.xml exclude-patterns and a 311-line
+phpstan-baseline.neon. PHPMD has no baseline yet. The work is a
+moderate burn-down: clear PHPCS excludes, run PHPMD unified, and
+chip away at the PHPStan baseline.
+
+This is a tracking change so the burn-down can be picked up later.
+It is spec-only; no code changes are proposed in this change.
+
+## What Changes
+
+- Inventory and clear the 6 phpcs.xml exclude-patterns. For each:
+  add proper docblocks + named-parameter call audits, then drop
+  the exclude.
+- Run PHPMD for the first time as a unified gate (phpmd.xml is
+  configured but no baseline exists). Capture surfacing violations
+  as a baseline OR fix outright depending on volume.
+- Burn down the 311-line phpstan-baseline.neon. Group errors by
+  directory cluster; one PR per cluster; regenerate baseline
+  between PRs.
+- Wire phpcs/phpmd/phpstan into CI as the unified quality gate.
+
+## Problem
+
+Exclude-patterns and the PHPStan baseline exist because the audit
+captured legacy files / errors that predated the current quality
+conventions. The audit flagged docudesk as a moderate-volume
+case — small enough to clear in 3-4 PRs, large enough to need
+phasing.
+
+PHPMD baseline doesn't exist yet because the gate hasn't been run
+as part of unified `check:strict`. Capturing it (or fixing
+outright) is a Phase 1 activity.
+
+Now is the time because the per-app OR-abstraction adoption work
+(Hydra ADR-022) is touching the same files. Cleanup amortises
+across both efforts.
+
+## Proposed Solution
+
+File-by-file cleanup phased by directory cluster. Phase 2 lists
+each excluded file. Phase 4 groups PHPStan errors by `lib/Service/`,
+`lib/Controller/`, `lib/Db/`, etc. — exact buckets emerge from the
+baseline inventory in Phase 1.
+
+Estimated effort: 3-4 PRs over 1-2 sprints.
+
+## Out of scope
+
+- Refactoring beyond what the sniff requires
+- New features (separate adoption-spec changes own those)
+- Test additions (separate test-coverage spec change if needed)
+
+## See also
+
+- The canonical audit lives in openregister at
+  `.claude/audit-2026-05-03/03-repo-hygiene.md`. DocuDesk references
+  it from there.
+- `phpcs.xml` (the legacy-debt baseline section)
+- `phpstan-baseline.neon` (the PHPStan baseline file)
+- Hydra ADR-022 (apps consume OR abstractions) — quality conventions
+- `composer.json` `check:strict` script (the unified gate target)

--- a/openspec/changes/docudesk-legacy-quality-cleanup/tasks.md
+++ b/openspec/changes/docudesk-legacy-quality-cleanup/tasks.md
@@ -1,0 +1,80 @@
+# Tasks: DocuDesk Legacy Quality Cleanup
+
+## Phase 1 — Inventory + planning
+
+- [ ] Run `composer phpcs` and capture current baseline error count
+      (target: starting from 6 exclude-patterns in phpcs.xml)
+- [ ] Run `composer phpmd` for the first time as a unified gate
+      and capture violation count + categories
+- [ ] Run `composer phpstan` and capture current error count
+      (target: starting from 311-line phpstan-baseline.neon)
+- [ ] Group PHPStan errors by directory cluster
+- [ ] Decide PHPMD strategy: fix-outright or capture baseline
+- [ ] Confirm CI runs `composer check:strict` on every PR before
+      starting burn-down work
+
+## Phase 2 — PHPCS burn-down (per excluded file)
+
+For each file: fix errors, remove the phpcs.xml `<exclude-pattern>`
+entry, verify gate stays green.
+
+- [ ] Excluded file 1 — fix sniffs + drop exclude
+- [ ] Excluded file 2 — fix sniffs + drop exclude
+- [ ] Excluded file 3 — fix sniffs + drop exclude
+- [ ] Excluded file 4 — fix sniffs + drop exclude
+- [ ] Excluded file 5 — fix sniffs + drop exclude
+- [ ] Excluded file 6 — fix sniffs + drop exclude
+- [ ] Once all excludes are gone, drop the legacy-debt block from
+      phpcs.xml entirely
+
+## Phase 3 — PHPMD burn-down
+
+Contingent on Phase 1's first-run output.
+
+- [ ] If baseline captured: ElseExpression — re-shape `if/else` to
+      early-return
+- [ ] If baseline captured: CyclomaticComplexity / NPathComplexity —
+      extract methods
+- [ ] If baseline captured: MissingImport — add `use` statements
+- [ ] If baseline captured: ExcessiveMethodLength — extract helpers
+- [ ] If baseline captured: StaticAccess — replace with DI
+- [ ] If baseline captured: variable-naming sniffs (Long/Short/
+      Undefined/UnusedFormalParameter)
+- [ ] Once baseline reaches 0 lines: delete phpmd.baseline.xml and
+      drop `--baseline-file` from composer.json's phpmd script
+
+## Phase 4 — PHPStan burn-down (311 lines)
+
+Group errors by directory cluster (per Phase 1 inventory) and
+work cluster-by-cluster. Regenerate baseline between PRs.
+
+- [ ] Cluster 1: Controllers (`lib/Controller/`)
+- [ ] Cluster 2: Services (`lib/Service/`)
+- [ ] Cluster 3: Db mappers + entities (`lib/Db/`)
+- [ ] Cluster 4: Migrations (`lib/Migration/`)
+- [ ] Cluster 5: Settings (`lib/Settings/`)
+- [ ] Cluster 6: Cron / background jobs
+- [ ] Cluster 7: Bootstrap / appinfo / util
+- [ ] Common patterns to fix:
+  - [ ] Missing return-type / param-type declarations
+  - [ ] Mixed types (specify generic / union)
+  - [ ] Possibly-null dereferences
+  - [ ] Strict-comparison nudges (`==` to `===`)
+- [ ] Once baseline reaches 0 lines: delete phpstan-baseline.neon
+
+## Phase 5 — CI integration
+
+- [ ] Verify `composer check:strict` runs in CI on every PR
+- [ ] Once all baselines are empty:
+  - [ ] Delete `phpmd.baseline.xml` (if it was created)
+  - [ ] Delete `phpstan-baseline.neon`
+  - [ ] Drop the legacy-debt section from `phpcs.xml`
+- [ ] Add a smoke-test cron that runs `composer check:strict`
+      weekly on `development`
+
+## Phase 6 — Documentation
+
+- [ ] Update README quality-gates section
+- [ ] Note in `app-config.json` that legacy quality cleanup is done
+- [ ] Close the burn-down tracking issue once the last baseline
+      line is removed


### PR DESCRIPTION
## Summary

Drafts the openspec change that captures docudesk's legacy quality-debt cleanup as a tracked initiative. **Spec-only, markdown-only.**

Per the 2026-05-03 OR-abstraction audit, stream 3 (repo hygiene). Tracks the burn-down of any phpcs.xml exclude-pattern, phpmd.baseline.xml, or phpstan-baseline state so future PR diffs are gated against real issues only.

## Auto-merge rationale

Markdown-only per `feedback_pr-merge-authority.md`.