### PR TITLE
retrofit: reverse-spec openregister-bridge (1 REQ / 3 methods, new cap)

### DIFF
--- a/lib/Service/OpenRegisterResolver.php
+++ b/lib/Service/OpenRegisterResolver.php
@@ -52,6 +52,8 @@ class OpenRegisterResolver
      * @return array{register: string, schema: string} Register and schema IDs
      *
      * @throws RegisterNotConfiguredException If template register/schema is not configured
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-openregister-bridge/tasks.md#task-1
      */
     public function getRegisterAndSchema(): array
     {
@@ -73,6 +75,8 @@ class OpenRegisterResolver
      * @return array{register: string, schema: string} Register and schema IDs
      *
      * @throws RegisterNotConfiguredException If template version register/schema is not configured
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-openregister-bridge/tasks.md#task-1
      */
     public function getVersionRegisterAndSchema(): array
     {
@@ -98,6 +102,8 @@ class OpenRegisterResolver
      * @return bool True if valid
      *
      * @throws Exception If the namespace is invalid
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-openregister-bridge/tasks.md#task-1
      */
     public function validateNamespace(string $namespace): bool
     {

--- a/openspec/changes/archive/retrofit-2026-05-24-openregister-bridge/design.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-openregister-bridge/design.md
@@ -1,0 +1,45 @@
+# Design — retrofit-2026-05-24-openregister-bridge
+
+**Retrofit change. Tasks describe retroactive annotation, not new implementation work.**
+
+## Goal
+
+Mint a new `openregister-bridge` capability describing the observed contract of `OpenRegisterResolver` — a 3-method config-translation seam consumed by `TemplateService` and `TemplateVersionService`.
+
+## Why a new capability instead of extending template-management
+
+- `OpenRegisterResolver` is reused outside the template path: it gates the version-history schema separately.
+- Future register-backed features (signing requests, document register, dossier register, consent log) will need the same config-translation seam. Keeping the bridge standalone surfaces the contract.
+- The class is independent of any consumer's data model. Embedding the resolver REQ inside template-management would tie the resolver's evolution to template feature changes.
+
+## Method → Task Map
+
+| File | Method | Task |
+|------|--------|------|
+| `lib/Service/OpenRegisterResolver.php` | `getRegisterAndSchema` | task-1 |
+| `lib/Service/OpenRegisterResolver.php` | `getVersionRegisterAndSchema` | task-1 |
+| `lib/Service/OpenRegisterResolver.php` | `validateNamespace` | task-1 |
+
+## Granularity calls
+
+- **All 3 methods collapse to one REQ.** They implement one cohesive observable contract: "translate config → register/schema, enforce namespace shape." Splitting per-method would inflate the spec.
+- The two lookups share an identical failure mode (500 on missing config) and an identical input source (`SettingsService::getAllSettings()['configuration']`), so they belong in one REQ.
+- Namespace validation joins the same REQ because the regex is the shape used by every register-scoping operation that the resolver intermediates.
+
+## Notable observed-but-suspicious behavior surfaced in REQ Notes
+
+- Resolver caches what `SettingsService` has cached — no live re-read on each call.
+- 500 status used for both register-missing and schema-missing; callers cannot distinguish without message parsing.
+- Namespace regex duplicated implicitly with REQ-TMPL-03's namespace contract; TODO note added.
+- Expansion model for future registers is deferred (single class? sibling resolvers?).
+
+## What this change does NOT do
+
+- No code logic changes — observed behavior only.
+- Does not pre-emptively expand the resolver for other registers (signing, dossier, document).
+- Does not extract the namespace regex to a shared constant.
+
+## Source
+
+- `openspec/coverage-report.json` generated 2026-05-24
+- Cluster: `bucket_2b.openregister-bridge`

--- a/openspec/changes/archive/retrofit-2026-05-24-openregister-bridge/proposal.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-openregister-bridge/proposal.md
@@ -1,0 +1,16 @@
+# Retrofit — openregister-bridge
+
+Mints a new `openregister-bridge` capability describing the observed behavior of 3 methods in `OpenRegisterResolver`. The methods are consumed by both `TemplateService` and `TemplateVersionService` and surface a config-translation contract that does not naturally fit inside any one consumer's spec.
+
+## Affected code units
+
+- `lib/Service/OpenRegisterResolver.php` — `getRegisterAndSchema`, `getVersionRegisterAndSchema`, `validateNamespace`
+
+## Approach
+
+- Read `OpenRegisterResolver` and its two consumers (`TemplateService`, `TemplateVersionService`) to confirm that the resolver owns the contract for translating IAppConfig keys into register/schema slugs and for the namespace-validation regex.
+- Mint a new capability (`openregister-bridge`) rather than extending `template-management` — the resolver is reused beyond the template path (it also gates the version schema), and future register-backed features (document register, signing register) will likely consume the same translator pattern. Keeping it standalone surfaces the seam.
+- Draft a single REQ describing the three observable behaviors as a cohesive contract: resolve template register/schema, resolve version register/schema, validate namespace.
+- Surface in Notes: the configuration keys (`template_register`, `template_schema`, `templateVersion_register`, `templateVersion_schema`) are exposed via `SettingsService::getAllSettings()` — coupling that the resolver inherits but does not re-document.
+
+Source: `openspec/coverage-report.json` generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/archive/retrofit-2026-05-24-openregister-bridge/specs/openregister-bridge/spec.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-openregister-bridge/specs/openregister-bridge/spec.md
@@ -1,0 +1,63 @@
+---
+retrofit: true
+---
+
+# OpenRegister Bridge — Retrofit (new capability)
+
+Captures the observed contract of `OpenRegisterResolver` as a standalone capability so future register-backed features (signing register, document register, dossier register) can reuse the same config-translation seam without coupling to any one consumer's spec.
+
+## ADDED Requirements
+
+### REQ-001: OpenRegister Configuration and Namespace Resolver
+
+DocuDesk SHALL expose a single resolver service that translates DocuDesk IAppConfig keys into OpenRegister register/schema slug pairs and validates namespace identifiers used by per-app data partitions. The resolver SHALL be the only consumer of the underlying config keys within DocuDesk — services that need to talk to OpenRegister SHALL depend on the resolver, not directly on `SettingsService` or `IAppConfig`.
+
+The class owns three observable behaviors:
+
+1. **Template register/schema lookup** — returns the configured slugs for the primary template store; throws if either is unset.
+2. **Template version register/schema lookup** — returns the configured slugs for the version-history store; throws if either is unset.
+3. **Namespace validation** — enforces the `/^[a-z0-9]+$/` constraint used by every register-scoping operation (matches REQ-TMPL-03's namespace contract).
+
+Both lookups read `SettingsService::getAllSettings()['configuration']` and surface configuration gaps as `RegisterNotConfiguredException` (a domain exception that callers can catch to render a calm "register not configured yet" empty state instead of a 500). Namespace validation surfaces invalid input as a generic `Exception` with `code = 400`.
+
+#### Scenario: Resolve template register/schema
+
+- **WHEN** `OpenRegisterResolver::getRegisterAndSchema()` is called
+- **AND** `SettingsService::getAllSettings()['configuration']` contains both `template_register` and `template_schema`
+- **THEN** an array `['register' => <id>, 'schema' => <id>]` is returned
+
+#### Scenario: Missing template register/schema raises RegisterNotConfiguredException
+
+- **WHEN** `getRegisterAndSchema()` is called
+- **AND** either `template_register` or `template_schema` is empty / missing
+- **THEN** a `RegisterNotConfiguredException` with message `"Template register/schema not configured"` is thrown
+- **AND** controllers may catch this exception to render an empty list with `notConfigured: true` rather than a 500 error response
+
+#### Scenario: Resolve template version register/schema
+
+- **WHEN** `OpenRegisterResolver::getVersionRegisterAndSchema()` is called
+- **AND** both `templateVersion_register` and `templateVersion_schema` are configured
+- **THEN** an array `['register' => <id>, 'schema' => <id>]` is returned
+
+#### Scenario: Missing version register/schema raises RegisterNotConfiguredException
+
+- **WHEN** `getVersionRegisterAndSchema()` is called
+- **AND** either `templateVersion_register` or `templateVersion_schema` is empty / missing
+- **THEN** a `RegisterNotConfiguredException` with message `"Template version register/schema not configured"` is thrown
+
+#### Scenario: Valid namespace passes
+
+- **WHEN** `OpenRegisterResolver::validateNamespace("larpingapp")` is called
+- **THEN** the method returns `true` and no exception is raised
+
+#### Scenario: Invalid namespace raises 400
+
+- **WHEN** `validateNamespace()` is called with a string containing uppercase letters, hyphens, underscores, or any non-`[a-z0-9]` character (e.g. `"my-app"`, `"My App"`, `""`)
+- **THEN** an `Exception` with code `400` and message `"Invalid namespace: must be lowercase alphanumeric only"` is thrown
+
+#### Notes
+
+- The resolver does NOT discover register/schema slugs at runtime — it reads what `SettingsService` has cached. If admin settings change at runtime, callers must re-resolve.
+- Both lookups raise `RegisterNotConfiguredException` with the same exception class. Callers cannot distinguish "template register missing" from "template schema missing" without parsing the message; that's acceptable because both are admin-side setup gaps with the same remediation (open admin settings, fill in the field). The dedicated exception class lets controllers render an empty-state response instead of a 500.
+- The namespace regex matches REQ-TMPL-03 verbatim — if either spec ever loosens the constraint (e.g. to allow hyphens), both must move together. TODO: extract the regex to a shared constant if a second consumer needs it.
+- The resolver currently only knows template + template-version registers. New register-backed features (signing requests, document register, dossier register, consent log) will need to either extend this class with new lookups or follow the same pattern in sibling resolvers. The decision is deferred until the second feature lands; this REQ documents the existing contract without prescribing the expansion model.

--- a/openspec/changes/archive/retrofit-2026-05-24-openregister-bridge/tasks.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-openregister-bridge/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] task-1: openregister-bridge#REQ-001 — OpenRegister Configuration and Namespace Resolver (retroactive annotation)

--- a/openspec/specs/openregister-bridge/spec.md
+++ b/openspec/specs/openregister-bridge/spec.md
@@ -1,0 +1,92 @@
+---
+status: implemented
+retrofit: true
+---
+
+# OpenRegister Bridge
+
+## Purpose
+
+Provides a single resolver service that translates DocuDesk `IAppConfig` keys into OpenRegister register/schema slug pairs and validates namespace identifiers used by per-app data partitions. Services that need to read or write OpenRegister objects depend on the resolver instead of reading config keys directly — this keeps the config-translation seam in one place, isolates the IAppConfig naming convention from consumer code, and gives controllers a typed exception to render setup-state UIs.
+
+The resolver is consumed by `TemplateService` and `TemplateVersionService` today; future register-backed features (signing requests, document register, dossier register, consent log) are expected to consume the same translator pattern.
+
+## Requirements
+
+### REQ-001: OpenRegister Configuration and Namespace Resolver
+
+DocuDesk SHALL expose a single resolver service that translates DocuDesk IAppConfig keys into OpenRegister register/schema slug pairs and validates namespace identifiers used by per-app data partitions. The resolver SHALL be the only consumer of the underlying config keys within DocuDesk — services that need to talk to OpenRegister SHALL depend on the resolver, not directly on `SettingsService` or `IAppConfig`.
+
+The class owns three observable behaviors:
+
+1. **Template register/schema lookup** — returns the configured slugs for the primary template store; throws if either is unset.
+2. **Template version register/schema lookup** — returns the configured slugs for the version-history store; throws if either is unset.
+3. **Namespace validation** — enforces the `/^[a-z0-9]+$/` constraint used by every register-scoping operation (matches REQ-TMPL-03's namespace contract).
+
+Both lookups read `SettingsService::getAllSettings()['configuration']` and surface configuration gaps as `RegisterNotConfiguredException` (a domain exception that callers can catch to render a calm "register not configured yet" empty state instead of a 500). Namespace validation surfaces invalid input as a generic `Exception` with `code = 400`.
+
+#### Scenario: Resolve template register/schema
+
+- **WHEN** `OpenRegisterResolver::getRegisterAndSchema()` is called
+- **AND** `SettingsService::getAllSettings()['configuration']` contains both `template_register` and `template_schema`
+- **THEN** an array `['register' => <id>, 'schema' => <id>]` is returned
+
+#### Scenario: Missing template register/schema raises RegisterNotConfiguredException
+
+- **WHEN** `getRegisterAndSchema()` is called
+- **AND** either `template_register` or `template_schema` is empty / missing
+- **THEN** a `RegisterNotConfiguredException` with message `"Template register/schema not configured"` is thrown
+- **AND** controllers may catch this exception to render an empty list with `notConfigured: true` rather than a 500 error response
+
+#### Scenario: Resolve template version register/schema
+
+- **WHEN** `OpenRegisterResolver::getVersionRegisterAndSchema()` is called
+- **AND** both `templateVersion_register` and `templateVersion_schema` are configured
+- **THEN** an array `['register' => <id>, 'schema' => <id>]` is returned
+
+#### Scenario: Missing version register/schema raises RegisterNotConfiguredException
+
+- **WHEN** `getVersionRegisterAndSchema()` is called
+- **AND** either `templateVersion_register` or `templateVersion_schema` is empty / missing
+- **THEN** a `RegisterNotConfiguredException` with message `"Template version register/schema not configured"` is thrown
+
+#### Scenario: Valid namespace passes
+
+- **WHEN** `OpenRegisterResolver::validateNamespace("larpingapp")` is called
+- **THEN** the method returns `true` and no exception is raised
+
+#### Scenario: Invalid namespace raises 400
+
+- **WHEN** `validateNamespace()` is called with a string containing uppercase letters, hyphens, underscores, or any non-`[a-z0-9]` character (e.g. `"my-app"`, `"My App"`, `""`)
+- **THEN** an `Exception` with code `400` and message `"Invalid namespace: must be lowercase alphanumeric only"` is thrown
+
+#### Notes
+
+- The resolver does NOT discover register/schema slugs at runtime — it reads what `SettingsService` has cached. If admin settings change at runtime, callers must re-resolve.
+- Both lookups raise `RegisterNotConfiguredException` with the same exception class. Callers cannot distinguish "template register missing" from "template schema missing" without parsing the message; that's acceptable because both are admin-side setup gaps with the same remediation (open admin settings, fill in the field). The dedicated exception class lets controllers render an empty-state response instead of a 500.
+- The namespace regex matches REQ-TMPL-03 verbatim — if either spec ever loosens the constraint (e.g. to allow hyphens), both must move together. TODO: extract the regex to a shared constant if a second consumer needs it.
+- The resolver currently only knows template + template-version registers. New register-backed features (signing requests, document register, dossier register, consent log) will need to either extend this class with new lookups or follow the same pattern in sibling resolvers. The decision is deferred until the second feature lands; this REQ documents the existing contract without prescribing the expansion model.
+
+## Configuration
+
+| Key | Type | Set by | Consumed by |
+|-----|------|--------|-------------|
+| `configuration.template_register` | string (OR register slug) | Admin settings | `getRegisterAndSchema()` |
+| `configuration.template_schema` | string (OR schema slug) | Admin settings | `getRegisterAndSchema()` |
+| `configuration.templateVersion_register` | string (OR register slug) | Admin settings | `getVersionRegisterAndSchema()` |
+| `configuration.templateVersion_schema` | string (OR schema slug) | Admin settings | `getVersionRegisterAndSchema()` |
+
+## Dependencies
+
+- **SettingsService** — provides the cached configuration via `getAllSettings()['configuration']`
+- **OCA\DocuDesk\Exception\RegisterNotConfiguredException** — domain exception thrown when register/schema config is missing
+
+### Current Implementation Status
+
+- **Fully implemented** with file path:
+  - `lib/Service/OpenRegisterResolver.php` — single class, 3 public methods
+
+### Consumers
+
+- `lib/Service/TemplateService.php` — calls `getRegisterAndSchema()` + `validateNamespace()`
+- `lib/Service/TemplateVersionService.php` — calls `getVersionRegisterAndSchema()`


### PR DESCRIPTION
## Retrofit — Reverse-Spec (new capability)

Mints a new `openregister-bridge` capability and describes the observed behavior of 3 methods in `OpenRegisterResolver` as 1 new REQ.

Ghost change: `retrofit-2026-05-24-openregister-bridge` (archived).

Refs #252.

### Why a new capability instead of `--extend template-management`

- `OpenRegisterResolver` is reused outside the template path: it gates the version-history schema separately.
- Future register-backed features (signing requests, document register, dossier register, consent log) will need the same config-translation seam.
- The class is independent of any consumer's data model. Embedding the resolver REQ inside `template-management` would tie the resolver's evolution to template feature changes.

### What this PR does

- Creates `openspec/specs/openregister-bridge/spec.md` with `retrofit: true` frontmatter
- Drafts REQ-001 — OpenRegister Configuration and Namespace Resolver — covering:
  - Template register/schema lookup (`getRegisterAndSchema`)
  - Template version register/schema lookup (`getVersionRegisterAndSchema`)
  - Namespace validation (`validateNamespace`)
- Documents the typed-exception contract: `RegisterNotConfiguredException` enables controllers to render setup-state empty responses instead of 500s
- Creates `tasks.md` with 1 task (`[x]` — code already exists)
- Annotates 3 methods with `@spec openspec/changes/retrofit-2026-05-24-openregister-bridge/tasks.md#task-1`
- Archives the ghost change

### What this PR does NOT do

- No code behaviour changes — annotations only
- Does not pre-emptively expand the resolver for other registers (signing, dossier, document) — deferred until the second feature lands (TODO note in REQ Notes)
- Does not extract the namespace regex to a shared constant (currently mirrors REQ-TMPL-03 verbatim)

### Review focus

- New-capability decision: is `openregister-bridge` the right home, or should this live inside `template-management`?
- REQ language matches observed code (RegisterNotConfiguredException, not generic Exception)
- Scenarios cover both lookup paths + both namespace outcomes

Source: `openspec/coverage-report.json` generated 2026-05-24 | Cluster: `bucket_2b.openregister-bridge`