### PR TITLE
chore(specs): normalize requirement headings to Form A (ADR-037)

### DIFF
--- a/openspec/specs/admin-settings/spec.md
+++ b/openspec/specs/admin-settings/spec.md
@@ -10,9 +10,8 @@ Provides configuration management for DocuDesk, including OpenRegister integrati
 
 ## Requirements
 
-### Requirement: Nextcloud Admin Panel Integration
+### Requirement: Nextcloud Admin Panel Integration (REQ-SET-01)
 
-**ID:** REQ-SET-01
 **Priority:** Must
 
 DocuDesk registers a dedicated section in the Nextcloud admin settings panel with its own icon, accessible only to administrators.
@@ -49,9 +48,8 @@ DocuDesk registers a dedicated section in the Nextcloud admin settings panel wit
 | SET-003 | The admin section is registered via `OCA\DocuDesk\Settings\DocuDeskAdmin` (ISettings) and `OCA\DocuDesk\Sections\DocuDeskAdmin` (IIconSection) -- two separate classes in different namespaces | MUST | Implemented |
 | SET-004 | Settings are rendered using a Vue component (`Settings.vue`) via the `settings` entry point | MUST | Implemented |
 
-### Requirement: OpenRegister Integration Configuration
+### Requirement: OpenRegister Integration Configuration (REQ-SET-02)
 
-**ID:** REQ-SET-02
 **Priority:** Must
 
 Administrators can configure which OpenRegister register and schema to use for consent object storage, with validation and discovery of available registers.
@@ -94,9 +92,8 @@ Administrators can configure which OpenRegister register and schema to use for c
 | SET-015 | Store register/schema configuration as `publicationConsent_register`, `publicationConsent_schema`, `publicationConsent_source` in IAppConfig | MUST | Implemented |
 | SET-016 | Schema listing excludes the `properties` field for cleaner API responses | MUST | Implemented |
 
-### Requirement: Auto-Initialization on Boot
+### Requirement: Auto-Initialization on Boot (REQ-SET-03)
 
-**ID:** REQ-SET-03
 **Priority:** Must
 
 On application boot, DocuDesk automatically imports its register/schema definitions from a versioned JSON file, ensuring the required data structures exist in OpenRegister.
@@ -144,9 +141,8 @@ On application boot, DocuDesk automatically imports its register/schema definiti
 | SET-022 | Initialization failures are logged but do not prevent app startup (silent failure) | MUST | Implemented |
 | SET-023 | The `docudesk_register.json` file follows OpenAPI 3.0.0 format with `x-openregister` extensions | MUST | Implemented |
 
-### Requirement: WOO Consent Period Configuration
+### Requirement: WOO Consent Period Configuration (REQ-SET-04)
 
-**ID:** REQ-SET-04
 **Priority:** Must
 
 Administrators can configure the publication objection period per WOO requirements, with validation ensuring compliance with the minimum 4-week objection period.
@@ -176,9 +172,8 @@ Administrators can configure the publication objection period per WOO requiremen
 | SET-031 | Objection period input accepts values from 1 to 365 | MUST | Implemented |
 | SET-032 | Display descriptive text referencing WOO minimum 4-week requirement | MUST | Implemented |
 
-### Requirement: Metadata Enrichment Feature Toggles
+### Requirement: Metadata Enrichment Feature Toggles (REQ-SET-05)
 
-**ID:** REQ-SET-05
 **Priority:** Must
 
 Administrators can independently toggle language detection, keyword extraction, and topic classification features on or off.
@@ -211,9 +206,8 @@ Administrators can independently toggle language detection, keyword extraction, 
 | SET-042 | Toggle topic classification on/off (`enable_topic_classification`, default: enabled) | MUST | Implemented |
 | SET-043 | Toggles use NcCheckboxRadioSwitch components with descriptive labels | MUST | Implemented |
 
-### Requirement: Settings REST API
+### Requirement: Settings REST API (REQ-SET-06)
 
-**ID:** REQ-SET-06
 **Priority:** Must
 
 Settings can be retrieved and updated programmatically via REST API endpoints.
@@ -251,9 +245,8 @@ Settings can be retrieved and updated programmatically via REST API endpoints.
 | SET-053 | Array/object values are JSON-encoded before storage in IAppConfig | MUST | Implemented |
 | SET-054 | Empty keys are skipped with a warning log during update | MUST | Implemented |
 
-### Requirement: SettingsService Public Helper Methods
+### Requirement: SettingsService Public Helper Methods (REQ-SET-07)
 
-**ID:** REQ-SET-07
 **Priority:** Must
 
 SettingsService exposes reusable public methods for OpenRegister service resolution and availability checking, used by other DocuDesk services and controllers.
@@ -285,9 +278,8 @@ SettingsService exposes reusable public methods for OpenRegister service resolut
 | SET-063 | `getConfigurationService()` provides public access to the OpenRegister ConfigurationService via lazy resolution | MUST | Implemented |
 | SET-064 | Both service getters throw `\RuntimeException` when OpenRegister is not available | MUST | Implemented |
 
-### Requirement: App Metadata and Compatibility
+### Requirement: App Metadata and Compatibility (REQ-SET-08)
 
-**ID:** REQ-SET-08
 **Priority:** Must
 
 DocuDesk declares platform compatibility and app identity in its `appinfo/info.xml`.
@@ -315,9 +307,8 @@ DocuDesk declares platform compatibility and app identity in its `appinfo/info.x
 | SET-071 | App requires PHP 8.0+ with 64-bit integer support | MUST | Implemented |
 | SET-072 | App is compatible with Nextcloud versions 28 through 32 | MUST | Implemented |
 
-### Requirement: External Documentation URLs
+### Requirement: External Documentation URLs (REQ-SET-09)
 
-**ID:** REQ-SET-09
 **Priority:** Must
 
 DocuDesk references external documentation for users, administrators, and developers.
@@ -340,9 +331,8 @@ DocuDesk references external documentation for users, administrators, and develo
 | SET-074 | All doc types (user, admin, developer) in info.xml use the same Gitbook URL | MUST | Implemented |
 | SET-075 | Roadmap is tracked at GitHub Projects | MUST | Implemented |
 
-### Requirement: Configuration File Resolution and Validation
+### Requirement: Configuration File Resolution and Validation (REQ-SET-10)
 
-**ID:** REQ-SET-10
 **Priority:** Must
 
 SettingsService resolves and validates the configuration JSON file with a strict validation chain.
@@ -370,9 +360,8 @@ SettingsService resolves and validates the configuration JSON file with a strict
 | SET-076 | Settings file path is resolved relative to SettingsService via `__DIR__.'/../Settings/docudesk_register.json'` | MUST | Implemented |
 | SET-077 | File existence, readability, JSON validity, and version presence are all validated with descriptive RuntimeException messages | MUST | Implemented |
 
-### Requirement: TypeError Catch Fallback for OpenRegister
+### Requirement: TypeError Catch Fallback for OpenRegister (REQ-SET-11)
 
-**ID:** REQ-SET-11
 **Priority:** Must
 
 Settings retrieval gracefully handles TypeErrors from OpenRegister internals to prevent crashes.

--- a/openspec/specs/admin-settings/spec.md
+++ b/openspec/specs/admin-settings/spec.md
@@ -10,7 +10,10 @@ Provides configuration management for DocuDesk, including OpenRegister integrati
 
 ## Requirements
 
-### REQ-SET-01: Nextcloud Admin Panel Integration (Priority: Must)
+### Requirement: Nextcloud Admin Panel Integration
+
+**ID:** REQ-SET-01
+**Priority:** Must
 
 DocuDesk registers a dedicated section in the Nextcloud admin settings panel with its own icon, accessible only to administrators.
 
@@ -46,7 +49,10 @@ DocuDesk registers a dedicated section in the Nextcloud admin settings panel wit
 | SET-003 | The admin section is registered via `OCA\DocuDesk\Settings\DocuDeskAdmin` (ISettings) and `OCA\DocuDesk\Sections\DocuDeskAdmin` (IIconSection) -- two separate classes in different namespaces | MUST | Implemented |
 | SET-004 | Settings are rendered using a Vue component (`Settings.vue`) via the `settings` entry point | MUST | Implemented |
 
-### REQ-SET-02: OpenRegister Integration Configuration (Priority: Must)
+### Requirement: OpenRegister Integration Configuration
+
+**ID:** REQ-SET-02
+**Priority:** Must
 
 Administrators can configure which OpenRegister register and schema to use for consent object storage, with validation and discovery of available registers.
 
@@ -88,7 +94,10 @@ Administrators can configure which OpenRegister register and schema to use for c
 | SET-015 | Store register/schema configuration as `publicationConsent_register`, `publicationConsent_schema`, `publicationConsent_source` in IAppConfig | MUST | Implemented |
 | SET-016 | Schema listing excludes the `properties` field for cleaner API responses | MUST | Implemented |
 
-### REQ-SET-03: Auto-Initialization on Boot (Priority: Must)
+### Requirement: Auto-Initialization on Boot
+
+**ID:** REQ-SET-03
+**Priority:** Must
 
 On application boot, DocuDesk automatically imports its register/schema definitions from a versioned JSON file, ensuring the required data structures exist in OpenRegister.
 
@@ -135,7 +144,10 @@ On application boot, DocuDesk automatically imports its register/schema definiti
 | SET-022 | Initialization failures are logged but do not prevent app startup (silent failure) | MUST | Implemented |
 | SET-023 | The `docudesk_register.json` file follows OpenAPI 3.0.0 format with `x-openregister` extensions | MUST | Implemented |
 
-### REQ-SET-04: WOO Consent Period Configuration (Priority: Must)
+### Requirement: WOO Consent Period Configuration
+
+**ID:** REQ-SET-04
+**Priority:** Must
 
 Administrators can configure the publication objection period per WOO requirements, with validation ensuring compliance with the minimum 4-week objection period.
 
@@ -164,7 +176,10 @@ Administrators can configure the publication objection period per WOO requiremen
 | SET-031 | Objection period input accepts values from 1 to 365 | MUST | Implemented |
 | SET-032 | Display descriptive text referencing WOO minimum 4-week requirement | MUST | Implemented |
 
-### REQ-SET-05: Metadata Enrichment Feature Toggles (Priority: Must)
+### Requirement: Metadata Enrichment Feature Toggles
+
+**ID:** REQ-SET-05
+**Priority:** Must
 
 Administrators can independently toggle language detection, keyword extraction, and topic classification features on or off.
 
@@ -196,7 +211,10 @@ Administrators can independently toggle language detection, keyword extraction, 
 | SET-042 | Toggle topic classification on/off (`enable_topic_classification`, default: enabled) | MUST | Implemented |
 | SET-043 | Toggles use NcCheckboxRadioSwitch components with descriptive labels | MUST | Implemented |
 
-### REQ-SET-06: Settings REST API (Priority: Must)
+### Requirement: Settings REST API
+
+**ID:** REQ-SET-06
+**Priority:** Must
 
 Settings can be retrieved and updated programmatically via REST API endpoints.
 
@@ -233,7 +251,10 @@ Settings can be retrieved and updated programmatically via REST API endpoints.
 | SET-053 | Array/object values are JSON-encoded before storage in IAppConfig | MUST | Implemented |
 | SET-054 | Empty keys are skipped with a warning log during update | MUST | Implemented |
 
-### REQ-SET-07: SettingsService Public Helper Methods (Priority: Must)
+### Requirement: SettingsService Public Helper Methods
+
+**ID:** REQ-SET-07
+**Priority:** Must
 
 SettingsService exposes reusable public methods for OpenRegister service resolution and availability checking, used by other DocuDesk services and controllers.
 
@@ -264,7 +285,10 @@ SettingsService exposes reusable public methods for OpenRegister service resolut
 | SET-063 | `getConfigurationService()` provides public access to the OpenRegister ConfigurationService via lazy resolution | MUST | Implemented |
 | SET-064 | Both service getters throw `\RuntimeException` when OpenRegister is not available | MUST | Implemented |
 
-### REQ-SET-08: App Metadata and Compatibility (Priority: Must)
+### Requirement: App Metadata and Compatibility
+
+**ID:** REQ-SET-08
+**Priority:** Must
 
 DocuDesk declares platform compatibility and app identity in its `appinfo/info.xml`.
 
@@ -291,7 +315,10 @@ DocuDesk declares platform compatibility and app identity in its `appinfo/info.x
 | SET-071 | App requires PHP 8.0+ with 64-bit integer support | MUST | Implemented |
 | SET-072 | App is compatible with Nextcloud versions 28 through 32 | MUST | Implemented |
 
-### REQ-SET-09: External Documentation URLs (Priority: Must)
+### Requirement: External Documentation URLs
+
+**ID:** REQ-SET-09
+**Priority:** Must
 
 DocuDesk references external documentation for users, administrators, and developers.
 
@@ -313,7 +340,10 @@ DocuDesk references external documentation for users, administrators, and develo
 | SET-074 | All doc types (user, admin, developer) in info.xml use the same Gitbook URL | MUST | Implemented |
 | SET-075 | Roadmap is tracked at GitHub Projects | MUST | Implemented |
 
-### REQ-SET-10: Configuration File Resolution and Validation (Priority: Must)
+### Requirement: Configuration File Resolution and Validation
+
+**ID:** REQ-SET-10
+**Priority:** Must
 
 SettingsService resolves and validates the configuration JSON file with a strict validation chain.
 
@@ -340,7 +370,10 @@ SettingsService resolves and validates the configuration JSON file with a strict
 | SET-076 | Settings file path is resolved relative to SettingsService via `__DIR__.'/../Settings/docudesk_register.json'` | MUST | Implemented |
 | SET-077 | File existence, readability, JSON validity, and version presence are all validated with descriptive RuntimeException messages | MUST | Implemented |
 
-### REQ-SET-11: TypeError Catch Fallback for OpenRegister (Priority: Must)
+### Requirement: TypeError Catch Fallback for OpenRegister
+
+**ID:** REQ-SET-11
+**Priority:** Must
 
 Settings retrieval gracefully handles TypeErrors from OpenRegister internals to prevent crashes.
 

--- a/openspec/specs/anonymization/spec.md
+++ b/openspec/specs/anonymization/spec.md
@@ -10,9 +10,8 @@ Provides a complete document anonymization pipeline: upload files to a user-scop
 
 ## Requirements
 
-### Requirement: File Upload to User-Scoped Folder
+### Requirement: File Upload to User-Scoped Folder (REQ-ANON-01)
 
-**ID:** REQ-ANON-01
 **Priority:** Must
 
 Users upload files via multipart form data, and files are stored in a per-user DocuDesk folder within Nextcloud Files.
@@ -55,9 +54,8 @@ Users upload files via multipart form data, and files are stored in a per-user D
 | ANON-005 | Upload response includes fileId, filePath, fileName, and fileSize | MUST | Implemented |
 | ANON-006 | Upload requires an authenticated user session | MUST | Implemented |
 
-### Requirement: Text Extraction and Entity Detection
+### Requirement: Text Extraction and Entity Detection (REQ-ANON-02)
 
-**ID:** REQ-ANON-02
 **Priority:** Must
 
 Text is extracted from uploaded documents and entities (persons, organizations, emails, phone numbers) are detected using OpenRegister's NER capabilities.
@@ -96,9 +94,8 @@ Text is extracted from uploaded documents and entities (persons, organizations, 
 | ANON-014 | Extraction endpoint is `POST /api/anonymization/extract/{fileId}` | MUST | Implemented |
 | ANON-015 | Response includes `entities` array and `entityCount` | MUST | Implemented |
 
-### Requirement: Document Anonymization with Entity Replacement
+### Requirement: Document Anonymization with Entity Replacement (REQ-ANON-03)
 
-**ID:** REQ-ANON-03
 **Priority:** Must
 
 Detected entities are replaced with anonymized placeholders in the document, producing an anonymized copy.
@@ -143,9 +140,8 @@ Detected entities are replaced with anonymized placeholders in the document, pro
 | ANON-025 | Anonymization endpoint is `POST /api/anonymization/anonymize/{fileId}` with entities array in request body | MUST | Implemented |
 | ANON-026 | Response includes anonymizedFileId, anonymizedFileName, anonymizedFilePath, and replacementCount | MUST | Implemented |
 
-### Requirement: Processed File Listing with Risk Assessment
+### Requirement: Processed File Listing with Risk Assessment (REQ-ANON-04)
 
-**ID:** REQ-ANON-04
 **Priority:** Must
 
 List all files in the user's DocuDesk folder with entity counts, anonymization status, and risk level assessment.
@@ -177,9 +173,8 @@ List all files in the user's DocuDesk folder with entity counts, anonymization s
 | ANON-034 | File listing includes fileId, fileName, filePath, fileSize, and mimeType | MUST | Implemented |
 | ANON-035 | Only actual files are listed (directories are skipped) | MUST | Implemented |
 
-### Requirement: Lazy OpenRegister Service Resolution
+### Requirement: Lazy OpenRegister Service Resolution (REQ-ANON-05)
 
-**ID:** REQ-ANON-05
 **Priority:** Must
 
 AnonymizationService lazily resolves OpenRegister services at call time to gracefully handle the case where OpenRegister is not installed.
@@ -210,9 +205,8 @@ AnonymizationService lazily resolves OpenRegister services at call time to grace
 | ANON-042 | Service resolution is lazy (per-call), not eagerly loaded at construction time | MUST | Implemented |
 | ANON-043 | `listProcessedFiles()` gracefully handles unavailable services by catching RuntimeException | MUST | Implemented |
 
-### Requirement: UUID v4 Generation for Anonymization Keys
+### Requirement: UUID v4 Generation for Anonymization Keys (REQ-ANON-06)
 
-**ID:** REQ-ANON-06
 **Priority:** Must
 
 Each anonymized entity is assigned a cryptographically secure UUID v4 key as its replacement identifier.
@@ -239,9 +233,8 @@ Each anonymized entity is assigned a cryptographically secure UUID v4 key as its
 | ANON-045 | Generated UUIDs conform to RFC 4122 version 4 format | MUST | Implemented |
 | ANON-046 | Each entity gets a unique UUID key in the anonymization mapping | MUST | Implemented |
 
-### Requirement: User Session Authentication
+### Requirement: User Session Authentication (REQ-ANON-07)
 
-**ID:** REQ-ANON-07
 **Priority:** Must
 
 File operations require an authenticated user session to scope files to the correct user's folder.
@@ -268,9 +261,8 @@ File operations require an authenticated user session to scope files to the corr
 | ANON-047 | `getCurrentUserId()` throws `Exception` with code 401 when no user session exists | MUST | Implemented |
 | ANON-048 | `files()` and `upload()` correctly propagate 401; `extract()` and `anonymize()` return 500 on exception | MUST | Partial |
 
-### Requirement: Anonymization Pipeline UI
+### Requirement: Anonymization Pipeline UI (REQ-ANON-08)
 
-**ID:** REQ-ANON-08
 **Priority:** Must
 
 The frontend provides a step-by-step UI for the complete anonymization workflow with drag-and-drop upload, progress tracking, and result display.
@@ -301,9 +293,8 @@ The frontend provides a step-by-step UI for the complete anonymization workflow 
 | ANON-052 | Return 500 with "Failed to read uploaded file" when temp file cannot be read | MUST | Implemented |
 | ANON-053 | Return 400 with "No entities provided for anonymization" when entities array is empty | MUST | Implemented |
 
-### Requirement: EntityRelationMapper Method Usage
+### Requirement: EntityRelationMapper Method Usage (REQ-ANON-09)
 
-**ID:** REQ-ANON-09
 **Priority:** Must
 
 Two distinct EntityRelationMapper methods serve different purposes in the pipeline: entity detail retrieval vs. relation counting.
@@ -333,9 +324,8 @@ Two distinct EntityRelationMapper methods serve different purposes in the pipeli
 | ANON-055 | File listing uses `findByFileId()` for entity counts and status | MUST | Implemented |
 | ANON-056 | `findByFileId()` relations expose `getAnonymized()` for per-entity tracking | MUST | Implemented |
 
-### Requirement: Frontend File Processing Queue
+### Requirement: Frontend File Processing Queue (REQ-ANON-10)
 
-**ID:** REQ-ANON-10
 **Priority:** Must
 
 The Pinia store manages a sequential file processing queue with status tracking through the pipeline stages.

--- a/openspec/specs/anonymization/spec.md
+++ b/openspec/specs/anonymization/spec.md
@@ -10,7 +10,10 @@ Provides a complete document anonymization pipeline: upload files to a user-scop
 
 ## Requirements
 
-### REQ-ANON-01: File Upload to User-Scoped Folder (Priority: Must)
+### Requirement: File Upload to User-Scoped Folder
+
+**ID:** REQ-ANON-01
+**Priority:** Must
 
 Users upload files via multipart form data, and files are stored in a per-user DocuDesk folder within Nextcloud Files.
 
@@ -52,7 +55,10 @@ Users upload files via multipart form data, and files are stored in a per-user D
 | ANON-005 | Upload response includes fileId, filePath, fileName, and fileSize | MUST | Implemented |
 | ANON-006 | Upload requires an authenticated user session | MUST | Implemented |
 
-### REQ-ANON-02: Text Extraction and Entity Detection (Priority: Must)
+### Requirement: Text Extraction and Entity Detection
+
+**ID:** REQ-ANON-02
+**Priority:** Must
 
 Text is extracted from uploaded documents and entities (persons, organizations, emails, phone numbers) are detected using OpenRegister's NER capabilities.
 
@@ -90,7 +96,10 @@ Text is extracted from uploaded documents and entities (persons, organizations, 
 | ANON-014 | Extraction endpoint is `POST /api/anonymization/extract/{fileId}` | MUST | Implemented |
 | ANON-015 | Response includes `entities` array and `entityCount` | MUST | Implemented |
 
-### REQ-ANON-03: Document Anonymization with Entity Replacement (Priority: Must)
+### Requirement: Document Anonymization with Entity Replacement
+
+**ID:** REQ-ANON-03
+**Priority:** Must
 
 Detected entities are replaced with anonymized placeholders in the document, producing an anonymized copy.
 
@@ -134,7 +143,10 @@ Detected entities are replaced with anonymized placeholders in the document, pro
 | ANON-025 | Anonymization endpoint is `POST /api/anonymization/anonymize/{fileId}` with entities array in request body | MUST | Implemented |
 | ANON-026 | Response includes anonymizedFileId, anonymizedFileName, anonymizedFilePath, and replacementCount | MUST | Implemented |
 
-### REQ-ANON-04: Processed File Listing with Risk Assessment (Priority: Must)
+### Requirement: Processed File Listing with Risk Assessment
+
+**ID:** REQ-ANON-04
+**Priority:** Must
 
 List all files in the user's DocuDesk folder with entity counts, anonymization status, and risk level assessment.
 
@@ -165,7 +177,10 @@ List all files in the user's DocuDesk folder with entity counts, anonymization s
 | ANON-034 | File listing includes fileId, fileName, filePath, fileSize, and mimeType | MUST | Implemented |
 | ANON-035 | Only actual files are listed (directories are skipped) | MUST | Implemented |
 
-### REQ-ANON-05: Lazy OpenRegister Service Resolution (Priority: Must)
+### Requirement: Lazy OpenRegister Service Resolution
+
+**ID:** REQ-ANON-05
+**Priority:** Must
 
 AnonymizationService lazily resolves OpenRegister services at call time to gracefully handle the case where OpenRegister is not installed.
 
@@ -195,7 +210,10 @@ AnonymizationService lazily resolves OpenRegister services at call time to grace
 | ANON-042 | Service resolution is lazy (per-call), not eagerly loaded at construction time | MUST | Implemented |
 | ANON-043 | `listProcessedFiles()` gracefully handles unavailable services by catching RuntimeException | MUST | Implemented |
 
-### REQ-ANON-06: UUID v4 Generation for Anonymization Keys (Priority: Must)
+### Requirement: UUID v4 Generation for Anonymization Keys
+
+**ID:** REQ-ANON-06
+**Priority:** Must
 
 Each anonymized entity is assigned a cryptographically secure UUID v4 key as its replacement identifier.
 
@@ -221,7 +239,10 @@ Each anonymized entity is assigned a cryptographically secure UUID v4 key as its
 | ANON-045 | Generated UUIDs conform to RFC 4122 version 4 format | MUST | Implemented |
 | ANON-046 | Each entity gets a unique UUID key in the anonymization mapping | MUST | Implemented |
 
-### REQ-ANON-07: User Session Authentication (Priority: Must)
+### Requirement: User Session Authentication
+
+**ID:** REQ-ANON-07
+**Priority:** Must
 
 File operations require an authenticated user session to scope files to the correct user's folder.
 
@@ -247,7 +268,10 @@ File operations require an authenticated user session to scope files to the corr
 | ANON-047 | `getCurrentUserId()` throws `Exception` with code 401 when no user session exists | MUST | Implemented |
 | ANON-048 | `files()` and `upload()` correctly propagate 401; `extract()` and `anonymize()` return 500 on exception | MUST | Partial |
 
-### REQ-ANON-08: Anonymization Pipeline UI (Priority: Must)
+### Requirement: Anonymization Pipeline UI
+
+**ID:** REQ-ANON-08
+**Priority:** Must
 
 The frontend provides a step-by-step UI for the complete anonymization workflow with drag-and-drop upload, progress tracking, and result display.
 
@@ -277,7 +301,10 @@ The frontend provides a step-by-step UI for the complete anonymization workflow 
 | ANON-052 | Return 500 with "Failed to read uploaded file" when temp file cannot be read | MUST | Implemented |
 | ANON-053 | Return 400 with "No entities provided for anonymization" when entities array is empty | MUST | Implemented |
 
-### REQ-ANON-09: EntityRelationMapper Method Usage (Priority: Must)
+### Requirement: EntityRelationMapper Method Usage
+
+**ID:** REQ-ANON-09
+**Priority:** Must
 
 Two distinct EntityRelationMapper methods serve different purposes in the pipeline: entity detail retrieval vs. relation counting.
 
@@ -306,7 +333,10 @@ Two distinct EntityRelationMapper methods serve different purposes in the pipeli
 | ANON-055 | File listing uses `findByFileId()` for entity counts and status | MUST | Implemented |
 | ANON-056 | `findByFileId()` relations expose `getAnonymized()` for per-entity tracking | MUST | Implemented |
 
-### REQ-ANON-10: Frontend File Processing Queue (Priority: Must)
+### Requirement: Frontend File Processing Queue
+
+**ID:** REQ-ANON-10
+**Priority:** Must
 
 The Pinia store manages a sequential file processing queue with status tracking through the pipeline stages.
 

--- a/openspec/specs/consent-management/spec.md
+++ b/openspec/specs/consent-management/spec.md
@@ -10,7 +10,10 @@ Provides GDPR-compliant publication consent tracking for entities (persons and o
 
 ## Requirements
 
-### REQ-CONS-01: Consent Record Creation (Priority: Must)
+### Requirement: Consent Record Creation
+
+**ID:** REQ-CONS-01
+**Priority:** Must
 
 Consent records are created for detected entities in documents, initialized with pending status and an automatic objection deadline.
 
@@ -44,7 +47,10 @@ Consent records are created for detected entities in documents, initialized with
 | CONS-005 | An objection deadline is automatically calculated based on the configurable objection period (default 28 days) | MUST | Implemented |
 | CONS-006 | Consent records are stored in OpenRegister via ObjectService using the configured register and schema | MUST | Implemented |
 
-### REQ-CONS-02: Consent Status Lifecycle (Priority: Must)
+### Requirement: Consent Status Lifecycle
+
+**ID:** REQ-CONS-02
+**Priority:** Must
 
 Consent records progress through defined status transitions for consent, notification, and publication decision fields.
 
@@ -82,7 +88,10 @@ Consent records progress through defined status transitions for consent, notific
 | CONS-013 | Consent status can be updated via `PUT /api/consents/{id}` | MUST | Implemented |
 | CONS-014 | Objection deadline expiry can be checked via ConsentService::checkObjectionDeadline() | MUST | Implemented |
 
-### REQ-CONS-03: Consent Listing and Querying (Priority: Must)
+### Requirement: Consent Listing and Querying
+
+**ID:** REQ-CONS-03
+**Priority:** Must
 
 Consent records can be listed, queried by ID, and filtered by document.
 
@@ -115,7 +124,10 @@ Consent records can be listed, queried by ID, and filtered by document.
 | CONS-023 | Consent listing requires the publicationConsent register and schema to be configured | MUST | Implemented |
 | CONS-024 | If register/schema is not configured, a 400 error is returned | MUST | Implemented |
 
-### REQ-CONS-04: WOO Objection Period Compliance (Priority: Must)
+### Requirement: WOO Objection Period Compliance
+
+**ID:** REQ-CONS-04
+**Priority:** Must
 
 The objection period complies with Wet Open Overheid requirements for a minimum 4-week notification period before publication.
 
@@ -143,7 +155,10 @@ The objection period complies with Wet Open Overheid requirements for a minimum 
 | CONS-031 | The objection period is configurable via admin settings | MUST | Implemented |
 | CONS-032 | The objection deadline is stored as ISO 8601 datetime | MUST | Implemented |
 
-### REQ-CONS-05: Controller Read Path Architecture (Priority: Must)
+### Requirement: Controller Read Path Architecture
+
+**ID:** REQ-CONS-05
+**Priority:** Must
 
 ConsentController uses different service paths for read vs. write operations -- reading directly via ObjectService, writing via ConsentService.
 
@@ -172,7 +187,10 @@ ConsentController uses different service paths for read vs. write operations -- 
 | CONS-042 | `ConsentController::update()` delegates to ConsentService | MUST | Implemented |
 | CONS-043 | `ConsentController::byDocument()` delegates to ConsentService | MUST | Implemented |
 
-### REQ-CONS-06: RBAC and Multitenancy Configuration (Priority: Must)
+### Requirement: RBAC and Multitenancy Configuration
+
+**ID:** REQ-CONS-06
+**Priority:** Must
 
 All consent ObjectService calls currently bypass RBAC and multitenancy, which is a known security concern for multi-tenant deployments.
 
@@ -200,7 +218,10 @@ All consent ObjectService calls currently bypass RBAC and multitenancy, which is
 | CONS-045 | All ConsentService ObjectService calls bypass multitenancy (`_multitenancy: false`) | MUST | Bug |
 | CONS-046 | ConsentController::show() bypasses RBAC when querying directly | MUST | Bug |
 
-### REQ-CONS-07: Consent Creation API Gap (Priority: Must)
+### Requirement: Consent Creation API Gap
+
+**ID:** REQ-CONS-07
+**Priority:** Must
 
 ConsentService::createConsentRequest() exists but has no REST API endpoint or automated trigger, making consent records impossible to create via the frontend.
 
@@ -229,7 +250,10 @@ ConsentService::createConsentRequest() exists but has no REST API endpoint or au
 | CONS-049 | The event listener does NOT trigger consent creation | MUST | Implemented |
 | CONS-050 | Consent records cannot currently be created via REST API or UI | MUST | Bug |
 
-### REQ-CONS-08: Objection Period Configuration Reading (Priority: Must)
+### Requirement: Objection Period Configuration Reading
+
+**ID:** REQ-CONS-08
+**Priority:** Must
 
 ConsentService reads the objection period directly from IAppConfig, bypassing SettingsService.
 
@@ -255,7 +279,10 @@ ConsentService reads the objection period directly from IAppConfig, bypassing Se
 | CONS-051 | ConsentService reads objection period directly from IAppConfig | MUST | Implemented |
 | CONS-052 | Default objection period is 28 days (hardcoded in getValueString default) | MUST | Implemented |
 
-### REQ-CONS-09: Duplicated ObjectService Resolution Pattern (Priority: Must)
+### Requirement: Duplicated ObjectService Resolution Pattern
+
+**ID:** REQ-CONS-09
+**Priority:** Must
 
 ConsentService and ObjectionDeadlineChecker have their own private getObjectService() methods duplicating the pattern found in SettingsService.
 
@@ -281,7 +308,10 @@ ConsentService and ObjectionDeadlineChecker have their own private getObjectServ
 | CONS-053 | ConsentService has its own private `getObjectService()` duplicating SettingsService pattern | MUST | Implemented |
 | CONS-054 | ObjectionDeadlineChecker has its own private `getObjectService()` with the same pattern | MUST | Implemented |
 
-### REQ-CONS-10: Consent UI (Priority: Must)
+### Requirement: Consent UI
+
+**ID:** REQ-CONS-10
+**Priority:** Must
 
 The consent management UI provides a list view with statistics and a detail view for editing consent records.
 

--- a/openspec/specs/consent-management/spec.md
+++ b/openspec/specs/consent-management/spec.md
@@ -10,9 +10,8 @@ Provides GDPR-compliant publication consent tracking for entities (persons and o
 
 ## Requirements
 
-### Requirement: Consent Record Creation
+### Requirement: Consent Record Creation (REQ-CONS-01)
 
-**ID:** REQ-CONS-01
 **Priority:** Must
 
 Consent records are created for detected entities in documents, initialized with pending status and an automatic objection deadline.
@@ -47,9 +46,8 @@ Consent records are created for detected entities in documents, initialized with
 | CONS-005 | An objection deadline is automatically calculated based on the configurable objection period (default 28 days) | MUST | Implemented |
 | CONS-006 | Consent records are stored in OpenRegister via ObjectService using the configured register and schema | MUST | Implemented |
 
-### Requirement: Consent Status Lifecycle
+### Requirement: Consent Status Lifecycle (REQ-CONS-02)
 
-**ID:** REQ-CONS-02
 **Priority:** Must
 
 Consent records progress through defined status transitions for consent, notification, and publication decision fields.
@@ -88,9 +86,8 @@ Consent records progress through defined status transitions for consent, notific
 | CONS-013 | Consent status can be updated via `PUT /api/consents/{id}` | MUST | Implemented |
 | CONS-014 | Objection deadline expiry can be checked via ConsentService::checkObjectionDeadline() | MUST | Implemented |
 
-### Requirement: Consent Listing and Querying
+### Requirement: Consent Listing and Querying (REQ-CONS-03)
 
-**ID:** REQ-CONS-03
 **Priority:** Must
 
 Consent records can be listed, queried by ID, and filtered by document.
@@ -124,9 +121,8 @@ Consent records can be listed, queried by ID, and filtered by document.
 | CONS-023 | Consent listing requires the publicationConsent register and schema to be configured | MUST | Implemented |
 | CONS-024 | If register/schema is not configured, a 400 error is returned | MUST | Implemented |
 
-### Requirement: WOO Objection Period Compliance
+### Requirement: WOO Objection Period Compliance (REQ-CONS-04)
 
-**ID:** REQ-CONS-04
 **Priority:** Must
 
 The objection period complies with Wet Open Overheid requirements for a minimum 4-week notification period before publication.
@@ -155,9 +151,8 @@ The objection period complies with Wet Open Overheid requirements for a minimum 
 | CONS-031 | The objection period is configurable via admin settings | MUST | Implemented |
 | CONS-032 | The objection deadline is stored as ISO 8601 datetime | MUST | Implemented |
 
-### Requirement: Controller Read Path Architecture
+### Requirement: Controller Read Path Architecture (REQ-CONS-05)
 
-**ID:** REQ-CONS-05
 **Priority:** Must
 
 ConsentController uses different service paths for read vs. write operations -- reading directly via ObjectService, writing via ConsentService.
@@ -187,9 +182,8 @@ ConsentController uses different service paths for read vs. write operations -- 
 | CONS-042 | `ConsentController::update()` delegates to ConsentService | MUST | Implemented |
 | CONS-043 | `ConsentController::byDocument()` delegates to ConsentService | MUST | Implemented |
 
-### Requirement: RBAC and Multitenancy Configuration
+### Requirement: RBAC and Multitenancy Configuration (REQ-CONS-06)
 
-**ID:** REQ-CONS-06
 **Priority:** Must
 
 All consent ObjectService calls currently bypass RBAC and multitenancy, which is a known security concern for multi-tenant deployments.
@@ -218,9 +212,8 @@ All consent ObjectService calls currently bypass RBAC and multitenancy, which is
 | CONS-045 | All ConsentService ObjectService calls bypass multitenancy (`_multitenancy: false`) | MUST | Bug |
 | CONS-046 | ConsentController::show() bypasses RBAC when querying directly | MUST | Bug |
 
-### Requirement: Consent Creation API Gap
+### Requirement: Consent Creation API Gap (REQ-CONS-07)
 
-**ID:** REQ-CONS-07
 **Priority:** Must
 
 ConsentService::createConsentRequest() exists but has no REST API endpoint or automated trigger, making consent records impossible to create via the frontend.
@@ -250,9 +243,8 @@ ConsentService::createConsentRequest() exists but has no REST API endpoint or au
 | CONS-049 | The event listener does NOT trigger consent creation | MUST | Implemented |
 | CONS-050 | Consent records cannot currently be created via REST API or UI | MUST | Bug |
 
-### Requirement: Objection Period Configuration Reading
+### Requirement: Objection Period Configuration Reading (REQ-CONS-08)
 
-**ID:** REQ-CONS-08
 **Priority:** Must
 
 ConsentService reads the objection period directly from IAppConfig, bypassing SettingsService.
@@ -279,9 +271,8 @@ ConsentService reads the objection period directly from IAppConfig, bypassing Se
 | CONS-051 | ConsentService reads objection period directly from IAppConfig | MUST | Implemented |
 | CONS-052 | Default objection period is 28 days (hardcoded in getValueString default) | MUST | Implemented |
 
-### Requirement: Duplicated ObjectService Resolution Pattern
+### Requirement: Duplicated ObjectService Resolution Pattern (REQ-CONS-09)
 
-**ID:** REQ-CONS-09
 **Priority:** Must
 
 ConsentService and ObjectionDeadlineChecker have their own private getObjectService() methods duplicating the pattern found in SettingsService.
@@ -308,9 +299,8 @@ ConsentService and ObjectionDeadlineChecker have their own private getObjectServ
 | CONS-053 | ConsentService has its own private `getObjectService()` duplicating SettingsService pattern | MUST | Implemented |
 | CONS-054 | ObjectionDeadlineChecker has its own private `getObjectService()` with the same pattern | MUST | Implemented |
 
-### Requirement: Consent UI
+### Requirement: Consent UI (REQ-CONS-10)
 
-**ID:** REQ-CONS-10
 **Priority:** Must
 
 The consent management UI provides a list view with statistics and a detail view for editing consent records.

--- a/openspec/specs/dashboard/spec.md
+++ b/openspec/specs/dashboard/spec.md
@@ -10,7 +10,10 @@ Provides a central overview of DocuDesk activity, including consent tracking sta
 
 ## Requirements
 
-### REQ-DASH-01: DocuDesk Dashboard View (Priority: Must)
+### Requirement: DocuDesk Dashboard View
+
+**ID:** REQ-DASH-01
+**Priority:** Must
 
 The dashboard serves as the default landing page displaying consent statistics, recent activity, and quick anonymization access.
 
@@ -51,7 +54,10 @@ The dashboard serves as the default landing page displaying consent statistics, 
 | DASH-007 | Show empty state when no consent records exist | MUST | Implemented |
 | DASH-008 | Dashboard is the default landing page for the DocuDesk app | MUST | Implemented |
 
-### REQ-DASH-02: Nextcloud Dashboard Widgets (Priority: Must)
+### Requirement: Nextcloud Dashboard Widgets
+
+**ID:** REQ-DASH-02
+**Priority:** Must
 
 DocuDesk registers two widgets on the main Nextcloud Dashboard for at-a-glance document processing information.
 
@@ -83,7 +89,10 @@ DocuDesk registers two widgets on the main Nextcloud Dashboard for at-a-glance d
 | DASH-016 | Both widgets load the `docudesk-dashboard` script bundle | MUST | Implemented |
 | DASH-017 | Widgets registered in Application::register() via registerDashboardWidget() | MUST | Implemented |
 
-### REQ-DASH-03: Navigation Menu (Priority: Must)
+### Requirement: Navigation Menu
+
+**ID:** REQ-DASH-03
+**Priority:** Must
 
 The main navigation provides three items with Material Design icons for switching between DocuDesk views.
 
@@ -122,7 +131,10 @@ The main navigation provides three items with Material Design icons for switchin
 | DASH-024 | Active navigation item is visually highlighted | MUST | Implemented |
 | DASH-025 | Consent Management item active for both list and detail views | MUST | Implemented |
 
-### REQ-DASH-04: Dashboard Controller (Priority: Must)
+### Requirement: Dashboard Controller
+
+**ID:** REQ-DASH-04
+**Priority:** Must
 
 The DashboardController serves the main app page as a Nextcloud TemplateResponse.
 
@@ -150,7 +162,10 @@ The DashboardController serves the main app page as a Nextcloud TemplateResponse
 | DASH-031 | Default Nextcloud CSP applies (no custom CSP) | MUST | Implemented |
 | DASH-032 | Error handling returns an error template on failure | MUST | Implemented |
 
-### REQ-DASH-05: Status Badge Display (Priority: Must)
+### Requirement: Status Badge Display
+
+**ID:** REQ-DASH-05
+**Priority:** Must
 
 Consent status values are displayed with consistent color-coded badges throughout the dashboard and consent views.
 
@@ -174,7 +189,10 @@ Consent status values are displayed with consistent color-coded badges throughou
 | DASH-040 | Status badges use consistent color mapping across all views | MUST | Implemented |
 | DASH-041 | Five status values mapped: pending, consent_given, objection_received, no_response, anonymized | MUST | Implemented |
 
-### REQ-DASH-06: Icon File Differentiation (Priority: Must)
+### Requirement: Icon File Differentiation
+
+**ID:** REQ-DASH-06
+**Priority:** Must
 
 DocuDesk uses different icon files for navigation vs. dashboard widgets, following Nextcloud conventions.
 
@@ -200,7 +218,10 @@ DocuDesk uses different icon files for navigation vs. dashboard widgets, followi
 | DASH-044 | Dashboard widgets use `app-dark.svg` icon | MUST | Implemented |
 | DASH-045 | Two icon files serve different contexts (navigation vs widget/settings) | MUST | Implemented |
 
-### REQ-DASH-07: Dead Code and Removed Features (Priority: Must)
+### Requirement: Dead Code and Removed Features
+
+**ID:** REQ-DASH-07
+**Priority:** Must
 
 Previously identified issues have been resolved through removal.
 

--- a/openspec/specs/dashboard/spec.md
+++ b/openspec/specs/dashboard/spec.md
@@ -10,9 +10,8 @@ Provides a central overview of DocuDesk activity, including consent tracking sta
 
 ## Requirements
 
-### Requirement: DocuDesk Dashboard View
+### Requirement: DocuDesk Dashboard View (REQ-DASH-01)
 
-**ID:** REQ-DASH-01
 **Priority:** Must
 
 The dashboard serves as the default landing page displaying consent statistics, recent activity, and quick anonymization access.
@@ -54,9 +53,8 @@ The dashboard serves as the default landing page displaying consent statistics, 
 | DASH-007 | Show empty state when no consent records exist | MUST | Implemented |
 | DASH-008 | Dashboard is the default landing page for the DocuDesk app | MUST | Implemented |
 
-### Requirement: Nextcloud Dashboard Widgets
+### Requirement: Nextcloud Dashboard Widgets (REQ-DASH-02)
 
-**ID:** REQ-DASH-02
 **Priority:** Must
 
 DocuDesk registers two widgets on the main Nextcloud Dashboard for at-a-glance document processing information.
@@ -89,9 +87,8 @@ DocuDesk registers two widgets on the main Nextcloud Dashboard for at-a-glance d
 | DASH-016 | Both widgets load the `docudesk-dashboard` script bundle | MUST | Implemented |
 | DASH-017 | Widgets registered in Application::register() via registerDashboardWidget() | MUST | Implemented |
 
-### Requirement: Navigation Menu
+### Requirement: Navigation Menu (REQ-DASH-03)
 
-**ID:** REQ-DASH-03
 **Priority:** Must
 
 The main navigation provides three items with Material Design icons for switching between DocuDesk views.
@@ -131,9 +128,8 @@ The main navigation provides three items with Material Design icons for switchin
 | DASH-024 | Active navigation item is visually highlighted | MUST | Implemented |
 | DASH-025 | Consent Management item active for both list and detail views | MUST | Implemented |
 
-### Requirement: Dashboard Controller
+### Requirement: Dashboard Controller (REQ-DASH-04)
 
-**ID:** REQ-DASH-04
 **Priority:** Must
 
 The DashboardController serves the main app page as a Nextcloud TemplateResponse.
@@ -162,9 +158,8 @@ The DashboardController serves the main app page as a Nextcloud TemplateResponse
 | DASH-031 | Default Nextcloud CSP applies (no custom CSP) | MUST | Implemented |
 | DASH-032 | Error handling returns an error template on failure | MUST | Implemented |
 
-### Requirement: Status Badge Display
+### Requirement: Status Badge Display (REQ-DASH-05)
 
-**ID:** REQ-DASH-05
 **Priority:** Must
 
 Consent status values are displayed with consistent color-coded badges throughout the dashboard and consent views.
@@ -189,9 +184,8 @@ Consent status values are displayed with consistent color-coded badges throughou
 | DASH-040 | Status badges use consistent color mapping across all views | MUST | Implemented |
 | DASH-041 | Five status values mapped: pending, consent_given, objection_received, no_response, anonymized | MUST | Implemented |
 
-### Requirement: Icon File Differentiation
+### Requirement: Icon File Differentiation (REQ-DASH-06)
 
-**ID:** REQ-DASH-06
 **Priority:** Must
 
 DocuDesk uses different icon files for navigation vs. dashboard widgets, following Nextcloud conventions.
@@ -218,9 +212,8 @@ DocuDesk uses different icon files for navigation vs. dashboard widgets, followi
 | DASH-044 | Dashboard widgets use `app-dark.svg` icon | MUST | Implemented |
 | DASH-045 | Two icon files serve different contexts (navigation vs widget/settings) | MUST | Implemented |
 
-### Requirement: Dead Code and Removed Features
+### Requirement: Dead Code and Removed Features (REQ-DASH-07)
 
-**ID:** REQ-DASH-07
 **Priority:** Must
 
 Previously identified issues have been resolved through removal.

--- a/openspec/specs/document-register/spec.md
+++ b/openspec/specs/document-register/spec.md
@@ -10,7 +10,10 @@ Defines the data model for the `document` register used by DocuDesk to store doc
 
 ## Requirements
 
-### REQ-DREG-01: Document Register Structure (Priority: Must)
+### Requirement: Document Register Structure
+
+**ID:** REQ-DREG-01
+**Priority:** Must
 
 A dedicated document register exists with three schemas for storing analysis results, templates, and entity tracking.
 
@@ -42,7 +45,10 @@ A dedicated document register exists with three schemas for storing analysis res
 | DREG-004 | The JSON follows OpenAPI-like structure with components | MUST | Implemented |
 | DREG-005 | The register is separate from docudesk_register.json | MUST | Implemented |
 
-### REQ-DREG-02: Report Schema for Analysis Results (Priority: Must)
+### Requirement: Report Schema for Analysis Results
+
+**ID:** REQ-DREG-02
+**Priority:** Must
 
 The report schema stores document analysis results including file metadata, entity detection, risk assessment, and processing status.
 
@@ -90,7 +96,10 @@ The report schema stores document analysis results including file metadata, enti
 | DREG-017 | Report objects store file integrity hash (MD5) | MUST | Implemented |
 | DREG-018 | Report objects have anonymizationResults field (reserved) | MUST | Implemented |
 
-### REQ-DREG-03: Planned Report Features (Priority: Should)
+### Requirement: Planned Report Features
+
+**ID:** REQ-DREG-03
+**Priority:** Should
 
 Report objects include placeholder fields for future features: WCAG compliance, language level analysis, retention policy, and GDPR data controller tracking.
 
@@ -122,7 +131,10 @@ Report objects include placeholder fields for future features: WCAG compliance, 
 | DREG-023 | dataController for GDPR data controller assignment | SHOULD | Planned |
 | DREG-024 | Report schema has `hardValidation: false` for flexible usage | MUST | Implemented |
 
-### REQ-DREG-04: Template Schema (Priority: Must)
+### Requirement: Template Schema
+
+**ID:** REQ-DREG-04
+**Priority:** Must
 
 The template schema provides a placeholder for storing document templates within the document register.
 
@@ -146,7 +158,10 @@ The template schema provides a placeholder for storing document templates within
 | DREG-032 | Template schema has `hardValidation: false` | MUST | Implemented |
 | DREG-033 | Template objects intended for document template storage (TBD) | SHOULD | Planned |
 
-### REQ-DREG-05: Entity Schema for Cross-Document Tracking (Priority: Must)
+### Requirement: Entity Schema for Cross-Document Tracking
+
+**ID:** REQ-DREG-05
+**Priority:** Must
 
 The entity schema enables tracking detected entities across multiple documents for consistent entity management.
 
@@ -175,7 +190,10 @@ The entity schema enables tracking detected entities across multiple documents f
 | DREG-043 | Entity schema has no defined properties yet | MUST | Implemented |
 | DREG-044 | Entity schema has `hardValidation: false` | MUST | Implemented |
 
-### REQ-DREG-06: Pre-Seeded Sample Objects (Priority: Must)
+### Requirement: Pre-Seeded Sample Objects
+
+**ID:** REQ-DREG-06
+**Priority:** Must
 
 Three pre-seeded sample objects demonstrate the anonymization pipeline's output format.
 
@@ -207,7 +225,10 @@ Three pre-seeded sample objects demonstrate the anonymization pipeline's output 
 | DREG-051 | Anonymization result sample with replacement mappings | MUST | Implemented |
 | DREG-052 | Anonymized document re-analysis sample showing token detection limitation | MUST | Implemented |
 
-### REQ-DREG-07: Register Loading Gap (Priority: Must)
+### Requirement: Register Loading Gap
+
+**ID:** REQ-DREG-07
+**Priority:** Must
 
 The document_register.json is NOT loaded during application boot, which is a critical gap.
 

--- a/openspec/specs/document-register/spec.md
+++ b/openspec/specs/document-register/spec.md
@@ -10,9 +10,8 @@ Defines the data model for the `document` register used by DocuDesk to store doc
 
 ## Requirements
 
-### Requirement: Document Register Structure
+### Requirement: Document Register Structure (REQ-DREG-01)
 
-**ID:** REQ-DREG-01
 **Priority:** Must
 
 A dedicated document register exists with three schemas for storing analysis results, templates, and entity tracking.
@@ -45,9 +44,8 @@ A dedicated document register exists with three schemas for storing analysis res
 | DREG-004 | The JSON follows OpenAPI-like structure with components | MUST | Implemented |
 | DREG-005 | The register is separate from docudesk_register.json | MUST | Implemented |
 
-### Requirement: Report Schema for Analysis Results
+### Requirement: Report Schema for Analysis Results (REQ-DREG-02)
 
-**ID:** REQ-DREG-02
 **Priority:** Must
 
 The report schema stores document analysis results including file metadata, entity detection, risk assessment, and processing status.
@@ -96,9 +94,8 @@ The report schema stores document analysis results including file metadata, enti
 | DREG-017 | Report objects store file integrity hash (MD5) | MUST | Implemented |
 | DREG-018 | Report objects have anonymizationResults field (reserved) | MUST | Implemented |
 
-### Requirement: Planned Report Features
+### Requirement: Planned Report Features (REQ-DREG-03)
 
-**ID:** REQ-DREG-03
 **Priority:** Should
 
 Report objects include placeholder fields for future features: WCAG compliance, language level analysis, retention policy, and GDPR data controller tracking.
@@ -131,9 +128,8 @@ Report objects include placeholder fields for future features: WCAG compliance, 
 | DREG-023 | dataController for GDPR data controller assignment | SHOULD | Planned |
 | DREG-024 | Report schema has `hardValidation: false` for flexible usage | MUST | Implemented |
 
-### Requirement: Template Schema
+### Requirement: Template Schema (REQ-DREG-04)
 
-**ID:** REQ-DREG-04
 **Priority:** Must
 
 The template schema provides a placeholder for storing document templates within the document register.
@@ -158,9 +154,8 @@ The template schema provides a placeholder for storing document templates within
 | DREG-032 | Template schema has `hardValidation: false` | MUST | Implemented |
 | DREG-033 | Template objects intended for document template storage (TBD) | SHOULD | Planned |
 
-### Requirement: Entity Schema for Cross-Document Tracking
+### Requirement: Entity Schema for Cross-Document Tracking (REQ-DREG-05)
 
-**ID:** REQ-DREG-05
 **Priority:** Must
 
 The entity schema enables tracking detected entities across multiple documents for consistent entity management.
@@ -190,9 +185,8 @@ The entity schema enables tracking detected entities across multiple documents f
 | DREG-043 | Entity schema has no defined properties yet | MUST | Implemented |
 | DREG-044 | Entity schema has `hardValidation: false` | MUST | Implemented |
 
-### Requirement: Pre-Seeded Sample Objects
+### Requirement: Pre-Seeded Sample Objects (REQ-DREG-06)
 
-**ID:** REQ-DREG-06
 **Priority:** Must
 
 Three pre-seeded sample objects demonstrate the anonymization pipeline's output format.
@@ -225,9 +219,8 @@ Three pre-seeded sample objects demonstrate the anonymization pipeline's output 
 | DREG-051 | Anonymization result sample with replacement mappings | MUST | Implemented |
 | DREG-052 | Anonymized document re-analysis sample showing token detection limitation | MUST | Implemented |
 
-### Requirement: Register Loading Gap
+### Requirement: Register Loading Gap (REQ-DREG-07)
 
-**ID:** REQ-DREG-07
 **Priority:** Must
 
 The document_register.json is NOT loaded during application boot, which is a critical gap.

--- a/openspec/specs/letter-correspondence-generation/spec.md
+++ b/openspec/specs/letter-correspondence-generation/spec.md
@@ -10,7 +10,7 @@ Provides a dedicated correspondence generation workflow for government users to 
 
 ## Requirements
 
-### Correspondence generation API
+### Requirement: Correspondence generation API
 
 The system SHALL provide a dedicated `CorrespondenceService` at `OCA\DocuDesk\Service\CorrespondenceService` that orchestrates the end-to-end correspondence generation workflow: resolve recipient data from OpenRegister objects, merge into a template, apply huisstijl defaults (margins, header, footer, logo), and produce the output document. The service SHALL delegate template lookup to `TemplateService`, data resolution to `DataResolverService`, template rendering to `TemplateRenderer`, and PDF output to `PdfService`.
 
@@ -31,7 +31,7 @@ The system SHALL provide a dedicated `CorrespondenceService` at `OCA\DocuDesk\Se
 - **THEN** the response includes a `warnings` array with an entry describing the missing field
 - **AND** the document is still generated with the field rendered as empty
 
-### Correspondence REST endpoint
+### Requirement: Correspondence REST endpoint
 
 The system SHALL expose `POST /api/correspondence/generate` as an authenticated endpoint (`@NoAdminRequired @NoCSRFRequired`). The endpoint SHALL accept a JSON body with `templateId` (string, required), `dataRefs` (array of object references, required), `options` (object, optional), and `filename` (string, optional, default "correspondence.pdf"). The endpoint SHALL return a `DataDownloadResponse` with the generated document binary.
 
@@ -44,7 +44,7 @@ The system SHALL expose `POST /api/correspondence/generate` as an authenticated 
 - **WHEN** `POST /api/correspondence/generate` is called without a `templateId` field
 - **THEN** a 400 JSON response is returned with message "templateId is required"
 
-### Batch correspondence generation
+### Requirement: Batch correspondence generation
 
 The system SHALL provide `CorrespondenceService::generateBatch(string $templateId, array $recipientIds, array $options): array` that generates one letter per recipient. For batches of 10 or fewer, generation SHALL be synchronous and return an array of results. For batches larger than 10, generation SHALL be dispatched as a Nextcloud background job and return a job ID. Each recipient failure SHALL NOT abort the batch; partial results with per-recipient error details SHALL be returned.
 
@@ -64,7 +64,7 @@ The system SHALL provide `CorrespondenceService::generateBatch(string $templateI
 - **THEN** recipients 1, 2, 4-10 receive successfully generated letters
 - **AND** recipient 3 has `status: "error"` with a descriptive error message
 
-### Batch correspondence REST endpoints
+### Requirement: Batch correspondence REST endpoints
 
 The system SHALL expose `POST /api/correspondence/generate/batch` for batch generation and `GET /api/correspondence/jobs/{jobId}` for job status queries. Both endpoints SHALL require authentication (`@NoAdminRequired @NoCSRFRequired`).
 
@@ -76,7 +76,7 @@ The system SHALL expose `POST /api/correspondence/generate/batch` for batch gene
 - **WHEN** `GET /api/correspondence/jobs/{jobId}` is called for an in-progress job
 - **THEN** a 200 JSON response is returned with `{"jobId": "<uuid>", "status": "processing", "completed": 25, "total": 50, "errors": []}`
 
-### Output format selection
+### Requirement: Output format selection
 
 The system SHALL support multiple output formats for correspondence: PDF (default), DOCX (via LibreOffice server-side conversion), HTML (for preview), and email (clean HTML). The format SHALL be selectable per request via the `options.format` field accepting values `pdf`, `docx`, `html`, or `email`.
 
@@ -93,7 +93,7 @@ The system SHALL support multiple output formats for correspondence: PDF (defaul
 - **WHEN** `generate()` is called with `options.format = "html"`
 - **THEN** the rendered HTML string is returned directly without PDF conversion
 
-### Huisstijl default configuration
+### Requirement: Huisstijl default configuration
 
 The system SHALL support a huisstijl configuration object stored in OpenRegister (schema: `huisstijl`, register: `document`) containing `logo` (base64 or file reference), `primaryColor` (CSS color), `headerHtml` (Twig template for page header), `footerHtml` (Twig template for page footer), and `defaultMargins` (object with top/right/bottom/left in mm). When generating correspondence, if the template references a huisstijl ID or a default huisstijl is configured, these settings SHALL be applied automatically to the output.
 
@@ -108,7 +108,7 @@ The system SHALL support a huisstijl configuration object stored in OpenRegister
 - **THEN** the letter is generated with default PdfService margins (15mm all sides)
 - **AND** no header/footer is applied
 
-### Correspondence register logging
+### Requirement: Correspondence register logging
 
 The system SHALL log every generated correspondence as an object in the document register (schema: `correspondence`, register: `document`). Each entry SHALL contain: `templateId` (UUID of template used), `templateName` (human-readable), `recipientId` (UUID of recipient object), `recipientType` (e.g., PERSON, ORGANIZATION), `caseReference` (optional UUID linking to source zaak/case), `generatedAt` (ISO 8601 datetime), `format` (pdf/docx/html), `status` (generated/failed), and `generatedBy` (Nextcloud user ID). The schema SHALL be added to `docudesk_register.json`.
 
@@ -124,7 +124,7 @@ The system SHALL log every generated correspondence as an object in the document
 - **AND** `status` is set to "failed"
 - **AND** an `errorMessage` field contains the failure reason
 
-### Email body generation
+### Requirement: Email body generation
 
 The system SHALL support generating email body content from templates using the same merge logic as letter generation. When `options.format = "email"`, the system SHALL return rendered HTML suitable for email body inclusion (no PDF wrapper, no page-specific styling). Email templates SHALL use the namespace `email` in the template management system.
 

--- a/openspec/specs/metadata-enrichment/spec.md
+++ b/openspec/specs/metadata-enrichment/spec.md
@@ -10,9 +10,8 @@ Provides automatic metadata enrichment for documents stored in OpenRegister. Whe
 
 ## Requirements
 
-### Requirement: Language Detection
+### Requirement: Language Detection (REQ-META-01)
 
-**ID:** REQ-META-01
 **Priority:** Must
 
 Detect document language from text content using word frequency analysis for Dutch and English.
@@ -56,9 +55,8 @@ Detect document language from text content using word frequency analysis for Dut
 | META-006 | Skip detection if object already has `language` populated | MUST | Implemented |
 | META-007 | Toggle via admin settings (`enable_language_detection`) | MUST | Implemented |
 
-### Requirement: Keyword Extraction
+### Requirement: Keyword Extraction (REQ-META-02)
 
-**ID:** REQ-META-02
 **Priority:** Must
 
 Extract top keywords from document text using word frequency analysis with stop word filtering.
@@ -94,9 +92,8 @@ Extract top keywords from document text using word frequency analysis with stop 
 | META-014 | Skip if `keywords` already populated | MUST | Implemented |
 | META-015 | Toggle via admin settings (`enable_keyword_extraction`) | MUST | Implemented |
 
-### Requirement: Topic Classification
+### Requirement: Topic Classification (REQ-META-03)
 
-**ID:** REQ-META-03
 **Priority:** Must
 
 Classify documents into topic categories using keyword matching against predefined vocabularies.
@@ -131,9 +128,8 @@ Classify documents into topic categories using keyword matching against predefin
 | META-025 | Skip if `topic` already populated | MUST | Implemented |
 | META-026 | Toggle via admin settings (`enable_topic_classification`) | MUST | Implemented |
 
-### Requirement: Document Type Standardization
+### Requirement: Document Type Standardization (REQ-META-04)
 
-**ID:** REQ-META-04
 **Priority:** Must
 
 Standardize document type strings to canonical categories by mapping file extensions and names.
@@ -160,9 +156,8 @@ Standardize document type strings to canonical categories by mapping file extens
 | META-032 | Map extensions: doc/docx -> word, xls/xlsx -> spreadsheet, ppt/pptx -> presentation | MUST | Implemented |
 | META-033 | Unknown types passed through unchanged | MUST | Implemented |
 
-### Requirement: Date Normalization
+### Requirement: Date Normalization (REQ-META-05)
 
-**ID:** REQ-META-05
 **Priority:** Must
 
 Normalize date fields to ISO 8601 format across standard field names.
@@ -189,9 +184,8 @@ Normalize date fields to ISO 8601 format across standard field names.
 | META-041 | Normalize: created, modified, date, creationDate, modificationDate | MUST | Implemented |
 | META-042 | Skip unparseable dates gracefully (log debug, no throw) | MUST | Implemented |
 
-### Requirement: Event-Driven Enrichment
+### Requirement: Event-Driven Enrichment (REQ-META-06)
 
-**ID:** REQ-META-06
 **Priority:** Must
 
 Automatically enrich metadata when objects are created or updated in OpenRegister, with content change detection on updates.
@@ -239,9 +233,8 @@ Automatically enrich metadata when objects are created or updated in OpenRegiste
 | META-055 | Check admin settings before running enrichment | MUST | Implemented |
 | META-056 | Save enriched metadata back to OpenRegister | MUST | Implemented |
 
-### Requirement: API On-Demand Enrichment
+### Requirement: API On-Demand Enrichment (REQ-META-07)
 
-**ID:** REQ-META-07
 **Priority:** Must
 
 On-demand metadata enrichment via REST API for specific objects.
@@ -272,9 +265,8 @@ On-demand metadata enrichment via REST API for specific objects.
 | META-063 | Returns enriched fields list and updated object data | MUST | Implemented |
 | META-064 | Returns success if no enrichment needed | MUST | Implemented |
 
-### Requirement: Duplicated ObjectService Resolution
+### Requirement: Duplicated ObjectService Resolution (REQ-META-08)
 
-**ID:** REQ-META-08
 **Priority:** Must
 
 MetadataService has its own private getObjectService() duplicating the pattern found in other services.
@@ -296,9 +288,8 @@ MetadataService has its own private getObjectService() duplicating the pattern f
 | META-070 | MetadataService has private `getObjectService()` duplicating SettingsService | MUST | Implemented |
 | META-071 | Same `getInstalledApps()` + `container->get()` pattern used | MUST | Implemented |
 
-### Requirement: Event Listener Service Resolution
+### Requirement: Event Listener Service Resolution (REQ-META-09)
 
-**ID:** REQ-META-09
 **Priority:** Must
 
 The event listener resolves services via `\OC::$server->get()` at handle time rather than constructor DI to avoid circular dependencies.
@@ -333,9 +324,8 @@ The event listener resolves services via `\OC::$server->get()` at handle time ra
 | META-078 | Enrichment failures are non-fatal | MUST | Implemented |
 | META-079 | Nested try/catch re-resolves logger for error scope safety | MUST | Implemented |
 
-### Requirement: Text Content Extraction from Object Data
+### Requirement: Text Content Extraction from Object Data (REQ-META-10)
 
-**ID:** REQ-META-10
 **Priority:** Must
 
 MetadataService extracts text content from object data fields in a defined priority order for analysis.

--- a/openspec/specs/metadata-enrichment/spec.md
+++ b/openspec/specs/metadata-enrichment/spec.md
@@ -10,7 +10,10 @@ Provides automatic metadata enrichment for documents stored in OpenRegister. Whe
 
 ## Requirements
 
-### REQ-META-01: Language Detection (Priority: Must)
+### Requirement: Language Detection
+
+**ID:** REQ-META-01
+**Priority:** Must
 
 Detect document language from text content using word frequency analysis for Dutch and English.
 
@@ -53,7 +56,10 @@ Detect document language from text content using word frequency analysis for Dut
 | META-006 | Skip detection if object already has `language` populated | MUST | Implemented |
 | META-007 | Toggle via admin settings (`enable_language_detection`) | MUST | Implemented |
 
-### REQ-META-02: Keyword Extraction (Priority: Must)
+### Requirement: Keyword Extraction
+
+**ID:** REQ-META-02
+**Priority:** Must
 
 Extract top keywords from document text using word frequency analysis with stop word filtering.
 
@@ -88,7 +94,10 @@ Extract top keywords from document text using word frequency analysis with stop 
 | META-014 | Skip if `keywords` already populated | MUST | Implemented |
 | META-015 | Toggle via admin settings (`enable_keyword_extraction`) | MUST | Implemented |
 
-### REQ-META-03: Topic Classification (Priority: Must)
+### Requirement: Topic Classification
+
+**ID:** REQ-META-03
+**Priority:** Must
 
 Classify documents into topic categories using keyword matching against predefined vocabularies.
 
@@ -122,7 +131,10 @@ Classify documents into topic categories using keyword matching against predefin
 | META-025 | Skip if `topic` already populated | MUST | Implemented |
 | META-026 | Toggle via admin settings (`enable_topic_classification`) | MUST | Implemented |
 
-### REQ-META-04: Document Type Standardization (Priority: Must)
+### Requirement: Document Type Standardization
+
+**ID:** REQ-META-04
+**Priority:** Must
 
 Standardize document type strings to canonical categories by mapping file extensions and names.
 
@@ -148,7 +160,10 @@ Standardize document type strings to canonical categories by mapping file extens
 | META-032 | Map extensions: doc/docx -> word, xls/xlsx -> spreadsheet, ppt/pptx -> presentation | MUST | Implemented |
 | META-033 | Unknown types passed through unchanged | MUST | Implemented |
 
-### REQ-META-05: Date Normalization (Priority: Must)
+### Requirement: Date Normalization
+
+**ID:** REQ-META-05
+**Priority:** Must
 
 Normalize date fields to ISO 8601 format across standard field names.
 
@@ -174,7 +189,10 @@ Normalize date fields to ISO 8601 format across standard field names.
 | META-041 | Normalize: created, modified, date, creationDate, modificationDate | MUST | Implemented |
 | META-042 | Skip unparseable dates gracefully (log debug, no throw) | MUST | Implemented |
 
-### REQ-META-06: Event-Driven Enrichment (Priority: Must)
+### Requirement: Event-Driven Enrichment
+
+**ID:** REQ-META-06
+**Priority:** Must
 
 Automatically enrich metadata when objects are created or updated in OpenRegister, with content change detection on updates.
 
@@ -221,7 +239,10 @@ Automatically enrich metadata when objects are created or updated in OpenRegiste
 | META-055 | Check admin settings before running enrichment | MUST | Implemented |
 | META-056 | Save enriched metadata back to OpenRegister | MUST | Implemented |
 
-### REQ-META-07: API On-Demand Enrichment (Priority: Must)
+### Requirement: API On-Demand Enrichment
+
+**ID:** REQ-META-07
+**Priority:** Must
 
 On-demand metadata enrichment via REST API for specific objects.
 
@@ -251,7 +272,10 @@ On-demand metadata enrichment via REST API for specific objects.
 | META-063 | Returns enriched fields list and updated object data | MUST | Implemented |
 | META-064 | Returns success if no enrichment needed | MUST | Implemented |
 
-### REQ-META-08: Duplicated ObjectService Resolution (Priority: Must)
+### Requirement: Duplicated ObjectService Resolution
+
+**ID:** REQ-META-08
+**Priority:** Must
 
 MetadataService has its own private getObjectService() duplicating the pattern found in other services.
 
@@ -272,7 +296,10 @@ MetadataService has its own private getObjectService() duplicating the pattern f
 | META-070 | MetadataService has private `getObjectService()` duplicating SettingsService | MUST | Implemented |
 | META-071 | Same `getInstalledApps()` + `container->get()` pattern used | MUST | Implemented |
 
-### REQ-META-09: Event Listener Service Resolution (Priority: Must)
+### Requirement: Event Listener Service Resolution
+
+**ID:** REQ-META-09
+**Priority:** Must
 
 The event listener resolves services via `\OC::$server->get()` at handle time rather than constructor DI to avoid circular dependencies.
 
@@ -306,7 +333,10 @@ The event listener resolves services via `\OC::$server->get()` at handle time ra
 | META-078 | Enrichment failures are non-fatal | MUST | Implemented |
 | META-079 | Nested try/catch re-resolves logger for error scope safety | MUST | Implemented |
 
-### REQ-META-10: Text Content Extraction from Object Data (Priority: Must)
+### Requirement: Text Content Extraction from Object Data
+
+**ID:** REQ-META-10
+**Priority:** Must
 
 MetadataService extracts text content from object data fields in a defined priority order for analysis.
 

--- a/openspec/specs/pdf-generation/spec.md
+++ b/openspec/specs/pdf-generation/spec.md
@@ -10,7 +10,10 @@ Provides a shared, reusable PDF rendering service that any co-installed Nextclou
 
 ## Requirements
 
-### REQ-PDF-01: PDF Rendering Service (Priority: Must)
+### Requirement: PDF Rendering Service
+
+**ID:** REQ-PDF-01
+**Priority:** Must
 
 PdfService accepts a Twig template string and data context, renders HTML via a sandboxed Twig environment, and converts to PDF via mPDF.
 
@@ -48,7 +51,10 @@ PdfService accepts a Twig template string and data context, renders HTML via a s
 | PDF-004 | Empty data with static HTML produces valid PDF | MUST | Implemented |
 | PDF-005 | Invalid Twig syntax throws Exception with descriptive message | MUST | Implemented |
 
-### REQ-PDF-02: Page Configuration Options (Priority: Must)
+### Requirement: Page Configuration Options
+
+**ID:** REQ-PDF-02
+**Priority:** Must
 
 PDF output can be configured with page format, orientation, margins, and document title metadata.
 
@@ -80,7 +86,10 @@ PDF output can be configured with page format, orientation, margins, and documen
 | PDF-013 | `title` option: PDF document title metadata | MUST | Implemented |
 | PDF-014 | Empty options = A4 portrait with 15mm margins | MUST | Implemented |
 
-### REQ-PDF-03: Twig Sandbox Security Policy (Priority: Must)
+### Requirement: Twig Sandbox Security Policy
+
+**ID:** REQ-PDF-03
+**Priority:** Must
 
 Twig templates are rendered in a sandboxed environment with strict security policy to prevent template injection attacks.
 
@@ -121,7 +130,10 @@ Twig templates are rendered in a sandboxed environment with strict security poli
 | PDF-024 | Zero allowed methods and properties on objects | MUST | Implemented |
 | PDF-025 | Forbidden functions (system, exec, etc.) blocked by sandbox | MUST | Implemented |
 
-### REQ-PDF-04: mPDF Temp Directory Management (Priority: Must)
+### Requirement: mPDF Temp Directory Management
+
+**ID:** REQ-PDF-04
+**Priority:** Must
 
 mPDF requires a writable temp directory, which is created and configured automatically.
 
@@ -149,7 +161,10 @@ mPDF requires a writable temp directory, which is created and configured automat
 | PDF-031 | Temp directory created if not exists | MUST | Implemented |
 | PDF-032 | MpdfException caught, logged, and re-thrown as Exception with code 500 | MUST | Implemented |
 
-### REQ-PDF-05: PDF Rendering API Endpoint (Priority: Must)
+### Requirement: PDF Rendering API Endpoint
+
+**ID:** REQ-PDF-05
+**Priority:** Must
 
 An HTTP endpoint allows authenticated users to generate PDFs on demand.
 
@@ -181,7 +196,10 @@ An HTTP endpoint allows authenticated users to generate PDFs on demand.
 | PDF-042 | Returns DataDownloadResponse with PDF binary and application/pdf MIME | MUST | Implemented |
 | PDF-043 | Returns 400 if template field is missing or empty | MUST | Implemented |
 
-### REQ-PDF-06: Dependencies (Priority: Must)
+### Requirement: Dependencies
+
+**ID:** REQ-PDF-06
+**Priority:** Must
 
 PdfService requires mPDF and Twig libraries at specific minimum versions.
 
@@ -207,7 +225,10 @@ PdfService requires mPDF and Twig libraries at specific minimum versions.
 | PDF-051 | `twig/twig: ^3.18` in composer.json | MUST | Implemented |
 | PDF-052 | TemplateRenderer extracted from PdfService for separation of concerns | MUST | Implemented |
 
-### REQ-PDF-07: Twig Sandbox Configuration Details (Priority: Must)
+### Requirement: Twig Sandbox Configuration Details
+
+**ID:** REQ-PDF-07
+**Priority:** Must
 
 The sandbox configuration is centralized in TemplateRenderer with explicit whitelists.
 

--- a/openspec/specs/pdf-generation/spec.md
+++ b/openspec/specs/pdf-generation/spec.md
@@ -10,9 +10,8 @@ Provides a shared, reusable PDF rendering service that any co-installed Nextclou
 
 ## Requirements
 
-### Requirement: PDF Rendering Service
+### Requirement: PDF Rendering Service (REQ-PDF-01)
 
-**ID:** REQ-PDF-01
 **Priority:** Must
 
 PdfService accepts a Twig template string and data context, renders HTML via a sandboxed Twig environment, and converts to PDF via mPDF.
@@ -51,9 +50,8 @@ PdfService accepts a Twig template string and data context, renders HTML via a s
 | PDF-004 | Empty data with static HTML produces valid PDF | MUST | Implemented |
 | PDF-005 | Invalid Twig syntax throws Exception with descriptive message | MUST | Implemented |
 
-### Requirement: Page Configuration Options
+### Requirement: Page Configuration Options (REQ-PDF-02)
 
-**ID:** REQ-PDF-02
 **Priority:** Must
 
 PDF output can be configured with page format, orientation, margins, and document title metadata.
@@ -86,9 +84,8 @@ PDF output can be configured with page format, orientation, margins, and documen
 | PDF-013 | `title` option: PDF document title metadata | MUST | Implemented |
 | PDF-014 | Empty options = A4 portrait with 15mm margins | MUST | Implemented |
 
-### Requirement: Twig Sandbox Security Policy
+### Requirement: Twig Sandbox Security Policy (REQ-PDF-03)
 
-**ID:** REQ-PDF-03
 **Priority:** Must
 
 Twig templates are rendered in a sandboxed environment with strict security policy to prevent template injection attacks.
@@ -130,9 +127,8 @@ Twig templates are rendered in a sandboxed environment with strict security poli
 | PDF-024 | Zero allowed methods and properties on objects | MUST | Implemented |
 | PDF-025 | Forbidden functions (system, exec, etc.) blocked by sandbox | MUST | Implemented |
 
-### Requirement: mPDF Temp Directory Management
+### Requirement: mPDF Temp Directory Management (REQ-PDF-04)
 
-**ID:** REQ-PDF-04
 **Priority:** Must
 
 mPDF requires a writable temp directory, which is created and configured automatically.
@@ -161,9 +157,8 @@ mPDF requires a writable temp directory, which is created and configured automat
 | PDF-031 | Temp directory created if not exists | MUST | Implemented |
 | PDF-032 | MpdfException caught, logged, and re-thrown as Exception with code 500 | MUST | Implemented |
 
-### Requirement: PDF Rendering API Endpoint
+### Requirement: PDF Rendering API Endpoint (REQ-PDF-05)
 
-**ID:** REQ-PDF-05
 **Priority:** Must
 
 An HTTP endpoint allows authenticated users to generate PDFs on demand.
@@ -196,9 +191,8 @@ An HTTP endpoint allows authenticated users to generate PDFs on demand.
 | PDF-042 | Returns DataDownloadResponse with PDF binary and application/pdf MIME | MUST | Implemented |
 | PDF-043 | Returns 400 if template field is missing or empty | MUST | Implemented |
 
-### Requirement: Dependencies
+### Requirement: Dependencies (REQ-PDF-06)
 
-**ID:** REQ-PDF-06
 **Priority:** Must
 
 PdfService requires mPDF and Twig libraries at specific minimum versions.
@@ -225,9 +219,8 @@ PdfService requires mPDF and Twig libraries at specific minimum versions.
 | PDF-051 | `twig/twig: ^3.18` in composer.json | MUST | Implemented |
 | PDF-052 | TemplateRenderer extracted from PdfService for separation of concerns | MUST | Implemented |
 
-### Requirement: Twig Sandbox Configuration Details
+### Requirement: Twig Sandbox Configuration Details (REQ-PDF-07)
 
-**ID:** REQ-PDF-07
 **Priority:** Must
 
 The sandbox configuration is centralized in TemplateRenderer with explicit whitelists.

--- a/openspec/specs/prometheus-metrics/spec.md
+++ b/openspec/specs/prometheus-metrics/spec.md
@@ -10,7 +10,10 @@ Expose application metrics in Prometheus text exposition format at `GET /api/met
 
 ## Requirements
 
-### REQ-PROM-01: Metrics Endpoint (Priority: Must)
+### Requirement: Metrics Endpoint
+
+**ID:** REQ-PROM-01
+**Priority:** Must
 
 Expose a Prometheus-compatible metrics endpoint with proper content type and authentication.
 
@@ -38,7 +41,10 @@ Expose a Prometheus-compatible metrics endpoint with proper content type and aut
 | PROM-002 | Content-Type: `text/plain; version=0.0.4; charset=utf-8` | MUST | Implemented |
 | PROM-003 | Require admin authentication | MUST | Implemented |
 
-### REQ-PROM-02: Standard Application Metrics (Priority: Must)
+### Requirement: Standard Application Metrics
+
+**ID:** REQ-PROM-02
+**Priority:** Must
 
 Every DocuDesk installation exposes standard metrics for version info, health, and basic operational data.
 
@@ -63,7 +69,10 @@ Every DocuDesk installation exposes standard metrics for version info, health, a
 | PROM-011 | `docudesk_up` gauge (1 = healthy) | MUST | Implemented |
 | PROM-012 | Version labels from IConfig app values | MUST | Implemented |
 
-### REQ-PROM-03: App-Specific Metrics (Priority: Must)
+### Requirement: App-Specific Metrics
+
+**ID:** REQ-PROM-03
+**Priority:** Must
 
 DocuDesk exposes metrics specific to its document processing capabilities.
 
@@ -98,7 +107,10 @@ DocuDesk exposes metrics specific to its document processing capabilities.
 | PROM-022 | `docudesk_pdf_generations_total` counter from IConfig | MUST | Implemented |
 | PROM-023 | `docudesk_anonymizations_total` counter from IConfig | MUST | Implemented |
 
-### REQ-PROM-04: Planned Standard Metrics (Priority: Should)
+### Requirement: Planned Standard Metrics
+
+**ID:** REQ-PROM-04
+**Priority:** Should
 
 The app MUST expose additional standard metrics for request tracking and error monitoring.
 
@@ -123,7 +135,10 @@ The app MUST expose additional standard metrics for request tracking and error m
 | PROM-031 | `docudesk_request_duration_seconds` histogram | SHOULD | Planned |
 | PROM-032 | `docudesk_errors_total` counter with type label | SHOULD | Planned |
 
-### REQ-PROM-05: Planned Duration Metrics (Priority: Should)
+### Requirement: Planned Duration Metrics
+
+**ID:** REQ-PROM-05
+**Priority:** Should
 
 The app MUST expose duration histograms for PDF generation and anonymization operations.
 
@@ -143,7 +158,10 @@ The app MUST expose duration histograms for PDF generation and anonymization ope
 | PROM-040 | `docudesk_pdf_generation_duration_seconds` histogram | SHOULD | Planned |
 | PROM-041 | `docudesk_anonymization_duration_seconds` histogram | SHOULD | Planned |
 
-### REQ-PROM-06: Health Check Endpoint (Priority: Must)
+### Requirement: Health Check Endpoint
+
+**ID:** REQ-PROM-06
+**Priority:** Must
 
 A health check endpoint provides infrastructure monitoring with component-level status checks.
 
@@ -168,7 +186,10 @@ A health check endpoint provides infrastructure monitoring with component-level 
 | PROM-051 | Component-level checks: database, dependencies | MUST | Implemented |
 | PROM-052 | Status values: ok, degraded, error | MUST | Implemented |
 
-### REQ-PROM-07: MetricsCollector Delegation (Priority: Must)
+### Requirement: MetricsCollector Delegation
+
+**ID:** REQ-PROM-07
+**Priority:** Must
 
 MetricsController delegates count queries to MetricsCollector for separation of concerns.
 

--- a/openspec/specs/prometheus-metrics/spec.md
+++ b/openspec/specs/prometheus-metrics/spec.md
@@ -10,9 +10,8 @@ Expose application metrics in Prometheus text exposition format at `GET /api/met
 
 ## Requirements
 
-### Requirement: Metrics Endpoint
+### Requirement: Metrics Endpoint (REQ-PROM-01)
 
-**ID:** REQ-PROM-01
 **Priority:** Must
 
 Expose a Prometheus-compatible metrics endpoint with proper content type and authentication.
@@ -41,9 +40,8 @@ Expose a Prometheus-compatible metrics endpoint with proper content type and aut
 | PROM-002 | Content-Type: `text/plain; version=0.0.4; charset=utf-8` | MUST | Implemented |
 | PROM-003 | Require admin authentication | MUST | Implemented |
 
-### Requirement: Standard Application Metrics
+### Requirement: Standard Application Metrics (REQ-PROM-02)
 
-**ID:** REQ-PROM-02
 **Priority:** Must
 
 Every DocuDesk installation exposes standard metrics for version info, health, and basic operational data.
@@ -69,9 +67,8 @@ Every DocuDesk installation exposes standard metrics for version info, health, a
 | PROM-011 | `docudesk_up` gauge (1 = healthy) | MUST | Implemented |
 | PROM-012 | Version labels from IConfig app values | MUST | Implemented |
 
-### Requirement: App-Specific Metrics
+### Requirement: App-Specific Metrics (REQ-PROM-03)
 
-**ID:** REQ-PROM-03
 **Priority:** Must
 
 DocuDesk exposes metrics specific to its document processing capabilities.
@@ -107,9 +104,8 @@ DocuDesk exposes metrics specific to its document processing capabilities.
 | PROM-022 | `docudesk_pdf_generations_total` counter from IConfig | MUST | Implemented |
 | PROM-023 | `docudesk_anonymizations_total` counter from IConfig | MUST | Implemented |
 
-### Requirement: Planned Standard Metrics
+### Requirement: Planned Standard Metrics (REQ-PROM-04)
 
-**ID:** REQ-PROM-04
 **Priority:** Should
 
 The app MUST expose additional standard metrics for request tracking and error monitoring.
@@ -135,9 +131,8 @@ The app MUST expose additional standard metrics for request tracking and error m
 | PROM-031 | `docudesk_request_duration_seconds` histogram | SHOULD | Planned |
 | PROM-032 | `docudesk_errors_total` counter with type label | SHOULD | Planned |
 
-### Requirement: Planned Duration Metrics
+### Requirement: Planned Duration Metrics (REQ-PROM-05)
 
-**ID:** REQ-PROM-05
 **Priority:** Should
 
 The app MUST expose duration histograms for PDF generation and anonymization operations.
@@ -158,9 +153,8 @@ The app MUST expose duration histograms for PDF generation and anonymization ope
 | PROM-040 | `docudesk_pdf_generation_duration_seconds` histogram | SHOULD | Planned |
 | PROM-041 | `docudesk_anonymization_duration_seconds` histogram | SHOULD | Planned |
 
-### Requirement: Health Check Endpoint
+### Requirement: Health Check Endpoint (REQ-PROM-06)
 
-**ID:** REQ-PROM-06
 **Priority:** Must
 
 A health check endpoint provides infrastructure monitoring with component-level status checks.
@@ -186,9 +180,8 @@ A health check endpoint provides infrastructure monitoring with component-level 
 | PROM-051 | Component-level checks: database, dependencies | MUST | Implemented |
 | PROM-052 | Status values: ok, degraded, error | MUST | Implemented |
 
-### Requirement: MetricsCollector Delegation
+### Requirement: MetricsCollector Delegation (REQ-PROM-07)
 
-**ID:** REQ-PROM-07
 **Priority:** Must
 
 MetricsController delegates count queries to MetricsCollector for separation of concerns.

--- a/openspec/specs/template-management/spec.md
+++ b/openspec/specs/template-management/spec.md
@@ -10,9 +10,8 @@ Provides CRUD operations for reusable Twig/HTML templates stored as OpenRegister
 
 ## Requirements
 
-### Requirement: Template Data Model
+### Requirement: Template Data Model (REQ-TMPL-01)
 
-**ID:** REQ-TMPL-01
 **Priority:** Must
 
 Templates are stored as OpenRegister objects with defined properties for name, content, namespace, and page configuration.
@@ -40,9 +39,8 @@ Templates are stored as OpenRegister objects with defined properties for name, c
 | TMPL-003 | Schema in docudesk_register.json, imported on boot | MUST | Implemented |
 | TMPL-004 | Schema is searchable | MUST | Implemented |
 
-### Requirement: Template CRUD API
+### Requirement: Template CRUD API (REQ-TMPL-02)
 
-**ID:** REQ-TMPL-02
 **Priority:** Must
 
 Full CRUD operations for templates via REST API with pagination and filtering support.
@@ -85,9 +83,8 @@ Full CRUD operations for templates via REST API with pagination and filtering su
 | TMPL-014 | `DELETE /api/templates/{id}` to delete | MUST | Implemented |
 | TMPL-015 | All endpoints require authentication (@NoAdminRequired @NoCSRFRequired) | MUST | Implemented |
 
-### Requirement: Namespace Enforcement
+### Requirement: Namespace Enforcement (REQ-TMPL-03)
 
-**ID:** REQ-TMPL-03
 **Priority:** Must
 
 Templates are scoped to app namespaces with strict validation and immutability after creation.
@@ -120,9 +117,8 @@ Templates are scoped to app namespaces with strict validation and immutability a
 | TMPL-022 | Namespace immutable on update (silently ignored) | MUST | Implemented |
 | TMPL-023 | Invalid namespace returns 400 error | MUST | Implemented |
 
-### Requirement: TemplateService Programmatic Access
+### Requirement: TemplateService Programmatic Access (REQ-TMPL-04)
 
-**ID:** REQ-TMPL-04
 **Priority:** Must
 
 TemplateService is injectable via DI, enabling other Nextcloud apps to manage templates programmatically.
@@ -159,9 +155,8 @@ TemplateService is injectable via DI, enabling other Nextcloud apps to manage te
 | TMPL-035 | `getTemplatesByNamespace(namespace)` convenience method | MUST | Implemented |
 | TMPL-036 | Injectable via DI: `OCA\DocuDesk\Service\TemplateService::class` | MUST | Implemented |
 
-### Requirement: OpenRegister Integration
+### Requirement: OpenRegister Integration (REQ-TMPL-05)
 
-**ID:** REQ-TMPL-05
 **Priority:** Must
 
 TemplateService resolves register and schema configuration via OpenRegisterResolver and uses ObjectService for all data operations.
@@ -190,9 +185,8 @@ TemplateService resolves register and schema configuration via OpenRegisterResol
 | TMPL-041 | ObjectService resolved via container with OpenRegister availability check | MUST | Implemented |
 | TMPL-042 | Namespace validation delegated to OpenRegisterResolver | MUST | Implemented |
 
-### Requirement: Search and Pagination
+### Requirement: Search and Pagination (REQ-TMPL-06)
 
-**ID:** REQ-TMPL-06
 **Priority:** Must
 
 Template listing supports search, filtering, and pagination via OpenRegister's query builder.
@@ -219,9 +213,8 @@ Template listing supports search, filtering, and pagination via OpenRegister's q
 | TMPL-051 | Text search via _search param | MUST | Implemented |
 | TMPL-052 | Combined namespace filter and search | MUST | Implemented |
 
-### Requirement: Object Serialization
+### Requirement: Object Serialization (REQ-TMPL-07)
 
-**ID:** REQ-TMPL-07
 **Priority:** Must
 
 Template objects from OpenRegister are consistently serialized for API responses.

--- a/openspec/specs/template-management/spec.md
+++ b/openspec/specs/template-management/spec.md
@@ -10,7 +10,10 @@ Provides CRUD operations for reusable Twig/HTML templates stored as OpenRegister
 
 ## Requirements
 
-### REQ-TMPL-01: Template Data Model (Priority: Must)
+### Requirement: Template Data Model
+
+**ID:** REQ-TMPL-01
+**Priority:** Must
 
 Templates are stored as OpenRegister objects with defined properties for name, content, namespace, and page configuration.
 
@@ -37,7 +40,10 @@ Templates are stored as OpenRegister objects with defined properties for name, c
 | TMPL-003 | Schema in docudesk_register.json, imported on boot | MUST | Implemented |
 | TMPL-004 | Schema is searchable | MUST | Implemented |
 
-### REQ-TMPL-02: Template CRUD API (Priority: Must)
+### Requirement: Template CRUD API
+
+**ID:** REQ-TMPL-02
+**Priority:** Must
 
 Full CRUD operations for templates via REST API with pagination and filtering support.
 
@@ -79,7 +85,10 @@ Full CRUD operations for templates via REST API with pagination and filtering su
 | TMPL-014 | `DELETE /api/templates/{id}` to delete | MUST | Implemented |
 | TMPL-015 | All endpoints require authentication (@NoAdminRequired @NoCSRFRequired) | MUST | Implemented |
 
-### REQ-TMPL-03: Namespace Enforcement (Priority: Must)
+### Requirement: Namespace Enforcement
+
+**ID:** REQ-TMPL-03
+**Priority:** Must
 
 Templates are scoped to app namespaces with strict validation and immutability after creation.
 
@@ -111,7 +120,10 @@ Templates are scoped to app namespaces with strict validation and immutability a
 | TMPL-022 | Namespace immutable on update (silently ignored) | MUST | Implemented |
 | TMPL-023 | Invalid namespace returns 400 error | MUST | Implemented |
 
-### REQ-TMPL-04: TemplateService Programmatic Access (Priority: Must)
+### Requirement: TemplateService Programmatic Access
+
+**ID:** REQ-TMPL-04
+**Priority:** Must
 
 TemplateService is injectable via DI, enabling other Nextcloud apps to manage templates programmatically.
 
@@ -147,7 +159,10 @@ TemplateService is injectable via DI, enabling other Nextcloud apps to manage te
 | TMPL-035 | `getTemplatesByNamespace(namespace)` convenience method | MUST | Implemented |
 | TMPL-036 | Injectable via DI: `OCA\DocuDesk\Service\TemplateService::class` | MUST | Implemented |
 
-### REQ-TMPL-05: OpenRegister Integration (Priority: Must)
+### Requirement: OpenRegister Integration
+
+**ID:** REQ-TMPL-05
+**Priority:** Must
 
 TemplateService resolves register and schema configuration via OpenRegisterResolver and uses ObjectService for all data operations.
 
@@ -175,7 +190,10 @@ TemplateService resolves register and schema configuration via OpenRegisterResol
 | TMPL-041 | ObjectService resolved via container with OpenRegister availability check | MUST | Implemented |
 | TMPL-042 | Namespace validation delegated to OpenRegisterResolver | MUST | Implemented |
 
-### REQ-TMPL-06: Search and Pagination (Priority: Must)
+### Requirement: Search and Pagination
+
+**ID:** REQ-TMPL-06
+**Priority:** Must
 
 Template listing supports search, filtering, and pagination via OpenRegister's query builder.
 
@@ -201,7 +219,10 @@ Template listing supports search, filtering, and pagination via OpenRegister's q
 | TMPL-051 | Text search via _search param | MUST | Implemented |
 | TMPL-052 | Combined namespace filter and search | MUST | Implemented |
 
-### REQ-TMPL-07: Object Serialization (Priority: Must)
+### Requirement: Object Serialization
+
+**ID:** REQ-TMPL-07
+**Priority:** Must
 
 Template objects from OpenRegister are consistently serialized for API responses.
 


### PR DESCRIPTION
2026/05/24 15:28:18.598199 cmd_run.go:1605: WARNING: cannot start document portal: dial unix /run/user/1000/bus: connect: no such file or directory
## Summary

Phase 1c of the fleet-wide ADR-037 rollout. Normalizes all `openspec/specs/**/spec.md` requirement headings on docudesk to the canonical Form A (`### Requirement: <title>`) per ADR-037 (ConductionNL/hydra#326).

This eliminates Form B (`### REQ-XX-NNN: <title> (Priority: ...)`) and Form C (heading-only `### <title>`) variants that defeated the `opsx-coverage-scan` regex and caused REQ-ID synthesis (breaking `/opsx-annotate` idempotency).

## What changed

**Specs normalized (10 specs, 84 requirements):**

| Spec | Form before | Form after | REQ count |
|---|---|---|---|
| admin-settings | Form B | Form A | 11 |
| anonymization | Form B | Form A | 10 |
| consent-management | Form B | Form A | 10 |
| dashboard | Form B | Form A | 7 |
| document-register | Form B | Form A | 7 |
| letter-correspondence-generation | Form C | Form A | 8 |
| metadata-enrichment | Form B | Form A | 10 |
| pdf-generation | Form B | Form A | 7 |
| prometheus-metrics | Form B | Form A | 7 |
| template-management | Form B | Form A | 7 |

**Conversion pattern (Form B → A):**
- `### REQ-SET-01: Title (Priority: Must)` becomes `### Requirement: Title` with `**ID:** REQ-SET-01` and `**Priority:** Must` on subsequent lines.

**Conversion pattern (Form C → A):**
- `### Title` simply becomes `### Requirement: Title`. No ID synthesised (none was present).

**Specs left intact (4 specs):**
- `anonymization-entity-review` (6 REQs) — already canonical Form A
- `batch-anonymization` (6 REQs) — already canonical Form A
- `ocr-document-scanning` — REQ rows live inside markdown tables under group headings; per task guidance ("too risky to auto-promote"), tables and their group headings are left intact
- `print-preview` — same as above (table-based REQ rows + GIVEN/WHEN/THEN code blocks under `## Scenarios`)

## What did NOT change

- Frontmatter, body text, scenarios, section ordering, ADR cross-refs — all preserved
- The 4 table-based specs noted above

## openspec validate result

Pre-PR baseline: 1 passed, 13 failed (same totals before + after this PR).

The 13 failures are pre-existing strict-mode errors flagging `Requirement must contain SHALL or MUST keyword` — the body prose of these specs uses descriptive sentences rather than RFC-2119 keywords. **This is out of scope for the Phase 1c heading-format normalization** and is tracked separately under the umbrella issue's later phases.

## Test plan

- [x] Diff is purely heading-text rewrites (10 files, +312/-84 lines)
- [x] `openspec validate --specs` shows no _new_ failures introduced by this PR
- [x] No SHALL/MUST/scenario content modified
- [x] Production app — no yolo label; awaits human review

Refs #252, ADR-037 (ConductionNL/hydra#326)

---

## Amended 2026-05-24 — heading-suffix form

The original Phase 1c commit used a body-line ID recipe:

```markdown
### Requirement: <title>

**ID:** REQ-XX-NN
**Priority:** X
```

The openspec validator treated `**ID:**` as the requirement text, masking the actual SHALL/MUST body and matching no other spec across the fleet. ADR-037 was revised on `hydra#326` to the canonical heading-suffix form:

```markdown
### Requirement: <title> (REQ-XX-NN)

**Priority:** X
```

The `**Priority:**` / `**Status:**` body lines stay as body lines — only the ID moves to the heading. Commit `d3ba25c` reworks 76 requirement headings across 9 specs:

| Spec | Rewrites |
|---|---|
| admin-settings | 11 |
| anonymization | 10 |
| consent-management | 10 |
| dashboard | 7 |
| document-register | 7 |
| metadata-enrichment | 10 |
| pdf-generation | 7 |
| prometheus-metrics | 7 |
| template-management | 7 |
| **Total** | **76** |

`letter-correspondence-generation` was Form C → Form A in the original commit (8 headings, no IDs) and is unaffected.

`openspec validate --specs --strict` baseline (1 passed / 13 failed) is unchanged — the pre-existing `SHALL or MUST keyword` errors remain out of scope for this heading-format normalization, but the parser now correctly recognises the ID-suffix per the revised ADR-037.
