### PR TITLE
retrofit: spec-cover preferences API (REQ-PREF-001/002)

### DIFF
--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -60,6 +60,8 @@ class PreferencesController extends Controller
      *
      * @return JSONResponse `{value: string|null}`.
      *
+     * @spec openspec/changes/retrofit-2026-05-26-preferences-api/tasks.md#task-1
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      */
@@ -98,6 +100,8 @@ class PreferencesController extends Controller
      * @param string $value The value to store (empty string clears it).
      *
      * @return JSONResponse `{value: string|null}`.
+     *
+     * @spec openspec/changes/retrofit-2026-05-26-preferences-api/tasks.md#task-2
      *
      * @NoAdminRequired
      * @NoCSRFRequired

--- a/openspec/changes/retrofit-2026-05-26-preferences-api/proposal.md
+++ b/openspec/changes/retrofit-2026-05-26-preferences-api/proposal.md
@@ -1,0 +1,16 @@
+# retrofit-2026-05-26-preferences-api
+
+## Why
+
+This app exposes a generic per-user preferences endpoint (read/write a small key/value flag, backed by Nextcloud `IConfig` user values) consumed by shared `@conduction/nextcloud-vue` widgets that need to persist a cross-device UI flag without a bespoke endpoint per feature. This is a real backend capability lacking a written spec; this change reverse-specs it.
+
+## What Changes
+
+- Document the get/set preference endpoints (authentication, key sanitization to a `pref_` namespace, empty-value-clears semantics).
+- No code changes — annotation-only retrofit.
+
+## Impact
+
+- **Affected specs**: new capability `preferences-api`
+- **Affected code**: `lib/Controller/PreferencesController.php` (docblock `@spec` annotations only)
+- **Risk**: none — comment-only.

--- a/openspec/changes/retrofit-2026-05-26-preferences-api/specs/preferences-api/spec.md
+++ b/openspec/changes/retrofit-2026-05-26-preferences-api/specs/preferences-api/spec.md
@@ -1,0 +1,24 @@
+# Capability: preferences-api
+
+## ADDED Requirements
+
+### Requirement: Get user preference (REQ-PREF-001)
+The system SHALL return a stored per-user preference value for a given key (scoped to the current user), or a default when unset. The get-preference endpoint MUST require an authenticated user, MUST sanitize the requested key to a safe charset within the `pref_` namespace, and MUST return the stored value (or null when unset). An unauthenticated request MUST be rejected and an invalid key MUST yield a bad-request response.
+
+#### Scenario: Unauthenticated read rejected
+- **GIVEN** no logged-in user
+- **WHEN** get-preference is called
+- **THEN** the response MUST be 401 Unauthorized
+
+#### Scenario: Key is sanitized
+- **GIVEN** a key containing unsafe characters
+- **WHEN** the value is read
+- **THEN** only the sanitized key within the `pref_` namespace MUST be consulted
+
+### Requirement: Set user preference (REQ-PREF-002)
+The system SHALL persist a per-user preference value for a given key scoped to the authenticated user. The set-preference endpoint MUST require an authenticated user, MUST sanitize the key, MUST store a non-empty value, and MUST clear the value when an empty string is supplied; an unauthenticated request MUST be rejected and an invalid key MUST yield a bad-request response.
+
+#### Scenario: Empty value clears the preference
+- **GIVEN** an existing stored preference
+- **WHEN** set-preference is called with an empty value
+- **THEN** the preference MUST be deleted and null returned

--- a/openspec/changes/retrofit-2026-05-26-preferences-api/tasks.md
+++ b/openspec/changes/retrofit-2026-05-26-preferences-api/tasks.md
@@ -1,0 +1,10 @@
+# Tasks — retrofit-2026-05-26-preferences-api
+
+## 1. Annotate preferences endpoints
+
+- [x] task-1 Annotate `PreferencesController::getPreference` against REQ-PREF-001
+- [x] task-2 Annotate `PreferencesController::setPreference` against REQ-PREF-002
+
+## 2. Validate
+
+- [x] task-3 `python3 /tmp/csc.py . --mode report` shows this app at zero uncovered


### PR DESCRIPTION
## Why

The generic per-user preferences endpoint introduced two uncovered backend methods — `getPreference` / `setPreference` in `lib/Controller/PreferencesController.php` — pushing this repo to 2 uncovered methods on Gate-16 spec coverage. This is a true capability, so it gets a real reverse-spec (not an exclude).

## What

- New reverse-spec change `retrofit-2026-05-26-preferences-api` with capability `preferences-api` (REQ-PREF-001 get / REQ-PREF-002 set).
- `@spec` docblock annotations on both controller methods.
- `openspec validate --strict` green; `python3 /tmp/csc.py . --mode report` → uncovered_count == 0.

Comment-only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)