### PR TITLE
fix: filter audit trail server-side + whitelist consent create fields (#290)

### DIFF
--- a/lib/Service/ConsentCrudService.php
+++ b/lib/Service/ConsentCrudService.php
@@ -35,6 +35,8 @@ use Psr\Log\LoggerInterface;
  * @author   Conduction B.V. <info@conduction.nl>
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-docudesk/tasks.md#task-13
  */
 class ConsentCrudService
 {
@@ -149,7 +151,28 @@ class ConsentCrudService
     }//end getConsent()
 
     /**
+     * Fields accepted at consent creation time.
+     *
+     * Any request parameter NOT in this list is silently dropped before the
+     * record is written to OpenRegister (finding #290b).  Callers must not be
+     * able to force internal state fields such as `consentStatus`,
+     * `publicationDecision`, or `userId` at creation time.
+     *
+     * @var array<string>
+     */
+    private const ALLOWED_CREATE_FIELDS = [
+        'documentId',
+        'entityType',
+        'entityText',
+    ];
+
+    /**
      * Create a consent request from controller data
+     *
+     * Only the fields listed in {@see ALLOWED_CREATE_FIELDS} are accepted.
+     * All other request parameters are silently dropped so that callers cannot
+     * set internal status fields (e.g. `consentStatus`, `publicationDecision`,
+     * `userId`) at creation time, bypassing status-machine logic (finding #290b).
      *
      * @param array<string, mixed> $data     The request data
      * @param string               $register The register ID
@@ -163,20 +186,13 @@ class ConsentCrudService
      */
     public function createFromRequest(array $data, string $register, string $schema): array
     {
-        // Extract known fields and pass any remaining as extra.
-        $knownFields = ['documentId', 'entityType', 'entityText'];
-        $extra       = array_diff_key($data, array_flip($knownFields));
-
-        // Remove framework-injected params that are not consent data.
-        unset($extra['_route'], $extra['_method']);
-
+        // Only forward the explicitly allowed fields; drop everything else.
         return $this->consentService->createConsentRequest(
             $data['documentId'],
             $data['entityType'],
             $data['entityText'],
             $register,
-            $schema,
-            $extra
+            $schema
         );
 
     }//end createFromRequest()

--- a/lib/Service/SigningAuditService.php
+++ b/lib/Service/SigningAuditService.php
@@ -33,6 +33,8 @@ use RuntimeException;
  * @author   Conduction B.V. <info@conduction.nl>
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/changes/digital-signing-integration/tasks.md#4-1
  */
 class SigningAuditService
 {
@@ -124,6 +126,12 @@ class SigningAuditService
     /**
      * Get all audit entries for a signing request
      *
+     * Uses a server-side filter on `signingRequestId` via OR's `searchObjects`
+     * so that only matching records are fetched from the database.  The
+     * previous implementation loaded the entire audit register into PHP memory
+     * and filtered in-application, causing excessive memory usage and slow
+     * response times as the audit log grows (finding #290a).
+     *
      * @param string $signingRequestId The signing request ID
      *
      * @return array<int, array<string, mixed>> The audit entries
@@ -136,14 +144,22 @@ class SigningAuditService
         $register      = $this->config->getValueString('docudesk', 'signingAuditEntry_register', '');
         $schema        = $this->config->getValueString('docudesk', 'signingAuditEntry_schema', '');
 
-        $allEntries = $objectService->getObjects($register, $schema);
-
-        $entries = array_filter(
-            $allEntries,
-            function (array $entry) use ($signingRequestId): bool {
-                return ($entry['signingRequestId'] ?? '') === $signingRequestId;
-            }
+        $results = $objectService->searchObjects(
+            [
+                '@self'            => ['register' => $register, 'schema' => $schema],
+                'signingRequestId' => $signingRequestId,
+            ]
         );
+
+        $entries = [];
+        foreach ($results as $result) {
+            if (is_object($result) === true && method_exists($result, 'jsonSerialize') === true) {
+                $entries[] = $result->jsonSerialize();
+                continue;
+            }
+
+            $entries[] = (array) $result;
+        }
 
         usort(
             $entries,

--- a/tests/stubs/OpenRegisterStubs.php
+++ b/tests/stubs/OpenRegisterStubs.php
@@ -109,11 +109,13 @@ class ObjectService
 
 
     /**
-     * Search objects (legacy)
+     * Search objects
+     *
+     * @param array<string, mixed> $query Search query with optional @self scope and filters
      *
      * @return array
      */
-    public function searchObjects()
+    public function searchObjects(array $query=[])
     {
         return [];
 

--- a/tests/unit/Service/ConsentCrudServiceTest.php
+++ b/tests/unit/Service/ConsentCrudServiceTest.php
@@ -121,7 +121,8 @@ class ConsentCrudServiceTest extends TestCase
 
 
     /**
-     * Test createFromRequest delegates to ConsentService
+     * Test createFromRequest delegates to ConsentService with only the three
+     * documented fields (documentId, entityType, entityText) — no $extra.
      *
      * @return void
      */
@@ -130,7 +131,7 @@ class ConsentCrudServiceTest extends TestCase
         $expected = ['id' => 'uuid-1', 'consentStatus' => 'pending'];
         $this->mockConsentService->expects($this->once())
             ->method('createConsentRequest')
-            ->with('doc-1', 'PERSON', 'Jan de Vries', 'reg-1', 'schema-1', [])
+            ->with('doc-1', 'PERSON', 'Jan de Vries', 'reg-1', 'schema-1')
             ->willReturn($expected);
 
         $result = $this->service->createFromRequest(
@@ -142,6 +143,48 @@ class ConsentCrudServiceTest extends TestCase
         $this->assertEquals($expected, $result);
 
     }//end testCreateFromRequestDelegatesToConsentService()
+
+
+    /**
+     * Extra request fields (e.g. consentStatus, publicationDecision, userId)
+     * must be dropped before the record is written — callers must not be able
+     * to force internal state at creation time (finding #290b).
+     *
+     * The mock asserts that createConsentRequest is called WITHOUT any extra
+     * fields, regardless of what the caller sends.
+     *
+     * @return void
+     */
+    public function testCreateFromRequestDropsExtraFields(): void
+    {
+        $expected = ['id' => 'uuid-2', 'consentStatus' => 'pending'];
+
+        // The mock must be called with only the three positional args + register + schema.
+        // No extra $extra array should be forwarded.
+        $this->mockConsentService->expects($this->once())
+            ->method('createConsentRequest')
+            ->with('doc-2', 'ORGANISATION', 'Gemeente Amsterdam', 'reg-1', 'schema-1')
+            ->willReturn($expected);
+
+        $result = $this->service->createFromRequest(
+            [
+                'documentId'          => 'doc-2',
+                'entityType'          => 'ORGANISATION',
+                'entityText'          => 'Gemeente Amsterdam',
+                // These extra fields must be silently dropped (finding #290b).
+                'consentStatus'       => 'granted',
+                'publicationDecision' => 'approved',
+                'userId'              => 'attacker',
+                '_route'              => 'some.route',
+                '_method'             => 'POST',
+            ],
+            'reg-1',
+            'schema-1'
+        );
+
+        $this->assertEquals($expected, $result);
+
+    }//end testCreateFromRequestDropsExtraFields()
 
 
     /**

--- a/tests/unit/Service/SigningAuditServiceTest.php
+++ b/tests/unit/Service/SigningAuditServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Unit tests for SigningAuditService — finding #289 regression coverage.
+ * Unit tests for SigningAuditService — finding #289 and #290a regression coverage.
  *
  * Asserts:
  *  1. The dead-code `rejectUpdate()` / `rejectDelete()` methods no longer
@@ -12,6 +12,9 @@
  *     carries BOTH `immutable: true` and `appendOnly: true`, which is the
  *     storage-layer guard that actually enforces Archiefwet 1995
  *     immutability of audit records.
+ *  3. `getAuditTrail()` uses a server-side filter (passes `signingRequestId`
+ *     to `searchObjects`) instead of loading all records into PHP memory
+ *     and filtering in-application (finding #290a).
  *
  * @category Tests
  * @package  OCA\DocuDesk\Tests\Unit\Service
@@ -27,8 +30,13 @@ declare(strict_types=1);
 
 namespace OCA\DocuDesk\Tests\Unit\Service;
 
+use OCA\DocuDesk\Service\SettingsService;
 use OCA\DocuDesk\Service\SigningAuditService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use ReflectionClass;
 
 /**
@@ -140,6 +148,114 @@ class SigningAuditServiceTest extends TestCase
         $this->assertContains('signingAuditEntry', $signingSchemas);
 
     }//end testSigningRegisterIncludesAuditSchema()
+
+
+    /**
+     * getAuditTrail() must call searchObjects with a server-side signingRequestId
+     * filter rather than loading all entries into PHP memory (finding #290a).
+     *
+     * The mock asserts that:
+     *  - searchObjects is called exactly once
+     *  - the query contains the @self register/schema scope AND the
+     *    signingRequestId filter
+     *  - the returned entries are normalised to arrays and sorted by timestamp
+     *
+     * @return void
+     */
+    public function testGetAuditTrailUsesServerSideFilter(): void
+    {
+        /** @var ObjectService|MockObject $mockObjectService */
+        $mockObjectService = $this->createMock(ObjectService::class);
+
+        $capturedQuery = null;
+        $mockObjectService->expects($this->once())
+            ->method('searchObjects')
+            ->willReturnCallback(
+                function (array $query) use (&$capturedQuery): array {
+                    $capturedQuery = $query;
+                    // Return two matching entries (already filtered server-side).
+                    return [
+                        ['signingRequestId' => 'req-1', 'timestamp' => '2026-01-02T00:00:00+00:00', 'action' => 'SIGNED'],
+                        ['signingRequestId' => 'req-1', 'timestamp' => '2026-01-01T00:00:00+00:00', 'action' => 'CREATED'],
+                    ];
+                }
+            );
+
+        // SettingsService stub returns the object-service stub and config values.
+        /** @var SettingsService|MockObject $mockSettings */
+        $mockSettings = $this->createMock(SettingsService::class);
+        $mockSettings->method('getObjectService')->willReturn($mockObjectService);
+
+        /** @var IAppConfig|MockObject $mockConfig */
+        $mockConfig = $this->createMock(IAppConfig::class);
+        $mockConfig->method('getValueString')
+            ->willReturnMap(
+                [
+                    ['docudesk', 'signingAuditEntry_register', '', 'reg-audit'],
+                    ['docudesk', 'signingAuditEntry_schema', '', 'schema-audit'],
+                ]
+            );
+
+        $service = new SigningAuditService(
+            $mockSettings,
+            $mockConfig,
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $result = $service->getAuditTrail('req-1');
+
+        // The query passed to searchObjects must include the server-side filter.
+        $this->assertNotNull($capturedQuery);
+        $this->assertArrayHasKey('@self', $capturedQuery, 'searchObjects query must scope to register+schema via @self');
+        $this->assertSame('reg-audit', $capturedQuery['@self']['register'] ?? null);
+        $this->assertSame('schema-audit', $capturedQuery['@self']['schema'] ?? null);
+        $this->assertArrayHasKey('signingRequestId', $capturedQuery, 'searchObjects query must contain signingRequestId filter (finding #290a)');
+        $this->assertSame('req-1', $capturedQuery['signingRequestId']);
+
+        // Results are returned sorted by timestamp (ascending).
+        $this->assertCount(2, $result);
+        $this->assertSame('CREATED', $result[0]['action']);
+        $this->assertSame('SIGNED', $result[1]['action']);
+
+    }//end testGetAuditTrailUsesServerSideFilter()
+
+
+    /**
+     * getAuditTrail() must NOT call getObjects (the old full-scan path).
+     *
+     * The ObjectService stub does not declare getObjects(), so the mock
+     * will throw if it is called — no explicit `expects($this->never())` needed.
+     * We assert that searchObjects IS called, which is the only read path.
+     *
+     * @return void
+     */
+    public function testGetAuditTrailDoesNotCallGetObjects(): void
+    {
+        /** @var ObjectService|MockObject $mockObjectService */
+        $mockObjectService = $this->createMock(ObjectService::class);
+        $mockObjectService->method('searchObjects')->willReturn([]);
+
+        /** @var SettingsService|MockObject $mockSettings */
+        $mockSettings = $this->createMock(SettingsService::class);
+        $mockSettings->method('getObjectService')->willReturn($mockObjectService);
+
+        /** @var IAppConfig|MockObject $mockConfig */
+        $mockConfig = $this->createMock(IAppConfig::class);
+        $mockConfig->method('getValueString')->willReturn('');
+
+        $service = new SigningAuditService(
+            $mockSettings,
+            $mockConfig,
+            $this->createMock(LoggerInterface::class)
+        );
+
+        // If the old getObjects path were still present, PHPUnit would raise
+        // "method does not exist" because the stub has no getObjects() — the
+        // test would fail rather than pass silently.
+        $result = $service->getAuditTrail('req-no-scan');
+        $this->assertSame([], $result);
+
+    }//end testGetAuditTrailDoesNotCallGetObjects()
 
 
 }//end class


### PR DESCRIPTION
## Summary

Fixes both findings from issue #290 (LOW bundle deep-review):

### (a) `SigningAuditService::getAuditTrail` — server-side filter (`lib/Service/SigningAuditService.php`)

**Before:** Called `getObjects($register, $schema)` to load the entire audit register into PHP memory, then `array_filter`ed in-application by `signingRequestId`. As the audit log grows (high-volume signing), this causes excessive memory usage and slow response times.

**After:** Replaced with `searchObjects(['@self' => ['register' => ..., 'schema' => ...], 'signingRequestId' => $signingRequestId])` — only matching records are fetched from OR/the database. Follows the exact pattern already used by `ConsentUpdateHandler::getConsentsByDocument` and `ConsentCrudService::listConsents`.

### (b) `ConsentCrudService::createFromRequest` — explicit allowlist (`lib/Service/ConsentCrudService.php`)

**Before:** Collected all non-`_route`/`_method` request params into `$extra` and merged them into the consent record, allowing callers to set arbitrary internal fields (`consentStatus`, `publicationDecision`, `userId`, etc.) at creation time.

**After:** Removed the `$extra` merge entirely. Only `documentId`, `entityType`, `entityText` are forwarded to `createConsentRequest()`. The `ALLOWED_CREATE_FIELDS` constant documents the policy. All other params are silently dropped.

## Verification

### Unit test evidence

**Finding (a) — `SigningAuditServiceTest`:**
- `testGetAuditTrailUsesServerSideFilter`: mocks `ObjectService::searchObjects`, asserts it is called exactly once with `@self` register+schema scope AND `signingRequestId` filter; asserts returned entries are sorted by timestamp ascending. ✅ PASS
- `testGetAuditTrailDoesNotCallGetObjects`: the stub has no `getObjects()` method — if the old path were re-introduced, PHPUnit would raise an error. ✅ PASS

**Finding (b) — `ConsentCrudServiceTest`:**
- `testCreateFromRequestDropsExtraFields`: calls `createFromRequest` with `consentStatus:"granted"`, `publicationDecision:"approved"`, `userId:"attacker"`, `_route`, `_method` — mock asserts `createConsentRequest` is called with only the three positional args, no `$extra`. ✅ PASS
- `testCreateFromRequestDelegatesToConsentService`: updated to assert no `$extra` arg is forwarded. ✅ PASS

### PHP lint
All edited files pass `php -l` (no syntax errors).

### PHPCS
Both changed service files pass `phpcs --standard=phpcs.xml` with 0 errors and 0 warnings (also fixed pre-existing missing `@spec` class-level docblock tags).

### Test run output (PHP 8.3 in NC container)
```
Consent Crud Service
 ✔ Get consent config returns null when not configured
 ✔ Get consent config returns config when configured
 ✔ Create from request delegates to consent service
 ✔ Create from request drops extra fields
 ✔ Get consents by document delegates to consent service

Signing Audit Service
 ✔ Reject update method removed
 ✔ Reject delete method removed
 ✔ Real surface still present
 ✔ Audit schema is immutable and append only
 ✔ Signing register includes audit schema
 ✔ Get audit trail uses server side filter
 ✔ Get audit trail does not call get objects

Tests: 12, Assertions: 31
```