### PR TITLE
docs(spec-coverage): drive docudesk to zero uncovered methods

### DIFF
--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -98,6 +98,8 @@ class DashboardController extends Controller
      * @NoCSRFRequired
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-docudesk/tasks.md#task-18
      */
     public function catchAll(string $path=''): TemplateResponse
     {

--- a/lib/Controller/SigningController.php
+++ b/lib/Controller/SigningController.php
@@ -79,6 +79,8 @@ class SigningController extends Controller
      * @return JSONResponse The created signing request
      *
      * @NoAdminRequired
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#6-1
      */
     public function createRequest(): JSONResponse
     {
@@ -98,6 +100,8 @@ class SigningController extends Controller
      * @return JSONResponse List of signing requests
      *
      * @NoAdminRequired
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#6-1
      */
     public function listRequests(): JSONResponse
     {
@@ -150,6 +154,8 @@ class SigningController extends Controller
      * @return JSONResponse The signing request details
      *
      * @NoAdminRequired
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#6-1
      */
     public function showRequest(string $id): JSONResponse
     {
@@ -170,6 +176,8 @@ class SigningController extends Controller
      * @return JSONResponse The cancelled request
      *
      * @NoAdminRequired
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#6-1
      */
     public function cancelRequest(string $id): JSONResponse
     {
@@ -190,6 +198,8 @@ class SigningController extends Controller
      * @return JSONResponse The updated signer record
      *
      * @NoAdminRequired
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#6-1
      */
     public function sign(string $id): JSONResponse
     {
@@ -211,6 +221,8 @@ class SigningController extends Controller
      * @return JSONResponse The updated signer record
      *
      * @NoAdminRequired
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#6-1
      */
     public function decline(string $id): JSONResponse
     {
@@ -231,6 +243,8 @@ class SigningController extends Controller
      * @return JSONResponse Results for each request
      *
      * @NoAdminRequired
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#6-1
      */
     public function bulkSign(): JSONResponse
     {
@@ -256,6 +270,8 @@ class SigningController extends Controller
      * @return JSONResponse The verification results
      *
      * @NoAdminRequired
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#6-1
      */
     public function verify(int $fileId): JSONResponse
     {
@@ -284,6 +300,8 @@ class SigningController extends Controller
      * @return JSONResponse The audit trail entries
      *
      * @NoAdminRequired
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#6-1
      */
     public function getAudit(string $id): JSONResponse
     {

--- a/lib/Controller/TemplatesController.php
+++ b/lib/Controller/TemplatesController.php
@@ -336,6 +336,8 @@ class TemplatesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/advanced-template-management/tasks.md#task-5
      */
     public function preview(): JSONResponse
     {
@@ -367,6 +369,8 @@ class TemplatesController extends Controller
      * @NoCSRFRequired
      *
      * @SuppressWarnings(PHPMD.ShortVariable)
+     *
+     * @spec openspec/changes/advanced-template-management/tasks.md#task-5
      */
     public function previewTemplate(string $id): JSONResponse
     {

--- a/lib/Service/BatchStateService.php
+++ b/lib/Service/BatchStateService.php
@@ -71,6 +71,8 @@ class BatchStateService
      * Return the maximum number of files allowed in a single batch.
      *
      * @return int Configured or default maximum.
+     *
+     * @spec openspec/specs/batch-anonymization/spec.md
      */
     public function getMaxFiles(): int
     {
@@ -142,6 +144,8 @@ class BatchStateService
      * @param array<string, mixed> $batch   Full batch record to store.
      *
      * @return void
+     *
+     * @spec openspec/specs/batch-anonymization/spec.md
      */
     public function updateBatch(string $batchId, array $batch): void
     {
@@ -155,6 +159,8 @@ class BatchStateService
      * @param string $batchId Batch identifier.
      *
      * @return void
+     *
+     * @spec openspec/specs/batch-anonymization/spec.md
      */
     public function deleteBatch(string $batchId): void
     {

--- a/lib/Service/DataResolverService.php
+++ b/lib/Service/DataResolverService.php
@@ -297,6 +297,8 @@ class DataResolverService
      * Clear the per-request resolved object cache
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-docudesk/tasks.md#task-38
      */
     public function clearCache(): void
     {

--- a/lib/Service/FileUploadService.php
+++ b/lib/Service/FileUploadService.php
@@ -60,6 +60,8 @@ class FileUploadService
      * @return string The current user ID
      *
      * @throws Exception If no user is logged in
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-docudesk/tasks.md#task-2
      */
     public function getCurrentUserId(): string
     {

--- a/lib/Service/Signing/NativeSigningProvider.php
+++ b/lib/Service/Signing/NativeSigningProvider.php
@@ -81,6 +81,8 @@ class NativeSigningProvider implements SigningProviderInterface
      * @return array<string, mixed> Result with signing session identifier
      *
      * @throws RuntimeException If the signature level is not supported
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-2
      */
     public function initiateSigning(
         string $documentPath,
@@ -123,6 +125,8 @@ class NativeSigningProvider implements SigningProviderInterface
      * @return array<string, mixed> The session status
      *
      * @throws RuntimeException If session not found
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-2
      */
     public function checkStatus(string $externalId): array
     {
@@ -149,6 +153,8 @@ class NativeSigningProvider implements SigningProviderInterface
      * @return string The signed document path
      *
      * @throws RuntimeException If session not found or not completed
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-2
      */
     public function downloadSignedDocument(string $externalId): string
     {
@@ -173,6 +179,8 @@ class NativeSigningProvider implements SigningProviderInterface
      * @return bool True if cancelled
      *
      * @throws RuntimeException If session not found
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-2
      */
     public function cancelSigning(string $externalId): bool
     {
@@ -192,6 +200,8 @@ class NativeSigningProvider implements SigningProviderInterface
      * @param string $level The signature level to check
      *
      * @return bool True if SES level
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-2
      */
     public function supportsLevel(string $level): bool
     {

--- a/lib/Service/Signing/SigningProviderFactory.php
+++ b/lib/Service/Signing/SigningProviderFactory.php
@@ -66,6 +66,8 @@ class SigningProviderFactory
      * Get the currently configured signing provider
      *
      * @return SigningProviderInterface The active signing provider
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-4
      */
     public function getActiveProvider(): SigningProviderInterface
     {
@@ -87,6 +89,8 @@ class SigningProviderFactory
      * @return SigningProviderInterface The requested provider
      *
      * @throws RuntimeException If the provider is not available
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-4
      */
     public function getProvider(string $identifier): SigningProviderInterface
     {

--- a/lib/Service/Signing/SigningProviderInterface.php
+++ b/lib/Service/Signing/SigningProviderInterface.php
@@ -46,6 +46,8 @@ interface SigningProviderInterface
      * @param array<string, mixed> $options      Additional options
      *
      * @return array<string, mixed> Result with keys: success, externalId, message
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-1
      */
     public function initiateSigning(
         string $documentPath,
@@ -61,6 +63,8 @@ interface SigningProviderInterface
      * @param string $externalId The external signing flow identifier
      *
      * @return array<string, mixed> Status with keys: status, signers, completedAt
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-1
      */
     public function checkStatus(string $externalId): array;
 
@@ -70,6 +74,8 @@ interface SigningProviderInterface
      * @param string $externalId The external signing flow identifier
      *
      * @return string The signed document content
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-1
      */
     public function downloadSignedDocument(string $externalId): string;
 
@@ -79,6 +85,8 @@ interface SigningProviderInterface
      * @param string $externalId The external signing flow identifier
      *
      * @return bool True if cancellation succeeded
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-1
      */
     public function cancelSigning(string $externalId): bool;
 
@@ -88,6 +96,8 @@ interface SigningProviderInterface
      * @param string $level The signature level (SES, AdES, QES)
      *
      * @return bool True if the level is supported
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-1
      */
     public function supportsLevel(string $level): bool;
 }//end interface

--- a/lib/Service/Signing/ValidSignProvider.php
+++ b/lib/Service/Signing/ValidSignProvider.php
@@ -71,6 +71,8 @@ class ValidSignProvider implements SigningProviderInterface
      * @return array<string, mixed> Result with ValidSign package ID
      *
      * @throws RuntimeException If provider is not configured
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-3
      */
     public function initiateSigning(
         string $documentPath,
@@ -103,6 +105,8 @@ class ValidSignProvider implements SigningProviderInterface
      * @param string $externalId The ValidSign package identifier
      *
      * @return array<string, mixed> The signing flow status
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-3
      */
     public function checkStatus(string $externalId): array
     {
@@ -122,6 +126,8 @@ class ValidSignProvider implements SigningProviderInterface
      * @return string The signed document content
      *
      * @throws RuntimeException Always throws - not yet implemented
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-3
      */
     public function downloadSignedDocument(string $externalId): string
     {
@@ -137,6 +143,8 @@ class ValidSignProvider implements SigningProviderInterface
      * @param string $externalId The ValidSign package identifier
      *
      * @return bool True if cancelled
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-3
      */
     public function cancelSigning(string $externalId): bool
     {
@@ -150,6 +158,8 @@ class ValidSignProvider implements SigningProviderInterface
      * @param string $level The signature level to check
      *
      * @return bool True if supported
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#2-3
      */
     public function supportsLevel(string $level): bool
     {

--- a/lib/Service/SigningAuditService.php
+++ b/lib/Service/SigningAuditService.php
@@ -84,6 +84,8 @@ class SigningAuditService
      * @return array<string, mixed> The created audit entry
      *
      * @throws RuntimeException If logging fails
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#4-2
      */
     public function logEvent(
         string $signingRequestId,
@@ -125,6 +127,8 @@ class SigningAuditService
      * @param string $signingRequestId The signing request ID
      *
      * @return array<int, array<string, mixed>> The audit entries
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#4-1
      */
     public function getAuditTrail(string $signingRequestId): array
     {
@@ -162,6 +166,8 @@ class SigningAuditService
      * @throws RuntimeException Always throws
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#4-3
      */
     public function rejectUpdate(string $entryId): void
     {
@@ -181,6 +187,8 @@ class SigningAuditService
      * @throws RuntimeException Always throws
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#4-3
      */
     public function rejectDelete(string $entryId): void
     {

--- a/lib/Service/SigningService.php
+++ b/lib/Service/SigningService.php
@@ -91,6 +91,8 @@ class SigningService
      * @return array<string, mixed> The created signing request
      *
      * @throws RuntimeException If creation fails
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#3-2
      */
     public function createRequest(array $data): array
     {
@@ -168,6 +170,8 @@ class SigningService
      * @return array<string, mixed> The signing request
      *
      * @throws RuntimeException If not found
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#3-1
      */
     public function getRequest(string $requestId): array
     {
@@ -188,6 +192,8 @@ class SigningService
      * List signing requests
      *
      * @return array<int, array<string, mixed>> List of signing requests
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#3-1
      */
     public function listRequests(): array
     {
@@ -208,6 +214,8 @@ class SigningService
      * @return array<string, mixed> The updated signer record
      *
      * @throws RuntimeException If signing fails
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#3-3
      */
     public function sign(string $requestId, string $signerId): array
     {
@@ -266,6 +274,8 @@ class SigningService
      * @param string $reason    The decline reason
      *
      * @return array<string, mixed> The updated signer record
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#3-2
      */
     public function decline(string $requestId, string $signerId, string $reason): array
     {
@@ -318,6 +328,8 @@ class SigningService
      * @param string $requestId The signing request ID
      *
      * @return array<string, mixed> The cancelled request
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#3-2
      */
     public function cancelRequest(string $requestId): array
     {
@@ -356,6 +368,8 @@ class SigningService
      * @param array<string> $requestIds Array of request IDs to sign
      *
      * @return array<string, array<string, mixed>> Results keyed by request ID
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#3-4
      */
     public function bulkSign(array $requestIds): array
     {
@@ -401,6 +415,8 @@ class SigningService
      * @param string $newStatus     The proposed new status
      *
      * @return bool True if transition is valid
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#3-2
      */
     public function isValidTransition(string $currentStatus, string $newStatus): bool
     {

--- a/lib/Service/SigningVerificationService.php
+++ b/lib/Service/SigningVerificationService.php
@@ -60,6 +60,8 @@ class SigningVerificationService
      * @return array<string, mixed> Verification result
      *
      * @throws RuntimeException If file cannot be accessed
+     *
+     * @spec openspec/changes/digital-signing-integration/tasks.md#5-1
      */
     public function verifyDocument(int $fileId, string $userId): array
     {

--- a/lib/Service/TemplateRenderer.php
+++ b/lib/Service/TemplateRenderer.php
@@ -176,6 +176,8 @@ class TemplateRenderer
      * @param string $html HTML content with conditional data attributes
      *
      * @return string HTML with data attributes replaced by Twig if blocks
+     *
+     * @spec openspec/changes/advanced-template-management/tasks.md#task-7
      */
     public function convertConditionalSections(string $html): string
     {

--- a/lib/Service/TextAnalysisService.php
+++ b/lib/Service/TextAnalysisService.php
@@ -55,6 +55,8 @@ class TextAnalysisService
      * @param array<string> $words The words to count
      *
      * @return int Total occurrence count
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-docudesk/tasks.md#task-46
      */
     public function countWordOccurrences(string $text, array $words): int
     {

--- a/src/App.vue
+++ b/src/App.vue
@@ -89,6 +89,11 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * Current user's Nextcloud permission set, passed to the app shell.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-navigation-menu-req-dash-03
+		 */
 		permissions() {
 			return window.OC?.currentUser?.permissions ?? []
 		},
@@ -102,6 +107,8 @@ export default {
 		 *
 		 * @param {string} key Translation key.
 		 * @return {string} Translated string (or the key on miss).
+		 *
+		 * @spec exclude Thin i18n wrapper around @nextcloud/l10n translate; no domain behavior.
 		 */
 		translateForApp(key) {
 			return ncT('docudesk', key)

--- a/src/dialogs/ConditionalSectionDialog.vue
+++ b/src/dialogs/ConditionalSectionDialog.vue
@@ -43,6 +43,11 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Conditional operator options for the dialog dropdown.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		opOptions() {
 			return [
 				{ label: t('docudesk', 'equals'), value: 'equals' },
@@ -52,10 +57,20 @@ export default {
 				{ label: t('docudesk', 'is not empty'), value: 'is_not_empty' },
 			]
 		},
+		/**
+		 * Whether the selected operator requires a comparison value.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		needsValue() {
 			const op = this.condOp?.value || this.condOp
 			return op !== 'is_empty' && op !== 'is_not_empty'
 		},
+		/**
+		 * Live Twig-syntax preview of the conditional section.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		preview() {
 			const field = this.condField || 'field'
 			const op = this.condOp?.value || this.condOp || 'is_not_empty'
@@ -72,6 +87,11 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Emit the configured conditional section to the parent editor.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		confirm() {
 			const field = this.condField || 'field'
 			const op = this.condOp?.value || this.condOp || 'is_not_empty'

--- a/src/dialogs/MergeFieldDialog.vue
+++ b/src/dialogs/MergeFieldDialog.vue
@@ -32,6 +32,11 @@ export default {
 		return { fieldName: '' }
 	},
 	computed: {
+		/**
+		 * Hint text showing the merge-field placeholder that will be inserted.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		hintText() {
 			const name = this.fieldName || 'field'
 			return t('docudesk', 'This inserts {placeholder} into the template.', { placeholder: '{{ ' + name + ' }}' })
@@ -39,6 +44,11 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Emit the chosen merge-field name to the parent editor.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		confirm() {
 			if (!this.fieldName) return
 			this.$emit('insert', this.fieldName)

--- a/src/services/getTheme.js
+++ b/src/services/getTheme.js
@@ -8,6 +8,8 @@
  * accordingly. If neither attribute is present, it defaults to 'dark'.
  *
  * @return { 'light' | 'dark' } The current theme, either 'light' or 'dark'.
+ *
+ * @spec openspec/specs/dashboard/spec.md#requirement-docudesk-dashboard-view-req-dash-01
  */
 export const getTheme = () => {
 	if (document.body.hasAttribute('data-theme-light')) {

--- a/src/store/modules/anonymization.js
+++ b/src/store/modules/anonymization.js
@@ -38,6 +38,8 @@ export const useAnonymizationStore = defineStore(
                  * Add files to the queue and start processing.
                  *
                  * @param {File[]} fileList Array of File objects.
+                 *
+                 * @spec openspec/specs/anonymization/spec.md#requirement-frontend-file-processing-queue-req-anon-10
                  */
 			async addFiles(fileList) {
 				const newEntries = Array.from(fileList).map(
@@ -65,6 +67,8 @@ export const useAnonymizationStore = defineStore(
 
 			/*
                  * Process all queued files sequentially.
+                 *
+                 * @spec openspec/specs/anonymization/spec.md#requirement-frontend-file-processing-queue-req-anon-10
                  */
 			async processQueue() {
 				if (this.processing) {
@@ -88,6 +92,8 @@ export const useAnonymizationStore = defineStore(
                  * Run the full pipeline for a single file entry.
                  *
                  * @param {object} entry File entry from the queue.
+                 *
+                 * @spec openspec/specs/anonymization/spec.md#requirement-frontend-file-processing-queue-req-anon-10
                  */
 			async processFile(entry) {
 				try {
@@ -149,6 +155,8 @@ export const useAnonymizationStore = defineStore(
 
 			/*
                  * Clear all completed/errored files from the list.
+                 *
+                 * @spec openspec/specs/anonymization/spec.md#requirement-frontend-file-processing-queue-req-anon-10
                  */
 			clearCompleted() {
 				this.files = this.files.filter((f) => f.status !== 'completed' && f.status !== 'error')
@@ -156,6 +164,8 @@ export const useAnonymizationStore = defineStore(
 
 			/*
                  * Reset everything.
+                 *
+                 * @spec openspec/specs/anonymization/spec.md#requirement-frontend-file-processing-queue-req-anon-10
                  */
 			reset() {
 				this.files = []

--- a/src/store/modules/batchAnonymization.js
+++ b/src/store/modules/batchAnonymization.js
@@ -7,9 +7,19 @@ export const useBatchAnonymizationStore = defineStore('batchAnonymization', {
 		isActive: (state) => state.batchId !== null,
 		selectedEntityCount: (state) => state.entities.filter((e) => e.included).length,
 		filesWithEntities: (state) => state.files.filter((f) => (f.entityCount || 0) > 0).length,
+		/**
+		 * Derive the wizard step index from the current batch status.
+		 *
+		 * @spec openspec/specs/batch-anonymization/spec.md
+		 */
 		stepNumber(state) { return { uploading: 0, extracting: 1, review: 2, anonymizing: 3, completed: 4, error: 0 }[state.batchStatus] || 0 },
 	},
 	actions: {
+		/**
+		 * Upload a multi-file batch and start sequential extraction.
+		 *
+		 * @spec openspec/specs/batch-anonymization/spec.md
+		 */
 		async uploadBatch(fileList) {
 			this.processing = true; this.error = null
 			try {
@@ -19,6 +29,11 @@ export const useBatchAnonymizationStore = defineStore('batchAnonymization', {
 				await this.extractAll()
 			} catch (e) { this.error = e.response?.data?.error || e.message; this.batchStatus = 'error' } finally { this.processing = false }
 		},
+		/**
+		 * Poll the sequential extraction endpoint until the batch is ready for review.
+		 *
+		 * @spec openspec/specs/batch-anonymization/spec.md
+		 */
 		async extractAll() {
 			while (this.batchStatus === 'extracting') {
 				try {
@@ -29,6 +44,11 @@ export const useBatchAnonymizationStore = defineStore('batchAnonymization', {
 				} catch (e) { this.error = e.response?.data?.error || e.message; this.batchStatus = 'error'; break }
 			}
 		},
+		/**
+		 * Fetch the consolidated entity list for review, applying the confidence filter.
+		 *
+		 * @spec openspec/specs/anonymization-entity-review/spec.md
+		 */
 		async fetchEntities() {
 			try {
 				let u = '/apps/docudesk/api/anonymization/batch/' + this.batchId + '/entities'
@@ -36,8 +56,18 @@ export const useBatchAnonymizationStore = defineStore('batchAnonymization', {
 				const r = await axios.get(generateUrl(u)); this.entities = r.data.entities || []; this.totalEntities = r.data.entityCount || 0
 			} catch (e) { this.error = e.response?.data?.error || e.message }
 		},
+		/**
+		 * Toggle whether a reviewed entity is included in anonymization.
+		 *
+		 * @spec openspec/specs/anonymization-entity-review/spec.md
+		 */
 		toggleEntity(i) { if (this.entities[i]) this.entities[i].included = !this.entities[i].included },
 		setVisibleEntities(indices, inc) { indices.forEach((i) => { if (this.entities[i]) this.entities[i].included = inc }) },
+		/**
+		 * Anonymize the batch using the reviewed/included entities.
+		 *
+		 * @spec openspec/specs/batch-anonymization/spec.md
+		 */
 		async anonymizeBatch() {
 			this.processing = true; this.error = null; this.batchStatus = 'anonymizing'
 			try {
@@ -46,11 +76,21 @@ export const useBatchAnonymizationStore = defineStore('batchAnonymization', {
 				this.batchStatus = 'completed'; await this.refreshStatus()
 			} catch (e) { this.error = e.response?.data?.error || e.message; this.batchStatus = 'error' } finally { this.processing = false }
 		},
+		/**
+		 * Refresh the batch status and file list from the status endpoint.
+		 *
+		 * @spec openspec/specs/batch-anonymization/spec.md
+		 */
 		async refreshStatus() {
 			if (!this.batchId) return
 			try { const r = await axios.get(generateUrl('/apps/docudesk/api/anonymization/batch/' + this.batchId + '/status')); this.batchStatus = r.data.batchStatus; this.files = r.data.files || this.files } catch (e) { /* silent */ }
 		},
 		getReportUrl() { return generateUrl('/apps/docudesk/api/anonymization/batch/' + this.batchId + '/report') },
+		/**
+		 * Reset the batch wizard state to its initial values.
+		 *
+		 * @spec openspec/specs/batch-anonymization/spec.md
+		 */
 		reset() { Object.assign(this, { batchId: null, batchStatus: null, files: [], entities: [], progress: 0, totalFiles: 0, totalEntities: 0, error: null, processing: false, minConfidence: 0.0 }) },
 	},
 })

--- a/src/store/modules/consent.js
+++ b/src/store/modules/consent.js
@@ -27,6 +27,11 @@ export const useConsentStore = defineStore(
 			},
 		},
 		actions: {
+			/**
+			 * Fetch all consent records.
+			 *
+			 * @spec openspec/specs/consent-management/spec.md#requirement-consent-listing-and-querying-req-cons-03
+			 */
 			async fetchConsents() {
 				this.loading = true
 				this.error = null
@@ -40,6 +45,11 @@ export const useConsentStore = defineStore(
 					this.loading = false
 				}
 			},
+			/**
+			 * Fetch a single consent record by ID.
+			 *
+			 * @spec openspec/specs/consent-management/spec.md#requirement-consent-listing-and-querying-req-cons-03
+			 */
 			async fetchConsent(id) {
 				this.loading = true
 				this.error = null
@@ -55,6 +65,11 @@ export const useConsentStore = defineStore(
 					this.loading = false
 				}
 			},
+			/**
+			 * Update a consent record and sync it in the local list.
+			 *
+			 * @spec openspec/specs/consent-management/spec.md#requirement-consent-status-lifecycle-req-cons-02
+			 */
 			async updateConsent(id, data) {
 				this.loading = true
 				this.error = null
@@ -76,6 +91,11 @@ export const useConsentStore = defineStore(
 					this.loading = false
 				}
 			},
+			/**
+			 * Fetch all consent records linked to a specific document.
+			 *
+			 * @spec openspec/specs/consent-management/spec.md#requirement-consent-listing-and-querying-req-cons-03
+			 */
 			async fetchConsentsByDocument(documentId) {
 				this.loading = true
 				this.error = null
@@ -93,6 +113,11 @@ export const useConsentStore = defineStore(
 			setConsentItem(consent) {
 				this.consentItem = consent
 			},
+			/**
+			 * Clear the currently selected consent record.
+			 *
+			 * @spec openspec/specs/consent-management/spec.md#requirement-consent-ui-req-cons-10
+			 */
 			clearConsentItem() {
 				this.consentItem = null
 			},

--- a/src/store/modules/folderAnonymization.js
+++ b/src/store/modules/folderAnonymization.js
@@ -24,6 +24,11 @@ export const useFolderAnonymizationStore = defineStore('folderAnonymization', {
 		extractedCount: (state) => state.files.filter((f) => f.status === 'extracted' || f.status === 'error').length,
 	},
 	actions: {
+		/**
+		 * Start a folder anonymization batch and begin polling for progress.
+		 *
+		 * @spec openspec/changes/folder-analysis-anonymization/tasks.md#3-1
+		 */
 		async startFolderBatch(folderPath) {
 			this.processing = true
 			this.error = null
@@ -46,11 +51,21 @@ export const useFolderAnonymizationStore = defineStore('folderAnonymization', {
 			}
 		},
 
+		/**
+		 * Begin polling the batch status endpoint every 3 seconds.
+		 *
+		 * @spec openspec/changes/folder-analysis-anonymization/tasks.md#5-1
+		 */
 		startPolling() {
 			this.stopPolling()
 			this.pollTimer = setInterval(() => this.pollStatus(), 3000)
 		},
 
+		/**
+		 * Stop the active status polling timer.
+		 *
+		 * @spec openspec/changes/folder-analysis-anonymization/tasks.md#5-1
+		 */
 		stopPolling() {
 			if (this.pollTimer) {
 				clearInterval(this.pollTimer)
@@ -58,6 +73,11 @@ export const useFolderAnonymizationStore = defineStore('folderAnonymization', {
 			}
 		},
 
+		/**
+		 * Poll the batch status, update progress, and load entities once ready for review.
+		 *
+		 * @spec openspec/changes/folder-analysis-anonymization/tasks.md#5-2
+		 */
 		async pollStatus() {
 			if (!this.batchId) return
 			try {
@@ -78,6 +98,11 @@ export const useFolderAnonymizationStore = defineStore('folderAnonymization', {
 			}
 		},
 
+		/**
+		 * Fetch consolidated entities for the folder batch, applying the confidence filter.
+		 *
+		 * @spec openspec/specs/anonymization-entity-review/spec.md
+		 */
 		async fetchEntities() {
 			try {
 				let url = '/apps/docudesk/api/anonymization/batch/' + this.batchId + '/entities'
@@ -92,18 +117,33 @@ export const useFolderAnonymizationStore = defineStore('folderAnonymization', {
 			}
 		},
 
+		/**
+		 * Toggle whether a reviewed entity is included in anonymization.
+		 *
+		 * @spec openspec/specs/anonymization-entity-review/spec.md
+		 */
 		toggleEntity(index) {
 			if (this.entities[index]) {
 				this.entities[index].included = !this.entities[index].included
 			}
 		},
 
+		/**
+		 * Set the inclusion flag for a set of currently visible entities.
+		 *
+		 * @spec openspec/specs/anonymization-entity-review/spec.md
+		 */
 		setVisibleEntities(indices, included) {
 			indices.forEach((i) => {
 				if (this.entities[i]) this.entities[i].included = included
 			})
 		},
 
+		/**
+		 * Anonymize the folder batch using the reviewed/included entities.
+		 *
+		 * @spec openspec/changes/folder-analysis-anonymization/tasks.md#3-1
+		 */
 		async anonymizeBatch() {
 			this.processing = true
 			this.error = null
@@ -129,6 +169,11 @@ export const useFolderAnonymizationStore = defineStore('folderAnonymization', {
 			return generateUrl('/apps/docudesk/api/anonymization/batch/' + this.batchId + '/report')
 		},
 
+		/**
+		 * Reset the folder batch state and stop any active polling.
+		 *
+		 * @spec openspec/changes/folder-analysis-anonymization/tasks.md#3-1
+		 */
 		reset() {
 			this.stopPolling()
 			Object.assign(this, {

--- a/src/store/modules/navigation.ts
+++ b/src/store/modules/navigation.ts
@@ -16,14 +16,29 @@ export const useNavigationStore = defineStore('ui', {
 		transferData: null,
 	} as NavigationStoreState),
 	actions: {
+		/**
+		 * Switch the active DocuDesk view in the SPA navigation shell.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-navigation-menu-req-dash-03
+		 */
 		setSelected(selected: NavigationStoreState['selected']) {
 			this.selected = selected
 			console.log('Active menu item set to ' + selected)
 		},
+		/**
+		 * Set the currently active modal identifier.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-navigation-menu-req-dash-03
+		 */
 		setModal(modal: NavigationStoreState['modal']) {
 			this.modal = modal
 			console.log('Active modal set to ' + modal)
 		},
+		/**
+		 * Set the currently active dialog identifier.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-navigation-menu-req-dash-03
+		 */
 		setDialog(dialog: NavigationStoreState['dialog']) {
 			this.dialog = dialog
 			console.log('Active dialog set to ' + dialog)

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -20,6 +20,11 @@ export const useSettingsStore = defineStore(
 			getIsAdmin: (state) => state.isAdmin,
 		},
 		actions: {
+			/**
+			 * Fetch DocuDesk settings, OpenRegister availability and admin status.
+			 *
+			 * @spec openspec/specs/admin-settings/spec.md#requirement-settings-rest-api-req-set-06
+			 */
 			async fetchSettings() {
 				this.loading = true
 				this.error = null
@@ -67,6 +72,11 @@ export const useSettingsStore = defineStore(
 				}
 			},
 
+			/**
+			 * Persist DocuDesk settings via the settings REST API.
+			 *
+			 * @spec openspec/specs/admin-settings/spec.md#requirement-settings-rest-api-req-set-06
+			 */
 			async saveSettings(settingsData) {
 				this.loading = true
 				this.error = null

--- a/src/store/modules/signing.js
+++ b/src/store/modules/signing.js
@@ -19,6 +19,11 @@ export const useSigningStore = defineStore(
 			completedRequests: (state) => state.signingRequests.filter((r) => r.status === 'COMPLETED'),
 		},
 		actions: {
+			/**
+			 * Fetch all signing requests from the backend.
+			 *
+			 * @spec openspec/changes/digital-signing-integration/tasks.md#8-1
+			 */
 			async fetchSigningRequests() {
 				this.loading = true
 				this.error = null
@@ -32,6 +37,11 @@ export const useSigningStore = defineStore(
 					this.loading = false
 				}
 			},
+			/**
+			 * Fetch a single signing request by ID.
+			 *
+			 * @spec openspec/changes/digital-signing-integration/tasks.md#8-1
+			 */
 			async fetchSigningRequest(id) {
 				this.loading = true
 				this.error = null
@@ -47,6 +57,11 @@ export const useSigningStore = defineStore(
 					this.loading = false
 				}
 			},
+			/**
+			 * Create a new signing request.
+			 *
+			 * @spec openspec/changes/digital-signing-integration/tasks.md#8-1
+			 */
 			async createSigningRequest(data) {
 				this.loading = true
 				this.error = null
@@ -62,6 +77,11 @@ export const useSigningStore = defineStore(
 					this.loading = false
 				}
 			},
+			/**
+			 * Sign a document for a given signer in a signing request.
+			 *
+			 * @spec openspec/changes/digital-signing-integration/tasks.md#8-1
+			 */
 			async signDocument(requestId, signerId) {
 				this.loading = true
 				this.error = null
@@ -79,6 +99,11 @@ export const useSigningStore = defineStore(
 					this.loading = false
 				}
 			},
+			/**
+			 * Decline a signing request for a given signer with a reason.
+			 *
+			 * @spec openspec/changes/digital-signing-integration/tasks.md#8-1
+			 */
 			async declineRequest(requestId, signerId, reason) {
 				this.loading = true
 				this.error = null
@@ -96,6 +121,11 @@ export const useSigningStore = defineStore(
 					this.loading = false
 				}
 			},
+			/**
+			 * Cancel a signing request.
+			 *
+			 * @spec openspec/changes/digital-signing-integration/tasks.md#8-1
+			 */
 			async cancelRequest(requestId) {
 				this.loading = true
 				try {
@@ -107,6 +137,11 @@ export const useSigningStore = defineStore(
 					this.loading = false
 				}
 			},
+			/**
+			 * Bulk-sign multiple signing requests at once.
+			 *
+			 * @spec openspec/changes/digital-signing-integration/tasks.md#8-1
+			 */
 			async bulkSign(requestIds) {
 				this.loading = true
 				try {
@@ -123,6 +158,11 @@ export const useSigningStore = defineStore(
 					this.loading = false
 				}
 			},
+			/**
+			 * Verify the signatures embedded in a document file.
+			 *
+			 * @spec openspec/changes/digital-signing-integration/tasks.md#8-1
+			 */
 			async verifyDocument(fileId) {
 				this.loading = true
 				try {
@@ -137,6 +177,11 @@ export const useSigningStore = defineStore(
 					this.loading = false
 				}
 			},
+			/**
+			 * Fetch the immutable audit trail for a signing request.
+			 *
+			 * @spec openspec/changes/digital-signing-integration/tasks.md#8-1
+			 */
 			async fetchAuditTrail(requestId) {
 				this.loading = true
 				try {

--- a/src/store/modules/template.js
+++ b/src/store/modules/template.js
@@ -13,6 +13,11 @@ export const useTemplateStore = defineStore('template', {
 		error: null,
 	}),
 	actions: {
+		/**
+		 * Fetch templates with optional category/tag/search filters.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-6
+		 */
 		async fetchTemplates(filters = {}) {
 			this.loading = true
 			this.error = null
@@ -33,6 +38,11 @@ export const useTemplateStore = defineStore('template', {
 				this.loading = false
 			}
 		},
+		/**
+		 * Fetch a single template by ID.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-6
+		 */
 		async fetchTemplate(id) {
 			this.loading = true
 			this.error = null
@@ -48,6 +58,11 @@ export const useTemplateStore = defineStore('template', {
 				this.loading = false
 			}
 		},
+		/**
+		 * Create a new template.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		async createTemplate(data) {
 			this.loading = true
 			this.error = null
@@ -63,6 +78,11 @@ export const useTemplateStore = defineStore('template', {
 				this.loading = false
 			}
 		},
+		/**
+		 * Update an existing template.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		async updateTemplate(id, data) {
 			this.loading = true
 			this.error = null
@@ -78,6 +98,11 @@ export const useTemplateStore = defineStore('template', {
 				this.loading = false
 			}
 		},
+		/**
+		 * Delete a template by ID.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		async deleteTemplate(id) {
 			this.loading = true
 			this.error = null
@@ -93,6 +118,11 @@ export const useTemplateStore = defineStore('template', {
 				this.loading = false
 			}
 		},
+		/**
+		 * Duplicate an existing template into a new draft.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		async duplicateTemplate(id) {
 			this.loading = true
 			this.error = null
@@ -107,6 +137,11 @@ export const useTemplateStore = defineStore('template', {
 				this.loading = false
 			}
 		},
+		/**
+		 * Fetch the version history for a template.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-4
+		 */
 		async fetchVersions(id) {
 			this.loading = true
 			this.error = null
@@ -122,6 +157,11 @@ export const useTemplateStore = defineStore('template', {
 				this.loading = false
 			}
 		},
+		/**
+		 * Restore a template to a prior version.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-4
+		 */
 		async restoreVersion(templateId, versionId) {
 			this.loading = true
 			this.error = null
@@ -137,6 +177,11 @@ export const useTemplateStore = defineStore('template', {
 				this.loading = false
 			}
 		},
+		/**
+		 * Render a live preview of template content with sample data.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-5
+		 */
 		async previewTemplate(content, data = {}) {
 			this.error = null
 			try {
@@ -148,6 +193,11 @@ export const useTemplateStore = defineStore('template', {
 				return null
 			}
 		},
+		/**
+		 * Acquire an edit lock on a template.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		async acquireLock(id) {
 			this.error = null
 			try {
@@ -159,6 +209,11 @@ export const useTemplateStore = defineStore('template', {
 				return null
 			}
 		},
+		/**
+		 * Release the edit lock on a template.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		async releaseLock(id) {
 			this.error = null
 			try {

--- a/src/views/Views.vue
+++ b/src/views/Views.vue
@@ -40,6 +40,12 @@ export default {
 		BatchAnonymizationView,
 		FolderAnonymizationView,
 	},
+	/**
+	 * Expose the navigation store so the shell can conditionally render the
+	 * selected DocuDesk view.
+	 *
+	 * @spec openspec/specs/dashboard/spec.md#requirement-navigation-menu-req-dash-03
+	 */
 	setup() {
 		return { navigationStore }
 	},

--- a/src/views/anonymization/AnonymizationWidget.vue
+++ b/src/views/anonymization/AnonymizationWidget.vue
@@ -179,6 +179,11 @@ export default {
 	// bind into a sibling Options API `<script>` block — which
 	// previously left `anonymizationStore` undefined and broke every
 	// v-if in the template.
+	/**
+	 * Expose the anonymization pipeline store reactively to the Options API.
+	 *
+	 * @spec openspec/specs/anonymization/spec.md#requirement-anonymization-pipeline-ui-req-anon-08
+	 */
 	setup() {
 		return { anonymizationStore }
 	},
@@ -194,6 +199,11 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Whether any completed/errored files exist that can be cleared.
+		 *
+		 * @spec openspec/specs/anonymization/spec.md#requirement-anonymization-pipeline-ui-req-anon-08
+		 */
 		canClear() {
 			return this.anonymizationStore.files.some(
 				(f) => f.status === 'completed' || f.status === 'error',
@@ -202,6 +212,11 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Queue files dropped onto the pipeline drop zone.
+		 *
+		 * @spec openspec/specs/anonymization/spec.md#requirement-anonymization-pipeline-ui-req-anon-08
+		 */
 		handleDrop(event) {
 			this.isDragging = false
 			const files = event.dataTransfer?.files
@@ -209,6 +224,11 @@ export default {
 				this.anonymizationStore.addFiles(files)
 			}
 		},
+		/**
+		 * Queue files chosen via the file picker into the pipeline.
+		 *
+		 * @spec openspec/specs/anonymization/spec.md#requirement-anonymization-pipeline-ui-req-anon-08
+		 */
 		handleFileSelect(event) {
 			const files = event.target?.files
 			if (files && files.length > 0) {
@@ -217,9 +237,19 @@ export default {
 			// Reset input so the same files can be re-selected.
 			event.target.value = ''
 		},
+		/**
+		 * Map a file's status to its pipeline step index.
+		 *
+		 * @spec openspec/specs/anonymization/spec.md#requirement-anonymization-pipeline-ui-req-anon-08
+		 */
 		stepIndex(file) {
 			return STATUS_TO_STEP[file.status] ?? 0
 		},
+		/**
+		 * Compute the CSS state classes for a pipeline step.
+		 *
+		 * @spec openspec/specs/anonymization/spec.md#requirement-anonymization-pipeline-ui-req-anon-08
+		 */
 		stepClass(file, index) {
 			const current = this.stepIndex(file)
 			if (file.status === 'completed') {
@@ -233,6 +263,11 @@ export default {
 				current: index === current,
 			}
 		},
+		/**
+		 * Human-readable label for a file processing status.
+		 *
+		 * @spec openspec/specs/anonymization/spec.md#requirement-anonymization-pipeline-ui-req-anon-08
+		 */
 		statusLabel(status) {
 			const labels = {
 				queued: t('docudesk', 'Queued'),
@@ -244,6 +279,11 @@ export default {
 			}
 			return labels[status] || status
 		},
+		/**
+		 * Progress message describing the current processing stage of a file.
+		 *
+		 * @spec openspec/specs/anonymization/spec.md#requirement-anonymization-pipeline-ui-req-anon-08
+		 */
 		processingText(file) {
 			if (file.status === 'uploading') {
 				return t('docudesk', 'Uploading {name}...', { name: file.name })
@@ -256,6 +296,11 @@ export default {
 			}
 			return ''
 		},
+		/**
+		 * Format a detection confidence score as a percentage.
+		 *
+		 * @spec openspec/specs/anonymization/spec.md#requirement-anonymization-pipeline-ui-req-anon-08
+		 */
 		formatConfidence(confidence) {
 			if (typeof confidence === 'number') {
 				return (confidence * 100).toFixed(1) + '%'

--- a/src/views/anonymization/BatchAnonymizationView.vue
+++ b/src/views/anonymization/BatchAnonymizationView.vue
@@ -65,12 +65,27 @@ import EntityReviewTable from './EntityReviewTable.vue'
 export default {
 	name: 'BatchAnonymizationView',
 	components: { NcButton, NcProgressBar, NcLoadingIcon, NcNoteCard, EntityReviewTable },
+	/**
+	 * Expose the batch anonymization wizard store to the Options API.
+	 *
+	 * @spec openspec/specs/batch-anonymization/spec.md
+	 */
 	setup() {
 		return { batchAnonymizationStore }
 	},
 	data() { return { isDragging: false } },
 	methods: {
+		/**
+		 * Upload files dropped onto the batch wizard drop zone.
+		 *
+		 * @spec openspec/specs/batch-anonymization/spec.md
+		 */
 		handleDrop(e) { const f = e.dataTransfer?.files; if (f?.length) batchAnonymizationStore.uploadBatch(f) },
+		/**
+		 * Upload files chosen via the batch wizard file picker.
+		 *
+		 * @spec openspec/specs/batch-anonymization/spec.md
+		 */
 		handleFileSelect(e) { const f = e.target?.files; if (f?.length) batchAnonymizationStore.uploadBatch(f) },
 	},
 }

--- a/src/views/anonymization/EntityReviewTable.vue
+++ b/src/views/anonymization/EntityReviewTable.vue
@@ -55,8 +55,23 @@ export default {
 	emits: ['toggle', 'bulk-select', 'bulk-deselect', 'confidence-change'],
 	data() { return { searchQuery: '', typeFilter: '', sf: 'highestConfidence', sa: false } },
 	computed: {
+		/**
+		 * Count of entities currently included for anonymization.
+		 *
+		 * @spec openspec/specs/anonymization-entity-review/spec.md
+		 */
 		selectedCount() { return this.entities.filter(e => e.included).length },
+		/**
+		 * Distinct sorted list of entity types for the type filter dropdown.
+		 *
+		 * @spec openspec/specs/anonymization-entity-review/spec.md
+		 */
 		availableTypes() { return [...new Set(this.entities.map(e => e.type))].sort() },
+		/**
+		 * Entities filtered by search query and type, then sorted.
+		 *
+		 * @spec openspec/specs/anonymization-entity-review/spec.md
+		 */
 		filteredEntities() {
 			const q = this.searchQuery.toLowerCase()
 			return this.entities.map((e, i) => ({ e, idx: i }))

--- a/src/views/anonymization/FolderAnonymizationView.vue
+++ b/src/views/anonymization/FolderAnonymizationView.vue
@@ -95,6 +95,11 @@ import EntityReviewTable from './EntityReviewTable.vue'
 export default {
 	name: 'FolderAnonymizationView',
 	components: { NcButton, NcProgressBar, NcLoadingIcon, NcNoteCard, EntityReviewTable },
+	/**
+	 * Expose the folder anonymization store to the Options API.
+	 *
+	 * @spec openspec/changes/folder-analysis-anonymization/tasks.md#3-1
+	 */
 	setup() {
 		return { store: folderAnonymizationStore }
 	},
@@ -103,12 +108,22 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Start a folder anonymization batch for the entered folder path.
+		 *
+		 * @spec openspec/changes/folder-analysis-anonymization/tasks.md#3-1
+		 */
 		startAnalysis() {
 			const path = this.folderPath.trim()
 			if (path) {
 				folderAnonymizationStore.startFolderBatch(path)
 			}
 		},
+		/**
+		 * Open the completed batch report in a new tab.
+		 *
+		 * @spec openspec/changes/folder-analysis-anonymization/tasks.md#8-1
+		 */
 		downloadReport() {
 			window.open(folderAnonymizationStore.getReportUrl(), '_blank')
 		},

--- a/src/views/consent/ConsentDetail.vue
+++ b/src/views/consent/ConsentDetail.vue
@@ -202,6 +202,11 @@ export default {
 	watch: {
 		'consentStore.consentItem': {
 			immediate: true,
+			/**
+			 * Sync the editable form fields when the selected consent record changes.
+			 *
+			 * @spec openspec/specs/consent-management/spec.md#requirement-consent-ui-req-cons-10
+			 */
 			handler(item) {
 				if (item) {
 					this.editData.consentStatus = this.consentStatusOptions.find(o => o.value === item.consentStatus) || null
@@ -212,10 +217,20 @@ export default {
 		},
 	},
 	methods: {
+		/**
+		 * Clear the selected consent and return to the consent list.
+		 *
+		 * @spec openspec/specs/consent-management/spec.md#requirement-consent-ui-req-cons-10
+		 */
 		goBack() {
 			consentStore.clearConsentItem()
 			navigationStore.setSelected('consent')
 		},
+		/**
+		 * Format a date string for display, falling back gracefully.
+		 *
+		 * @spec openspec/specs/consent-management/spec.md#requirement-consent-ui-req-cons-10
+		 */
 		formatDate(dateStr) {
 			if (!dateStr) return '-'
 			try {
@@ -224,6 +239,11 @@ export default {
 				return dateStr
 			}
 		},
+		/**
+		 * Persist edited consent status/decision fields for the record.
+		 *
+		 * @spec openspec/specs/consent-management/spec.md#requirement-consent-status-lifecycle-req-cons-02
+		 */
 		async saveChanges() {
 			const id = consentStore.consentItem?.id || consentStore.consentItem?.uuid
 			if (!id) return

--- a/src/views/consent/ConsentIndex.vue
+++ b/src/views/consent/ConsentIndex.vue
@@ -164,6 +164,11 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Column definitions for the consent records table.
+		 *
+		 * @spec openspec/specs/consent-management/spec.md#requirement-consent-ui-req-cons-10
+		 */
 		tableColumns() {
 			return [
 				{ key: 'entityText', label: t('docudesk', 'Entity'), sortable: true },
@@ -174,11 +179,21 @@ export default {
 				{ key: 'publicationDecision', label: t('docudesk', 'Decision'), sortable: true },
 			]
 		},
+		/**
+		 * Pagination metadata derived from the loaded consent list.
+		 *
+		 * @spec openspec/specs/consent-management/spec.md#requirement-consent-listing-and-querying-req-cons-03
+		 */
 		paginationData() {
 			const total = consentStore.consents.length
 			const pages = Math.ceil(total / this.pageSize)
 			return { page: this.currentPage, pages, total, limit: this.pageSize }
 		},
+		/**
+		 * Empty-state message, surfacing any store error when present.
+		 *
+		 * @spec openspec/specs/consent-management/spec.md#requirement-consent-ui-req-cons-10
+		 */
 		emptyContentName() {
 			if (consentStore.error) {
 				return consentStore.error
@@ -190,10 +205,20 @@ export default {
 		consentStore.fetchConsents()
 	},
 	methods: {
+		/**
+		 * Open the selected consent record in the detail view.
+		 *
+		 * @spec openspec/specs/consent-management/spec.md#requirement-consent-ui-req-cons-10
+		 */
 		viewConsent(consent) {
 			consentStore.setConsentItem(consent)
 			navigationStore.setSelected('consentDetail')
 		},
+		/**
+		 * Reload the consent list from the backend.
+		 *
+		 * @spec openspec/specs/consent-management/spec.md#requirement-consent-listing-and-querying-req-cons-03
+		 */
 		async handleRefresh() {
 			this.isRefreshing = true
 			try {
@@ -202,13 +227,28 @@ export default {
 				this.isRefreshing = false
 			}
 		},
+		/**
+		 * Update the current page index of the consent table.
+		 *
+		 * @spec openspec/specs/consent-management/spec.md#requirement-consent-listing-and-querying-req-cons-03
+		 */
 		onPageChanged(page) {
 			this.currentPage = page
 		},
+		/**
+		 * Update the page size and reset to the first page.
+		 *
+		 * @spec openspec/specs/consent-management/spec.md#requirement-consent-listing-and-querying-req-cons-03
+		 */
 		onPageSizeChanged(size) {
 			this.pageSize = size
 			this.currentPage = 1
 		},
+		/**
+		 * Map a consent/notification status code to a localized label.
+		 *
+		 * @spec openspec/specs/consent-management/spec.md#requirement-consent-ui-req-cons-10
+		 */
 		formatStatus(status) {
 			const map = {
 				pending: t('docudesk', 'Pending'),
@@ -223,6 +263,11 @@ export default {
 			}
 			return map[status] || status || t('docudesk', 'Unknown')
 		},
+		/**
+		 * Map a publication-decision code to a localized label.
+		 *
+		 * @spec openspec/specs/consent-management/spec.md#requirement-consent-ui-req-cons-10
+		 */
 		formatDecision(decision) {
 			const map = {
 				pending: t('docudesk', 'Pending'),
@@ -233,6 +278,11 @@ export default {
 			}
 			return map[decision] || decision || t('docudesk', 'Pending')
 		},
+		/**
+		 * Format a date string for display, falling back gracefully.
+		 *
+		 * @spec openspec/specs/consent-management/spec.md#requirement-consent-ui-req-cons-10
+		 */
 		formatDate(dateStr) {
 			if (!dateStr) return '-'
 			try {

--- a/src/views/dashboard/DashboardIndex.vue
+++ b/src/views/dashboard/DashboardIndex.vue
@@ -108,6 +108,11 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Definitions of the dashboard statistic/activity widgets.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-docudesk-dashboard-view-req-dash-01
+		 */
 		widgetDefs() {
 			return [
 				{ id: 'total-consents', title: t('docudesk', 'Total Consents') },
@@ -118,6 +123,11 @@ export default {
 				{ id: 'anonymization', title: t('docudesk', 'Quick Anonymization') },
 			]
 		},
+		/**
+		 * The ten most recent consent records for the activity panel.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-docudesk-dashboard-view-req-dash-01
+		 */
 		recentConsents() {
 			return consentStore.consents.slice(0, 10)
 		},
@@ -126,6 +136,11 @@ export default {
 		consentStore.fetchConsents()
 	},
 	methods: {
+		/**
+		 * Map a consent status code to a localized label for the dashboard.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-docudesk-dashboard-view-req-dash-01
+		 */
 		formatStatus(status) {
 			const map = {
 				pending: t('docudesk', 'Pending'),

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -297,6 +297,11 @@ export default {
 		this.fetchAll()
 	},
 	methods: {
+		/**
+		 * Reset the selected schema when the register for a type changes.
+		 *
+		 * @spec openspec/specs/admin-settings/spec.md#requirement-openregister-integration-configuration-req-set-02
+		 */
 		onRegisterChange(type) {
 			this.sections = {
 				...this.sections,
@@ -306,6 +311,11 @@ export default {
 				},
 			}
 		},
+		/**
+		 * Load all settings, available registers and OpenRegister status.
+		 *
+		 * @spec openspec/specs/admin-settings/spec.md#requirement-settings-rest-api-req-set-06
+		 */
 		fetchAll() {
 			this.loading = true
 			fetch('/index.php/apps/docudesk/api/settings', { method: 'GET' })
@@ -390,6 +400,11 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * Save the register/schema configuration for a single object type.
+		 *
+		 * @spec openspec/specs/admin-settings/spec.md#requirement-openregister-integration-configuration-req-set-02
+		 */
 		saveConfig(type) {
 			this.sections[type].loading = true
 			this.saving = true
@@ -418,6 +433,11 @@ export default {
 					this.sections[type].loading = false
 				})
 		},
+		/**
+		 * Save all DocuDesk settings (consent period, feature toggles, OCR, registers).
+		 *
+		 * @spec openspec/specs/admin-settings/spec.md#requirement-settings-rest-api-req-set-06
+		 */
 		saveAll() {
 			this.saving = true
 
@@ -461,6 +481,11 @@ export default {
 					this.saving = false
 				})
 		},
+		/**
+		 * Open an external documentation/configuration link.
+		 *
+		 * @spec openspec/specs/admin-settings/spec.md#requirement-external-documentation-urls-req-set-09
+		 */
 		openLink(url, target = '') {
 			window.open(url, target)
 		},

--- a/src/views/signing/BulkSigningPanel.vue
+++ b/src/views/signing/BulkSigningPanel.vue
@@ -39,16 +39,36 @@ export default {
 	components: { NcButton, NcLoadingIcon, NcEmptyContent },
 	data() { return { selected: [] } },
 	computed: {
+		/**
+		 * Pinia signing store accessor for the bulk-signing panel.
+		 *
+		 * @spec openspec/changes/digital-signing-integration/tasks.md#8-5
+		 */
 		signingStore() { return useSigningStore() },
+		/**
+		 * Requests eligible for bulk signing (PENDING or IN_PROGRESS).
+		 *
+		 * @spec openspec/changes/digital-signing-integration/tasks.md#8-5
+		 */
 		pending() { return this.signingStore.signingRequests.filter((r) => ['PENDING', 'IN_PROGRESS'].includes(r.status)) },
 	},
 	mounted() { this.signingStore.fetchSigningRequests() },
 	methods: {
 		t,
+		/**
+		 * Toggle selection of a request in the bulk-signing batch.
+		 *
+		 * @spec openspec/changes/digital-signing-integration/tasks.md#8-5
+		 */
 		toggle(id) {
 			const idx = this.selected.indexOf(id)
 			if (idx === -1) { this.selected.push(id) } else { this.selected.splice(idx, 1) }
 		},
+		/**
+		 * Submit the selected requests for batch signing.
+		 *
+		 * @spec openspec/changes/digital-signing-integration/tasks.md#8-5
+		 */
 		async bulkSign() {
 			await this.signingStore.bulkSign(this.selected)
 			showSuccess(t('docudesk', 'Bulk signing completed'))

--- a/src/views/signing/SignatureVerification.vue
+++ b/src/views/signing/SignatureVerification.vue
@@ -27,6 +27,11 @@ export default {
 	computed: { signingStore() { return useSigningStore() } },
 	methods: {
 		t,
+		/**
+		 * Verify the signatures of the entered file ID.
+		 *
+		 * @spec openspec/changes/digital-signing-integration/tasks.md#8-6
+		 */
 		async verify() { if (this.fileId) { await this.signingStore.verifyDocument(this.fileId) } },
 	},
 }

--- a/src/views/signing/SigningRequestDetail.vue
+++ b/src/views/signing/SigningRequestDetail.vue
@@ -42,6 +42,11 @@ export default {
 	name: 'SigningRequestDetail',
 	components: { NcLoadingIcon },
 	props: { requestId: { type: String, required: true } },
+	/**
+	 * Load the signing request and its audit trail on mount.
+	 *
+	 * @spec openspec/changes/digital-signing-integration/tasks.md#8-3
+	 */
 	setup(props) {
 		const signingStore = useSigningStore()
 		signingStore.fetchSigningRequest(props.requestId)

--- a/src/views/signing/SigningRequestForm.vue
+++ b/src/views/signing/SigningRequestForm.vue
@@ -56,6 +56,11 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Validate and submit the new signing request form.
+		 *
+		 * @spec openspec/changes/digital-signing-integration/tasks.md#8-4
+		 */
 		async submit() {
 			const signingStore = useSigningStore()
 			const result = await signingStore.createSigningRequest(this.form)

--- a/src/views/signing/SigningRequestList.vue
+++ b/src/views/signing/SigningRequestList.vue
@@ -40,6 +40,11 @@ import { useSigningStore } from '../../store/modules/signing.js'
 export default {
 	name: 'SigningRequestList',
 	components: { NcLoadingIcon, NcEmptyContent },
+	/**
+	 * Load all signing requests for the list view on mount.
+	 *
+	 * @spec openspec/changes/digital-signing-integration/tasks.md#8-2
+	 */
 	setup() {
 		const signingStore = useSigningStore()
 		signingStore.fetchSigningRequests()

--- a/src/views/templates/TemplateDetail.vue
+++ b/src/views/templates/TemplateDetail.vue
@@ -268,15 +268,30 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Pinia template store accessor for the detail editor.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		templateStore() { return useTemplateStore() },
 		isNew() { return this.templateStore.templateItem === null },
 		isLockMine() {
 			return this.lockOwner === null || this.lockOwner === this.currentUserId
 		},
+		/**
+		 * Current Nextcloud user ID, used for lock ownership checks.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		currentUserId() {
 			return window.OC?.currentUser || ''
 		},
 	},
+	/**
+	 * Hydrate the editor form from the selected template and acquire its edit lock.
+	 *
+	 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+	 */
 	async mounted() {
 		if (!this.isNew) {
 			const tmpl = this.templateStore.templateItem
@@ -303,33 +318,68 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Release any held lock and navigate back to the template list.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		async handleBack() {
 			await this.releaseLockIfMine()
 			navigationStore.setSelected('templates')
 		},
+		/**
+		 * Release the edit lock if the current user owns it.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		async releaseLockIfMine() {
 			const tmpl = this.templateStore.templateItem
 			if (!this.isNew && tmpl && this.isLockMine) {
 				await this.templateStore.releaseLock(tmpl.id)
 			}
 		},
+		/**
+		 * Apply an inline formatting command in the WYSIWYG editor.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		execFormat(cmd) {
 			document.execCommand(cmd, false, null)
 			this.syncFromEditor()
 		},
+		/**
+		 * Apply a block-level format (heading) in the WYSIWYG editor.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		execBlock(tag) {
 			document.execCommand('formatBlock', false, tag)
 			this.syncFromEditor()
 		},
+		/**
+		 * Sync the form content from the WYSIWYG editor's HTML.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		syncFromEditor() {
 			if (this.$refs.editor) {
 				this.form.content = this.$refs.editor.innerHTML
 			}
 		},
+		/**
+		 * Sync the form content from the raw HTML textarea.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		syncFromRaw(event) {
 			this.form.content = event.target.value
 			this.editorHtml = event.target.value
 		},
+		/**
+		 * Render a live preview of the current template content with sample data.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		async loadPreview() {
 			this.activeTab = 'preview'
 			this.previewLoading = true
@@ -351,6 +401,11 @@ export default {
 				this.previewLoading = false
 			}
 		},
+		/**
+		 * Load the version history for the current template.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		async loadVersions() {
 			this.activeTab = 'versions'
 			if (this.isNew) return
@@ -359,6 +414,11 @@ export default {
 			this.versions = result?.results || []
 			this.versionsLoading = false
 		},
+		/**
+		 * Restore the template to a selected prior version.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		async restoreVersion(ver) {
 			if (!window.confirm(t('docudesk', 'Restore to version {n}?', { n: ver.version }))) return
 			const result = await this.templateStore.restoreVersion(
@@ -371,6 +431,11 @@ export default {
 				this.activeTab = 'edit'
 			}
 		},
+		/**
+		 * Persist the template (create or update), release the lock and return to the list.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		async saveTemplate() {
 			this.saving = true
 			const tags = this.form.tagsInput
@@ -404,11 +469,21 @@ export default {
 				this.saving = false
 			}
 		},
+		/**
+		 * Insert a merge-field token at the cursor in the editor.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		insertMergeField(fieldName) {
 			const token = `{{ ${fieldName} }}`
 			document.execCommand('insertText', false, token)
 			this.syncFromEditor()
 		},
+		/**
+		 * Insert a conditional section block (data-condition attributes) at the cursor.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-7
+		 */
 		insertConditionalSection({ field, op, value }) {
 			const opAttr = `data-condition-field="${field}" data-condition-op="${op}"`
 			const valAttr = (op !== 'is_empty' && op !== 'is_not_empty') ? ` data-condition-value="${value}"` : ''

--- a/src/views/templates/TemplateIndex.vue
+++ b/src/views/templates/TemplateIndex.vue
@@ -98,7 +98,17 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Pinia template store accessor for the index view.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-6
+		 */
 		templateStore() { return useTemplateStore() },
+		/**
+		 * Build the category filter dropdown options from loaded templates.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-6
+		 */
 		categoryOptions() {
 			const cats = new Set(
 				this.templateStore.templates
@@ -116,6 +126,11 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Apply category and search filters and reload the template list.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-6
+		 */
 		applyFilters() {
 			const filters = {}
 			if (this.selectedCategory?.value) {
@@ -126,20 +141,40 @@ export default {
 			}
 			this.templateStore.fetchTemplates(filters)
 		},
+		/**
+		 * Open the selected template in the detail editor.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-6
+		 */
 		openTemplate(tmpl) {
 			this.templateStore.templateItem = tmpl
 			navigationStore.setSelected('templateDetail')
 		},
+		/**
+		 * Open the detail editor for a brand-new template.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-6
+		 */
 		openNewTemplate() {
 			this.templateStore.templateItem = null
 			navigationStore.setSelected('templateDetail')
 		},
+		/**
+		 * Duplicate a template and refresh the list.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-6
+		 */
 		async duplicateTemplate(tmpl) {
 			const result = await this.templateStore.duplicateTemplate(tmpl.id)
 			if (result) {
 				await this.templateStore.fetchTemplates()
 			}
 		},
+		/**
+		 * Confirm and delete a template, then refresh the list.
+		 *
+		 * @spec openspec/changes/advanced-template-management/tasks.md#task-6
+		 */
 		async confirmDelete(tmpl) {
 			if (!window.confirm(t('docudesk', 'Delete template "{name}"?', { name: tmpl.name }))) {
 				return

--- a/src/views/widgets/AnonymizationDashboardWidget.vue
+++ b/src/views/widgets/AnonymizationDashboardWidget.vue
@@ -142,11 +142,21 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Deep link to the DocuDesk app from the dashboard widget footer.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-nextcloud-dashboard-widgets-req-dash-02
+		 */
 		appUrl() {
 			return generateUrl('/apps/docudesk')
 		},
 	},
 	methods: {
+		/**
+		 * Queue files dropped onto the dashboard widget for anonymization.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-nextcloud-dashboard-widgets-req-dash-02
+		 */
 		handleDrop(event) {
 			this.isDragging = false
 			const files = event.dataTransfer?.files
@@ -154,6 +164,11 @@ export default {
 				anonymizationStore.addFiles(files)
 			}
 		},
+		/**
+		 * Queue files chosen via the dashboard widget picker for anonymization.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-nextcloud-dashboard-widgets-req-dash-02
+		 */
 		handleFileSelect(event) {
 			const files = event.target?.files
 			if (files && files.length > 0) {
@@ -162,6 +177,11 @@ export default {
 			// Reset input so same files can be re-selected
 			event.target.value = ''
 		},
+		/**
+		 * Build a Files-app link to the original processed file.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-nextcloud-dashboard-widgets-req-dash-02
+		 */
 		fileLink(filePath) {
 			// filePath is like /admin/files/DocuDesk/file.txt
 			// Nextcloud files app URL: /index.php/apps/files/?dir=/DocuDesk&file=file.txt
@@ -177,6 +197,11 @@ export default {
 			}
 			return generateUrl('/apps/files')
 		},
+		/**
+		 * Build a WebDAV download URL for the anonymized output file.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-nextcloud-dashboard-widgets-req-dash-02
+		 */
 		downloadUrl(filePath) {
 			// filePath is like /admin/files/DocuDesk/file_anonymized.txt
 			// WebDAV download: /remote.php/webdav/DocuDesk/file_anonymized.txt
@@ -188,6 +213,11 @@ export default {
 			}
 			return generateRemoteUrl('webdav')
 		},
+		/**
+		 * Localized label for a file's processing status in the widget.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-nextcloud-dashboard-widgets-req-dash-02
+		 */
 		statusLabel(status) {
 			const labels = {
 				queued: t('docudesk', 'Queued'),

--- a/src/views/widgets/FileEntitiesDashboardWidget.vue
+++ b/src/views/widgets/FileEntitiesDashboardWidget.vue
@@ -116,6 +116,11 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Deep link to the DocuDesk app from the widget footer.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-nextcloud-dashboard-widgets-req-dash-02
+		 */
 		appUrl() {
 			return generateUrl('/apps/docudesk')
 		},
@@ -124,6 +129,11 @@ export default {
 		this.fetchFiles()
 	},
 	methods: {
+		/**
+		 * Fetch the processed-file list with risk assessment for the widget.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-nextcloud-dashboard-widgets-req-dash-02
+		 */
 		async fetchFiles() {
 			this.loading = true
 			this.error = null
@@ -139,6 +149,11 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * Build a Files-app link to a processed file.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-nextcloud-dashboard-widgets-req-dash-02
+		 */
 		fileLink(filePath) {
 			const parts = filePath.split('/')
 			const filesIndex = parts.indexOf('files')
@@ -150,6 +165,11 @@ export default {
 			}
 			return generateUrl('/apps/files')
 		},
+		/**
+		 * Localized label for a file's personal-data risk level.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-nextcloud-dashboard-widgets-req-dash-02
+		 */
 		riskLevelLabel(level) {
 			const labels = {
 				none: t('docudesk', 'None'),
@@ -160,6 +180,11 @@ export default {
 			}
 			return labels[level] || labels.none
 		},
+		/**
+		 * Localized label for a file's processing status.
+		 *
+		 * @spec openspec/specs/dashboard/spec.md#requirement-nextcloud-dashboard-widgets-req-dash-02
+		 */
 		statusLabel(status) {
 			const labels = {
 				uploaded: t('docudesk', 'Uploaded'),


### PR DESCRIPTION
## Summary

Drives docudesk to **0 uncovered spec-coverage methods** (was 192: 49 backend + 143 frontend). Annotation-only — no logic changed (45 files, +793 lines of `@spec` docblock tags).

### Backend (49)
- **Signing** (controller, SigningService, SigningAuditService, SigningVerificationService, provider interface + Native/ValidSign/Factory) → `digital-signing-integration` tasks 2-6.
- **Templates preview / conditional rendering** → `advanced-template-management` tasks 5/7.
- **BatchStateService** (max-files, update/delete) → `batch-anonymization` spec.
- **DataResolverService::clearCache, FileUploadService::getCurrentUserId, TextAnalysisService::countWordOccurrences, DashboardController::catchAll** → reuse the archived `retrofit-2026-05-24-annotate-docudesk` refs of their sibling methods.

### Frontend (143) — reverse-spec by domain to existing specs/changes
- Signing store + 5 views → `digital-signing-integration` task 8.x.
- Template store + TemplateIndex/Detail + dialogs → `advanced-template-management`.
- Anonymization / batch / folder stores + views → `anonymization` (REQ-ANON-08/10), `batch-anonymization`, `folder-analysis-anonymization`, `anonymization-entity-review`.
- Consent store + ConsentIndex/Detail → `consent-management` (REQ-CONS-02/03/10).
- navigation store / Views / App.permissions → `dashboard` REQ-DASH-03.
- Dashboard + Nextcloud dashboard widgets → `dashboard` REQ-DASH-01/02.
- Settings store + view → `admin-settings` REQ-SET-02/06/09.

### Excludes (1)
- `src/App.vue::translateForApp` — thin i18n wrapper around `@nextcloud/l10n` translate, no domain behavior.

`python3 csc.py --mode report` → **uncovered_count: 0**. All edited PHP files pass `php -l`; all edited JS files pass `node --check`.

## Test plan
- [x] `python3 csc.py <worktree> --mode report` returns 0 uncovered
- [x] PHP lint on all 15 edited backend files
- [x] node --check on all edited JS stores/services