### PR TITLE
sync: development → documentation (meta descriptions #81)

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,3 +1,8 @@
+---
+title: DocuDesk Documentation
+description: Get started with DocuDesk, document and contract generation on Nextcloud. Render Word, PDF and email from templates with OCR and anonymisation.
+---
+
 # DocuDesk Documentation
 
 DocuDesk provides services for generating and anonymizing PDF, Word, HTML or Excel documents in a GDPR and WCAG compliant manner, all while keeping your data secure within your local Nextcloud instance.

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -180,7 +180,7 @@ export default function Home() {
   return (
     <Layout
       title="DocuDesk, document and contract generation for Nextcloud"
-      description="Generate, anonymise, sign, and template documents on Nextcloud. Templates ship for the most-used Dutch government documents."
+      description="Generate documents and contracts from Nextcloud. Template-driven Word, PDF, and email output. WOPI editing, anonymisation, OCR built in."
     >
       <main className="marketing-page">
         <DetailHero


### PR DESCRIPTION
Sync development → documentation so the meta-description deploy fires.