### PR TITLE
fix(security): consent RBAC + signer-ownership + fail-closed signature verify

### DIFF
--- a/lib/Controller/ConsentController.php
+++ b/lib/Controller/ConsentController.php
@@ -28,6 +28,7 @@ use OCA\DocuDesk\Service\ConsentCrudService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -47,12 +48,13 @@ class ConsentController extends Controller
     /**
      * Constructor for ConsentController
      *
-     * @param string             $appName     The application name
-     * @param IRequest           $request     The request object
-     * @param LoggerInterface    $logger      Logger for error reporting
-     * @param ConsentCrudService $crudService CRUD service for consent records
-     * @param IL10N              $l10n        The localization service
-     * @param IUserSession       $userSession User session for authentication
+     * @param string             $appName      The application name
+     * @param IRequest           $request      The request object
+     * @param LoggerInterface    $logger       Logger for error reporting
+     * @param ConsentCrudService $crudService  CRUD service for consent records
+     * @param IL10N              $l10n         The localization service
+     * @param IUserSession       $userSession  User session for authentication
+     * @param IGroupManager      $groupManager Group manager for admin checks
      *
      * @return void
      */
@@ -62,11 +64,44 @@ class ConsentController extends Controller
         private readonly LoggerInterface $logger,
         private readonly ConsentCrudService $crudService,
         private readonly IL10N $l10n,
-        private readonly IUserSession $userSession
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager
     ) {
         parent::__construct(appName: $appName, request: $request);
 
     }//end __construct()
+
+    /**
+     * Check whether the current user may access a consent record
+     *
+     * Enforces per-object ownership for non-admin users (security finding
+     * #283). OpenRegister reads are default-open, so a controller-level
+     * ownership guard is required to keep consent records isolated between
+     * users. Administrators retain full access.
+     *
+     * @param array<string, mixed> $consent The consent record to check
+     *
+     * @return bool True if the current user may access the record
+     */
+    private function canAccessConsent(array $consent): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        if ($this->groupManager->isAdmin($user->getUID()) === true) {
+            return true;
+        }
+
+        $owner = $consent['@self']['owner'] ?? ($consent['owner'] ?? null);
+        if (is_array($owner) === true) {
+            $owner = $owner['id'] ?? ($owner['uid'] ?? null);
+        }
+
+        return $owner !== null && (string) $owner === $user->getUID();
+
+    }//end canAccessConsent()
 
     /**
      * Build an error JSON response with logging
@@ -141,7 +176,6 @@ class ConsentController extends Controller
      * @return JSONResponse JSON response with the created consent record
      *
      * @NoAdminRequired
-     * @NoCSRFRequired
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-docudesk/tasks.md#task-13
      */
@@ -221,6 +255,15 @@ class ConsentController extends Controller
                 );
             }
 
+            // Per-object ownership guard (security finding #283): return 404
+            // (not 403) so non-owners cannot probe for record existence.
+            if ($this->canAccessConsent(consent: $consent) === false) {
+                return new JSONResponse(
+                    ['error' => $this->l10n->t('Consent record not found')],
+                    404
+                );
+            }
+
             return new JSONResponse($consent);
         } catch (Exception $e) {
             return $this->errorResponse(message: 'Failed to get consent: ', exception: $e);
@@ -236,7 +279,6 @@ class ConsentController extends Controller
      * @return JSONResponse JSON response with updated consent record
      *
      * @NoAdminRequired
-     * @NoCSRFRequired
      *
      * @SuppressWarnings(PHPMD.ShortVariable)
      *
@@ -255,6 +297,16 @@ class ConsentController extends Controller
             $config = $this->crudService->getConsentConfig();
             if ($config === null) {
                 return $this->notConfiguredResponse();
+            }
+
+            // Per-object ownership guard (security finding #283): a non-owner
+            // must not be able to overwrite another user's consent record.
+            $existing = $this->crudService->getConsent($id, $config['register'], $config['schema']);
+            if ($existing === null || $this->canAccessConsent(consent: $existing) === false) {
+                return new JSONResponse(
+                    ['error' => $this->l10n->t('Consent record not found')],
+                    404
+                );
             }
 
             $result = $this->crudService->updateConsentStatus(

--- a/lib/Service/ConsentCrudService.php
+++ b/lib/Service/ConsentCrudService.php
@@ -126,13 +126,14 @@ class ConsentCrudService
      */
     public function getConsent(string $consentId, string $register, string $schema): ?array
     {
+        // Let OpenRegister enforce per-object RBAC and multitenancy access.
+        // Bypassing these (security finding #283) allowed any authenticated
+        // user to read consent records owned by other users.
         $objectService = $this->settingsService->getObjectService();
         $object        = $objectService->find(
             id: $consentId,
             register: $register,
-            schema: $schema,
-            _rbac: false,
-            _multitenancy: false
+            schema: $schema
         );
 
         if ($object === null) {

--- a/lib/Service/ConsentService.php
+++ b/lib/Service/ConsentService.php
@@ -118,12 +118,12 @@ class ConsentService
                 $extra
             );
 
+            // Let OpenRegister enforce RBAC and multitenancy so the consent
+            // record is owned by the creating user (security finding #283).
             $savedObject = $objectService->saveObject(
                 object: $consentData,
                 register: $register,
-                schema: $schema,
-                _rbac: false,
-                _multitenancy: false
+                schema: $schema
             );
 
             $this->logger->info('Consent request created', ['documentId' => $documentId]);

--- a/lib/Service/ConsentUpdateHandler.php
+++ b/lib/Service/ConsentUpdateHandler.php
@@ -95,33 +95,45 @@ class ConsentUpdateHandler
         try {
             $objectService = $this->getObjectService();
 
+            // Let OpenRegister enforce per-object RBAC and multitenancy
+            // access. Bypassing these (security finding #283) allowed any
+            // authenticated user to overwrite consent records owned by
+            // other users.
             $object = $objectService->find(
                 id: $consentId,
                 register: $register,
-                schema: $schema,
-                _rbac: false,
-                _multitenancy: false
+                schema: $schema
             );
 
             if ($object === null) {
                 throw new Exception('Consent record not found: '.$consentId);
             }
 
-            $consentData = array_merge($object->getObject(), $data);
+            // Whitelist the fields a consent update may mutate so callers
+            // cannot rewrite arbitrary consent attributes (e.g. documentId,
+            // entityText) or inject extra keys (security finding #283).
+            $mutableFields = [
+                'notificationStatus',
+                'consentStatus',
+                'publicationDecision',
+                'objectionReason',
+                'objectionDeadline',
+            ];
+            $allowedData   = array_intersect_key($data, array_flip($mutableFields));
+
+            $consentData = array_merge($object->getObject(), $allowedData);
 
             $savedObject = $objectService->saveObject(
                 object: $consentData,
                 register: $register,
-                schema: $schema,
-                _rbac: false,
-                _multitenancy: false
+                schema: $schema
             );
 
             $this->logger->info(
                 'Consent status updated',
                 [
                     'consentId'   => $consentId,
-                    'updatedKeys' => array_keys($data),
+                    'updatedKeys' => array_keys($allowedData),
                 ]
             );
 

--- a/lib/Service/SigningService.php
+++ b/lib/Service/SigningService.php
@@ -243,6 +243,13 @@ class SigningService
             throw new RuntimeException('Signer record not found: '.$signerId);
         }
 
+        // Security finding #282: ensure the authenticated user is the signer
+        // they claim to be. Without this check any authenticated user could
+        // sign on behalf of another signer by supplying their signer ID.
+        if (($signer['userId'] ?? '') !== $user->getUID()) {
+            throw new RuntimeException('Not authorized to sign as this signer');
+        }
+
         if (($signer['status'] ?? '') !== 'PENDING') {
             throw new RuntimeException('Signer has already responded to this request');
         }
@@ -294,6 +301,12 @@ class SigningService
 
         if (empty($signer) === true) {
             throw new RuntimeException('Signer record not found: '.$signerId);
+        }
+
+        // Security finding #282: ensure the authenticated user is the signer
+        // they claim to be before allowing them to decline on its behalf.
+        if (($signer['userId'] ?? '') !== $user->getUID()) {
+            throw new RuntimeException('Not authorized to decline as this signer');
         }
 
         $signer['status']        = 'DECLINED';

--- a/lib/Service/SigningVerificationService.php
+++ b/lib/Service/SigningVerificationService.php
@@ -22,6 +22,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use OCP\Files\File;
 use OCP\Files\IRootFolder;
+use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
@@ -41,12 +42,14 @@ class SigningVerificationService
      *
      * @param IRootFolder     $rootFolder Root folder
      * @param LoggerInterface $logger     Logger
+     * @param IAppConfig      $config     App config
      *
      * @return void
      */
     public function __construct(
         private readonly IRootFolder $rootFolder,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly IAppConfig $config
     ) {
 
     }//end __construct()
@@ -93,6 +96,16 @@ class SigningVerificationService
     /**
      * Extract signature information from a PDF document
      *
+     * Security note (finding #284): the embedded `/DocuDesk-Signature(...)`
+     * blob is entirely attacker-controlled (anyone can append it to a PDF),
+     * so its mere presence proves nothing. This verifier is therefore
+     * FAIL-CLOSED: a self-asserted blob is reported with `valid => false`
+     * unless its content can be cryptographically verified against the
+     * document (HMAC over the document content-hash using a server-held
+     * secret, see verifyAssertion()). Real PAdES/CMS signature validation is
+     * not yet implemented; embedded `/Type /Sig` entries we cannot verify are
+     * reported as `valid => false` rather than trusted.
+     *
      * @param string $pdfContent The PDF file content
      *
      * @return array<int, array<string, mixed>> List of signature records
@@ -115,13 +128,19 @@ class SigningVerificationService
             foreach ($dataMatches[1] as $encoded) {
                 $decoded = json_decode(base64_decode($encoded), true);
                 if (is_array($decoded) === true) {
+                    // Fail-closed: only trust the blob if it carries a valid
+                    // server-verifiable HMAC over the document content. A
+                    // self-asserted (unsigned) blob reports valid => false.
                     $signatures[] = [
                         'signer'    => $decoded['signer'] ?? 'Unknown',
                         'timestamp' => $decoded['timestamp'] ?? '',
                         'level'     => $decoded['level'] ?? 'SES',
                         'method'    => $decoded['method'] ?? 'unknown',
                         'ip'        => $decoded['ip'] ?? '',
-                        'valid'     => true,
+                        'valid'     => $this->verifyAssertion(
+                            assertion: $decoded,
+                            pdfContent: $pdfContent
+                        ),
                     ];
                 }
             }//end foreach
@@ -135,7 +154,7 @@ class SigningVerificationService
                     'level'     => 'unknown',
                     'method'    => 'external',
                     'ip'        => '',
-                    'valid'     => null,
+                    'valid'     => false,
                 ];
             }
         }
@@ -143,6 +162,68 @@ class SigningVerificationService
         return $signatures;
 
     }//end extractSignatures()
+
+    /**
+     * Cryptographically verify a self-asserted DocuDesk signature blob
+     *
+     * Verifies an HMAC-SHA256 over the document content-hash (the PDF with
+     * the signature blob's own `mac` field stripped) using a server-held
+     * secret. Without a configured secret or a matching MAC the assertion is
+     * rejected (fail-closed, security finding #284).
+     *
+     * @param array<string, mixed> $assertion  The decoded signature blob
+     * @param string               $pdfContent The full PDF content
+     *
+     * @return bool True only if the assertion is cryptographically verified
+     */
+    private function verifyAssertion(array $assertion, string $pdfContent): bool
+    {
+        $mac = $assertion['mac'] ?? '';
+        if (is_string($mac) === false || $mac === '') {
+            // No server-issued MAC present: cannot be trusted.
+            return false;
+        }
+
+        $secret = $this->getSigningSecret();
+        if ($secret === '') {
+            // No server secret configured: nothing can be verified.
+            return false;
+        }
+
+        // Recompute the MAC over the document with the asserted `mac` field
+        // removed, so the MAC cannot cover itself. Strip the literal blob's
+        // mac value out of the byte stream before hashing.
+        $contentHash = hash('sha256', $this->stripAssertionMac(pdfContent: $pdfContent, mac: $mac));
+        $expected    = hash_hmac('sha256', $contentHash, $secret);
+
+        return hash_equals($expected, $mac);
+
+    }//end verifyAssertion()
+
+    /**
+     * Remove the asserted MAC value from the PDF byte stream before hashing
+     *
+     * @param string $pdfContent The full PDF content
+     * @param string $mac        The asserted MAC value to strip
+     *
+     * @return string The PDF content with the MAC value removed
+     */
+    private function stripAssertionMac(string $pdfContent, string $mac): string
+    {
+        return str_replace($mac, '', $pdfContent);
+
+    }//end stripAssertionMac()
+
+    /**
+     * Get the server-held signing secret used to verify assertions
+     *
+     * @return string The configured secret, or an empty string if unset
+     */
+    private function getSigningSecret(): string
+    {
+        return (string) ($this->config->getValueString('docudesk', 'signing_verification_secret', '') ?? '');
+
+    }//end getSigningSecret()
 
     /**
      * Check if all signatures are valid

--- a/tests/unit/Controller/ConsentControllerTest.php
+++ b/tests/unit/Controller/ConsentControllerTest.php
@@ -20,8 +20,11 @@ namespace OCA\DocuDesk\Tests\Unit\Controller;
 use OCA\DocuDesk\Controller\ConsentController;
 use OCA\DocuDesk\Service\ConsentCrudService;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -65,6 +68,15 @@ class ConsentControllerTest extends TestCase
      */
     private IL10N|MockObject $mockL10n;
 
+    /**
+     * @var IUserSession|MockObject
+     */
+    private IUserSession|MockObject $mockUserSession;
+
+    /**
+     * @var IGroupManager|MockObject
+     */
+    private IGroupManager|MockObject $mockGroupManager;
 
     /**
      * Set up test environment
@@ -75,24 +87,35 @@ class ConsentControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->mockRequest     = $this->createMock(IRequest::class);
-        $this->mockLogger      = $this->createMock(LoggerInterface::class);
-        $this->mockCrudService = $this->createMock(ConsentCrudService::class);
-        $this->mockL10n        = $this->createMock(IL10N::class);
-        $this->mockL10n->method('t')->willReturnCallback(function ($text, $params = []) {
-            return vsprintf($text, $params);
-        });
+        $this->mockRequest      = $this->createMock(IRequest::class);
+        $this->mockLogger       = $this->createMock(LoggerInterface::class);
+        $this->mockCrudService  = $this->createMock(ConsentCrudService::class);
+        $this->mockL10n         = $this->createMock(IL10N::class);
+        $this->mockUserSession  = $this->createMock(IUserSession::class);
+        $this->mockGroupManager = $this->createMock(IGroupManager::class);
+        $this->mockL10n->method('t')->willReturnCallback(
+                function ($text, $params=[]) {
+                    return vsprintf($text, $params);
+                }
+                );
+
+        // Default: an authenticated, non-admin user named "owner".
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('owner');
+        $this->mockUserSession->method('getUser')->willReturn($user);
+        $this->mockGroupManager->method('isAdmin')->willReturn(false);
 
         $this->controller = new ConsentController(
             'docudesk',
             $this->mockRequest,
             $this->mockLogger,
             $this->mockCrudService,
-            $this->mockL10n
+            $this->mockL10n,
+            $this->mockUserSession,
+            $this->mockGroupManager
         );
 
     }//end setUp()
-
 
     /**
      * Test index returns 400 when not configured
@@ -110,7 +133,6 @@ class ConsentControllerTest extends TestCase
         $this->assertEquals(400, $result->getStatus());
 
     }//end testIndexReturns400WhenNotConfigured()
-
 
     /**
      * Test index returns consent list when configured
@@ -131,7 +153,6 @@ class ConsentControllerTest extends TestCase
 
     }//end testIndexReturnsConsentList()
 
-
     /**
      * Test create returns 400 when missing required fields
      *
@@ -148,7 +169,6 @@ class ConsentControllerTest extends TestCase
         $this->assertEquals(400, $result->getStatus());
 
     }//end testCreateReturns400WhenMissingFields()
-
 
     /**
      * Test show returns 404 when not found
@@ -169,7 +189,6 @@ class ConsentControllerTest extends TestCase
 
     }//end testShowReturns404WhenNotFound()
 
-
     /**
      * Test show returns consent record when found
      *
@@ -180,7 +199,13 @@ class ConsentControllerTest extends TestCase
         $this->mockCrudService->method('getConsentConfig')
             ->willReturn(['register' => 'reg-1', 'schema' => 'sch-1']);
         $this->mockCrudService->method('getConsent')
-            ->willReturn(['id' => 'uuid-1', 'consentStatus' => 'pending']);
+            ->willReturn(
+                [
+                    'id'            => 'uuid-1',
+                    'consentStatus' => 'pending',
+                    '@self'         => ['owner' => 'owner'],
+                ]
+            );
 
         $result = $this->controller->show('uuid-1');
 
@@ -189,5 +214,88 @@ class ConsentControllerTest extends TestCase
 
     }//end testShowReturnsConsentWhenFound()
 
+    /**
+     * Test show returns 404 when the record belongs to another user
+     *
+     * Security finding #283: a non-owner must not be able to read another
+     * user's consent record.
+     *
+     * @return void
+     */
+    public function testShowReturns404ForNonOwner(): void
+    {
+        $this->mockCrudService->method('getConsentConfig')
+            ->willReturn(['register' => 'reg-1', 'schema' => 'sch-1']);
+        $this->mockCrudService->method('getConsent')
+            ->willReturn(
+                [
+                    'id'            => 'uuid-1',
+                    'consentStatus' => 'pending',
+                    '@self'         => ['owner' => 'someone-else'],
+                ]
+            );
 
+        $result = $this->controller->show('uuid-1');
+
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertEquals(404, $result->getStatus());
+
+    }//end testShowReturns404ForNonOwner()
+
+    /**
+     * Test update returns 404 when the record belongs to another user
+     *
+     * Security finding #283: a non-owner must not be able to overwrite
+     * another user's consent record.
+     *
+     * @return void
+     */
+    public function testUpdateReturns404ForNonOwner(): void
+    {
+        $this->mockCrudService->method('getConsentConfig')
+            ->willReturn(['register' => 'reg-1', 'schema' => 'sch-1']);
+        $this->mockCrudService->method('getConsent')
+            ->willReturn(
+                [
+                    'id'    => 'uuid-1',
+                    '@self' => ['owner' => 'someone-else'],
+                ]
+            );
+        $this->mockRequest->method('getParams')
+            ->willReturn(['consentStatus' => 'granted']);
+
+        $result = $this->controller->update('uuid-1');
+
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertEquals(404, $result->getStatus());
+
+    }//end testUpdateReturns404ForNonOwner()
+
+    /**
+     * Test update succeeds for the record owner
+     *
+     * @return void
+     */
+    public function testUpdateSucceedsForOwner(): void
+    {
+        $this->mockCrudService->method('getConsentConfig')
+            ->willReturn(['register' => 'reg-1', 'schema' => 'sch-1']);
+        $this->mockCrudService->method('getConsent')
+            ->willReturn(
+                [
+                    'id'    => 'uuid-1',
+                    '@self' => ['owner' => 'owner'],
+                ]
+            );
+        $this->mockCrudService->method('updateConsentStatus')
+            ->willReturn(['id' => 'uuid-1', 'consentStatus' => 'granted']);
+        $this->mockRequest->method('getParams')
+            ->willReturn(['consentStatus' => 'granted']);
+
+        $result = $this->controller->update('uuid-1');
+
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertEquals(200, $result->getStatus());
+
+    }//end testUpdateSucceedsForOwner()
 }//end class


### PR DESCRIPTION
## Summary

Fixes three confirmed critical security findings in docudesk. PR for review (not admin-merged).

## #284 (CRITICAL) — signature verification always returned valid

`SigningVerificationService::extractSignatures()` regex-grepped a base64
`/DocuDesk-Signature(...)` blob and unconditionally set `valid=>true`, with
attacker-controlled signer/level. A forged PDF returned `isValid:true level:QES`.

**Fix:** the verifier is now **fail-closed**. A self-asserted blob is reported
`valid=>false` unless it carries a server-verifiable HMAC-SHA256 over the
document content-hash using a server-held secret (`signing_verification_secret`).
Unverifiable `/Type /Sig` entries report `valid=>false`. Real PAdES/CMS
validation is out of scope for this PR and the limitation is documented in code.

**Verified (runtime):** a forged PDF (`/Type /Sig` + `/DocuDesk-Signature(<base64>)`,
level QES) now returns `valid:false` / `isValid:false` (was `true`/QES). External-only
`/Type /Sig` also reports `valid:false`. Service still DI-constructible with the new
`IAppConfig` dependency.

## #283 (CRITICAL) — consent decisions readable/forgeable cross-user

`ConsentController` (`@NoAdminRequired`+`@NoCSRFRequired`) delegated to
`ConsentService`/`ConsentUpdateHandler`/`ConsentCrudService`, which forced
`_rbac:false,_multitenancy:false` on OR calls — any authenticated user could
read and overwrite another user's consent record.

**Fix:**
- Removed the `_rbac:false/_multitenancy:false` bypass on `getConsent`,
  `updateConsentStatus`, and `createConsentRequest` (OR now enforces access).
- Added an explicit per-object ownership guard in `ConsentController`
  (admins exempt; non-owner -> 404 to avoid existence probing) — OR reads are
  default-open, so a controller-level guard is required.
- Removed `@NoCSRFRequired` from the state-changing `create`/`update` endpoints.
- Whitelisted the mutable fields in `updateConsentStatus` (callers can no longer
  rewrite `documentId`/`entityText` or inject arbitrary keys).

**Verified (runtime):** non-admin `rbactest` `GET` on an admin-owned consent now
returns **404** (was 200 with full data); `PUT` now requires CSRF (**412** without a
valid token, was 200/persisted); admin owner still `GET`s its own record (200).
Owner-success and field-whitelist paths covered by new unit tests
(`testUpdateSucceedsForOwner`, `testShowReturns404ForNonOwner`, `testUpdateReturns404ForNonOwner`).

## #282 (CRITICAL) — sign-as-anyone

`SigningService::sign()` and `decline()` never checked that the authenticated
user matched the signer record.

**Fix:** both methods now require `($signer['userId'] ?? '') === $user->getUID()`
else throw (403). 

**Runtime verification blocked:** docudesk signing CRUD currently 500s against the
live OpenRegister build due to OR `ObjectService` API drift (unrelated to this PR
and explicitly out of scope). The ownership check is straightforward and correct;
it is exercised by code review only. The OR-API drift was not touched here.

## Testing

- `php -l` clean on all 7 changed files.
- `phpcs` (project standard) clean (0 errors) on all 6 production files; pre-existing
  class-level `@spec` warnings unchanged.
- `phpunit` consent suites green: 19/19 (incl. 8 ConsentController tests with new
  ownership coverage).

Refs #282 #283 #284