### PR TITLE
ci(docs): deploy from documentation branch (not development)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,9 +2,9 @@ name: Documentation
 
 on:
   push:
-    branches: [development]
+    branches: [documentation]
   pull_request:
-    branches: [development]
+    branches: [documentation]
 
 jobs:
   deploy:


### PR DESCRIPTION
Reverts the earlier flip to `[development]` — docs should deploy from `documentation` so the docs site can be updated independently of the code CI/CD on `development`.