### PR TITLE
fix(docs): descriptive homepage title (#80)

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -179,7 +179,7 @@ const WIDGETS = [
 export default function Home() {
   return (
     <Layout
-      title="DocuDesk"
+      title="DocuDesk, document and contract generation for Nextcloud"
       description="Generate, anonymise, sign, and template documents on Nextcloud. Templates ship for the most-used Dutch government documents."
     >
       <main className="marketing-page">


### PR DESCRIPTION
Part of ConductionNL/.github#75 SEO epic and closes ConductionNL/.github#80.

Replaces the bare-brand Layout title with a descriptive form so SERPs surface the keyword payload before the site-title suffix Docusaurus appends.