### PR TITLE
perf: split shared Vue/@nextcloud/vue chunks across entry-points

### DIFF
--- a/lib/Dashboard/AnonymizationWidget.php
+++ b/lib/Dashboard/AnonymizationWidget.php
@@ -130,6 +130,9 @@ class AnonymizationWidget implements IWidget, IIconWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, 'docudesk-dashboard');
 
     }//end load()

--- a/lib/Dashboard/FileEntitiesWidget.php
+++ b/lib/Dashboard/FileEntitiesWidget.php
@@ -131,6 +131,9 @@ class FileEntitiesWidget implements IWidget, IIconWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, 'docudesk-dashboard');
 
     }//end load()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,4 +40,43 @@ webpackConfig.resolve.alias = {
 	'@nextcloud/dialogs': path.resolve(__dirname, 'node_modules/@nextcloud/dialogs'),
 }
 
+// Share Vue + @nextcloud/vue + pinia + icons + @conduction/nextcloud-vue
+// across the main / settings / dashboard entry-points so each bundle no
+// longer inlines its own ~3 MB framework copy. Stable filenames mean each
+// entry's `Util::addScript` PHP call can reference the chunk directly
+// without a manifest. The shared chunks are loaded once per page and
+// cached across navigations between docudesk's own pages. As docudesk
+// grows additional dashboard widgets, every new widget adds only its
+// per-widget delta on top of the shared baseline.
+webpackConfig.optimization = {
+	...(webpackConfig.optimization || {}),
+	splitChunks: {
+		...(webpackConfig.optimization?.splitChunks || {}),
+		chunks: 'all',
+		cacheGroups: {
+			default: false,
+			defaultVendors: false,
+			ncVue: {
+				name: appId + '-shared-nc-vue',
+				// Matches both node_modules entries AND the monorepo-dev alias
+				// `../nextcloud-vue/src/...` which webpack resolves outside
+				// node_modules when @conduction/nextcloud-vue is aliased to it.
+				test: /[\\/]node_modules[\\/](@nextcloud[\\/]vue|@conduction[\\/]nextcloud-vue)[\\/]|[\\/]nextcloud-vue[\\/]src[\\/]/,
+				priority: 30,
+				reuseExistingChunk: true,
+				enforce: true,
+				filename: appId + '-shared-nc-vue.js',
+			},
+			vendor: {
+				name: appId + '-shared-vendor',
+				test: /[\\/]node_modules[\\/](vue|pinia|vue-material-design-icons|@vueuse|core-js)[\\/]/,
+				priority: 20,
+				reuseExistingChunk: true,
+				enforce: true,
+				filename: appId + '-shared-vendor.js',
+			},
+		},
+	},
+}
+
 module.exports = webpackConfig


### PR DESCRIPTION
Same pattern that just landed on pipelinq and procest. Extracts shared Vue + `@nextcloud/vue` + pinia into stable-filename chunks so each entry keeps only entry-specific code.

## Bundle sizes after `npm run build`

| Bundle | Before | After |
|---|---:|---:|
| `docudesk-main.js` | 6.06 MB | **3.37 MB** |
| `docudesk-settings.js` | 5.97 MB | **3.30 MB** |
| `docudesk-dashboard.js` | 3.63 MB | **1.89 MB** |
| `docudesk-shared-nc-vue.js` | — | **2.71 MB** (loaded once) |
| `docudesk-shared-vendor.js` | — | **0.31 MB** (loaded once) |

## Trade-off on `/apps/mydash/`

Docudesk only has one widget bundle (`docudesk-dashboard.js`), so unlike pipelinq/procest there is nothing to dedupe at the widget level *today*. On the mydash dashboard page the docudesk payload actually grows from 3.63 MB to 4.91 MB on **cold cache** (+1.28 MB) because the shared chunks are new bytes that previously did not exist. On **warm cache** (a returning user, or a user who has visited any docudesk page first) the shared chunks are already cached and only the 1.89 MB widget delta loads (-1.74 MB net).

Shipping this anyway because:
- Docudesk is expected to grow more dashboard widgets (per discussion). Each new widget then adds only its widget-specific delta on top of the already-cached shared baseline, which is what the pattern was designed for.
- `/apps/docudesk/` and `/apps/docudesk/admin` benefit immediately from the cross-page caching.
- Keeping the same shape across pipelinq / procest / docudesk is easier to reason about.

## Validation

- Built locally with `NODE_OPTIONS=--max-old-space-size=8192 npm run build` ✓
- Reloaded `/apps/mydash/` and confirmed shared chunks load before `docudesk-dashboard.js` ✓
- Console: same baseline errors, no new errors

## Test plan
- [ ] CI build passes
- [ ] Open `/apps/mydash/`, confirm docudesk widgets render (file entities, anonymization)
- [ ] Open `/apps/docudesk/`, confirm main app renders