### PR TITLE
refactor: migrate deprecated IConfig app-values to IAppConfig

### DIFF
--- a/lib/Controller/MetricsCollector.php
+++ b/lib/Controller/MetricsCollector.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 namespace OCA\DocuDesk\Controller;
 
 use OCA\DocuDesk\AppInfo\Application;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 
@@ -39,14 +39,14 @@ class MetricsCollector
     /**
      * Constructor for MetricsCollector
      *
-     * @param IConfig         $config   The config service
+     * @param IAppConfig      $config   The typed app config service
      * @param IDBConnection   $database The database connection
      * @param LoggerInterface $logger   Logger for error reporting
      *
      * @return void
      */
     public function __construct(
-        private readonly IConfig $config,
+        private readonly IAppConfig $config,
         private readonly IDBConnection $database,
         private readonly LoggerInterface $logger
     ) {
@@ -91,8 +91,8 @@ class MetricsCollector
     private function countObjects(string $type): int
     {
         try {
-            $registerId = $this->config->getAppValue(Application::APP_ID, $type.'_register', '');
-            $schemaId   = $this->config->getAppValue(Application::APP_ID, $type.'_schema', '');
+            $registerId = $this->config->getValueString(Application::APP_ID, $type.'_register', '');
+            $schemaId   = $this->config->getValueString(Application::APP_ID, $type.'_schema', '');
 
             if ($registerId === '' || $schemaId === '') {
                 return 0;

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -23,6 +23,7 @@ namespace OCA\DocuDesk\Controller;
 use OCA\DocuDesk\AppInfo\Application;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TextPlainResponse;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IRequest;
 
@@ -42,7 +43,8 @@ class MetricsController extends Controller
      *
      * @param string           $appName          The name of the app
      * @param IRequest         $request          The request object
-     * @param IConfig          $config           The config service
+     * @param IConfig          $config           The config service (retained for getSystemValueString)
+     * @param IAppConfig       $appConfig        The typed app config service
      * @param MetricsCollector $metricsCollector Collector for document/template counts
      *
      * @return void
@@ -51,6 +53,7 @@ class MetricsController extends Controller
         string $appName,
         IRequest $request,
         private readonly IConfig $config,
+        private readonly IAppConfig $appConfig,
         private readonly MetricsCollector $metricsCollector
     ) {
         parent::__construct(appName: $appName, request: $request);
@@ -70,7 +73,7 @@ class MetricsController extends Controller
     {
         $lines = [];
 
-        $appVersion = $this->config->getAppValue(Application::APP_ID, 'installed_version', '0.0.0');
+        $appVersion = $this->appConfig->getValueString(Application::APP_ID, 'installed_version', '0.0.0');
         $phpVersion = PHP_VERSION;
         $ncVersion  = $this->config->getSystemValueString('version', '0.0.0');
 
@@ -99,20 +102,20 @@ class MetricsController extends Controller
         $lines[]        = 'docudesk_templates_total '.$templatesTotal;
 
         // PDF generations counter.
-        $pdfTotal = (int) $this->config->getAppValue(
+        $pdfTotal = $this->appConfig->getValueInt(
             Application::APP_ID,
             'pdf_generations_total',
-            '0'
+            0
         );
         $lines[]  = '# HELP docudesk_pdf_generations_total Total PDF generation operations';
         $lines[]  = '# TYPE docudesk_pdf_generations_total counter';
         $lines[]  = 'docudesk_pdf_generations_total '.$pdfTotal;
 
         // Anonymizations counter.
-        $anonTotal = (int) $this->config->getAppValue(
+        $anonTotal = $this->appConfig->getValueInt(
             Application::APP_ID,
             'anonymizations_total',
-            '0'
+            0
         );
         $lines[]   = '# HELP docudesk_anonymizations_total Total anonymization operations';
         $lines[]   = '# TYPE docudesk_anonymizations_total counter';


### PR DESCRIPTION
## Summary

Behaviour-preserving migration of deprecated `IConfig::getAppValue` calls to the modern typed `OCP\IAppConfig` API (deprecated since NC26).

## Call sites migrated

### `lib/Controller/MetricsController.php` (3 calls)
| Old call | New call |
|---|---|
| `$this->config->getAppValue(APP_ID, 'installed_version', '0.0.0')` | `$this->appConfig->getValueString(APP_ID, 'installed_version', '0.0.0')` |
| `(int) $this->config->getAppValue(APP_ID, 'pdf_generations_total', '0')` | `$this->appConfig->getValueInt(APP_ID, 'pdf_generations_total', 0)` |
| `(int) $this->config->getAppValue(APP_ID, 'anonymizations_total', '0')` | `$this->appConfig->getValueInt(APP_ID, 'anonymizations_total', 0)` |

`IAppConfig $appConfig` added as a new constructor injection. `IConfig $config` is retained because `getSystemValueString` is still used on line 75 (that accessor is not deprecated).

### `lib/Controller/MetricsCollector.php` (2 calls)
| Old call | New call |
|---|---|
| `$this->config->getAppValue(APP_ID, $type.'_register', '')` | `$this->config->getValueString(APP_ID, $type.'_register', '')` |
| `$this->config->getAppValue(APP_ID, $type.'_schema', '')` | `$this->config->getValueString(APP_ID, $type.'_schema', '')` |

`IConfig` injection replaced entirely by `IAppConfig` in this class (no system-value or user-value calls remain).

## User-values left on IConfig
`lib/Controller/PreferencesController.php` uses `getUserValue/setUserValue/deleteUserValue` on `IConfig` and is **intentionally left unchanged** — `OCP\IUserConfig` requires NC ≥ 31, and this app's `min-version` is **30**.

## Verification
- `php -l lib/Controller/MetricsController.php` → **No syntax errors**
- `php -l lib/Controller/MetricsCollector.php` → **No syntax errors**
- Hydra gate-16 spec-coverage (`HYDRA_GATE_BASE_REF=origin/development`) → **exit 0**
- phpstan: deferred to CI (vendor not installed in clone)

**Do NOT merge — leave open for review.**