### PR TITLE
retrofit: reverse-spec metadata-enrichment (1 REQ / 3 methods)

### DIFF
--- a/lib/Service/LanguageClassifier.php
+++ b/lib/Service/LanguageClassifier.php
@@ -86,6 +86,8 @@ class LanguageClassifier
      * @param array<string> $words The words to count
      *
      * @return int Total occurrence count
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-metadata-enrichment/tasks.md#task-1
      */
     private function countWordOccurrences(string $text, array $words): int
     {
@@ -104,6 +106,8 @@ class LanguageClassifier
      * @param string $text Text content to analyze
      *
      * @return string|null Detected language code or null if detection fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-metadata-enrichment/tasks.md#task-1
      */
     public function detectLanguage(string $text): ?string
     {
@@ -130,6 +134,8 @@ class LanguageClassifier
      * @param string $text Text content to analyze
      *
      * @return string|null Classified topic or null if classification fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-metadata-enrichment/tasks.md#task-1
      */
     public function classifyTopic(string $text): ?string
     {

--- a/openspec/changes/archive/retrofit-2026-05-24-metadata-enrichment/design.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-metadata-enrichment/design.md
@@ -1,0 +1,36 @@
+# Design — retrofit-2026-05-24-metadata-enrichment
+
+**Retrofit change. Tasks describe retroactive annotation, not new implementation work.**
+
+## Goal
+
+Bring 3 already-shipped methods of `LanguageClassifier` under `metadata-enrichment` coverage by drafting one numbered REQ (REQ-META-11) describing the class boundary, then attaching `@spec` annotations.
+
+## Method → Task Map
+
+| File | Method | Task |
+|------|--------|------|
+| `lib/Service/LanguageClassifier.php` | `detectLanguage` | task-1 |
+| `lib/Service/LanguageClassifier.php` | `classifyTopic` | task-1 |
+| `lib/Service/LanguageClassifier.php` | `countWordOccurrences` | task-1 |
+
+## Granularity calls
+
+- **All 3 methods collapse to one REQ.** They implement one cohesive behavior (the class-boundary contract for "who owns the word-list scoring algorithm"). Splitting per-method would inflate the spec without buying review clarity — the existing REQ-META-01/03 already cover the abstract behavior of each method.
+- **REQ-META-11 is about the class boundary, not algorithm details.** The algorithm itself is already specified in REQ-META-01..03; this REQ specifies *where* it lives and the consumer contract.
+
+## Notable observed-but-suspicious behavior surfaced in REQ Notes
+
+- `TextAnalysisService::countWordOccurrences()` is a byte-identical clone of the LanguageClassifier helper. The coverage scan flagged the wrong direction (it called LanguageClassifier the duplicate); HEAD shows TextAnalysisService is the leftover. TODO note added to REQ-META-11.
+- 5-match threshold and 10-keyword vocabularies are constants by design (calibration), not config.
+- `countWordOccurrences()` is whitespace-naive — only ASCII space ` ` counts as a word boundary.
+
+## What this change does NOT do
+
+- No code logic changes — observed behavior only.
+- Does not consolidate the residual `TextAnalysisService::countWordOccurrences()` duplicate (flagged as TODO in REQ Notes).
+
+## Source
+
+- `openspec/coverage-report.json` generated 2026-05-24
+- Cluster: `bucket_2a.metadata-enrichment`

--- a/openspec/changes/archive/retrofit-2026-05-24-metadata-enrichment/proposal.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-metadata-enrichment/proposal.md
@@ -1,0 +1,16 @@
+# Retrofit — metadata-enrichment
+
+Describes observed behavior of 3 methods under the `metadata-enrichment` capability as 1 new REQ (REQ-META-11). The existing REQs cover the abstract "detect language / classify topic" outcomes (REQ-META-01..03) without specifying that the algorithm + vocabularies live in a dedicated `LanguageClassifier` class. This retrofit closes that gap.
+
+## Affected code units
+
+- `lib/Service/LanguageClassifier.php` — `detectLanguage`, `classifyTopic`, `countWordOccurrences`
+
+## Approach
+
+- Read `LanguageClassifier` and its caller (`TextAnalysisService`, which delegates `detectLanguage` and `classifyTopic`) to confirm that the classifier is the canonical owner of the word-list/threshold algorithm and the topic-keyword vocabularies.
+- Note that the coverage report described the classifier as a "duplicate" of `TextAnalysisService` — at HEAD that framing is stale. `TextAnalysisService::detectLanguage()` and `::classifyTopic()` are thin forwarders to `LanguageClassifier`; the duplication has been collapsed by extraction.
+- Draft a single REQ describing the class boundary (LanguageClassifier owns the vocabularies, thresholds, and scoring; `countWordOccurrences` is a private helper).
+- Surface in Notes: TextAnalysisService still has its own `countWordOccurrences` clone (public) — that is observed-but-suspicious code outside this cluster but worth flagging here.
+
+Source: `openspec/coverage-report.json` generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/archive/retrofit-2026-05-24-metadata-enrichment/specs/metadata-enrichment/spec.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-metadata-enrichment/specs/metadata-enrichment/spec.md
@@ -1,0 +1,50 @@
+---
+retrofit_extensions:
+  - REQ-META-11
+---
+
+# Metadata Enrichment — Retrofit Delta
+
+Adds REQ-META-11 describing the `LanguageClassifier` class boundary — the canonical owner of the Dutch/English word-list scoring algorithm and the per-topic keyword vocabularies used by REQ-META-01 (language detection) and REQ-META-03 (topic classification).
+
+## ADDED Requirements
+
+### REQ-META-11: Language and Topic Classifier Class Boundary
+
+DocuDesk SHALL implement the language-detection and topic-classification algorithms in a dedicated `LanguageClassifier` service that owns the word-list vocabularies, the minimum-match threshold, and the scoring tiebreaker. Other services (`TextAnalysisService`, `MetadataService`) SHALL consume the classifier via dependency injection; they MUST NOT re-implement the vocabulary or scoring logic.
+
+The class encapsulates three constants — `DUTCH_WORDS` (10 stop-ish high-frequency Dutch words), `ENGLISH_WORDS` (10 high-frequency English words), and `TOPIC_KEYWORDS` (4 topic categories with 6 keywords each: `legal`, `financial`, `medical`, `technical`). The detection helpers share a private `countWordOccurrences()` implementation that counts whitespace-padded `' word '` substrings (so word boundaries are required on both sides, matching what REQ-META-01 / REQ-META-03 already specify abstractly).
+
+#### Scenario: Classifier owns the word lists
+
+- **WHEN** REQ-META-01 / REQ-META-03 are implemented
+- **THEN** the word vocabularies live in `LanguageClassifier` constants and are NOT redefined in `TextAnalysisService` or `MetadataService`
+- **AND** `TextAnalysisService::detectLanguage()` / `::classifyTopic()` forward to the injected `LanguageClassifier`
+
+#### Scenario: Language detection threshold
+
+- **WHEN** `LanguageClassifier::detectLanguage(text)` is called
+- **THEN** it lowercases the text, computes Dutch and English match counts via `countWordOccurrences`, and returns `"nl"` when `dutchCount > englishCount AND dutchCount > 5`
+- **AND** otherwise returns `"en"` when `englishCount > 5`
+- **AND** otherwise returns `null`
+
+#### Scenario: Topic classification scoring
+
+- **WHEN** `LanguageClassifier::classifyTopic(text)` is called
+- **THEN** for each of the four topics it computes the keyword-match count via `countWordOccurrences`
+- **AND** returns the topic with the highest non-zero score (`array_search` on the max score)
+- **AND** returns `null` if the highest score is `0`
+
+#### Scenario: Word-occurrence helper requires word boundaries
+
+- **WHEN** `countWordOccurrences(text, words)` is called
+- **THEN** for each target word it sums `substr_count(text, " word ")` — i.e. the word must be padded by spaces on both sides
+- **AND** the running total across the list is returned
+- **AND** a substring match inside a longer word (e.g. `"the"` inside `"theater"`) is NOT counted
+
+#### Notes
+
+- The class is stateless and has no constructor dependencies; it can be resolved either via DI or instantiated directly (used as a unit-test seam).
+- `TextAnalysisService` still defines its own public `countWordOccurrences()` with byte-identical logic — that is a residual duplicate not yet consolidated. TODO: remove `TextAnalysisService::countWordOccurrences()` once no external caller relies on it (the coverage scan flagged `LanguageClassifier::countWordOccurrences` as the duplicate, but at HEAD the situation has inverted — the classifier owns the logic, the analyzer is the leftover).
+- The 5-match threshold and the 10-keyword vocabularies are constants, not config — by design (REQ-META-04 calibration). Changing them requires a code change + spec revision.
+- `countWordOccurrences()` is byte-naive — non-ASCII whitespace (NBSP, tabs) is not treated as a boundary. Real-world DocuDesk text is whitespace-normalised earlier in the pipeline; if that ever changes, detection accuracy will drop.

--- a/openspec/changes/archive/retrofit-2026-05-24-metadata-enrichment/tasks.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-metadata-enrichment/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] task-1: metadata-enrichment#REQ-META-11 — Language and Topic Classifier Class Boundary (retroactive annotation)

--- a/openspec/specs/metadata-enrichment/spec.md
+++ b/openspec/specs/metadata-enrichment/spec.md
@@ -1,5 +1,7 @@
 ---
 status: implemented
+retrofit_extensions:
+  - REQ-META-11
 ---
 
 # Metadata Enrichment
@@ -409,3 +411,50 @@ MetadataService extracts text content from object data fields in a defined prior
 - **ISO 8601**: Date normalization format
 - **DCAT-AP**: EU metadata requirements
 - **OWMS**: Dutch government metadata standard
+
+---
+
+## Retrofit Requirements (REQ-META-11)
+
+Reverse-engineered from already-shipped code on 2026-05-24 via ghost change
+`retrofit-2026-05-24-metadata-enrichment` (archived).
+
+### REQ-META-11: Language and Topic Classifier Class Boundary
+
+DocuDesk SHALL implement the language-detection and topic-classification algorithms in a dedicated `LanguageClassifier` service that owns the word-list vocabularies, the minimum-match threshold, and the scoring tiebreaker. Other services (`TextAnalysisService`, `MetadataService`) SHALL consume the classifier via dependency injection; they MUST NOT re-implement the vocabulary or scoring logic.
+
+The class encapsulates three constants — `DUTCH_WORDS` (10 stop-ish high-frequency Dutch words), `ENGLISH_WORDS` (10 high-frequency English words), and `TOPIC_KEYWORDS` (4 topic categories with 6 keywords each: `legal`, `financial`, `medical`, `technical`). The detection helpers share a private `countWordOccurrences()` implementation that counts whitespace-padded `' word '` substrings (so word boundaries are required on both sides, matching what REQ-META-01 / REQ-META-03 already specify abstractly).
+
+#### Scenario: Classifier owns the word lists
+
+- **WHEN** REQ-META-01 / REQ-META-03 are implemented
+- **THEN** the word vocabularies live in `LanguageClassifier` constants and are NOT redefined in `TextAnalysisService` or `MetadataService`
+- **AND** `TextAnalysisService::detectLanguage()` / `::classifyTopic()` forward to the injected `LanguageClassifier`
+
+#### Scenario: Language detection threshold
+
+- **WHEN** `LanguageClassifier::detectLanguage(text)` is called
+- **THEN** it lowercases the text, computes Dutch and English match counts via `countWordOccurrences`, and returns `"nl"` when `dutchCount > englishCount AND dutchCount > 5`
+- **AND** otherwise returns `"en"` when `englishCount > 5`
+- **AND** otherwise returns `null`
+
+#### Scenario: Topic classification scoring
+
+- **WHEN** `LanguageClassifier::classifyTopic(text)` is called
+- **THEN** for each of the four topics it computes the keyword-match count via `countWordOccurrences`
+- **AND** returns the topic with the highest non-zero score (`array_search` on the max score)
+- **AND** returns `null` if the highest score is `0`
+
+#### Scenario: Word-occurrence helper requires word boundaries
+
+- **WHEN** `countWordOccurrences(text, words)` is called
+- **THEN** for each target word it sums `substr_count(text, " word ")` — i.e. the word must be padded by spaces on both sides
+- **AND** the running total across the list is returned
+- **AND** a substring match inside a longer word (e.g. `"the"` inside `"theater"`) is NOT counted
+
+#### Notes
+
+- The class is stateless and has no constructor dependencies; it can be resolved either via DI or instantiated directly (used as a unit-test seam).
+- `TextAnalysisService` still defines its own public `countWordOccurrences()` with byte-identical logic — that is a residual duplicate not yet consolidated. TODO: remove `TextAnalysisService::countWordOccurrences()` once no external caller relies on it (the coverage scan flagged `LanguageClassifier::countWordOccurrences` as the duplicate, but at HEAD the situation has inverted — the classifier owns the logic, the analyzer is the leftover).
+- The 5-match threshold and the 10-keyword vocabularies are constants, not config — by design (REQ-META-04 calibration). Changing them requires a code change + spec revision.
+- `countWordOccurrences()` is byte-naive — non-ASCII whitespace (NBSP, tabs) is not treated as a boundary. Real-world DocuDesk text is whitespace-normalised earlier in the pipeline; if that ever changes, detection accuracy will drop.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 3 methods under `metadata-enrichment` as 1 new REQ (REQ-META-11).

Ghost change: `retrofit-2026-05-24-metadata-enrichment` (archived).

Refs #252.

### What this PR does

- Drafts REQ-META-11 — Language and Topic Classifier Class Boundary:
  - Specifies `LanguageClassifier` as the canonical owner of the Dutch/English word lists, the 5-match threshold, and the 4-topic keyword vocabularies
  - Codifies the word-boundary contract for `countWordOccurrences()`
  - Annotates `detectLanguage`, `classifyTopic`, `countWordOccurrences`
- Adds `retrofit_extensions: [REQ-META-11]` to `openspec/specs/metadata-enrichment/spec.md`
- Creates `tasks.md` with 1 task (all `[x]` — code already exists)
- Archives the ghost change (delta merged into the main spec)

### Stale finding in coverage scan

The 2026-05-24 scan classified `LanguageClassifier` as a "duplicate of TextAnalysisService". At HEAD that framing is inverted — `TextAnalysisService::detectLanguage()` / `::classifyTopic()` are thin forwarders that delegate to the injected `LanguageClassifier`. The classifier is now the canonical owner. The leftover `TextAnalysisService::countWordOccurrences()` is the remaining duplicate; flagged as TODO in REQ-META-11 Notes.

### What this PR does NOT do

- No code behaviour changes — annotations only
- Does not consolidate the residual `TextAnalysisService::countWordOccurrences()` duplicate
- Does not change the 5-match threshold, 10-word vocabularies, or 4-topic list (all by-design calibration constants)

### Review focus

- REQ language matches observed code (not aspirational)
- Notes section accurately surfaces the inverted-duplicate finding
- Class boundary is described from the consumer's contract perspective

Source: `openspec/coverage-report.json` generated 2026-05-24 | Cluster: `bucket_2a.metadata-enrichment`