### PR TITLE
fix: resolve PHPCS, PHPStan, and PHPMD violations

### DIFF
--- a/lib/Controller/AnonymizationController.php
+++ b/lib/Controller/AnonymizationController.php
@@ -266,10 +266,9 @@ class AnonymizationController extends Controller
                 return $appendBasisSummary;
             }
 
+            $outputFormat = 'pdf';
             if (isset($params['outputFormat']) === true) {
                 $outputFormat = (string) $params['outputFormat'];
-            } else {
-                $outputFormat = 'pdf';
             }
 
             $entities = $this->filterByExcludeTypes(entities: $entities, params: $params);

--- a/lib/Controller/BatchAnonymizationController.php
+++ b/lib/Controller/BatchAnonymizationController.php
@@ -296,8 +296,8 @@ class BatchAnonymizationController extends Controller
                 return new JSONResponse(['error' => $this->l10n->t('Extraction has not started')], 409);
             }
 
-            $mc       = (float) ($this->request->getParam('minConfidence', '0.0'));
-            $entities = $this->entityService->consolidateEntities($batch, $mc);
+            $minConfidence  = (float) ($this->request->getParam('minConfidence', '0.0'));
+            $entities       = $this->entityService->consolidateEntities($batch, $minConfidence);
             $filesProcessed = 0;
             foreach ($batch['files'] as $f) {
                 if (in_array($f['status'], ['extracted', 'error'], true) === true) {
@@ -353,6 +353,7 @@ class BatchAnonymizationController extends Controller
                 return new JSONResponse(['error' => $this->l10n->t('No entities provided')], 400);
             }
 
+            $appendBasisSummary = false;
             if (array_key_exists('appendBasisSummary', $params) === true) {
                 $appendBasisSummary = $params['appendBasisSummary'];
                 if (is_bool($appendBasisSummary) === false) {
@@ -361,8 +362,6 @@ class BatchAnonymizationController extends Controller
                         400
                     );
                 }
-            } else {
-                $appendBasisSummary = false;
             }
 
             $basesError = $this->validateEntityBases(entities: $entities);
@@ -446,12 +445,12 @@ class BatchAnonymizationController extends Controller
                 return new JSONResponse(['error' => $this->l10n->t('Not authenticated')], Http::STATUS_UNAUTHORIZED);
             }
 
-            $p = $this->request->getParams();
-            if (is_array($p['anonymize'] ?? null) === false || is_array($p['keep'] ?? null) === false) {
+            $params = $this->request->getParams();
+            if (is_array($params['anonymize'] ?? null) === false || is_array($params['keep'] ?? null) === false) {
                 return new JSONResponse(['error' => 'Invalid format'], 400);
             }
 
-            $this->profileService->saveProfile(['anonymize' => $p['anonymize'], 'keep' => $p['keep']]);
+            $this->profileService->saveProfile(['anonymize' => $params['anonymize'], 'keep' => $params['keep']]);
             return new JSONResponse(['message' => 'Profile updated']);
         } catch (Exception $e) {
             return $this->err(msg: 'Failed to update profile', e: $e);

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -125,15 +125,16 @@ class PreferencesController extends Controller
                 appName: Application::APP_ID,
                 key: 'pref_'.$safeKey
             );
-        } else {
-            $this->config->setUserValue(
-                userId: $user->getUID(),
-                appName: Application::APP_ID,
-                key: 'pref_'.$safeKey,
-                value: $value
-            );
-            $stored = $value;
+            return new JSONResponse(data: ['value' => $stored]);
         }
+
+        $this->config->setUserValue(
+            userId: $user->getUID(),
+            appName: Application::APP_ID,
+            key: 'pref_'.$safeKey,
+            value: $value
+        );
+        $stored = $value;
 
         return new JSONResponse(data: ['value' => $stored]);
 

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -191,7 +191,7 @@ class SettingsController extends Controller
                 ]
             );
             return new JSONResponse(['error' => $e->getMessage()], 500);
-        }
+        }//end try
 
     }//end create()
 }//end class

--- a/lib/Controller/TemplatesController.php
+++ b/lib/Controller/TemplatesController.php
@@ -390,7 +390,7 @@ class TemplatesController extends Controller
             return new JSONResponse(data: $result);
         } catch (Exception $e) {
             return $this->requestHandler->buildErrorResponse($e, 'Failed to get version diff: ');
-        }
+        }//end try
 
     }//end diffVersions()
 
@@ -427,7 +427,7 @@ class TemplatesController extends Controller
             return new JSONResponse(data: ['html' => $html]);
         } catch (Exception $e) {
             return $this->requestHandler->buildErrorResponse($e, 'Failed to preview template: ');
-        }
+        }//end try
 
     }//end preview()
 
@@ -538,7 +538,7 @@ class TemplatesController extends Controller
             }
 
             return $this->requestHandler->buildErrorResponse($e, 'Failed to lock template: ');
-        }
+        }//end try
 
     }//end lock()
 

--- a/lib/Service/AnonymizationService.php
+++ b/lib/Service/AnonymizationService.php
@@ -555,7 +555,9 @@ class AnonymizationService
                 $summaryResult = $summaryService->appendSummaryAsSeparatePdf(node: $node);
                 $resultInfo['summaryFileId']   = $summaryResult['fileId'] ?? null;
                 $resultInfo['summaryFilePath'] = $summaryResult['filePath'] ?? null;
-            } else {
+            }
+
+            if ($outputFormat !== 'preserve') {
                 $summaryService->appendSummaryToPdf(node: $node);
             }
 

--- a/lib/Service/BatchUploadService.php
+++ b/lib/Service/BatchUploadService.php
@@ -83,7 +83,8 @@ class BatchUploadService
                 if ($index === 0) {
                     $arr = $request->getUploadedFile('files');
                     if (empty($arr) === false && is_array($arr['tmp_name']) === true) {
-                        for ($i = 0; $i < count($arr['tmp_name']); $i++) {
+                        $fileCount = count($arr['tmp_name']);
+                        for ($i = 0; $i < $fileCount; $i++) {
                             $files[] = [
                                 'name'     => (string) $arr['name'][$i],
                                 'tmp_name' => (string) $arr['tmp_name'][$i],

--- a/lib/Service/ConsentCrudService.php
+++ b/lib/Service/ConsentCrudService.php
@@ -187,10 +187,12 @@ class ConsentCrudService
     public function createFromRequest(array $data, string $register, string $schema): array
     {
         // Only forward the explicitly allowed fields; drop everything else.
+        $filtered = array_intersect_key($data, array_flip(self::ALLOWED_CREATE_FIELDS));
+
         return $this->consentService->createConsentRequest(
-            $data['documentId'],
-            $data['entityType'],
-            $data['entityText'],
+            (string) ($filtered['documentId'] ?? ''),
+            (string) ($filtered['entityType'] ?? ''),
+            (string) ($filtered['entityText'] ?? ''),
             $register,
             $schema
         );

--- a/lib/Service/EntityConsolidationService.php
+++ b/lib/Service/EntityConsolidationService.php
@@ -111,14 +111,14 @@ class EntityConsolidationService
      */
     private function mergeEntity(array $map, mixed $entity): array
     {
-        $d = (array) $entity;
+        $data = (array) $entity;
         if (is_object($entity) === true && method_exists($entity, 'jsonSerialize') === true) {
-            $d = $entity->jsonSerialize();
+            $data = $entity->jsonSerialize();
         }
 
-        $type  = $d['entity_type'] ?? $d['entityType'] ?? 'UNKNOWN';
-        $value = $d['entity_value'] ?? $d['entityValue'] ?? '';
-        $conf  = (float) ($d['confidence'] ?? 0.0);
+        $type  = $data['entity_type'] ?? $data['entityType'] ?? 'UNKNOWN';
+        $value = $data['entity_value'] ?? $data['entityValue'] ?? '';
+        $conf  = (float) ($data['confidence'] ?? 0.0);
         $key   = mb_strtolower((string) $value);
         if ($key === '') {
             return $map;

--- a/lib/Service/SigningVerificationService.php
+++ b/lib/Service/SigningVerificationService.php
@@ -144,7 +144,7 @@ class SigningVerificationService
                     ];
                 }
             }//end foreach
-        }
+        }//end if
 
         if (empty($signatures) === true) {
             for ($i = 0; $i < $matches; $i++) {
@@ -221,7 +221,7 @@ class SigningVerificationService
      */
     private function getSigningSecret(): string
     {
-        return (string) ($this->config->getValueString('docudesk', 'signing_verification_secret', '') ?? '');
+        return $this->config->getValueString('docudesk', 'signing_verification_secret', '');
 
     }//end getSigningSecret()
 


### PR DESCRIPTION
## Summary

- **PHPCS (5 errors → 0)**: phpcbf auto-fixed missing `//end try` closing comments in `SettingsController.php:194`, `SigningVerificationService.php:147`, `TemplatesController.php:393/430/541`.
- **PHPStan (2 errors → 0)**:
  - `ConsentCrudService::ALLOWED_CREATE_FIELDS` was defined but never referenced; wired it into `createFromRequest()` via `array_intersect_key` so the constant actually enforces the field allowlist it was documented to provide.
  - `SigningVerificationService::getSigningSecret():224` — removed redundant `?? ''` where `getValueString()` already returns a non-nullable `string`.
- **PHPMD (19 → 11 violations, easy ones only)**:
  - Renamed short variables `$mc→$minConfidence`, `$p→$params`, `$d→$data`.
  - Hoisted `count()` out of `for` loop in `BatchUploadService`.
  - Eliminated 3 `ElseExpression` violations (`AnonymizationController`, `BatchAnonymizationController`, `AnonymizationService`) using default-then-override and early-return patterns.
  - Skipped architectural complexity violations (ExcessiveClassComplexity, NPathComplexity, CyclomaticComplexity, CouplingBetweenObjects, TooManyPublicMethods, BooleanArgumentFlag, ExcessiveMethodLength) as out of scope.

## Test plan

- [ ] CI phpcs job passes (0 errors)
- [ ] CI phpstan job passes (0 errors)
- [ ] PHPMD violation count reduced from 19 to 11