### PR TITLE
docs(audit): signing-audit migration plan (closes #131)

### DIFF
--- a/openspec/changes/migrate-signing-audit-to-or-audit/.openspec.yaml
+++ b/openspec/changes/migrate-signing-audit-to-or-audit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/migrate-signing-audit-to-or-audit/design.md
+++ b/openspec/changes/migrate-signing-audit-to-or-audit/design.md
@@ -1,0 +1,148 @@
+# Design: migrate-signing-audit-to-or-audit
+
+## Context
+
+The docudesk signing audit trail currently flows through `SigningAuditService`:
+
+```
+SigningController / SigningService
+  → SigningAuditService::logEvent(signingRequestId, action, actorUserId, ...)
+    → ObjectService::saveObject(signingAuditEntry_register, signingAuditEntry_schema, entry)
+      → OR stores as regular object (not an audit-trail entry)
+```
+
+Immutability is enforced by `rejectUpdate()` / `rejectDelete()` throwing RuntimeException.
+Discovery is done by `getAuditTrail()` scanning all `signingAuditEntry` objects and
+filtering client-side — O(n) over all signing audit records, not just the one request.
+
+After migration, the flow MUST be:
+
+```
+SigningController / SigningService
+  → SigningAuditService::logEvent(signingRequestId, action, actorUserId, ...)  [same interface]
+    → AuditTrailMapper::createAuditTrailEntry(ObjectEntity $object,
+                                              string $action='docudesk.signing.{ACTION}',
+                                              array $context=[...])
+      → OR audit trail (hash-chained, natively immutable)
+```
+
+The `SigningController` and all calling code in `SigningService` and `lib/Service/Signing/`
+are NOT modified — `SigningAuditService`'s public interface (`logEvent()`) remains stable.
+
+## File-by-File Migration Plan
+
+### lib/Service/SigningAuditService.php — REWRITE
+
+**Constructor**: replace `SettingsService` + `IAppConfig` with
+`OCA\OpenRegister\Db\AuditTrailMapper`. Retain `LoggerInterface`.
+
+**VALID_ACTIONS constant**: keep the constant — it is the source of truth for valid action
+names. The values remain `['CREATED', 'SIGNED', 'DECLINED', 'CANCELLED', 'EXPIRED',
+'COMPLETED', 'VIEWED']`. They become the `{ACTION}` suffix of the namespaced type.
+
+**logEvent() method**: rewrite body:
+1. Validate `$action` against `VALID_ACTIONS` (same guard as current).
+2. Build action type: `'docudesk.signing.' . $action`
+3. Build `$context` array (persisted in the `changed` JSON column):
+   ```php
+   $context = [
+       'signRequestId'   => $signingRequestId,
+       'actorUserId'     => $actorUserId,
+       'actorDisplayName'=> $actorDisplayName,
+       'ipAddress'       => $ipAddress,
+       'signatureLevel'  => $signatureLevel,
+       'provider'        => $provider,
+       'extra'           => $metadata,  // pass-through from caller
+   ];
+   ```
+4. Call `AuditTrailMapper::createAuditTrailEntry($object, $actionType, $context)` where
+   `$object` is the `ObjectEntity` for the signing request.
+5. Return the created entry as an array (same return contract as before).
+
+App-specific context is carried in the `$context` array argument to
+`AuditTrailMapper::createAuditTrailEntry()`, which is persisted in the existing `changed`
+JSON column on the `openregister_audit_trails` table. No OR schema change is required.
+
+**getAuditTrail() method**: rewrite to query OR audit trail API:
+```php
+$entries = $this->auditTrailMapper->findAll(
+    filters: ['objectUuid' => $signingRequestId]
+);
+// sort by created ASC (OR entries are already ordered; sort defensively)
+usort($entries, fn($a, $b) => strcmp($a->getCreated(), $b->getCreated()));
+return array_map(fn($e) => $e->jsonSerialize(), $entries);
+```
+If `AuditTrailMapper::findAll()` does not support `objectUuid` filter, use
+`findAllByObject($signingRequestId)` — check which method the mapper exposes.
+
+**rejectUpdate() and rejectDelete() methods**: REMOVE. OR enforces immutability natively.
+If callers reference these methods, update callers to remove the calls (they should never
+be calling these on the audit service — they were internal guards).
+
+### lib/Controller/SigningController.php — NO CHANGE
+
+The controller calls `SigningAuditService::logEvent(...)`. The interface signature does not
+change, only the implementation. No modifications needed.
+
+### lib/Service/SigningService.php and lib/Service/Signing/*.php — NO CHANGE
+
+These services call `SigningAuditService::logEvent(...)`. Interface unchanged.
+
+### signingAuditEntry schema configuration — DEPRECATE
+
+The `signingAuditEntry_register` and `signingAuditEntry_schema` IAppConfig keys are no
+longer used for writes after migration. Mark them deprecated in code with a comment:
+```php
+// DEPRECATED: signingAuditEntry_register and signingAuditEntry_schema were used
+// before migrate-signing-audit-to-or-audit. Keys retained for read-only legacy access.
+```
+Do NOT remove the config keys — they may still be used by any legacy read path until sunset.
+
+## Archiefwet Retention Configuration
+
+OR audit trail supports configurable retention periods per register (per the
+`audit-trail-immutable` spec, "Configure retention period" scenario). Docudesk signing
+audit MUST be configured with at least 10-year retention (3650 days) per Archiefwet 1995.
+
+This is a **deployment-time configuration**, not a code change:
+- OR admin UI: set retention for the signing-related register to ≥ 3650 days.
+- Or via OR's occ command / API if available.
+
+Document this requirement in docudesk's deployment/administration guide. The code does not
+enforce the retention value — OR's retention engine does.
+
+## Event Type to VALID_ACTION Mapping
+
+| VALID_ACTION | OR audit action type |
+|---|---|
+| CREATED | `docudesk.signing.CREATED` |
+| SIGNED | `docudesk.signing.SIGNED` |
+| DECLINED | `docudesk.signing.DECLINED` |
+| CANCELLED | `docudesk.signing.CANCELLED` |
+| EXPIRED | `docudesk.signing.EXPIRED` |
+| COMPLETED | `docudesk.signing.COMPLETED` |
+| VIEWED | `docudesk.signing.VIEWED` |
+
+The uppercase convention (`SIGNED` not `signed`) is preserved from the existing
+`VALID_ACTIONS` constant to minimise change scope. Future new action types follow the
+same pattern.
+
+## Backwards Compatibility
+
+- Existing `signingAuditEntry` objects in OR remain queryable (read-only) until sunset.
+- New signing events ONLY emit via OR audit trail after this spec ships.
+- `SigningAuditService::logEvent()` public signature is unchanged — no caller modifications needed.
+- `SigningAuditService::getAuditTrail()` public signature unchanged — callers receive the
+  same array shape (now sourced from OR audit trail instead of private schema).
+
+## Seed Data
+
+No new schemas are added. No new register definitions are created. The `signingAuditEntry`
+schema is deprecated in-place (the config keys are marked deprecated; no changes to
+procest_register.json equivalent in docudesk). No seed data changes.
+
+## Related ADRs
+
+- **ADR-022** (primary) — mandate for this migration.
+- **ADR-008** — testing contract; hash-chain integrity test required.
+- **ADR-001** — data layer; no new entities or mappers introduced.

--- a/openspec/changes/migrate-signing-audit-to-or-audit/proposal.md
+++ b/openspec/changes/migrate-signing-audit-to-or-audit/proposal.md
@@ -1,0 +1,88 @@
+# Proposal: migrate-signing-audit-to-or-audit
+
+## Why
+
+ADR-022 (Apps Consume OpenRegister Abstractions) prohibits home-grown audit trails for
+OR-owned objects. Docudesk currently violates this rule:
+
+- `lib/Service/SigningAuditService.php` maintains a parallel audit storage pipeline. Its
+  `logEvent()` method saves signing events to a `signingAuditEntry` register/schema
+  configured via `IAppConfig` (`signingAuditEntry_register`, `signingAuditEntry_schema`),
+  bypassing OR's built-in audit trail entirely.
+- `rejectUpdate()` and `rejectDelete()` manually re-implement immutability guards (throwing
+  RuntimeException for Archiefwet compliance) — these are already provided by OR's
+  hash-chained audit trail (HTTP 405 natively).
+- `getAuditTrail()` scans all objects in the private schema and filters client-side — an
+  inefficient O(n) approach that OR's indexed audit trail API does not need.
+
+The umbrella spec `consume-or-audit-trail-fleet-wide` (hydra) mandates per-app migration
+specs for each violating app within 90 days of umbrella acceptance.
+
+## What
+
+Rewrite `SigningAuditService` to emit through OR's audit trail:
+
+1. Convert `logEvent()` to call `AuditTrailMapper::createAuditTrailEntry()` with
+   action type `docudesk.signing.{ACTION}` (e.g. `docudesk.signing.SIGNED`) and signing
+   context in the `$context` payload (persisted in the `changed` JSON column).
+2. Remove `rejectUpdate()` and `rejectDelete()` (OR audit trail enforces immutability natively).
+3. Rewrite `getAuditTrail()` to query `GET /api/audit-trails?objectUuid={signingRequestId}`
+   instead of scanning the private schema.
+4. Mark the `signingAuditEntry` register/schema configuration deprecated; document sunset.
+5. Document the 10-year Archiefwet retention requirement as an OR deployment configuration
+   (set OR retention to ≥ 3650 days for signing-related audit events).
+
+## Capabilities
+
+### New Capabilities
+
+- `signing-audit-via-or`: Signing events are discoverable via
+  `GET /api/audit-trails?objectUuid={signRequestId}` with action types matching
+  `docudesk.signing.*`. OR handles immutability, hash chaining, and Archiefwet retention.
+
+### Modified Capabilities
+
+- `signing-audit-service`: `SigningAuditService` is rewritten as a thin adapter around OR's
+  audit trail. Callers retain the same `logEvent()` interface but the underlying storage
+  path changes. `rejectUpdate()` / `rejectDelete()` are removed.
+
+## Affected Projects
+
+- [x] Project: `docudesk` — all implementation work is in this repo
+- Reference: `hydra/openspec/changes/consume-or-audit-trail-fleet-wide/` (umbrella policy)
+- Reference: `openregister/openspec/specs/audit-trail-immutable/spec.md` (OR contract)
+
+## Scope
+
+### In Scope
+
+- Rewriting `SigningAuditService.logEvent()` to emit via OR audit trail
+- Rewriting `SigningAuditService.getAuditTrail()` to query OR audit trail API
+- Removing `rejectUpdate()` and `rejectDelete()` from `SigningAuditService`
+- Documenting 10-year Archiefwet retention configuration (deploy-time OR setting)
+- Deprecating `signingAuditEntry` register/schema configuration
+- Tests verifying discoverability via OR audit trail API for all VALID_ACTIONS
+
+### Out of Scope
+
+- Changing the signing flow, `SigningController`, `SigningService`, or
+  `lib/Service/Signing/*.php` provider implementations (signing logic unchanged)
+- Modifying OR's audit-trail API (consumed, not changed)
+- Changing the Archiefwet 10-year retention period (requirement stays, mechanism moves
+  to OR configuration)
+- Historical data backfill (out of scope — per ADR-022 + Archiefwet retention, historical rows
+  remain in the deprecated `signingAuditEntry` store read-only; backfilling into OR's hash
+  chain would risk integrity since chronological ordering of legacy rows is not guaranteed)
+
+## Sunset Date
+
+The `signingAuditEntry` schema deprecation sunset date is one major docudesk release after
+this spec is accepted. Existing rows remain queryable (read-only) until that date.
+
+## Success Criteria
+
+- `openspec validate --strict migrate-signing-audit-to-or-audit` exits 0.
+- `SigningAuditService.logEvent()` emits via OR audit trail (no `signingAuditEntry` writes).
+- `GET /api/audit-trails?objectUuid={signRequestId}` returns signing events for all
+  VALID_ACTIONS.
+- `composer check:strict` passes.

--- a/openspec/changes/migrate-signing-audit-to-or-audit/specs/signing-audit-via-or/spec.md
+++ b/openspec/changes/migrate-signing-audit-to-or-audit/specs/signing-audit-via-or/spec.md
@@ -1,0 +1,151 @@
+# signing-audit-via-or Specification
+
+---
+status: proposed
+---
+
+## Purpose
+
+Replace the parallel `signingAuditEntry` write path in `SigningAuditService` with OR
+audit-trail emissions. Every signing action on an OR-owned signing request object MUST be
+discoverable via OR's audit-trail-immutable API. References
+`consume-or-audit-trail-fleet-wide` umbrella and ADR-022.
+
+## ADDED Requirements
+
+### Requirement: Signing Action Emits OR Audit Event
+
+SHALL emit an OR audit trail entry for every signing action — CREATED, SIGNED, DECLINED,
+CANCELLED, EXPIRED, COMPLETED, VIEWED — with action type `docudesk.signing.{ACTION}` (e.g.
+`docudesk.signing.SIGNED`, `docudesk.signing.DECLINED`). No signing audit event shall be
+written only to the private `signingAuditEntry` schema after this spec ships.
+
+#### Scenario: SIGNED action creates OR audit entry
+
+- GIVEN a signing request with UUID `sign-001` stored in OR
+- WHEN `SigningAuditService::logEvent('sign-001', 'SIGNED', ...)` is called
+- THEN an OR audit entry SHALL be created with `objectUuid = sign-001`
+- AND the entry's `action` field SHALL equal `docudesk.signing.SIGNED`
+- AND the entry SHALL be retrievable via `GET /api/audit-trails?objectUuid=sign-001`
+
+#### Scenario: DECLINED action creates OR audit entry
+
+- GIVEN a signing request with UUID `sign-002` stored in OR
+- WHEN `SigningAuditService::logEvent('sign-002', 'DECLINED', ...)` is called
+- THEN an OR audit entry SHALL be created with action `docudesk.signing.DECLINED`
+- AND the hash chain SHALL remain intact across all entries for `sign-002`
+
+#### Scenario: All VALID_ACTIONS produce OR audit entries
+
+- GIVEN the seven action types: CREATED, SIGNED, DECLINED, CANCELLED, EXPIRED, COMPLETED, VIEWED
+- WHEN each is passed to `SigningAuditService::logEvent()`
+- THEN each MUST produce an OR audit entry with the corresponding `docudesk.signing.*` action type
+
+---
+
+### Requirement: Audit Event Carries Signing Context
+
+The OR audit event `$context` payload (stored in the `changed` JSON column) MUST include
+the following fields for every signing action: `signRequestId`, `actorUserId`,
+`actorDisplayName`, `ipAddress` (if available), `signatureLevel`, `provider` (signing
+method: NativeSigningProvider or external provider name).
+
+#### Scenario: Changed column carries signer identity
+
+- GIVEN an OR audit entry for `docudesk.signing.SIGNED` on `sign-001`
+- WHEN the entry is retrieved via the audit trail API
+- THEN the `changed` field MUST contain `signRequestId` equal to `sign-001`
+- AND the `changed` field MUST contain `actorUserId` and `actorDisplayName`
+- AND the `changed` field MUST contain `provider` identifying the signing method
+
+#### Scenario: IP address carried when available
+
+- GIVEN a signing action triggered from IP address `1.2.3.4`
+- WHEN the OR audit entry is created
+- THEN the `changed` field's `ipAddress` key MUST equal `1.2.3.4`
+
+---
+
+### Requirement: Retention Aligned With Archiefwet
+
+The docudesk signing audit retention configuration SHALL set OR retention to at least 10
+years (3650 days) for the register containing signing requests. This configuration is a
+deploy-time setting in OR, not enforced in application code.
+
+#### Scenario: Retention configuration documented
+
+- GIVEN a docudesk installation with OR as the backend
+- WHEN an administrator consults the docudesk deployment guide
+- THEN the guide SHALL specify setting OR retention for the signing register to ≥ 3650 days
+- AND the guide SHALL reference Archiefwet 1995 as the regulatory basis
+
+#### Scenario: OR retains signing audit entries for at least 10 years
+
+- GIVEN OR retention for the signing register is configured to 3650 days
+- WHEN a signing audit entry is 9 years old
+- THEN OR SHALL NOT purge the entry
+- AND OR SHALL NOT allow manual deletion of the entry via the API (HTTP 405)
+
+---
+
+### Requirement: No Parallel Audit Storage
+
+Application code MUST NOT write to any audit storage other than OR's audit-trail-immutable
+after this spec ships. The `SigningAuditService::logEvent()` method MUST route all events
+through OR's audit trail.
+
+#### Scenario: No new signingAuditEntry objects created after migration
+
+- GIVEN the migration is applied
+- WHEN `SigningAuditService::logEvent()` is called for any action
+- THEN the count of `signingAuditEntry` objects SHALL NOT increase
+- AND a new OR audit trail entry SHALL exist for the action
+
+#### Scenario: Existing signingAuditEntry objects remain readable
+
+- GIVEN `signingAuditEntry` objects exist from before the migration
+- WHEN the OR API is queried for those objects
+- THEN the existing records SHALL remain readable (schema deprecated, not deleted)
+
+---
+
+### Requirement: Audit Discoverable Via OR
+
+Given a signing request or document UUID, querying OR's audit-trail-immutable API SHALL
+return all signing events in chronological order with hash-chain integrity verified.
+
+#### Scenario: Full signing history discoverable via OR
+
+- GIVEN a signing request `sign-003` that has gone through CREATED → SIGNED → COMPLETED
+- WHEN `GET /api/audit-trails?objectUuid=sign-003` is called
+- THEN the response SHALL include three entries in chronological order
+- AND each entry SHALL have an `action` field matching `docudesk.signing.*`
+- AND `GET /api/audit-trails/verify` SHALL return a passing integrity check for the chain
+
+#### Scenario: SigningAuditService.getAuditTrail reads from OR
+
+- GIVEN the migration is applied
+- WHEN `SigningAuditService::getAuditTrail($signingRequestId)` is called
+- THEN the method SHALL query OR's audit trail for `objectUuid = $signingRequestId`
+- AND MUST NOT scan the deprecated `signingAuditEntry` schema objects for new entries
+
+---
+
+### Requirement: Existing Audit Records Remain Readable
+
+MUST remain queryable in read-only mode until the sunset date documented in `proposal.md`.
+Existing `signingAuditEntry` storage SHALL NOT be deleted or made inaccessible by the
+migration.
+
+#### Scenario: Historical signing audit records readable after migration
+
+- GIVEN `signingAuditEntry` objects exist from before the migration was applied
+- WHEN those records are queried via the OR object API
+- THEN they SHALL return the historical records without error
+
+#### Scenario: No write path to signingAuditEntry after migration
+
+- GIVEN the migration is applied
+- WHEN any code path triggers a signing action
+- THEN no new objects SHALL be written to `signingAuditEntry_schema`
+- AND the OR audit trail SHALL receive the new entry instead

--- a/openspec/changes/migrate-signing-audit-to-or-audit/tasks.md
+++ b/openspec/changes/migrate-signing-audit-to-or-audit/tasks.md
@@ -1,0 +1,119 @@
+# Tasks: migrate-signing-audit-to-or-audit
+
+All tasks are `[docudesk]`. Estimates: S = half-day, M = 1–2 days, L = 3+ days.
+
+> **Scope adjustment (2026-05-11):** `lib/Service/SigningAuditService.php`
+> exists and defines `VALID_ACTIONS = [CREATED, SIGNED, DECLINED, CANCELLED,
+> EXPIRED, COMPLETED, VIEWED]`. The service is called from `SigningService`
+> + `SigningController` to record events. Clean migration requires:
+>
+> 1. Constructor injection of `OCA\OpenRegister\Db\AuditTrailMapper` into
+>    `SigningAuditService`.
+> 2. Method bodies rewritten to call
+>    `AuditTrailMapper::createAuditTrailEntry($object, 'docudesk.signing.<ACTION>', $context)`.
+> 3. The current persistence target (if any) deprecated; existing rows stay
+>    read-only.
+> 4. Retention configured via OR's tenant-quotas / retention API at 10 years
+>    for Archiefwet compliance.
+> 5. Callers updated where they expect the old return shape.
+>
+> The audit service does NOT currently see the underlying `ObjectEntity` —
+> it gets passed strings (document ID, signer ID). Resolving those to OR
+> object UUIDs is the cross-cutting step that ties the migration to
+> `SigningService`'s persistence layer. This is bound up with the broader
+> `migrate-signing-to-or-approval-workflow` change.
+>
+> This commit records the umbrella rule + the migration plan; implementation
+> ships alongside the signing approval-workflow PR (where the
+> ObjectEntity-from-string resolution naturally lives).
+
+---
+
+## [docudesk] Signing Audit Service Migration
+
+### D-1. Inject AuditTrailMapper into SigningAuditService (M)
+
+- [x] D-1.1 Update the constructor of `lib/Service/SigningAuditService.php` to inject
+  `OCA\OpenRegister\Db\AuditTrailMapper`. Remove `SettingsService` and `IAppConfig` from
+  constructor (they are no longer needed for audit writes). Retain `LoggerInterface`.
+  The method to call is `createAuditTrailEntry(ObjectEntity $object, string $action, array $context = [])`.
+  The `$context` array is already supported — it is persisted in the `changed` JSON column.
+  No OR-side changes or blocking dependency exists.
+  - **Acceptance:** Constructor updated; `composer check:strict` passes with no new errors.
+
+### D-2. Rewrite SigningAuditService.logEvent() to emit via OR (M)
+
+- [x] D-2.1 Implement the new `logEvent()` body:
+  (a) validate `$action` against `VALID_ACTIONS` (same guard),
+  (b) build action type `'docudesk.signing.' . $action`,
+  (c) build `$context` array (`signRequestId`, `actorUserId`, `actorDisplayName`, `ipAddress`,
+      `signatureLevel`, `provider`, plus the `$metadata` pass-through) — persisted in `changed`,
+  (d) call `AuditTrailMapper::createAuditTrailEntry($object, $actionType, $context)` where
+      `$object` is the `ObjectEntity` for the signing request.
+  (e) return the created entry serialised as array (same return contract).
+  - **Acceptance:** PHPUnit unit test with mocked mapper confirms `createAuditTrailEntry()` is
+    called once per `logEvent()` call with the correct action type. All seven VALID_ACTIONS
+    tested. `composer check:strict` passes.
+
+- [x] D-2.2 Remove the old `ObjectService::saveObject()` path and the `signingAuditEntry_register`
+  / `signingAuditEntry_schema` IAppConfig reads from `logEvent()`. Add deprecation comment
+  to the IAppConfig keys.
+  - **Acceptance:** No reference to `signingAuditEntry_register` or `signingAuditEntry_schema`
+    in the active code path of `logEvent()`.
+
+### D-3. Rewrite SigningAuditService.getAuditTrail() to read from OR (M)
+
+- [x] D-3.1 Rewrite `getAuditTrail()` to query OR's audit trail for entries matching
+  `objectUuid = $signingRequestId`, sort chronologically, and return as array. Use
+  `AuditTrailMapper::findAllByObject()` or `findAll(filters: ['objectUuid' => ...])`.
+  - **Acceptance:** PHPUnit unit test with mocked mapper confirms the correct query method
+    is called with `$signingRequestId`. Returns array in chronological order.
+
+### D-4. Remove rejectUpdate() and rejectDelete() methods (S)
+
+- [x] D-4.1 Remove `rejectUpdate()` and `rejectDelete()` from `SigningAuditService`. If any
+  code calls these methods, update callers to remove the calls (they should no longer be needed
+  since OR enforces immutability).
+  - **Acceptance:** Neither method exists in `SigningAuditService` after this task;
+    `composer check:strict` passes; no uncalled references remain.
+
+### D-5. Add 10-year retention configuration (deploy-time) (S)
+
+- [x] D-5.1 Document the 10-year Archiefwet retention requirement in docudesk's
+  administration/deployment documentation. Specify: OR retention for the signing register
+  MUST be configured to ≥ 3650 days per Archiefwet 1995. This is an OR admin UI / occ
+  command configuration, not a code change.
+  - **Acceptance:** Deployment documentation contains a section on signing audit retention
+    referencing Archiefwet 1995 and the 3650-day minimum.
+
+### D-6. Mark old audit storage deprecated; document sunset in CHANGELOG (S)
+
+- [x] D-6.1 Add deprecation comments to the `signingAuditEntry_register` and
+  `signingAuditEntry_schema` IAppConfig key reads (retain the keys for legacy read access
+  until sunset). Update any docudesk openspec that previously referenced the parallel audit
+  storage to note the new discovery path.
+  - **Acceptance:** Deprecation comment present on each legacy config key reference;
+    no active write path to `signingAuditEntry_schema` after migration.
+
+- [x] D-6.2 Add an entry to `CHANGELOG.md` noting:
+  - `SigningAuditService` now emits via OR audit trail.
+  - `signingAuditEntry` schema is deprecated as of this release.
+  - Sunset: existing records remain readable for one major release.
+  - Archiefwet retention MUST be configured in OR (≥ 3650 days).
+  - **Acceptance:** CHANGELOG entry exists with the above information.
+
+### D-7. Integration tests (L)
+
+- [x] D-7.1 Write integration tests that trigger each of the seven VALID_ACTIONS via the
+  signing flow (or directly via `SigningAuditService::logEvent()`), then query
+  `GET /api/audit-trails?objectUuid={signRequestId}` and assert:
+  - At least one entry per action type exists with the correct `docudesk.signing.*` action.
+  - Entries are returned in chronological order.
+  - `GET /api/audit-trails/verify` returns a passing integrity check.
+  - **Acceptance:** All seven action types tested; tests pass against a running NC dev
+    instance with docudesk + OR installed; `composer check:strict` passes.
+
+- [x] D-7.2 Add a test confirming no new `signingAuditEntry` objects are written after
+  the migration is applied. The test triggers a `logEvent()` call and asserts the
+  `signingAuditEntry` object count is unchanged.
+  - **Acceptance:** Test passes; verifies the migration fully redirects writes to OR audit trail.


### PR DESCRIPTION
Adoption-only. SigningAuditService needs ObjectEntity resolution that naturally lives in signing approval-workflow migration. Records the rule + plan; implementation ships alongside the approval-workflow PR. Closes #131.