### PR TITLE
chore(info.xml): canonicalize PHP min, NC version range, licence spelling

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ Create a [feature request](https://github.com/docudesk/.github/issues/new/choose
         <developer>https://conduction.gitbook.io/docudesk-nextcloud/</developer>
     </documentation>
     <dependencies>
-        <php min-version="8.2" min-int-size="64"/>
+        <php min-version="8.3" min-int-size="64"/>
         <database min-version="10">pgsql</database>
         <database>sqlite</database>
         <database min-version="8.0">mysql</database>


### PR DESCRIPTION
## Summary

Canonicalize `appinfo/info.xml` per the fleet drift research in
[nextcloud-app-template/docs/fleet-drift-deeper.md §4](https://github.com/ConductionNL/nextcloud-app-template/blob/development/docs/fleet-drift-deeper.md#4-appinfoinfoxml--significant-drift).

- `<php min-version="8.3">` — matches `composer require.php` (`^8.3` fleet-wide)
- `<nextcloud min-version="28" max-version="34">` — converge on the fleet's standard support range
- `<licence>agpl</licence>` — fix the casing/value drift (the fleet had 4 spellings: `agpl`, `eupl`, `EUPL-1.2`, `AGPL-3.0-or-later`)

Per-app fields (`<id>`, `<name>`, `<description>`, `<version>`, `<screenshot>`, etc.) are preserved.

## Licence note

We stay on the `agpl` workaround per the [EUPL store-listing pattern](https://github.com/ConductionNL/.github/blob/main/conduction/feedback_conduction-apps-eupl-license.md). The upstream fix landed in nextcloud/server#60212 (NC 34) and nextcloud/appstore#1754. Switch to `EUPL-1.2` once the fleet floor reaches NC 34 — tracked in ConductionNL/.github#98.

## How this PR was made

Opened by `hydra/scripts/fleet-sync/info-xml.sh` — see
[the script](https://github.com/ConductionNL/hydra/blob/development/scripts/fleet-sync/info-xml.sh)
for the canonical values + rewrite logic. The script reads
`appinfo/info.xml`, surgically rewrites the three canonical fields,
and opens a PR per fleet app.