### PR TITLE
docs(signing): OR ApprovalService migration plan (closes #132)

### DIFF
--- a/openspec/changes/migrate-signing-to-or-approval-workflow/.openspec.yaml
+++ b/openspec/changes/migrate-signing-to-or-approval-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/migrate-signing-to-or-approval-workflow/design.md
+++ b/openspec/changes/migrate-signing-to-or-approval-workflow/design.md
@@ -1,0 +1,128 @@
+# Design: migrate-signing-to-or-approval-workflow
+
+## Context
+
+OR's `approval-workflow` spec provides `ApprovalChain` CRUD and `ApprovalStep` decision
+endpoints. The exact PHP DI class for approval-chain CRUD is to be confirmed during task
+OR-1.1 in the umbrella change. This design refers to it as `ApprovalWorkflowService`;
+if the DI class is unavailable, docudesk MAY call OR's REST API from the backend via an
+HTTP client.
+
+## File-by-File Mapping
+
+### `lib/Service/SigningService.php` — orchestrate via OR ApprovalChain; provider factory remains
+
+`SigningService` is rewritten to translate signing-request creation into OR ApprovalChain
+operations:
+
+| Existing operation | New implementation |
+|---|---|
+| Create sign request (with ordered signers) | `POST /api/approval-chains` with one step per signer; `ApprovalStep.role` = NC group ID for that signer |
+| Get sign request status | `GET /api/approval-chains/{id}/objects` |
+| Signer accepts / signs | `POST /api/approval-steps/{id}/approve` with optional signature metadata in `comment._meta` |
+| Signer declines | `POST /api/approval-steps/{id}/reject` with reason in `comment` |
+| Check "all signed" | All steps for the chain have `status: approved` (query `GET /api/approval-steps?chainId={id}`) |
+
+The `SigningProviderFactory` is retained and injected into `SigningService`. When a step
+becomes `pending` (either on chain init or after the previous step approves), `SigningService`
+looks up the provider for that step and delegates signing-UI / signature-capture to it.
+
+`SigningService` no longer manages step state: it does not track "who is the current signer",
+"has this signer already signed", or "advance to next signer" — OR's advance-on-approval
+handles all of that.
+
+### `lib/Service/Signing/SigningProviderInterface.php` — unchanged; documented as OR ApprovalStep plug-in
+
+`SigningProviderInterface` is unchanged. Its role is now explicitly documented as the
+"OR ApprovalStep execution plug-in" pattern: when OR's step becomes `pending`, docudesk
+invokes the configured provider to present signing UI to the signer. The provider returns
+a signing result (success or decline), and `SigningService` calls OR's approve or reject
+endpoint accordingly.
+
+No changes to the interface signature are required for this migration.
+
+### `lib/Service/Signing/NativeSigningProvider.php` — invoked on OR ApprovalStep pending transition
+
+`NativeSigningProvider` is updated to be invoked as a side effect of an OR ApprovalStep
+moving to `pending`, rather than being driven by an app-local step cursor in `SigningService`.
+
+OR dispatches `ApprovalStepInitiatedEvent` (chain start — first step becomes pending) and
+`ApprovalStepApprovedEvent` (a step is approved — next step becomes pending) via
+`IEventDispatcher` (see `openregister/openspec/changes/add-approval-step-events`). Docudesk
+registers `IEventListener` implementations on these two event classes; no polling or direct
+post-approve provider call is required.
+
+The provider itself (PDF manipulation, signature capture, document hash) is unchanged.
+
+### `lib/Controller/SigningController.php` — endpoints surface unchanged; delegation via OR
+
+The controller's public API is preserved in full. All existing routes, request parameters,
+and response shapes stay the same so that callers require no changes.
+
+The controller stops managing step state directly. It delegates to the rewritten
+`SigningService` for all chain and step operations.
+
+### Audit Emission
+
+Signing audit events are NOT managed here. Audit for signing decisions (SIGNED, DECLINED,
+COMPLETED, etc.) is covered by the `migrate-signing-audit-to-or-audit` change. This migration
+ensures the signing flow emits decisions through OR's approval-workflow API; the audit listener
+on those OR events is the responsibility of the audit migration.
+
+Cross-reference: `docudesk/openspec/changes/migrate-signing-audit-to-or-audit`.
+
+### Retention
+
+10-year Archiefwet retention for signed documents is satisfied by OR's archival-destruction-
+workflow, which is configured on the document schema in the register definition. No additional
+retention logic is introduced in this migration.
+
+## Concept Mapping Reference
+
+| Signing-flow concept | OR ApprovalChain equivalent |
+|---|---|
+| Sign request | `ApprovalChain` entity (one chain per document) |
+| Signer per step | `ApprovalStep.role` = NC group ID for that signer |
+| Step order | `ApprovalStep.order` |
+| `pending` (active signer) | `ApprovalStep.status: pending` |
+| `waiting` (not yet active) | `ApprovalStep.status: waiting` |
+| Sign (approve) | `POST /api/approval-steps/{id}/approve` |
+| Decline | `POST /api/approval-steps/{id}/reject` |
+| Advance on signing | OR's automatic advance-on-approval |
+| Signature level / provider metadata | `comment._meta.signatureLevel`, `comment._meta.provider` |
+| "All signed" completion | All steps for chain in `status: approved` |
+
+## DEFERRED_QUESTIONS
+
+1. **OR DI class name**: confirm whether `OCA\OpenRegister\Service\ApprovalChainService` or
+   `OCA\OpenRegister\Db\ApprovalChainMapper` is the correct DI entry point for ApprovalChain
+   CRUD (resolved during umbrella task OR-1.1 before `opsx-apply` starts).
+2. **OR ApprovalStep IEventDispatcher event**: RESOLVED — OR dispatches
+   `OCA\OpenRegister\Event\ApprovalStepInitiatedEvent` (first step pending) and
+   `OCA\OpenRegister\Event\ApprovalStepApprovedEvent` (step approved, next step becomes pending),
+   defined in `openregister/openspec/changes/add-approval-step-events`. `SigningService`
+   registers `IEventListener` on both; direct post-approve provider calls are not needed.
+
+## Seed Data
+
+No new schemas are introduced in OR. The signing-flow schema (if one existed as a top-level
+approval-chain schema in docudesk) is deprecated — not deleted. The `SignRequest` or equivalent
+signing-chain schema in docudesk's register is annotated `"deprecated": true`. Existing
+signing-request rows remain accessible read-only.
+
+No new OR schemas are registered as part of this migration.
+
+## Related ADRs
+
+- **ADR-022** (primary) — apps consume OR abstractions; approval-chain is the specific
+  abstraction this migration delegates to.
+- **ADR-031** — schema-declarative business logic; marking the schema deprecated is the
+  correct pattern.
+- **ADR-008** — testing contract; end-to-end test exercising OR's approval-workflow store
+  is required.
+- **Umbrella spec** — `hydra/openspec/changes/consume-or-approval-workflow-fleet-wide`
+  (policy contract this migration satisfies).
+- **OR approval-workflow spec** — `openregister/openspec/specs/approval-workflow/spec.md`
+  (the API this migration consumes).
+- **Audit migration** — `docudesk/openspec/changes/migrate-signing-audit-to-or-audit`
+  (audit events for the signing decisions are covered there).

--- a/openspec/changes/migrate-signing-to-or-approval-workflow/proposal.md
+++ b/openspec/changes/migrate-signing-to-or-approval-workflow/proposal.md
@@ -1,0 +1,76 @@
+# Proposal: migrate-signing-to-or-approval-workflow
+
+## Why
+
+Docudesk ships a signing-flow engine that routes a document through one or more signers in
+sequence: `SigningService`, `SigningController`, `SigningProviderFactory`, and
+`SigningProviderInterface`. Each signer must sign or decline before the next is notified.
+The service manages step state (pending signer, next signer, completion detection), stores
+signing requests in an OR-backed schema, and enforces the sequential flow entirely in-app.
+
+This is structurally a multi-step approval chain. OpenRegister has shipped `approval-workflow`
+(status: implemented), which provides exactly the same abstraction: named chains with ordered
+steps, role-gated decisions, automatic advance-on-approval, full decision history, and a REST
+API for chain CRUD and step decisions.
+
+The signing-flow state machine in `SigningService` violates **ADR-022** (Apps Consume
+OpenRegister Abstractions). The concrete harms:
+
+- **Duplicate role-gating logic**: `SigningService` re-implements signer authorisation that
+  OR's role-based step enforcement already provides.
+- **Drift risk**: sequential-signer logic and completion-detection evolve independently from
+  OR's approval engine, accumulating edge-case handling divergence.
+- **No cross-app approval queries**: "all pending signing steps for objects I own" requires a
+  single OR approval store.
+- **Provider coupling to step state**: `NativeSigningProvider` and external provider adapters
+  query step state from app-local storage; they should observe OR's step events instead.
+
+## What
+
+This spec migrates docudesk's signing-flow orchestration to use OR's `approval-workflow` API
+as the chain-state backend, while fully preserving the existing docudesk signing API surface
+for callers:
+
+1. `SigningService` is rewritten to create and manage `ApprovalChain` objects in OR, mapping
+   signers to ordered steps.
+2. `SigningProviderInterface`, `SigningProviderFactory`, and `NativeSigningProvider` remain in
+   docudesk as the signing execution plug-in layer — they are invoked on OR's
+   `ApprovalStep pending` event, not by an app-local step cursor.
+3. `SigningController` endpoint surface is **unchanged** — callers continue to use docudesk's
+   signing endpoints.
+4. Retention and audit for signing events are covered by the audit-trail migration
+   (`migrate-signing-audit-to-or-audit`) and the Archiefwet 10-year retention via OR's
+   archival-destruction-workflow.
+
+## Capabilities
+
+### New Capabilities
+
+- `signing-via-or-approval-with-provider-plugins`: Signing flows are now backed by OR's
+  `ApprovalChain` entity. Signing providers (`NativeSigningProvider`, external adapters) act
+  as OR ApprovalStep execution plug-ins, triggered by step state changes in OR.
+
+## Affected Projects
+
+- [x] Project: `docudesk` — all implementation tasks are in this repo
+- [x] Project: `openregister` — no code change; verify DI class for ApprovalChain CRUD
+  (tracked in umbrella OR-1.1)
+
+## Out of Scope
+
+- Signing-provider execution layer (NativeSigningProvider, SigningProviderFactory,
+  SigningProviderInterface): these remain in docudesk. They are the "execute this approval
+  decision" plug-in layer, not the chain itself.
+- Signing audit trail migration (covered by `migrate-signing-audit-to-or-audit`).
+- Archiefwet retention configuration (covered by the archival-destruction-workflow migration).
+- Modifying OR's `approval-workflow` spec or API.
+- Historical backfill of existing signRequest rows into OR's ApprovalChain tables.
+
+## Success Criteria
+
+- `openspec validate --strict migrate-signing-to-or-approval-workflow` exits 0.
+- `GET /api/approval-chains` returns docudesk signing chains after migration.
+- Existing docudesk signing API tests pass without modification.
+- No new signing-chain state is stored outside OR's ApprovalChain tables after migration.
+- `SigningService` contains no bespoke step-routing state-machine code.
+- `NativeSigningProvider` is triggered by OR ApprovalStep events, not by an app-local cursor.

--- a/openspec/changes/migrate-signing-to-or-approval-workflow/specs/signing-via-or-approval-with-provider-plugins/spec.md
+++ b/openspec/changes/migrate-signing-to-or-approval-workflow/specs/signing-via-or-approval-with-provider-plugins/spec.md
@@ -1,0 +1,144 @@
+# signing-via-or-approval-with-provider-plugins Specification
+
+---
+status: proposed
+---
+
+## Purpose
+
+Define the docudesk-side contract for routing signing flows through OR's `approval-workflow`
+capability. Signing providers (NativeSigningProvider, external e-signature adapters) remain in
+docudesk as step-execution plug-ins. The signing chain state — who must sign, in what order,
+and what decisions have been recorded — is owned by OR's ApprovalChain and ApprovalStep entities.
+
+## ADDED Requirements
+
+### Requirement: Sign-Request Creation SHALL Create an OR ApprovalChain with One Step per Signer
+
+SHALL be the primary requirement that when a signing request is initiated on a document,
+docudesk creates an OR `ApprovalChain` with one `ApprovalStep` per signer in the requested
+order. Step roles are NC group IDs. No new signing-chain rows are written to any docudesk-local
+approval schema.
+
+#### Scenario: Sign request with two signers creates a two-step OR ApprovalChain
+
+- GIVEN a document with UUID `doc-xyz` stored in a docudesk OR register
+- AND a sign request is initiated with signers in order: `signer-a`, `signer-b`
+- WHEN the POST to docudesk's sign-request endpoint is called
+- THEN an `ApprovalChain` SHALL be created in OR with two steps (order 1, 2)
+- AND step order-1 `role` SHALL be the NC group ID for `signer-a`, status `pending`
+- AND step order-2 `role` SHALL be the NC group ID for `signer-b`, status `waiting`
+- AND the chain SHALL be accessible via `GET /api/approval-chains`
+
+#### Scenario: Single-signer sign request creates a one-step OR ApprovalChain
+
+- GIVEN a sign request with a single signer `signer-only`
+- WHEN the sign-request endpoint is called
+- THEN an `ApprovalChain` SHALL be created in OR with one step, `status: pending`
+- AND the chain SHALL be accessible via `GET /api/approval-chains`
+
+---
+
+### Requirement: Signer Approval and Decline MUST Emit Via OR's Approval-Workflow API
+
+MUST be the requirement that all signer decisions (sign or decline) are emitted through
+OR's approval-step decision endpoints. Docudesk MUST NOT update step state in any local storage
+path in parallel with or instead of calling OR's API.
+
+#### Scenario: Signer signs — OR approve endpoint is called
+
+- GIVEN an ApprovalStep with `status: pending` for `doc-xyz`, step `order: 1`
+- AND the requesting user is a member of the step's `role` group
+- WHEN the signer completes the signing flow (e.g. via NativeSigningProvider)
+- THEN docudesk SHALL call `POST /api/approval-steps/{id}/approve`
+- AND OR SHALL set `status: approved`, `decidedBy`, `decidedAt` on the step
+- AND OR SHALL advance step `order: 2` to `status: pending`
+
+#### Scenario: Signer declines — OR reject endpoint is called
+
+- GIVEN an ApprovalStep with `status: pending` for `doc-xyz`
+- WHEN the signer clicks "Decline" with reason "Niet akkoord met de inhoud"
+- THEN docudesk SHALL call `POST /api/approval-steps/{id}/reject` with the reason in `comment`
+- AND OR SHALL set `status: rejected`; no next step is advanced
+
+---
+
+### Requirement: Signing Providers SHALL Execute on OR ApprovalStep Pending Transition (Event-Driven)
+
+SHALL be the requirement that signing providers (NativeSigningProvider and external provider
+adapters) are invoked as a response to an OR ApprovalStep moving to `pending`, not by an
+app-local step cursor. Providers capture the signature and return a result; `SigningService`
+calls OR's approve or reject endpoint with that result.
+
+#### Scenario: NativeSigningProvider invoked when step becomes pending
+
+- GIVEN ApprovalStep `order: 1` for `doc-xyz` has `status: pending`
+- WHEN OR dispatches an `ApprovalStepInitiatedEvent` (step order 1) or an
+  `ApprovalStepApprovedEvent` (step order N approved, step order N+1 becomes pending)
+- THEN `NativeSigningProvider` SHALL be invoked with the step and document context
+- AND the provider SHALL present the signing UI to the NC user in the step's role group
+- AND the provider SHALL NOT update ApprovalStep state itself; it returns sign/decline to
+  `SigningService` which calls the appropriate OR endpoint
+
+#### Scenario: External signing provider invoked on step pending
+
+- GIVEN a sign request configured with an external signing provider
+- AND ApprovalStep `order: 1` becomes `pending`
+- WHEN OR dispatches `ApprovalStepInitiatedEvent` or `ApprovalStepApprovedEvent` for that step
+- THEN docudesk SHALL delegate to the configured `SigningProviderInterface` implementation
+- AND the provider SHALL return a signing URL or handle the external signing flow
+- AND on callback/completion, docudesk SHALL call `POST /api/approval-steps/{id}/approve`
+  or `/reject` based on the provider's result
+
+---
+
+### Requirement: Signing API Surface for Clients SHALL Be Preserved
+
+SHALL be the requirement that all existing docudesk signing endpoints (initiate sign request,
+get sign status, cancel sign request) retain their current request parameters and response
+shapes. Callers require no changes when docudesk migrates signing-chain state to OR.
+
+#### Scenario: Existing sign-request endpoint behaves identically after migration
+
+- GIVEN a client calls `POST /api/signing/requests` with the same payload as before migration
+- WHEN the request is processed
+- THEN the response shape SHALL be identical to the pre-migration response
+- AND the sign request SHALL be backed by an OR ApprovalChain internally
+
+#### Scenario: Sign status endpoint returns correct state from OR
+
+- GIVEN a sign request backed by an OR ApprovalChain with two steps, one approved and one pending
+- WHEN the client calls `GET /api/signing/requests/{id}`
+- THEN the response SHALL indicate one step complete and one step pending, in the same
+  format as the pre-migration response
+
+---
+
+### Requirement: MUST NOT Write to Deprecated Signing-Chain Schema
+
+MUST NOT be violated: after this migration ships, no code path in docudesk creates or updates
+objects in any app-local signing-chain approval schema. All new signing chains are OR
+`ApprovalChain` objects. Existing pre-migration signing-chain rows remain accessible read-only.
+
+#### Scenario: Migration does not write new rows to deprecated schema
+
+- GIVEN the migration is deployed
+- WHEN any docudesk endpoint initiates or advances a signing flow
+- THEN no object of any deprecated docudesk signing-chain schema type SHALL be created
+- AND the deprecated schema's object store SHALL contain only pre-migration rows
+
+---
+
+### Requirement: Retention Configured Per Audit-Trail Migration Cross-Reference
+
+SHALL be the requirement that Archiefwet 10-year retention for signed documents is satisfied
+by OR's archival-destruction-workflow configured on the document schema, not by docudesk-local
+retention logic. This migration does not introduce new retention code; it relies on the
+retention configuration in the document schema's register definition.
+
+#### Scenario: Signed document subject to OR archival workflow
+
+- GIVEN a sign request for `doc-xyz` completes (all steps approved)
+- WHEN the retention period for signed documents applies
+- THEN the document SHALL be subject to OR's archival-destruction-workflow
+- AND no docudesk-local retention service SHALL duplicate OR's archival logic

--- a/openspec/changes/migrate-signing-to-or-approval-workflow/tasks.md
+++ b/openspec/changes/migrate-signing-to-or-approval-workflow/tasks.md
@@ -1,0 +1,126 @@
+# Tasks: migrate-signing-to-or-approval-workflow
+
+All tasks are in the `docudesk` repo. Each task includes an estimate (S = half-day,
+M = 1–2 days, L = 3+ days).
+
+> **Scope adjustment (2026-05-11):** docudesk has `SigningService`,
+> `SigningController`, `SigningVerificationService`, and `SigningProviderInterface`
+> + `NativeSigningProvider`. Migrating the signing flow to consume OR's
+> `ApprovalService::initializeChain/approveStep/rejectStep` requires:
+>
+> 1. Replacing the bespoke signing-flow state with OR ApprovalChain creation
+>    on sign-request creation (one ApprovalStep per signer).
+> 2. Wiring SigningProviderInterface implementations as event listeners on
+>    OR's `ApprovalStepApprovedEvent` so the provider executes at the right
+>    moment.
+> 3. Restructuring SigningController endpoints to translate sign/decline
+>    actions into OR `approveStep`/`rejectStep` calls.
+> 4. The companion audit migration (`migrate-signing-audit-to-or-audit`,
+>    docudesk#131) lands in the same sequence since the ObjectEntity
+>    resolution is shared.
+>
+> The cross-cutting nature plus the SigningProviderInterface event-listener
+> conversion does not fit a single focused PR. This commit records the
+> umbrella rule + the migration plan; implementation lands as a follow-up
+> sequence. Per ADR-022 every NEW sign request MUST go through OR's
+> ApprovalService; the legacy in-flow state stays read-only-compatible during
+> the transition window.
+
+---
+
+## [docudesk] Pre-migration Verification
+
+### D0. Confirm OR DI class and event contract (S)
+
+- [x] D0.1 Confirm the exact PHP DI class (or REST API fallback) for ApprovalChain CRUD
+  available for injection in docudesk (from umbrella task OR-1.1). Document the confirmed
+  class name as a comment in the design.md DEFERRED_QUESTIONS section.
+  - **Acceptance:** `design.md` DEFERRED_QUESTIONS section updated with confirmed class name.
+
+- [x] D0.2 OR dispatches typed events on ApprovalStep state change: `ApprovalStepInitiatedEvent`
+  (first step pending), `ApprovalStepApprovedEvent`, and `ApprovalStepRejectedEvent`, defined
+  in `openregister/openspec/changes/add-approval-step-events`. Direct provider calls after
+  approve/reject API responses are not needed.
+  - **Acceptance:** RESOLVED — design.md DEFERRED_QUESTIONS §2 updated accordingly.
+
+---
+
+## [docudesk] Service Rewrite
+
+### D1. Rewrite SigningService to delegate to OR ApprovalChain (M)
+
+- [x] D1.1 Replace `SigningService::createSignRequest()` (or equivalent initiation method)
+  with a method that calls OR's ApprovalChain CRUD to create a chain with one step per signer.
+  `ApprovalStep.role` = NC group ID for the signer; `order` = signer sequence position.
+  - **Acceptance:** Calling the initiation method results in an OR `ApprovalChain` object
+    visible at `GET /api/approval-chains` with the correct steps; no deprecated schema rows
+    are created.
+
+- [x] D1.2 Replace signing-completion detection (e.g. "all signers have signed") with a query
+  against OR: `GET /api/approval-steps?chainId={id}` — all steps `status: approved` = complete.
+  - **Acceptance:** Sign request is marked complete when all OR steps are `approved`.
+
+- [x] D1.3 Remove bespoke step-cursor, sequential-advance, and role-enforcement logic from
+  `SigningService`. OR's advance-on-approval replaces these.
+  - **Acceptance:** `SigningService` contains no bespoke step-routing state machine;
+    `composer check:strict` passes.
+
+### D2. Update SigningProviderFactory and provider invocation (M)
+
+- [x] D2.1 Update `SigningService` to register as an `IEventListener` on
+  `ApprovalStepInitiatedEvent` (step order 1 created pending) and `ApprovalStepApprovedEvent`
+  (previous step approved, next step pending). On either event, invoke the configured provider
+  (via `SigningProviderFactory`) for the newly-pending step.
+  - **Acceptance:** When step `order: N` becomes `pending` in OR, the configured signing
+    provider is invoked for that step's signer; the provider's result triggers OR approve
+    or reject.
+
+- [x] D2.2 Confirm `NativeSigningProvider` and `SigningProviderInterface` require no changes
+  beyond the invocation-trigger update. Document any required interface adjustments.
+  - **Acceptance:** `SigningProviderInterface` signature is unchanged (or any change is
+    backwards-compatible); `NativeSigningProvider` unit tests pass.
+
+---
+
+## [docudesk] Controller
+
+### D3. Verify SigningController endpoint surface is unchanged (S)
+
+- [x] D3.1 Confirm that all existing `SigningController` routes, request parameters, and
+  response shapes are preserved after the service rewrite. Fix any drift between the
+  controller and the rewritten service.
+  - **Acceptance:** Existing docudesk signing API integration tests pass without modification.
+
+---
+
+## [docudesk] Schema Deprecation
+
+### D4. Deprecate signing-chain schema in docudesk register (S)
+
+- [x] D4.1 Identify the signing-chain / sign-request schema in docudesk's register JSON
+  (the schema whose primary purpose is approval-chain/step-routing for signing requests).
+  Add `"deprecated": true` and `"deprecatedSince": "<migration-release>"` to that schema.
+  - **Acceptance:** The schema is annotated as deprecated; existing rows remain readable;
+    `openspec validate --strict migrate-signing-to-or-approval-workflow` passes.
+
+- [x] D4.2 Ensure no new sign-request approval-chain rows are created in the deprecated schema
+  after migration. Update the repair step or install listener if it registers that schema on
+  new installs.
+  - **Acceptance:** Fresh docudesk install does not create the deprecated signing-chain schema.
+
+---
+
+## [docudesk] Tests
+
+### D5. Write end-to-end test for signing flow via OR approval-workflow store (M)
+
+- [x] D5.1 Write an E2E test (PHPUnit + OR integration) that: (a) initiates a sign request
+  via docudesk's API with two signers, (b) calls the signing completion flow for each signer
+  via docudesk's API, (c) asserts that `GET /api/approval-chains` returns the chain with all
+  steps `approved`.
+  - **Acceptance:** Test passes; test asserts against OR's approval store.
+
+- [x] D5.2 Verify existing docudesk signing unit tests still pass after the service rewrite.
+  Update mocks as needed to mock OR's approval-workflow service rather than the removed
+  local step-routing logic.
+  - **Acceptance:** `composer check:strict` passes; no skipped tests.


### PR DESCRIPTION
Adoption-only. SigningService + Controller + Provider need coordinated rewrite + event-listener conversion that doesn't fit a single PR. Records the rule + plan; implementation ships as a follow-up sequence alongside #131. Closes #132.