### PR TITLE
chore(deps): bump composer.lock platform-overrides php 8.2.0 -> 8.3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8226,7 +8226,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.2.0"
+        "php": "8.3"
     },
     "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Companion to #243 — bumps lockfile to match composer.json. One-line change, no composer update run. Unblocks development CI which has been failing with: 'Your lock file does not contain a compatible set of packages.'