### PR TITLE
fix: real bugs from fleet quality sweep (catch resolution, dup routes, client IP, publiccode)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -62,17 +62,6 @@ return [
         ['name' => 'print#preview', 'url' => 'api/print/preview', 'verb' => 'POST'],
         ['name' => 'print#downloadPdfA', 'url' => 'api/print/pdf-a', 'verb' => 'POST'],
 
-        // Signing routes.
-        ['name' => 'signing#createRequest', 'url' => 'api/signing/requests', 'verb' => 'POST'],
-        ['name' => 'signing#listRequests', 'url' => 'api/signing/requests', 'verb' => 'GET'],
-        ['name' => 'signing#showRequest', 'url' => 'api/signing/requests/{id}', 'verb' => 'GET'],
-        ['name' => 'signing#cancelRequest', 'url' => 'api/signing/requests/{id}', 'verb' => 'DELETE'],
-        ['name' => 'signing#sign', 'url' => 'api/signing/requests/{id}/sign', 'verb' => 'POST'],
-        ['name' => 'signing#decline', 'url' => 'api/signing/requests/{id}/decline', 'verb' => 'POST'],
-        ['name' => 'signing#bulkSign', 'url' => 'api/signing/bulk', 'verb' => 'POST'],
-        ['name' => 'signing#verify', 'url' => 'api/signing/verify/{fileId}', 'verb' => 'GET'],
-        ['name' => 'signing#getAudit', 'url' => 'api/signing/requests/{id}/audit', 'verb' => 'GET'],
-
         // Correspondence routes.
         ['name' => 'correspondence#generate', 'url' => 'api/correspondence/generate', 'verb' => 'POST'],
         ['name' => 'correspondence#generateBatch', 'url' => 'api/correspondence/generate/batch', 'verb' => 'POST'],

--- a/lib/Service/RegisterDiscoveryService.php
+++ b/lib/Service/RegisterDiscoveryService.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 
 namespace OCA\DocuDesk\Service;
 
-use Exception;
 use Throwable;
 use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
@@ -113,7 +112,7 @@ class RegisterDiscoveryService
                         try {
                             $schema     = $this->schemaMapper->find(id: $schemaId, _multitenancy: false);
                             $expanded[] = $schema->jsonSerialize();
-                        } catch (Exception $schemaError) {
+                        } catch (\Exception $schemaError) {
                             // Orphan schema — retain bare ID for transparency.
                             $expanded[] = $schemaId;
                         }

--- a/lib/Service/SigningService.php
+++ b/lib/Service/SigningService.php
@@ -23,6 +23,7 @@ use DateTimeInterface;
 use Exception;
 use OCA\DocuDesk\Service\Signing\SigningProviderFactory;
 use OCP\IAppConfig;
+use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\Notification\IManager as INotificationManager;
 use Psr\Log\LoggerInterface;
@@ -68,6 +69,7 @@ class SigningService
      * @param IUserSession           $userSession         User session
      * @param INotificationManager   $notificationManager Notification manager
      * @param LoggerInterface        $logger              Logger
+     * @param IRequest               $request             HTTP request
      *
      * @return void
      */
@@ -78,7 +80,8 @@ class SigningService
         private readonly IAppConfig $config,
         private readonly IUserSession $userSession,
         private readonly INotificationManager $notificationManager,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly IRequest $request
     ) {
 
     }//end __construct()
@@ -523,7 +526,7 @@ class SigningService
      */
     private function getClientIp(): string
     {
-        return $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+        return $this->request->getRemoteAddress();
 
     }//end getClientIp()
 }//end class

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,0 +1,71 @@
+publiccodeYmlVersion: "0.4"
+
+name: DocuDesk
+url: "https://github.com/ConductionNL/docudesk"
+softwareVersion: "0.0.34"
+releaseDate: "2026-05-26"
+developmentStatus: stable
+softwareType: "standalone/other"
+
+platforms:
+  - nextcloud
+
+categories:
+  - document-management
+
+description:
+  en:
+    shortDescription: >
+      GDPR publication consent management and document metadata enrichment for Nextcloud.
+    longDescription: >
+      DocuDesk provides GDPR-compliant publication consent tracking (Wet Open Overheid)
+      and automatic document metadata enrichment. It integrates with Open Register via
+      events to enrich documents as they are created and updated. Features include
+      consent tracking with configurable objection periods, WOO compliance (minimum
+      4-week objection period), automatic language detection, keyword extraction,
+      topic classification, PDF generation, document signing (SES/AES/QES), and
+      anonymization.
+    features:
+      - GDPR publication consent tracking
+      - Wet Open Overheid (WOO) compliance
+      - Automatic document metadata enrichment
+      - Language detection and keyword extraction
+      - Document signing (SES / AES / QES)
+      - Document anonymization
+
+  nl:
+    shortDescription: >
+      AVG-publicatietoestemmingsbeheer en documentmetadata-verrijking voor Nextcloud.
+    longDescription: >
+      DocuDesk biedt AVG-conforme bijhouding van publicatietoestemmingen (Wet Open
+      Overheid) en automatische verrijking van documentmetadata. Het integreert via
+      events met Open Register om documenten te verrijken zodra ze worden aangemaakt
+      of bijgewerkt. Functionaliteit omvat toestemmingsbeheer met instelbare
+      bezwaarperiodes, WOO-compliance (minimaal 4 weken bezwaartermijn), automatische
+      taaldetectie, trefwoordextractie, onderwerpclassificatie, PDF-generatie,
+      documentondertekening (SES/AES/QES) en anonimisering.
+    features:
+      - AVG-publicatietoestemmingsbeheer
+      - Wet Open Overheid (WOO)-compliance
+      - Automatische verrijking van documentmetadata
+      - Taaldetectie en trefwoordextractie
+      - Documentondertekening (SES / AES / QES)
+      - Documentanonimisering
+
+legal:
+  license: EUPL-1.2
+  mainCopyrightOwner: "Conduction B.V."
+  repoOwner: "Conduction B.V."
+
+maintenance:
+  type: community
+  contacts:
+    - name: Conduction B.V.
+      email: info@conduction.nl
+      affiliation: Conduction B.V.
+
+localisation:
+  localisationReady: true
+  availableLanguages:
+    - nl
+    - en


### PR DESCRIPTION
## Summary

Four targeted fixes from the fleet-wide quality sweep. PRODUCTION app — please review before merge.

- **`catch(\Exception)` resolution** (`lib/Service/RegisterDiscoveryService.php`): The `use Exception;` import caused Psalm/PHPStan to potentially resolve the bare `Exception` in the catch block to the non-existent `OCA\DocuDesk\Service\Exception`. Removed the ambiguous import and used the fully-qualified `\Exception` instead.

- **Duplicate signing routes** (`appinfo/routes.php`): The 9 signing routes were declared twice (once at lines 66-74, again at lines 97-105). The duplicate block has been removed. Confirmed zero duplicate route names after the fix.

- **`$_SERVER` direct read** (`lib/Service/SigningService.php`): `getClientIp()` read `$_SERVER['REMOTE_ADDR']` directly, bypassing Nextcloud's proxy-aware `IRequest::getRemoteAddress()`. `OCP\IRequest` is now injected into the constructor (autowired by NC DI — no container registration change needed) and `getClientIp()` delegates to it.

- **`publiccode.yml`** (repo root): Added minimal valid publiccode.yml v0.4 for Dutch-government compliance. Fields: name, repo URL, version from `appinfo/info.xml`, `developmentStatus: stable`, `softwareType: standalone/other`, `platforms: [nextcloud]`, `categories: [document-management]`, `legal.license: EUPL-1.2`, `localisation.availableLanguages: [nl, en]`, short `description.en` and `description.nl`.

## Test plan

- [ ] `php -l lib/Service/RegisterDiscoveryService.php` — no syntax errors
- [ ] `php -l lib/Service/SigningService.php` — no syntax errors
- [ ] `grep "'name'" appinfo/routes.php | sort | uniq -d` — empty (no duplicate names)
- [ ] Smoke-test a signing request end-to-end to confirm `IRequest` injection works (NC DI autowires it automatically)
- [ ] Confirm `publiccode.yml` passes `publiccode-validator` (https://publiccode.yml.org/)