### PR TITLE
feat(schemas): lifecycle annotation on signingRequest

### DIFF
--- a/lib/Settings/docudesk_register.json
+++ b/lib/Settings/docudesk_register.json
@@ -623,7 +623,28 @@
                 "updated": "2026-03-22T12:00:00+00:00", "created": "2026-03-22T12:00:00+00:00",
                 "maxDepth": 0, "owner": null, "application": null, "organisation": null, "groups": null, "authorization": null, "deleted": null,
                 "configuration": {"objectNameField": "documentName", "objectDescriptionField": "status", "autoPublish": false},
-                "searchable": true
+                "searchable": true,
+                "x-openregister-lifecycle": {
+                    "field": "status",
+                    "initialState": "DRAFT",
+                    "states": {
+                        "DRAFT":       {"label": "Draft",       "description": "Signing request is being assembled by the initiator; not yet sent to signers."},
+                        "PENDING":     {"label": "Pending",     "description": "Request has been sent and is awaiting signer action."},
+                        "IN_PROGRESS": {"label": "In progress", "description": "At least one signer has started; the request is being signed."},
+                        "COMPLETED":   {"label": "Completed",   "description": "All signers have signed. Terminal state."},
+                        "DECLINED":    {"label": "Declined",    "description": "A signer declined; the request is terminated. Terminal."},
+                        "EXPIRED":     {"label": "Expired",     "description": "The deadline passed before completion. Terminal."},
+                        "CANCELLED":   {"label": "Cancelled",   "description": "The initiator cancelled the request. Terminal."}
+                    },
+                    "transitions": {
+                        "send":     {"from": "DRAFT",       "to": "PENDING",     "label": "Send for signing", "description": "Notify the configured signers and start collecting signatures."},
+                        "start":    {"from": "PENDING",     "to": "IN_PROGRESS", "label": "Start signing",    "description": "A signer has opened the request; mark the request as in progress."},
+                        "complete": {"from": "IN_PROGRESS", "to": "COMPLETED",   "label": "Complete signing", "description": "All signers have signed; finalise the request. Terminal."},
+                        "decline":  {"from": "IN_PROGRESS", "to": "DECLINED",    "label": "Decline",          "description": "A signer declined; terminate the request. Terminal."},
+                        "expire":   {"from": "PENDING",     "to": "EXPIRED",     "label": "Expire",           "description": "Deadline passed before completion. Terminal."},
+                        "cancel":   {"from": "PENDING",     "to": "CANCELLED",   "label": "Cancel",           "description": "Initiator cancels the request before completion. Terminal."}
+                    }
+                }
             },
             "signerRecord": {
                 "uri": null,


### PR DESCRIPTION
Adds `x-openregister-lifecycle` to the **signingRequest** schema so OR's `platform-annotations` Newman suite can drive the signing workflow via the standard `/api/objects/{id}/transition` endpoint.

## What's added

Single field added to `signingRequest` in `lib/Settings/docudesk_register.json`:

```yaml
x-openregister-lifecycle:
  field: status                    # existing enum on the schema
  initialState: DRAFT
  states: DRAFT, PENDING, IN_PROGRESS, COMPLETED, DECLINED, EXPIRED, CANCELLED
  transitions:
    send     DRAFT       → PENDING       Notify the configured signers
    start    PENDING     → IN_PROGRESS   A signer opened the request
    complete IN_PROGRESS → COMPLETED     All signers signed; terminal
    decline  IN_PROGRESS → DECLINED      Terminal
    expire   PENDING     → EXPIRED       Deadline passed; terminal
    cancel   PENDING     → CANCELLED     Initiator cancels; terminal
```

State names match the existing `status` property's enum exactly. The 3 happy-path transitions match the Newman flow `send → start → complete` 1:1; the 3 terminal-branches (decline / expire / cancel) round out the model.

## Context

OR-side, the platform-annotations Newman collection was failing on the signingRequest workflow because the schema declared the `status` enum but had no lifecycle to drive transitions. This PR is the docudesk half of the OR session's Tier-3 follow-up; the decidesk half (Meeting / Motion / Minutes / ActionItem) lands as ConductionNL/decidesk#324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
