### PR TITLE
chore(phpcs): fix tab indentation in appinfo/routes.php

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1,108 +1,116 @@
 <?php
 
 /**
- * @copyright Copyright (c) 2024 Conduction B.V. <info@conduction.nl>
- * @license EUPL-1.2
+ * Application route definitions for DocuDesk.
+ *
+ * @category  AppInfo
+ * @package   OCA\DocuDesk\AppInfo
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git_id>
+ * @link      https://www.DocuDesk.app
  */
 
 return [
-	'routes' => [
-		// Metrics and health
-		['name' => 'metrics#index', 'url' => 'api/metrics', 'verb' => 'GET'],
-		['name' => 'health#index', 'url' => 'api/health', 'verb' => 'GET'],
+    'routes' => [
+        // Metrics and health.
+        ['name' => 'metrics#index', 'url' => 'api/metrics', 'verb' => 'GET'],
+        ['name' => 'health#index', 'url' => 'api/health', 'verb' => 'GET'],
 
-		// Dashboard
-		['name' => 'dashboard#page', 'url' => '/', 'verb' => 'GET'],
+        // Dashboard.
+        ['name' => 'dashboard#page', 'url' => '/', 'verb' => 'GET'],
 
-		// Settings routes
-		['name' => 'settings#index', 'url' => 'api/settings', 'verb' => 'GET'],
-		['name' => 'settings#create', 'url' => 'api/settings', 'verb' => 'POST'],
+        // Settings routes.
+        ['name' => 'settings#index', 'url' => 'api/settings', 'verb' => 'GET'],
+        ['name' => 'settings#create', 'url' => 'api/settings', 'verb' => 'POST'],
 
-		// Consent routes
-		['name' => 'consent#index', 'url' => 'api/consents', 'verb' => 'GET'],
-		['name' => 'consent#create', 'url' => 'api/consents', 'verb' => 'POST'],
-		['name' => 'consent#show', 'url' => 'api/consents/{id}', 'verb' => 'GET'],
-		['name' => 'consent#update', 'url' => 'api/consents/{id}', 'verb' => 'PUT'],
-		['name' => 'consent#byDocument', 'url' => 'api/consents/document/{documentId}', 'verb' => 'GET'],
+        // Consent routes.
+        ['name' => 'consent#index', 'url' => 'api/consents', 'verb' => 'GET'],
+        ['name' => 'consent#create', 'url' => 'api/consents', 'verb' => 'POST'],
+        ['name' => 'consent#show', 'url' => 'api/consents/{id}', 'verb' => 'GET'],
+        ['name' => 'consent#update', 'url' => 'api/consents/{id}', 'verb' => 'PUT'],
+        ['name' => 'consent#byDocument', 'url' => 'api/consents/document/{documentId}', 'verb' => 'GET'],
 
-		// Metadata enrichment route
-		['name' => 'metadata#enrich', 'url' => 'api/metadata/enrich', 'verb' => 'POST'],
+        // Metadata enrichment route.
+        ['name' => 'metadata#enrich', 'url' => 'api/metadata/enrich', 'verb' => 'POST'],
 
-		// Anonymization routes
-		['name' => 'anonymization#files', 'url' => 'api/anonymization/files', 'verb' => 'GET'],
-		['name' => 'anonymization#upload', 'url' => 'api/anonymization/upload', 'verb' => 'POST'],
-		['name' => 'anonymization#extract', 'url' => 'api/anonymization/extract/{fileId}', 'verb' => 'POST'],
-		['name' => 'anonymization#anonymize', 'url' => 'api/anonymization/anonymize/{fileId}', 'verb' => 'POST'],
+        // Anonymization routes.
+        ['name' => 'anonymization#files', 'url' => 'api/anonymization/files', 'verb' => 'GET'],
+        ['name' => 'anonymization#upload', 'url' => 'api/anonymization/upload', 'verb' => 'POST'],
+        ['name' => 'anonymization#extract', 'url' => 'api/anonymization/extract/{fileId}', 'verb' => 'POST'],
+        ['name' => 'anonymization#anonymize', 'url' => 'api/anonymization/anonymize/{fileId}', 'verb' => 'POST'],
 
-		// Batch anonymization routes
-		['name' => 'batch_anonymization#folderBatch', 'url' => 'api/anonymization/batch/folder', 'verb' => 'POST'],
-		['name' => 'batch_anonymization#batchUpload', 'url' => 'api/anonymization/batch/upload', 'verb' => 'POST'],
-		['name' => 'batch_anonymization#batchExtract', 'url' => 'api/anonymization/batch/{batchId}/extract', 'verb' => 'POST'],
-		['name' => 'batch_anonymization#batchStatus', 'url' => 'api/anonymization/batch/{batchId}/status', 'verb' => 'GET'],
-		['name' => 'batch_anonymization#batchEntities', 'url' => 'api/anonymization/batch/{batchId}/entities', 'verb' => 'GET'],
-		['name' => 'batch_anonymization#batchAnonymize', 'url' => 'api/anonymization/batch/{batchId}/anonymize', 'verb' => 'POST'],
-		['name' => 'batch_anonymization#batchReport', 'url' => 'api/anonymization/batch/{batchId}/report', 'verb' => 'GET'],
+        // Batch anonymization routes.
+        ['name' => 'batch_anonymization#folderBatch', 'url' => 'api/anonymization/batch/folder', 'verb' => 'POST'],
+        ['name' => 'batch_anonymization#batchUpload', 'url' => 'api/anonymization/batch/upload', 'verb' => 'POST'],
+        ['name' => 'batch_anonymization#batchExtract', 'url' => 'api/anonymization/batch/{batchId}/extract', 'verb' => 'POST'],
+        ['name' => 'batch_anonymization#batchStatus', 'url' => 'api/anonymization/batch/{batchId}/status', 'verb' => 'GET'],
+        ['name' => 'batch_anonymization#batchEntities', 'url' => 'api/anonymization/batch/{batchId}/entities', 'verb' => 'GET'],
+        ['name' => 'batch_anonymization#batchAnonymize', 'url' => 'api/anonymization/batch/{batchId}/anonymize', 'verb' => 'POST'],
+        ['name' => 'batch_anonymization#batchReport', 'url' => 'api/anonymization/batch/{batchId}/report', 'verb' => 'GET'],
 
-		// WOO entity profile routes
-		['name' => 'batch_anonymization#getProfiles', 'url' => 'api/anonymization/profiles', 'verb' => 'GET'],
-		['name' => 'batch_anonymization#updateProfiles', 'url' => 'api/anonymization/profiles', 'verb' => 'PUT'],
+        // WOO entity profile routes.
+        ['name' => 'batch_anonymization#getProfiles', 'url' => 'api/anonymization/profiles', 'verb' => 'GET'],
+        ['name' => 'batch_anonymization#updateProfiles', 'url' => 'api/anonymization/profiles', 'verb' => 'PUT'],
 
-		// PDF generation routes		['name' => 'pdf#render', 'url' => 'api/pdf/render', 'verb' => 'POST'],
-		['name' => 'pdf#renderPdfA', 'url' => 'api/pdf/render-pdfa', 'verb' => 'POST'],
+        // PDF generation routes.
+        ['name' => 'pdf#render', 'url' => 'api/pdf/render', 'verb' => 'POST'],
+        ['name' => 'pdf#renderPdfA', 'url' => 'api/pdf/render-pdfa', 'verb' => 'POST'],
 
-		// Print preview and PDF/A download routes
-		['name' => 'print#preview', 'url' => 'api/print/preview', 'verb' => 'POST'],
-		['name' => 'print#downloadPdfA', 'url' => 'api/print/pdf-a', 'verb' => 'POST'],
+        // Print preview and PDF/A download routes.
+        ['name' => 'print#preview', 'url' => 'api/print/preview', 'verb' => 'POST'],
+        ['name' => 'print#downloadPdfA', 'url' => 'api/print/pdf-a', 'verb' => 'POST'],
 
-		// Signing routes
-		['name' => 'signing#createRequest', 'url' => 'api/signing/requests', 'verb' => 'POST'],
-		['name' => 'signing#listRequests', 'url' => 'api/signing/requests', 'verb' => 'GET'],
-		['name' => 'signing#showRequest', 'url' => 'api/signing/requests/{id}', 'verb' => 'GET'],
-		['name' => 'signing#cancelRequest', 'url' => 'api/signing/requests/{id}', 'verb' => 'DELETE'],
-		['name' => 'signing#sign', 'url' => 'api/signing/requests/{id}/sign', 'verb' => 'POST'],
-		['name' => 'signing#decline', 'url' => 'api/signing/requests/{id}/decline', 'verb' => 'POST'],
-		['name' => 'signing#bulkSign', 'url' => 'api/signing/bulk', 'verb' => 'POST'],
-		['name' => 'signing#verify', 'url' => 'api/signing/verify/{fileId}', 'verb' => 'GET'],
-		['name' => 'signing#getAudit', 'url' => 'api/signing/requests/{id}/audit', 'verb' => 'GET'],
+        // Signing routes.
+        ['name' => 'signing#createRequest', 'url' => 'api/signing/requests', 'verb' => 'POST'],
+        ['name' => 'signing#listRequests', 'url' => 'api/signing/requests', 'verb' => 'GET'],
+        ['name' => 'signing#showRequest', 'url' => 'api/signing/requests/{id}', 'verb' => 'GET'],
+        ['name' => 'signing#cancelRequest', 'url' => 'api/signing/requests/{id}', 'verb' => 'DELETE'],
+        ['name' => 'signing#sign', 'url' => 'api/signing/requests/{id}/sign', 'verb' => 'POST'],
+        ['name' => 'signing#decline', 'url' => 'api/signing/requests/{id}/decline', 'verb' => 'POST'],
+        ['name' => 'signing#bulkSign', 'url' => 'api/signing/bulk', 'verb' => 'POST'],
+        ['name' => 'signing#verify', 'url' => 'api/signing/verify/{fileId}', 'verb' => 'GET'],
+        ['name' => 'signing#getAudit', 'url' => 'api/signing/requests/{id}/audit', 'verb' => 'GET'],
 
-		// Correspondence routes
-		['name' => 'correspondence#generate', 'url' => 'api/correspondence/generate', 'verb' => 'POST'],
-		['name' => 'correspondence#generateBatch', 'url' => 'api/correspondence/generate/batch', 'verb' => 'POST'],
-		['name' => 'correspondence#jobStatus', 'url' => 'api/correspondence/jobs/{jobId}', 'verb' => 'GET'],
+        // Correspondence routes.
+        ['name' => 'correspondence#generate', 'url' => 'api/correspondence/generate', 'verb' => 'POST'],
+        ['name' => 'correspondence#generateBatch', 'url' => 'api/correspondence/generate/batch', 'verb' => 'POST'],
+        ['name' => 'correspondence#jobStatus', 'url' => 'api/correspondence/jobs/{jobId}', 'verb' => 'GET'],
 
-		// Template routes
-		['name' => 'templates#index', 'url' => 'api/templates', 'verb' => 'GET'],
-		['name' => 'templates#create', 'url' => 'api/templates', 'verb' => 'POST'],
-		['name' => 'templates#preview', 'url' => 'api/templates/preview', 'verb' => 'POST'],
-		['name' => 'templates#show', 'url' => 'api/templates/{id}', 'verb' => 'GET'],
-		['name' => 'templates#update', 'url' => 'api/templates/{id}', 'verb' => 'PUT'],
-		['name' => 'templates#destroy', 'url' => 'api/templates/{id}', 'verb' => 'DELETE'],
-		['name' => 'templates#versions', 'url' => 'api/templates/{id}/versions', 'verb' => 'GET'],
-		['name' => 'templates#diffVersions', 'url' => 'api/templates/{id}/versions/diff', 'verb' => 'GET'],
-		['name' => 'templates#restoreVersion', 'url' => 'api/templates/{id}/versions/{versionId}/restore', 'verb' => 'POST'],
-		['name' => 'templates#previewTemplate', 'url' => 'api/templates/{id}/preview', 'verb' => 'POST'],
-		['name' => 'templates#duplicate', 'url' => 'api/templates/{id}/duplicate', 'verb' => 'POST'],
-		['name' => 'templates#lock', 'url' => 'api/templates/{id}/lock', 'verb' => 'POST'],
-		['name' => 'templates#unlock', 'url' => 'api/templates/{id}/lock', 'verb' => 'DELETE'],
+        // Template routes.
+        ['name' => 'templates#index', 'url' => 'api/templates', 'verb' => 'GET'],
+        ['name' => 'templates#create', 'url' => 'api/templates', 'verb' => 'POST'],
+        ['name' => 'templates#preview', 'url' => 'api/templates/preview', 'verb' => 'POST'],
+        ['name' => 'templates#show', 'url' => 'api/templates/{id}', 'verb' => 'GET'],
+        ['name' => 'templates#update', 'url' => 'api/templates/{id}', 'verb' => 'PUT'],
+        ['name' => 'templates#destroy', 'url' => 'api/templates/{id}', 'verb' => 'DELETE'],
+        ['name' => 'templates#versions', 'url' => 'api/templates/{id}/versions', 'verb' => 'GET'],
+        ['name' => 'templates#diffVersions', 'url' => 'api/templates/{id}/versions/diff', 'verb' => 'GET'],
+        ['name' => 'templates#restoreVersion', 'url' => 'api/templates/{id}/versions/{versionId}/restore', 'verb' => 'POST'],
+        ['name' => 'templates#previewTemplate', 'url' => 'api/templates/{id}/preview', 'verb' => 'POST'],
+        ['name' => 'templates#duplicate', 'url' => 'api/templates/{id}/duplicate', 'verb' => 'POST'],
+        ['name' => 'templates#lock', 'url' => 'api/templates/{id}/lock', 'verb' => 'POST'],
+        ['name' => 'templates#unlock', 'url' => 'api/templates/{id}/lock', 'verb' => 'DELETE'],
 
-		// Signing routes
-		['name' => 'signing#createRequest', 'url' => 'api/signing/requests', 'verb' => 'POST'],
-		['name' => 'signing#listRequests', 'url' => 'api/signing/requests', 'verb' => 'GET'],
-		['name' => 'signing#showRequest', 'url' => 'api/signing/requests/{id}', 'verb' => 'GET'],
-		['name' => 'signing#cancelRequest', 'url' => 'api/signing/requests/{id}', 'verb' => 'DELETE'],
-		['name' => 'signing#sign', 'url' => 'api/signing/requests/{id}/sign', 'verb' => 'POST'],
-		['name' => 'signing#decline', 'url' => 'api/signing/requests/{id}/decline', 'verb' => 'POST'],
-		['name' => 'signing#bulkSign', 'url' => 'api/signing/bulk', 'verb' => 'POST'],
-		['name' => 'signing#verify', 'url' => 'api/signing/verify/{fileId}', 'verb' => 'GET'],
-		['name' => 'signing#getAudit', 'url' => 'api/signing/requests/{id}/audit', 'verb' => 'GET'],
+        // Signing routes.
+        ['name' => 'signing#createRequest', 'url' => 'api/signing/requests', 'verb' => 'POST'],
+        ['name' => 'signing#listRequests', 'url' => 'api/signing/requests', 'verb' => 'GET'],
+        ['name' => 'signing#showRequest', 'url' => 'api/signing/requests/{id}', 'verb' => 'GET'],
+        ['name' => 'signing#cancelRequest', 'url' => 'api/signing/requests/{id}', 'verb' => 'DELETE'],
+        ['name' => 'signing#sign', 'url' => 'api/signing/requests/{id}/sign', 'verb' => 'POST'],
+        ['name' => 'signing#decline', 'url' => 'api/signing/requests/{id}/decline', 'verb' => 'POST'],
+        ['name' => 'signing#bulkSign', 'url' => 'api/signing/bulk', 'verb' => 'POST'],
+        ['name' => 'signing#verify', 'url' => 'api/signing/verify/{fileId}', 'verb' => 'GET'],
+        ['name' => 'signing#getAudit', 'url' => 'api/signing/requests/{id}/audit', 'verb' => 'GET'],
 
-		// SPA catch-all — serves the Vue app shell for any frontend deep
-		// link (vue-router HTML5 history mode). Must come LAST so it
-		// doesn't shadow specific routes above. The dedicated
-		// `dashboard#catchAll` controller method exists because
-		// `dashboard#page` takes a `getParameter` arg, not a `path`
-		// arg — matching arg names to the route placeholder lets NC's
-		// router inject the captured value cleanly.
-		['name' => 'dashboard#catchAll', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],
-	],
+        // SPA catch-all — serves the Vue app shell for any frontend deep
+        // link (vue-router HTML5 history mode). Must come LAST so it
+        // doesn't shadow specific routes above. The dedicated
+        // `dashboard#catchAll` controller method exists because
+        // `dashboard#page` takes a `getParameter` arg, not a `path`
+        // arg — matching arg names to the route placeholder lets NC's
+        // router inject the captured value cleanly.
+        ['name' => 'dashboard#catchAll', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],
+    ],
 ];


### PR DESCRIPTION
## Summary

Converts `appinfo/routes.php` from tab indentation (which the project's phpcs ruleset rejects via `Generic.WhiteSpace.ScopeIndent` `tabIndent=false`) to 4-space indentation, brings the file docblock in line with the PEAR-style header used across `lib/`, and appends terminating periods on the inline section comments.

Also splits the broken line where a section comment and a route definition had been concatenated on the same source line by a previous edit (`// PDF generation routes\t\t['name' => 'pdf#render', ...]`).

Result: `vendor/bin/phpcs --standard=phpcs.xml appinfo/routes.php` returns 0 errors (was 168).

PR #242 commit \`e487129\` added 5 new lines that followed the existing tab style; this PR normalises the whole file rather than just those lines, since the underlying file was already failing the project standard.

Closes #246.

## Test plan

- [x] `vendor/bin/phpcs --standard=phpcs.xml appinfo/routes.php` -> 0 errors
- [x] `php -l appinfo/routes.php` -> no syntax errors
- [x] Diff is confined to `appinfo/routes.php`