### PR TITLE
chore(openspec): leaf-migration changes for OR abstractions (ADR-022)

### DIFF
--- a/openspec/changes/document-detail-leaf-widgets/.openspec.yaml
+++ b/openspec/changes/document-detail-leaf-widgets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/document-detail-leaf-widgets/design.md
+++ b/openspec/changes/document-detail-leaf-widgets/design.md
@@ -1,0 +1,53 @@
+# Design: document-detail-leaf-widgets
+
+## Context
+
+The integration registry (ADR-019) renders DI-tagged `IntegrationProvider` tabs and widgets on
+an OR object's detail surface. OR ships the contacts (`integration-contacts`), activity
+(`integration-activity`), and shares (`integration-shares`) leaves. DocuDesk's document detail
+page (ADR-001) is an OR-backed record (`document` register, `report` schema), so consuming these
+leaves is a render-only consume — no app-local tab system.
+
+## File-by-File Mapping
+
+### Document detail page — render registry tabs/widgets
+
+The document detail surface (ADR-001 "Document detail" — `Inhoud · Metadata · OCR-tekst ·
+Entiteiten · … · Versies · Audit`) mounts the registry's enabled leaf tabs/widgets for the
+document object:
+
+| Leaf | Surface | Visibility |
+|---|---|---|
+| contacts | role-grouped person chips tab (`CnContactsTab`) — "who this document concerns" | present when NC Contacts installed |
+| activity | the object's activity stream tab/widget | present when the activity leaf is enabled |
+| shares | current NC shares on the document tab/widget | present when NC sharing / the shares leaf is enabled |
+
+Each is sourced from `IntegrationRegistry::getEnabled()` and rendered via the shared
+`@conduction/nextcloud-vue` registry tab host — DocuDesk does not author a parallel tab/widget
+system (ADR-019/ADR-022 anti-pattern).
+
+## Kept-in-app (documented ADR-022 exception)
+
+PDF/letter generation, eIDAS signing crypto, and anonymisation remain in DocuDesk — **no leaf
+exists for these and DocuDesk IS the partner service** that provides them. The existing
+document-detail tabs that surface these (`Anonimisatie`, `Redactie`, `Handtekeningen`) are
+app-owned and untouched; this change only adds the consumed leaf tabs alongside them.
+
+## DEFERRED_QUESTIONS
+
+1. **activity / contacts leaf status**: both are `proposed` in OR (`integration-activity`,
+   `integration-contacts`); shares is `implemented`. Confirm tab IDs + the registry host
+   props once contacts/activity reach `implemented`. Resolved before `opsx-apply`.
+
+## Seed Data
+
+No new OR schema. No new register file changes.
+
+## Related ADRs
+
+- **ADR-019** (primary mechanism) — integration registry tab+widget surface.
+- **ADR-022** — consume OR leaves over bespoke per-document panels.
+- **ADR-001** (docudesk) — the document detail page IA where the tabs land.
+- **Leaves** — `openregister/openspec/specs/integration-shares/spec.md`,
+  `openregister/openspec/changes/integration-contacts/`,
+  `openregister/openspec/changes/integration-activity/`.

--- a/openspec/changes/document-detail-leaf-widgets/proposal.md
+++ b/openspec/changes/document-detail-leaf-widgets/proposal.md
@@ -1,0 +1,58 @@
+# Proposal: document-detail-leaf-widgets
+
+## Why
+
+DocuDesk's primary detail surface is the `document` / `report` record (ADR-001: the
+"Document detail" page with its `Inhoud · Metadata · … · Versies · Audit` tab family). Per
+**ADR-022** + **ADR-019**, the contacts / activity / shares integration leaves OR provides
+SHALL be surfaced on that record through the integration registry's tab+widget mechanism —
+not re-implemented as bespoke per-document panels. Surfacing them is a pure *consume*: the
+leaves already exist in OR (`integration-contacts`, `integration-activity`,
+`integration-shares`); DocuDesk just renders their registry tabs/widgets on the document record.
+
+## What
+
+Place the contacts, activity, and shares leaf tabs/widgets on the document/report detail
+record via the integration registry:
+
+1. **contacts** leaf tab — who this document concerns (role-grouped person chips). This is the
+   tab consumed by `migrate-consent-recipients-to-contacts-leaf`; this change ensures it is
+   present on the generic document detail surface, not only the consent page.
+2. **activity** leaf tab/widget — the document's activity stream from OR.
+3. **shares** leaf tab/widget — current NC shares on the document, surfaced via the leaf.
+
+All three are rendered through the registry tab+widget mechanism (ADR-019) on the document
+detail page (ADR-001). No bespoke sidebar-tab or widget system is introduced.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `document-register`: the document/report detail surface renders the contacts, activity, and
+  shares integration-leaf tabs/widgets via the registry, on the document record.
+
+## Affected Projects
+
+- [x] Project: `docudesk` — all implementation work is in this repo
+- Reference: `openregister/openspec/specs/integration-shares/spec.md`
+- Reference: `openregister/openspec/changes/integration-contacts/`,
+  `openregister/openspec/changes/integration-activity/`
+- Reference: `hydra/openspec/architecture/adr-022-apps-consume-or-abstractions.md`,
+  `adr-019-*` (registry), docudesk `adr-001-information-architecture.md`
+
+## Out of Scope
+
+- Modifying any OR leaf or the integration registry (consumed, not changed).
+- The email/comms leaf surface (covered by `signer-consent-notifications-to-email-leaf`).
+- PDF/letter generation, eIDAS signing crypto, anonymisation (kept in-app — see Success
+  Criteria note).
+
+## Success Criteria
+
+- `openspec validate --strict document-detail-leaf-widgets` exits 0.
+- The document/report detail page renders the contacts, activity, and shares leaf tabs/widgets
+  via the registry when the corresponding NC apps are installed.
+- No bespoke per-document sidebar-tab or widget system is introduced (ADR-019/ADR-022
+  anti-pattern: duplicate sidebar tab systems).
+- DocuDesk's in-app PDF/letter generation, eIDAS signing crypto, and anonymisation surfaces are
+  untouched by this change.

--- a/openspec/changes/document-detail-leaf-widgets/specs/document-register/spec.md
+++ b/openspec/changes/document-detail-leaf-widgets/specs/document-register/spec.md
@@ -1,0 +1,45 @@
+# document-register Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Surface the OR contacts, activity, and shares integration leaves on the document/report detail
+record via the integration registry. References the leaves
+(`integration-contacts`, `integration-activity`, `integration-shares`), ADR-019, and ADR-022.
+
+## ADDED Requirements
+
+### Requirement: Document Detail Renders Integration Leaf Tabs
+
+The document/report detail surface SHALL render the contacts, activity, and shares integration
+leaf tabs/widgets for the document object via the integration registry
+(`IntegrationRegistry::getEnabled()`), when the corresponding NC apps / leaves are enabled. No
+bespoke per-document sidebar-tab or widget system SHALL be introduced for these capabilities.
+
+#### Scenario: Contacts, activity, and shares tabs appear on the document record
+
+- GIVEN a document/report record open on its detail page
+- AND NC Contacts, the activity leaf, and NC sharing are available
+- WHEN the detail page renders
+- THEN the contacts leaf tab (role-grouped person chips) SHALL be present
+- AND the activity leaf tab/widget SHALL be present
+- AND the shares leaf tab/widget SHALL be present
+- AND all three SHALL be sourced from the integration registry, not from an app-local tab system
+
+#### Scenario: A leaf is hidden when its app is absent
+
+- GIVEN a document/report record whose host instance does not have NC Contacts installed
+- WHEN the detail page renders
+- THEN the contacts leaf tab SHALL NOT be present
+- AND the page SHALL render the remaining enabled leaf tabs without error
+
+#### Scenario: In-app document surfaces are untouched
+
+- GIVEN the document detail page with its app-owned `Anonimisatie`, `Redactie`, and
+  `Handtekeningen` tabs
+- WHEN the leaf tabs are added
+- THEN the app-owned tabs SHALL remain present and unchanged
+- AND no leaf SHALL replace DocuDesk's in-app PDF/letter, eIDAS signing, or anonymisation surfaces

--- a/openspec/changes/document-detail-leaf-widgets/tasks.md
+++ b/openspec/changes/document-detail-leaf-widgets/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: document-detail-leaf-widgets
+
+All tasks are `[docudesk]`. Estimates: S = half-day, M = 1–2 days, L = 3+ days.
+NO apply in this change — implementation runs through Hydra later.
+
+## [docudesk] Surface integration leaves on the document detail record
+
+### D-1. Render contacts / activity / shares leaf tabs via the registry (M)
+
+- [ ] D-1.1 On the document/report detail page (ADR-001), mount the integration registry's
+  enabled leaf tabs/widgets for the document object — contacts (role-grouped person chips),
+  activity (stream), shares (current NC shares) — sourced from
+  `IntegrationRegistry::getEnabled()` via the shared `@conduction/nextcloud-vue` registry tab
+  host. Do NOT author a parallel per-document tab/widget system.
+  - **Acceptance:** With Contacts + activity + sharing available, the three leaf tabs render on
+    the document detail page; with an app absent, its tab is hidden and the page renders without
+    error. App-owned `Anonimisatie` / `Redactie` / `Handtekeningen` tabs remain present.
+
+### D-2. i18n + tests (S)
+
+- [ ] D-2.1 Provide nl + en translations for any new UI strings (tab labels) per ADR-007 /
+  ADR-025.
+  - **Acceptance:** Both `l10n/en.json` and `l10n/nl.json` carry the new keys.
+- [ ] D-2.2 Component/integration test asserting the registry tabs render on the document detail
+  page when their leaves are enabled and are hidden when absent.
+  - **Acceptance:** Tests pass; no duplicate sidebar-tab system introduced.

--- a/openspec/changes/migrate-consent-recipients-to-contacts-leaf/.openspec.yaml
+++ b/openspec/changes/migrate-consent-recipients-to-contacts-leaf/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/migrate-consent-recipients-to-contacts-leaf/design.md
+++ b/openspec/changes/migrate-consent-recipients-to-contacts-leaf/design.md
@@ -1,0 +1,81 @@
+# Design: migrate-consent-recipients-to-contacts-leaf
+
+## Context
+
+The OR contacts leaf (`integration-contacts`) registers a `ContactsProvider`
+(id=`contacts`, group=`core`, requiredApp=`contacts`, storage=`link-table`). Links are stored
+in OR's integration link-table keyed by object UUID, with first-class `role` support, and
+surfaced through the canonical `single-entity` / `CnContactsTab` person chip. DocuDesk consumes
+this leaf rather than its own free-text person/org capture.
+
+## File-by-File Mapping
+
+### `consent-management` — affected entity becomes a linked contact
+
+| Existing | New |
+|---|---|
+| `entityType` (PERSON/ORGANIZATION) + `entityText` (free-text) | retained read-only for legacy + display fallback |
+| `contactEmail` / `contactAddress` typed onto the consent object | fallback only; canonical channel resolved from the linked contact's vCard |
+| (none) | `contactRef` — a contacts-leaf link to a NC Contact, stored in OR's link-table via `POST /api/objects/{register}/{schema}/{id}/contacts` with `role='affected-entity'` |
+
+`ConsentService::createConsentRequest()` accepts an optional `contactRef`. When present, the
+person/org identity and notification channel are read from the linked contact at use time;
+`entityText` is populated as a denormalised display label. When absent (legacy / no NC Contact
+yet), behaviour is unchanged — free-text `entityText` + `contactEmail` remain valid.
+
+### `letter-correspondence-generation` — recipient resolution via contacts leaf
+
+`CorrespondenceService` recipient resolution (`dataRefs` / `recipientIds`) treats a
+contacts-leaf-linked contact as the canonical recipient: vCard `FN`/`ORG` → `{{ recipient.naam }}`,
+`EMAIL` → notification channel, `ADR` → postal merge fields. Free-text / ad-hoc OR object
+UUIDs remain accepted as a fallback for recipients that are not NC Contacts. No change to the
+Twig merge engine, batch logic, or PDF output — only the source of recipient person/org data.
+
+### Document/consent detail page — contacts leaf tab
+
+The document/consent detail surface (ADR-001 "Toestemming" page; document-detail `Verbindingen`
+tab family) renders the contacts-leaf `CnContactsTab` as the canonical "who this consent / letter
+concerns" surface — role-grouped person chips — instead of a bespoke entity-text field. This is a
+consume of the registry tab, not a new tab system (ADR-019 / ADR-022 anti-pattern: duplicate
+sidebar tab systems).
+
+## Concept Mapping Reference
+
+| Consent / letter concept | Contacts leaf equivalent |
+|---|---|
+| Affected entity (person/org) | NC Contact linked via contacts leaf, `role='affected-entity'` |
+| Letter recipient | NC Contact linked via contacts leaf, `role='recipient'` |
+| `entityText` display name | vCard `FN` / `ORG`; legacy free-text as fallback |
+| `contactEmail` | vCard `EMAIL`; legacy field as fallback |
+| `contactAddress` | vCard `ADR`; legacy field as fallback |
+| Who-this-concerns surface | `CnContactsTab` role-grouped person chips on the detail page |
+
+## Kept-in-app (documented ADR-022 exception)
+
+No exception is claimed by this change — person/org data is exactly what the contacts leaf
+exists for, so consuming it is mandatory, not optional. (DocuDesk's genuine ADR-022 exceptions
+— PDF/letter generation, eIDAS signing crypto, anonymisation — are documented in the
+signing-migration designs; this change does not touch them.)
+
+## DEFERRED_QUESTIONS
+
+1. **Link-table API surface**: confirm the exact `POST /api/objects/{register}/{schema}/{id}/contacts`
+   payload + `role` enum the contacts leaf exposes once `integration-contacts` is `implemented`
+   (currently `proposed`). Resolved before `opsx-apply`.
+2. **vCard → merge-field map**: confirm `DataResolverService` can read a linked contact's vCard
+   fields directly or whether it must go through the contacts-leaf read API.
+
+## Seed Data
+
+No new OR schema is introduced. The consent schema gains one optional `contactRef`
+linkage-pointer property; `entityType` / `entityText` / `contactEmail` / `contactAddress` are
+retained (not deleted) for legacy read access.
+
+## Related ADRs
+
+- **ADR-022** (primary) — consume the OR contacts abstraction over free-text person/org capture.
+- **ADR-019** — integration registry; the contacts leaf is the mechanism and the canonical chip.
+- **ADR-001** (docudesk) — information architecture; the consent/document detail page is where
+  the contacts tab lands.
+- **ADR-011** — schema standards; vCard / RFC 6350 is the person/org vocabulary.
+- **Contacts leaf** — `openregister/openspec/changes/integration-contacts/specs/integration-contacts/spec.md`.

--- a/openspec/changes/migrate-consent-recipients-to-contacts-leaf/proposal.md
+++ b/openspec/changes/migrate-consent-recipients-to-contacts-leaf/proposal.md
@@ -1,0 +1,72 @@
+# Proposal: migrate-consent-recipients-to-contacts-leaf
+
+## Why
+
+DocuDesk stores the person/organisation a consent record or a letter is addressed to as
+free-text fields rather than as references to NC Contacts. The harms this creates are the
+exact pattern **ADR-022** (Apps Consume OpenRegister Abstractions) and **ADR-019**
+(Integration Registry) were written to prevent:
+
+- **Consent records** (`consent-management` spec, CONS-003) capture the affected entity as
+  `entityType` (PERSON / ORGANIZATION) plus a free-text `entityText`, with contact details
+  duplicated into `contactEmail` and `contactAddress`. The person/org is a string, not a
+  linkable record.
+- **Letter / correspondence generation** (`letter-correspondence-generation` spec) resolves
+  recipients from arbitrary OR object UUIDs (`recipientId` / `recipientType`) with no uniform
+  person/org model, so "all letters addressed to Jan de Vries" is not answerable across
+  documents.
+
+OpenRegister ships the **contacts** integration leaf (`openregister/openspec/changes/
+integration-contacts`, RFC 6350 / CardDAV, ADR-019): a `ContactsProvider` (id=`contacts`,
+group=`core`, storage=`link-table`) that links NC Contacts to OR objects with first-class
+role support and a canonical `single-entity` person chip used across all Conduction apps.
+Person/org data on a DocuDesk document/consent record MUST come from this leaf rather than
+free-text.
+
+## What
+
+Re-point consent affected-entities and letter recipients at the contacts leaf, on the
+document/consent detail surface:
+
+1. The consent affected-entity (CONS-003) gains an optional `contactRef` link to a NC Contact
+   via the contacts leaf link-table. `entityType` / `entityText` are retained read-only for
+   legacy records and as a display fallback; new consent records resolve person/org identity
+   and contact channel (email/address) from the linked contact.
+2. Letter recipients are resolved through the contacts leaf rather than free-text or
+   ad-hoc OR object UUIDs. `CorrespondenceService` recipient resolution reads the linked
+   contact's vCard fields (naam, email, postal address) for merge-field population.
+3. The document/consent detail page renders the contacts leaf tab (role-grouped person chips)
+   as the canonical surface for who a consent or letter concerns.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `consent-management`: affected entities are linkable NC Contacts via the contacts leaf,
+  not free-text only. `contactEmail` / `contactAddress` become a fallback for un-linked
+  legacy records; the canonical channel is the linked contact.
+
+## Affected Projects
+
+- [x] Project: `docudesk` — all implementation work is in this repo
+- Reference: `openregister/openspec/changes/integration-contacts/` (the contacts leaf consumed)
+- Reference: `hydra/openspec/architecture/adr-022-apps-consume-or-abstractions.md` (policy)
+- Reference: `hydra/openspec/architecture/adr-019-*` (integration registry mechanism)
+
+## Out of Scope
+
+- Modifying the OR contacts leaf or the integration registry (consumed, not changed).
+- The notification *delivery* path for consent/letters (covered by
+  `signer-consent-notifications-to-email-leaf`).
+- Letter rendering, Twig merge engine, PDF output (unchanged — DocuDesk owns these).
+- Historical backfill of legacy free-text `entityText` rows into linked contacts
+  (legacy rows stay read-only; linkage is opt-in for new and re-saved records).
+
+## Success Criteria
+
+- `openspec validate --strict migrate-consent-recipients-to-contacts-leaf` exits 0.
+- A consent record can link a NC Contact via the contacts leaf link-table and render it as
+  a role-grouped person chip on the consent/document detail page.
+- `CorrespondenceService` resolves recipient merge data from a linked contact's vCard fields
+  when a `contactRef` is present, falling back to free-text only when none is linked.
+- No new free-text-only person/org capture path is introduced for new consent records.

--- a/openspec/changes/migrate-consent-recipients-to-contacts-leaf/specs/consent-management/spec.md
+++ b/openspec/changes/migrate-consent-recipients-to-contacts-leaf/specs/consent-management/spec.md
@@ -1,0 +1,53 @@
+# consent-management Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Re-point consent affected-entities (and, by extension, letter recipients) at the OR contacts
+leaf so that person/org data is a linkable NC Contact rather than free-text. References the
+contacts leaf (`integration-contacts`), ADR-019, and ADR-022.
+
+## ADDED Requirements
+
+### Requirement: Consent Affected Entity Links a NC Contact via the Contacts Leaf
+
+A consent record SHALL be able to link its affected entity to a NC Contact through the OR
+contacts integration leaf, stored in OR's integration link-table with role `affected-entity`,
+rather than capturing the person/org only as free-text. When a contact is linked, the
+person/org identity and notification channel (email, postal address) SHALL be resolved from the
+linked contact's vCard fields. Free-text `entityText`, `contactEmail`, and `contactAddress`
+SHALL be retained as a fallback for legacy or un-linked records only.
+
+#### Scenario: Link a NC Contact to a consent record
+
+- GIVEN a consent record for a detected PERSON entity "Jan de Vries"
+- WHEN the user links the NC Contact for Jan de Vries via the contacts leaf
+- THEN a link record SHALL be stored in OR's contacts link-table for the consent object with `role='affected-entity'`
+- AND the consent detail page SHALL render Jan de Vries as a role-grouped person chip via `CnContactsTab`
+- AND the consent record's notification channel SHALL resolve from the linked contact's vCard `EMAIL`
+
+#### Scenario: Legacy free-text entity remains valid as fallback
+
+- GIVEN a legacy consent record with `entityText='Jan de Vries'` and no linked contact
+- WHEN the consent record is displayed
+- THEN `entityText` SHALL be shown as the display label
+- AND `contactEmail` / `contactAddress` SHALL remain the notification channel until a contact is linked
+- AND no new free-text-only capture path SHALL be offered for newly created consent records
+
+### Requirement: Letter Recipients Resolve Through the Contacts Leaf
+
+Letter / correspondence recipient person/org data SHALL be resolved from a contacts-leaf-linked
+NC Contact (vCard `FN`/`ORG` → name, `EMAIL` → channel, `ADR` → postal merge fields) when a
+contact is linked to the recipient, falling back to free-text or ad-hoc OR object UUIDs only
+when no contact is linked. The Twig merge engine, batch logic, and PDF output SHALL be unchanged.
+
+#### Scenario: Recipient merge fields populated from a linked contact
+
+- GIVEN a correspondence-generation request whose recipient is linked to a NC Contact via the contacts leaf
+- WHEN `CorrespondenceService::generate()` resolves recipient data
+- THEN `{{ recipient.naam }}` SHALL be populated from the contact's vCard `FN` / `ORG`
+- AND the recipient email channel SHALL be the contact's vCard `EMAIL`
+- AND no bespoke free-text person/org capture SHALL be required for the resolution

--- a/openspec/changes/migrate-consent-recipients-to-contacts-leaf/tasks.md
+++ b/openspec/changes/migrate-consent-recipients-to-contacts-leaf/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: migrate-consent-recipients-to-contacts-leaf
+
+All tasks are `[docudesk]`. Estimates: S = half-day, M = 1–2 days, L = 3+ days.
+NO apply in this change — implementation runs through Hydra later.
+
+## [docudesk] Consume the OR contacts leaf for consent affected-entities
+
+### D-1. Add `contactRef` linkage to the consent schema (S)
+
+- [ ] D-1.1 Add an optional `contactRef` linkage-pointer property to the PublicationConsent
+  schema in the docudesk register definition. Retain `entityType`, `entityText`,
+  `contactEmail`, `contactAddress` (mark them as legacy/fallback in the schema description).
+  - **Acceptance:** Schema validates; legacy fields retained; `composer check:strict` passes.
+
+### D-2. Resolve affected-entity identity + channel from the linked contact (M)
+
+- [ ] D-2.1 Update `ConsentService::createConsentRequest()` to accept an optional `contactRef`.
+  When present, link the NC Contact to the consent object via the contacts-leaf link-table
+  (`role='affected-entity'`) and resolve person/org identity + notification channel from the
+  contact's vCard; populate `entityText` as a denormalised display label.
+  - **Acceptance:** Unit test: with `contactRef` present, a contacts-leaf link is created with
+    `role='affected-entity'` and the channel resolves from vCard `EMAIL`. Legacy path (no
+    `contactRef`) unchanged.
+
+### D-3. Resolve letter recipients through the contacts leaf (M)
+
+- [ ] D-3.1 Update `CorrespondenceService` recipient resolution so a contacts-leaf-linked
+  contact is the canonical recipient (vCard `FN`/`ORG`/`EMAIL`/`ADR` → merge fields), with
+  free-text / ad-hoc OR UUID as fallback. Do NOT change the Twig merge engine, batch logic, or
+  PDF output.
+  - **Acceptance:** Unit test: merge fields populate from a linked contact's vCard; fallback
+    path still works for un-linked recipients.
+
+### D-4. Render the contacts leaf tab on the consent/document detail page (M)
+
+- [ ] D-4.1 Render the contacts-leaf `CnContactsTab` (role-grouped person chips) on the
+  consent/document detail surface (ADR-001 "Toestemming" page) as the canonical
+  who-this-concerns surface. Do NOT register a bespoke entity-text tab system (ADR-019/ADR-022
+  anti-pattern).
+  - **Acceptance:** Detail page shows linked contacts as role-grouped chips via the registry tab;
+    no duplicate sidebar-tab system introduced.
+
+### D-5. i18n + tests (M)
+
+- [ ] D-5.1 Provide nl + en translations for any new UI strings (link affordance, "Affected
+  entity" / "Betrokkene", fallback labels) per ADR-007 / ADR-025.
+  - **Acceptance:** Both `l10n/en.json` and `l10n/nl.json` carry the new keys.
+- [ ] D-5.2 Integration test: create a consent record with a linked contact, assert the link
+  record exists with `role='affected-entity'` and the chip renders; assert the legacy free-text
+  path still functions.
+  - **Acceptance:** Tests pass against a dev instance with docudesk + OR + Contacts installed;
+    `composer check:strict` passes.

--- a/openspec/changes/signer-consent-notifications-to-email-leaf/.openspec.yaml
+++ b/openspec/changes/signer-consent-notifications-to-email-leaf/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/signer-consent-notifications-to-email-leaf/design.md
+++ b/openspec/changes/signer-consent-notifications-to-email-leaf/design.md
@@ -1,0 +1,87 @@
+# Design: signer-consent-notifications-to-email-leaf
+
+## Context
+
+The OR email leaf (`integration-email`) registers an `EmailProvider`
+(id=`email`, group=`comms`, requiredApp=`mail`, storage=`link-table`). It is a **link-only**
+integration: NC Mail owns compose/send; the leaf surfaces + links messages on an OR object and
+tracks them in OR's integration link-table, rendering them on the object's comms surface
+(`CnEmailTab` chips, subject/sender/date cached at link time). DocuDesk consumes this leaf as
+the comms surface for its two notification flows instead of a bespoke notifier with its own
+state table.
+
+## Why link-only is sufficient here
+
+The notifications themselves are short, templated, transactional messages. NC's Mail /
+notification subsystem performs the actual delivery (the link-only nature of the leaf means
+"Mail owns send"). What DocuDesk currently re-invents is the *tracking + surfacing*: a private
+notifier with its own `notificationStatus` table, not visible on the object's comms surface and
+not query-able cross-app. That tracking is exactly what the email leaf's link-table provides.
+So the migration is: keep NC Mail/notification as the transport, drop the bespoke tracking, and
+link the resulting message to the OR object through the email leaf.
+
+## File-by-File Mapping
+
+### Signing flow — signer/initiator notifications
+
+| Existing | New |
+|---|---|
+| Ad-hoc NC notification / provider email raised inline in the signing flow when a step becomes the active signer | Notification still sent via NC Mail/notification; the resulting message is linked to the signing-request OR object via the email leaf (`POST /api/objects/{register}/{schema}/{id}/email`) so it appears on the document's comms surface |
+| Initiator-on-decline notification raised inline | Same — linked to the signing-request object via the email leaf |
+| (no comms surface) | `CnEmailTab` on the document/signing detail page lists the notifications |
+
+The sequential-vs-parallel signer ordering is unchanged (it is driven by OR's
+approval-workflow per `migrate-signing-to-or-approval-workflow`); only the
+notification *surface* moves to the email leaf.
+
+### Consent flow — affected-entity notification (CONS-011)
+
+| Existing | New |
+|---|---|
+| Bespoke notifier sends the objection-period notification; private `notificationStatus` state | Notification sent via NC Mail; message linked to the consent OR object via the email leaf; `notificationStatus` derived from the linked message lifecycle |
+| `notificationStatus`: `pending → sent → delivered/failed/skipped` tracked internally | `sent` set when the email-leaf link is created; `delivered`/`failed` updated from the delivery signal; `skipped` retained for the no-channel case |
+
+`ConsentService` stops owning a private notifier state machine for delivery tracking and reads
+the linked-message status from the email leaf instead. The CONS-011 transition contract is
+preserved — its *source of truth* moves to the leaf.
+
+## Concept Mapping Reference
+
+| Notification concept | Email leaf equivalent |
+|---|---|
+| Signer "your turn to sign" notice | NC Mail message linked to signing-request object via email leaf |
+| Initiator "declined" notice | NC Mail message linked to signing-request object via email leaf |
+| Consent objection-period notice | NC Mail message linked to consent object via email leaf |
+| `notificationStatus` tracking | linked-message lifecycle on the email-leaf comms surface |
+| Comms history per document | `CnEmailTab` chips on the detail page |
+
+## Kept-in-app (documented ADR-022 exception)
+
+PDF/letter generation, eIDAS signing crypto, and anonymisation stay in DocuDesk — **no leaf
+exists for these and DocuDesk IS the partner service** that provides them. This change does not
+touch them; it only moves notification *tracking/surfacing*. External QTSP-sent signing emails
+(e.g. ValidSign's own "sign here" mail) remain the provider's responsibility and are explicitly
+out of scope.
+
+## DEFERRED_QUESTIONS
+
+1. **Delivery signal**: confirm whether NC Mail / the email leaf exposes a delivery callback to
+   drive the `delivered`/`failed` transition, or whether `delivered` is best-effort
+   (set on successful send) until Mail surfaces a bounce signal. Resolved before `opsx-apply`.
+2. **Link payload**: confirm the email-leaf `POST /api/objects/{register}/{schema}/{id}/email`
+   payload (`mailAccountId`, `mailMessageId`) once `integration-email` is `implemented`
+   (currently `proposed`).
+
+## Seed Data
+
+No new OR schema is introduced. The consent schema's `notificationStatus` enum is unchanged; its
+source of truth moves to the email-leaf-linked message.
+
+## Related ADRs
+
+- **ADR-022** (primary) — consume the OR email/comms abstraction over a bespoke notifier.
+- **ADR-019** — integration registry; the email leaf is the comms surface mechanism.
+- **ADR-001** (docudesk) — the document/consent detail page is where the comms tab lands.
+- **Email leaf** — `openregister/openspec/changes/integration-email/specs/integration-email/spec.md`.
+- **Signing migration** — `docudesk/openspec/changes/migrate-signing-to-or-approval-workflow`
+  (ordering is OR approval-workflow; this change moves only the notification surface).

--- a/openspec/changes/signer-consent-notifications-to-email-leaf/proposal.md
+++ b/openspec/changes/signer-consent-notifications-to-email-leaf/proposal.md
@@ -1,0 +1,73 @@
+# Proposal: signer-consent-notifications-to-email-leaf
+
+## Why
+
+DocuDesk sends outbound notifications from two flows through bespoke, app-local notifier code
+instead of the shared comms abstraction:
+
+- **Signer notifications** (`digital-signing-integration` change, `document-signing` capability):
+  each signer is notified when it is their turn to sign (sequential), or all signers are notified
+  at once (parallel); the initiator is notified on decline. Today these are raised as ad-hoc
+  Nextcloud notifications / provider emails wired directly into the signing flow.
+- **Consent notifications** (`consent-management` spec, CONS-011 "Notification System"): the
+  affected entity is notified of a pending WOO publication with an objection deadline;
+  `notificationStatus` tracks `pending → sent → delivered/failed/skipped`. The send itself is a
+  bespoke notifier.
+
+This duplicates a comms mechanism OR already provides via the **email** integration leaf
+(`openregister/openspec/changes/integration-email`, ADR-019): an `EmailProvider`
+(id=`email`, group=`comms`, requiredApp=`mail`) that surfaces and links NC Mail messages on OR
+objects through the registry, so every outbound/linked message is registry-tracked and visible
+on the object's comms surface. Routing notifications through this leaf — rather than a
+per-app notifier — is what **ADR-022** mandates (anti-pattern: "app-local 'linked
+bookmarks/files/notes/...' that mirror an OR integration").
+
+## What
+
+Route signer and consent notifications through the email-leaf comms surface rather than
+bespoke notifier code:
+
+1. The signing flow raises signer/initiator notifications via the email-leaf comms path; the
+   resulting message is linked to the signing-request OR object through the email leaf's
+   link-table so it appears on the document's comms surface.
+2. The consent flow raises affected-entity notifications via the same path; the linked message
+   drives `notificationStatus` transitions (`sent` on send, `delivered`/`failed` on delivery
+   signal) instead of a private notifier tracking its own state.
+3. The email leaf is **link-only** (NC Mail owns compose/send): DocuDesk continues to use NC's
+   Mail / notification capability to perform the actual send, but the *registry linkage and
+   comms surface* are the email leaf — not an app-local notifier with its own state table.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `consent-management`: consent notification (CONS-011) routes through the email-leaf comms
+  path; `notificationStatus` is driven by the linked message rather than a bespoke notifier.
+- `digital-signing-integration`: signer/initiator notifications route through the email-leaf
+  comms path and are linked to the signing-request object on its comms surface.
+
+## Affected Projects
+
+- [x] Project: `docudesk` — all implementation work is in this repo
+- Reference: `openregister/openspec/changes/integration-email/` (the email leaf consumed)
+- Reference: `hydra/openspec/architecture/adr-022-apps-consume-or-abstractions.md` (policy)
+- Reference: `hydra/openspec/architecture/adr-019-*` (integration registry mechanism)
+
+## Out of Scope
+
+- Replacing NC Mail's compose/send (the email leaf is link-only; Mail owns the send).
+- The contacts-leaf re-pointing of recipients (covered by
+  `migrate-consent-recipients-to-contacts-leaf`).
+- eIDAS / external-provider signing emails sent by the QTSP itself (e.g. ValidSign's own
+  "sign here" email) — those are the provider's responsibility and stay as-is.
+- Modifying the OR email leaf or the integration registry.
+
+## Success Criteria
+
+- `openspec validate --strict signer-consent-notifications-to-email-leaf` exits 0.
+- A signer notification and a consent notification both produce a message linked to the
+  relevant OR object via the email leaf's link-table, visible on the object's comms surface.
+- Consent `notificationStatus` transitions are driven by the linked message lifecycle, not a
+  private notifier state table.
+- No bespoke per-app notifier maintains its own duplicate of OR's comms-surface state for these
+  two flows after migration.

--- a/openspec/changes/signer-consent-notifications-to-email-leaf/specs/consent-management/spec.md
+++ b/openspec/changes/signer-consent-notifications-to-email-leaf/specs/consent-management/spec.md
@@ -1,0 +1,45 @@
+# consent-management Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Route the consent-management notification system (CONS-011) through the OR email integration
+leaf's comms surface rather than a bespoke notifier. References the email leaf
+(`integration-email`), ADR-019, and ADR-022.
+
+## ADDED Requirements
+
+### Requirement: Consent Notification Routes Through the Email Leaf
+
+The consent objection-period notification SHALL be delivered via NC Mail and linked to the
+consent OR object through the email integration leaf, so it appears on the object's comms
+surface. The `notificationStatus` transitions (`pending → sent → delivered/failed`, plus
+`skipped`) SHALL be driven by the linked message's lifecycle rather than by a private notifier
+state table. The CONS-011 transition contract SHALL be preserved; only its source of truth moves
+to the leaf.
+
+#### Scenario: Consent notification linked via the email leaf
+
+- GIVEN a consent record with `notificationStatus='pending'` and a resolvable contact channel
+- WHEN the objection-period notification is sent
+- THEN the message SHALL be linked to the consent object via the email leaf's link-table
+- AND `notificationStatus` SHALL transition to `sent`
+- AND the notification SHALL appear on the consent/document detail comms surface (`CnEmailTab`)
+
+#### Scenario: Delivery and failure are driven by the linked message
+
+- GIVEN a consent notification linked via the email leaf with `notificationStatus='sent'`
+- WHEN the linked message reports a delivery signal
+- THEN `notificationStatus` SHALL transition to `delivered`
+- AND on a failure signal it SHALL transition to `failed`
+- AND no private notifier state table SHALL be the source of truth for these transitions
+
+#### Scenario: No channel results in skipped
+
+- GIVEN a consent record with no resolvable contact channel
+- WHEN notification is attempted
+- THEN `notificationStatus` SHALL be set to `skipped`
+- AND no email-leaf link SHALL be created

--- a/openspec/changes/signer-consent-notifications-to-email-leaf/specs/digital-signing-integration/spec.md
+++ b/openspec/changes/signer-consent-notifications-to-email-leaf/specs/digital-signing-integration/spec.md
@@ -1,0 +1,47 @@
+# digital-signing-integration Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Route signer/initiator notifications through the OR email integration leaf's comms surface
+rather than ad-hoc inline notifications, so each notification is registry-tracked and visible on
+the document's comms surface. References the email leaf (`integration-email`), ADR-019, and
+ADR-022.
+
+## ADDED Requirements
+
+### Requirement: Signer and Initiator Notifications Route Through the Email Leaf
+
+The system SHALL deliver signer "your turn to sign" notifications (sequential or parallel) and
+the initiator "declined" notification via NC Mail/notification and SHALL link them to the
+signing-request OR object through the email integration leaf, so they appear on the document's
+comms surface. The signer ordering (sequential vs parallel) is governed by OR's
+approval-workflow (`migrate-signing-to-or-approval-workflow`); this requirement governs only the
+notification surface. No bespoke per-app notifier SHALL maintain a duplicate comms-state table
+for these notifications.
+
+#### Scenario: Sequential signer notification linked via the email leaf
+
+- GIVEN a sequential signing request with signers A, B, C
+- WHEN it becomes signer A's turn
+- THEN signer A SHALL be notified via NC Mail/notification
+- AND the message SHALL be linked to the signing-request object via the email leaf's link-table
+- AND the notification SHALL appear on the document/signing detail comms surface (`CnEmailTab`)
+- AND signers B and C SHALL NOT be notified until A completes
+
+#### Scenario: Decline notifies the initiator via the email leaf
+
+- GIVEN a signer declines a signing request
+- WHEN the decline is recorded
+- THEN the initiator SHALL be notified with the decline reason via NC Mail/notification
+- AND that message SHALL be linked to the signing-request object via the email leaf
+
+#### Scenario: External QTSP-sent emails are out of scope
+
+- GIVEN an external signing provider (e.g. ValidSign) that sends its own "sign here" email
+- WHEN the document is dispatched to that provider
+- THEN that provider-sent email SHALL remain the provider's responsibility
+- AND it SHALL NOT be required to route through the email leaf

--- a/openspec/changes/signer-consent-notifications-to-email-leaf/tasks.md
+++ b/openspec/changes/signer-consent-notifications-to-email-leaf/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: signer-consent-notifications-to-email-leaf
+
+All tasks are `[docudesk]`. Estimates: S = half-day, M = 1–2 days, L = 3+ days.
+NO apply in this change — implementation runs through Hydra later.
+
+## [docudesk] Route notifications through the email leaf
+
+### D-1. Signer/initiator notifications via the email leaf (M)
+
+- [ ] D-1.1 Update the signing flow so signer "your turn to sign" and initiator "declined"
+  notifications, after being sent via NC Mail/notification, are linked to the signing-request
+  OR object through the email leaf (`POST /api/objects/{register}/{schema}/{id}/email`). Remove
+  any bespoke notifier state table for these notifications. Do NOT change signer ordering
+  (governed by OR approval-workflow).
+  - **Acceptance:** Unit test: a signer notification produces an email-leaf link on the
+    signing-request object; no app-local comms-state table is written. `composer check:strict`
+    passes.
+
+### D-2. Consent notification via the email leaf, drive notificationStatus (M)
+
+- [ ] D-2.1 Update `ConsentService` so the objection-period notification is linked to the
+  consent OR object via the email leaf, and `notificationStatus` (`pending → sent →
+  delivered/failed`, plus `skipped`) is driven by the linked message lifecycle rather than a
+  private notifier. Preserve the CONS-011 transition contract.
+  - **Acceptance:** Unit test: sending sets `notificationStatus='sent'` and creates an
+    email-leaf link; a delivery signal moves it to `delivered`; a failure to `failed`; no
+    channel yields `skipped` with no link.
+
+### D-3. Render the comms surface on the detail page (S)
+
+- [ ] D-3.1 Render the email-leaf `CnEmailTab` (linked-message chips) on the document/signing and
+  consent detail pages (ADR-001) as the notification history surface. Do NOT register a bespoke
+  comms-tab system (ADR-019/ADR-022 anti-pattern).
+  - **Acceptance:** Detail pages show linked notifications via the registry tab; no duplicate
+    comms-tab system introduced.
+
+### D-4. i18n + tests (M)
+
+- [ ] D-4.1 Provide nl + en translations for any new UI strings (comms-tab labels, status
+  labels) per ADR-007 / ADR-025.
+  - **Acceptance:** Both `l10n/en.json` and `l10n/nl.json` carry the new keys.
+- [ ] D-4.2 Integration test: trigger a signer notification and a consent notification; assert
+  each produces an email-leaf link on the relevant OR object and appears on the comms surface;
+  assert consent `notificationStatus` reflects the linked-message lifecycle.
+  - **Acceptance:** Tests pass against a dev instance with docudesk + OR + Mail installed;
+    `composer check:strict` passes.


### PR DESCRIPTION
Aligns docudesk's OpenSpec changes with **ADR-022** (apps consume OpenRegister abstractions — leaf-first + catalogue). **SPECS ONLY — no code; apply runs through Hydra.**

## Changes

| Change | Status | Scope |
|---|---|---|
| `migrate-signing-to-or-approval-workflow` | verified-existing | Signing state machine → OR approval-workflow; ADR-022-cited, strict-valid, unchanged |
| `migrate-signing-audit-to-or-audit` | verified-existing | `SigningAuditService` → OR audit-trail; ADR-022-cited, strict-valid, unchanged |
| `migrate-consent-recipients-to-contacts-leaf` | created | Consent affected-entities + letter recipients → **contacts** leaf (link NC Contacts vs free-text person/org) |
| `signer-consent-notifications-to-email-leaf` | created | Signer + consent notifications → **email** leaf comms surface (vs bespoke notifier) |
| `document-detail-leaf-widgets` | created | Surface contacts/activity/shares leaf tabs on the document/report detail record via the registry |

All five pass `openspec validate <name> --strict`.

## Kept in-app (documented ADR-022 exception)
PDF/letter generation, eIDAS signing crypto, and anonymisation stay in DocuDesk — no leaf exists and **DocuDesk IS the partner service** for these. Stated in each design.md. External QTSP-sent signing emails (e.g. ValidSign's own) also stay out of the email-leaf scope.

## Notes
- The email leaf is link-only (NC Mail owns send); the notifications change keeps NC Mail/notification as transport and moves only tracking/surfacing onto the leaf.
- Two new changes target `consent-management`; one targets `digital-signing-integration` (pending change capability) and one `document-register`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)