### PR TITLE
fix: switch RegisterDiscoveryService to findAllSerialized to populate schema dropdown (#120)

### DIFF
--- a/lib/Service/RegisterDiscoveryService.php
+++ b/lib/Service/RegisterDiscoveryService.php
@@ -65,12 +65,21 @@ class RegisterDiscoveryService
     /**
      * Fetch available registers from OpenRegister with schemas
      *
+     * Calls `RegisterService::findAllSerialized` with `_extend: ['schemas']` so
+     * each register's `schemas` field is returned as full schema objects (not
+     * bare IDs). On orphan schema IDs, OpenRegister retains the ID in place
+     * (heterogeneous array of objects + ints) — `filterSchemaProperties()`
+     * passes those through unchanged.
+     *
+     * Requires `nextcloud/openregister` with `findAllSerialized` available
+     * (see openregister#1428).
+     *
      * @return array<int, array<string, mixed>> List of register arrays with filtered schemas
      */
     public function fetchAvailableRegisters(): array
     {
         try {
-            $rawRegisters = $this->registerService->findAll(
+            $rawRegisters = $this->registerService->findAllSerialized(
                 limit: null,
                 offset: null,
                 filters: [],
@@ -79,7 +88,7 @@ class RegisterDiscoveryService
                 _extend: ['schemas']
             );
 
-            return array_map([$this, 'serializeRegister'], $rawRegisters);
+            return array_map([$this, 'filterSchemas'], $rawRegisters);
         } catch (TypeError $e) {
             $this->logger->warning(
                 'OpenRegister internal error - using empty registers list',
@@ -92,7 +101,7 @@ class RegisterDiscoveryService
             return [];
         } catch (Exception $e) {
             $this->logger->warning(
-                'OpenRegister findAll() failed - using empty registers list',
+                'OpenRegister findAllSerialized() failed - using empty registers list',
                 [
                     'exception' => $e->getMessage(),
                     'file'      => $e->getFile(),
@@ -105,18 +114,21 @@ class RegisterDiscoveryService
     }//end fetchAvailableRegisters()
 
     /**
-     * Serialize a register entity and filter its schemas
+     * Strip the `properties` field from each schema in a serialized register
      *
-     * @param mixed $register The register entity
+     * Input is the already-serialized register array from
+     * `RegisterService::findAllSerialized` — each entry in `schemas` is either
+     * a full schema array (when expansion succeeded) or a bare ID (orphan
+     * schema). `filterSchemaProperties()` handles both transparently.
+     *
+     * @param array<string, mixed> $registerArray Serialized register
      *
      * @return array<string, mixed> Serialized register with filtered schemas
      *
      * @SuppressWarnings(PHPMD.UnusedPrivateMethod)
      */
-    private function serializeRegister(mixed $register): array
+    private function filterSchemas(array $registerArray): array
     {
-        $registerArray = $register->jsonSerialize();
-
         if (isset($registerArray['schemas']) === true && is_array($registerArray['schemas']) === true) {
             $registerArray['schemas'] = array_map(
                 [$this, 'filterSchemaProperties'],
@@ -126,7 +138,7 @@ class RegisterDiscoveryService
 
         return $registerArray;
 
-    }//end serializeRegister()
+    }//end filterSchemas()
 
     /**
      * Filter out the properties field from a schema array

--- a/tests/unit/Service/RegisterDiscoveryServiceTest.php
+++ b/tests/unit/Service/RegisterDiscoveryServiceTest.php
@@ -132,7 +132,7 @@ class RegisterDiscoveryServiceTest extends TestCase
      */
     public function testFetchAvailableRegistersReturnsEmptyOnException(): void
     {
-        $this->mockRegisterService->method('findAll')
+        $this->mockRegisterService->method('findAllSerialized')
             ->willThrowException(new \Exception('Service error'));
 
         $result = $this->service->fetchAvailableRegisters();
@@ -148,13 +148,119 @@ class RegisterDiscoveryServiceTest extends TestCase
      */
     public function testFetchAvailableRegistersReturnsEmptyOnTypeError(): void
     {
-        $this->mockRegisterService->method('findAll')
+        $this->mockRegisterService->method('findAllSerialized')
             ->willThrowException(new \TypeError('Type error'));
 
         $result = $this->service->fetchAvailableRegisters();
         $this->assertEmpty($result);
 
     }//end testFetchAvailableRegistersReturnsEmptyOnTypeError()
+
+
+    /**
+     * Test fetchAvailableRegisters strips `properties` from expanded schemas
+     *
+     * @return void
+     */
+    public function testFetchAvailableRegistersStripsPropertiesFromExpandedSchemas(): void
+    {
+        $this->mockRegisterService->method('findAllSerialized')
+            ->with(
+                $this->isNull(),
+                $this->isNull(),
+                $this->equalTo([]),
+                $this->equalTo([]),
+                $this->equalTo([]),
+                $this->equalTo(['schemas'])
+            )
+            ->willReturn(
+                [
+                    [
+                        'id'      => 1,
+                        'title'   => 'Register A',
+                        'schemas' => [
+                            [
+                                'id'         => 10,
+                                'title'      => 'Schema A',
+                                'properties' => ['foo' => ['type' => 'string']],
+                            ],
+                        ],
+                    ],
+                ]
+            );
+
+        $result = $this->service->fetchAvailableRegisters();
+
+        $this->assertCount(1, $result);
+        $this->assertSame(10, $result[0]['schemas'][0]['id']);
+        $this->assertArrayNotHasKey('properties', $result[0]['schemas'][0]);
+        $this->assertSame('Schema A', $result[0]['schemas'][0]['title']);
+
+    }//end testFetchAvailableRegistersStripsPropertiesFromExpandedSchemas()
+
+
+    /**
+     * Test fetchAvailableRegisters passes orphan schema IDs through unchanged
+     *
+     * Orphan IDs are bare ints/strings (not arrays), so `filterSchemaProperties`
+     * passes them through without trying to strip `properties`.
+     *
+     * @return void
+     */
+    public function testFetchAvailableRegistersPassesOrphanIdsThrough(): void
+    {
+        $this->mockRegisterService->method('findAllSerialized')
+            ->willReturn(
+                [
+                    [
+                        'id'      => 1,
+                        'schemas' => [
+                            [
+                                'id'         => 10,
+                                'title'      => 'Schema A',
+                                'properties' => [],
+                            ],
+                            999,
+                            'uuid-orphan-abc',
+                        ],
+                    ],
+                ]
+            );
+
+        $result = $this->service->fetchAvailableRegisters();
+
+        $this->assertCount(3, $result[0]['schemas']);
+        $this->assertIsArray($result[0]['schemas'][0]);
+        $this->assertSame(999, $result[0]['schemas'][1]);
+        $this->assertSame('uuid-orphan-abc', $result[0]['schemas'][2]);
+
+    }//end testFetchAvailableRegistersPassesOrphanIdsThrough()
+
+
+    /**
+     * Test fetchAvailableRegisters handles a register with an empty schemas array
+     *
+     * @return void
+     */
+    public function testFetchAvailableRegistersHandlesEmptySchemas(): void
+    {
+        $this->mockRegisterService->method('findAllSerialized')
+            ->willReturn(
+                [
+                    [
+                        'id'      => 1,
+                        'title'   => 'Register A',
+                        'schemas' => [],
+                    ],
+                ]
+            );
+
+        $result = $this->service->fetchAvailableRegisters();
+
+        $this->assertCount(1, $result);
+        $this->assertSame([], $result[0]['schemas']);
+
+    }//end testFetchAvailableRegistersHandlesEmptySchemas()
 
 
 }//end class


### PR DESCRIPTION
## Summary

Swap `RegisterService::findAll(_extend: ['schemas'])` for `RegisterService::findAllSerialized(_extend: ['schemas'])` inside `RegisterDiscoveryService::fetchAvailableRegisters()`. The admin-settings schema dropdown now actually populates with full schema objects instead of being silently empty (because `findAll` was returning bare IDs all along — the schema-expansion only happened on the HTTP path).

Closes #120.

## Why this works now

[ConductionNL/openregister#1430](https://github.com/ConductionNL/openregister/pull/1430) just shipped `findSerialized` / `findAllSerialized` on `RegisterService` so DI consumers (us) get the same expanded payload that the HTTP endpoint produces. Previously `findAll` silently dropped `_extend` at the mapper.

## What changed

**`lib/Service/RegisterDiscoveryService.php`**
- `fetchAvailableRegisters()`: swap `findAll` → `findAllSerialized`. Catch-block log message updated to match. Updated docblock to point at the openregister tracking issue.
- Rename `serializeRegister(mixed $register): array` → `filterSchemas(array $registerArray): array`. Body becomes a one-liner (no more `->jsonSerialize()` call — input is already an array).
- `filterSchemaProperties()` is unchanged. Because it returns non-array inputs untouched, orphan schema IDs (bare ints/strings, retained in place by openregister's serializer) flow through transparently.

**`tests/unit/Service/RegisterDiscoveryServiceTest.php`**
- Updates the two existing exception-path tests to mock `findAllSerialized`.
- Adds three new tests:
  - `testFetchAvailableRegistersStripsPropertiesFromExpandedSchemas` — verifies `properties` is removed from each expanded schema and asserts the call shape.
  - `testFetchAvailableRegistersPassesOrphanIdsThrough` — verifies bare ID entries (heterogeneous `schemas` array) survive the round-trip.
  - `testFetchAvailableRegistersHandlesEmptySchemas` — sanity check on registers with no schemas.

## Wire-format note

The `schemas` field is now possibly heterogeneous: a mix of expanded schema objects and bare orphan IDs (when a register references a schema that was later deleted in openregister). `filterSchemaProperties()` handles both. The frontend that consumes this output (`Settings.vue` schema list) already filters via `typeof schema === 'object'`, so no UI change is required.

## Quality

| Tool | Status |
|------|--------|
| PHPCS | ✅ 0 errors |
| Psalm | ✅ no errors |
| PHPStan | ✅ no errors |
| PHPUnit (`RegisterDiscoveryServiceTest`) | ✅ 7/7 inside the dev container |

## Test plan

- [x] Unit tests green (7/7)
- [ ] Manual smoke: in the local dev stack (which already has openregister with `findAllSerialized`), open the DocuDesk admin settings page and pick an object type — the schema dropdown should now show real schema titles instead of being empty
- [ ] Manual: trigger an orphan-schema scenario (delete a schema referenced by a register in openregister, then refresh DocuDesk admin settings) — the dropdown should not crash; the orphan ID is silently filtered by the frontend's `typeof === 'object'` guard

## Cross-repo dependency

Depends on `nextcloud/openregister` containing [ConductionNL/openregister#1428](https://github.com/ConductionNL/openregister/issues/1428) (PR [#1430](https://github.com/ConductionNL/openregister/pull/1430)). Once that PR merges and is included in a release we depend on, this PR is unblocked. **Do not merge before the openregister PR is in.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
