### PR TITLE
fix: resolve hydra mechanical gates (spdx, initial-state)

### DIFF
--- a/lib/Service/FolderBatchService.php
+++ b/lib/Service/FolderBatchService.php
@@ -8,6 +8,7 @@
  * @category Service
  * @package  OCA\DocuDesk\Service
  * @author   Conduction B.V. <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.app
  *

--- a/lib/Settings/DocuDeskAdmin.php
+++ b/lib/Settings/DocuDeskAdmin.php
@@ -32,6 +32,7 @@ namespace OCA\DocuDesk\Settings;
 use OCA\DocuDesk\AppInfo\Application;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\Settings\ISettings;
 
 /**
@@ -56,15 +57,24 @@ class DocuDeskAdmin implements ISettings
     private IAppManager $appManager;
 
     /**
+     * Initial state service for passing data to the frontend
+     *
+     * @var IInitialState $initialState
+     */
+    private IInitialState $initialState;
+
+    /**
      * Constructor for DocuDeskAdmin
      *
-     * @param IAppManager $appManager App manager for retrieving app version
+     * @param IAppManager   $appManager   App manager for retrieving app version
+     * @param IInitialState $initialState Initial state service for the frontend
      *
      * @return void
      */
-    public function __construct(IAppManager $appManager)
+    public function __construct(IAppManager $appManager, IInitialState $initialState)
     {
-        $this->appManager = $appManager;
+        $this->appManager   = $appManager;
+        $this->initialState = $initialState;
 
     }//end __construct()
 
@@ -82,12 +92,12 @@ class DocuDeskAdmin implements ISettings
     {
         $version = $this->appManager->getAppVersion(Application::APP_ID);
 
+        $this->initialState->provideInitialState('version', $version);
+
         return new TemplateResponse(
             'docudesk',
             'settings/admin',
-            [
-                'version' => $version,
-            ],
+            [],
             ''
         );
 

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -247,6 +247,7 @@ import { CnVersionInfoCard } from '@conduction/nextcloud-vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import Restart from 'vue-material-design-icons/Restart.vue'
 import { showSuccess, showError } from '@nextcloud/dialogs'
+import { loadState } from '@nextcloud/initial-state'
 
 export default {
 	name: 'Settings',
@@ -263,7 +264,7 @@ export default {
 	},
 	data() {
 		return {
-			appVersion: document.getElementById('admin-settings')?.dataset?.version || 'Unknown',
+			appVersion: loadState('docudesk', 'version', 'Unknown'),
 			loading: false,
 			saving: false,
 			openRegisterInstalled: false,

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -20,4 +20,4 @@ Util::addStyle($appId, 'main');
 /** @var \OCP\IL10N $l */
 ?>
 
-<div id="admin-settings" class="section" data-version="<?php p($_['version'] ?? ''); ?>"></div>
+<div id="admin-settings" class="section"></div>


### PR DESCRIPTION
Bucket-A safe fixes from the fleet-wide hydra-gates sweep: SPDX docblock tags + ADR-004 loadState/IInitialState for the settings app version. Security-semantic findings (no-admin-idor, route-auth, route-reachability) are tracked in a separate backlog issue.