### PR TITLE
fix(signing): migrate SigningService to canonical OR ObjectService API

### DIFF
--- a/lib/Controller/SigningController.php
+++ b/lib/Controller/SigningController.php
@@ -137,30 +137,6 @@ class SigningController extends Controller
                     'notConfigured' => true,
                 ]
             );
-        } catch (\Error $e) {
-            // Narrow OR-sidecar-lag fallback (finding #288). PHP raises an
-            // `\Error` (typically `\Error` from a method-not-found dispatch)
-            // when the deployed OpenRegister build lacks a method that
-            // SigningService calls (e.g. `getObjects`). That genuine
-            // deployment-drift case keeps the page rendering and the error
-            // is logged at ERROR level so monitoring sees the drift. Any
-            // real `\Exception` / `\Throwable` from a runtime infra failure
-            // (DB outage, mapper bug) is intentionally NOT caught here so
-            // it propagates to the framework's 500 handler and surfaces in
-            // alerting instead of being masked as "no requests".
-            $this->logger->error(
-                'Signing requests list failed — returning empty list. '
-                .'Likely a missing OpenRegister method on the deployed sidecar. '
-                .'Underlying: '.$e->getMessage(),
-                ['exception' => $e]
-            );
-            return new JSONResponse(
-                data: [
-                    'results'       => [],
-                    'total'         => 0,
-                    'notConfigured' => true,
-                ]
-            );
         }//end try
 
     }//end listRequests()

--- a/lib/Service/Signing/NativeSigningProvider.php
+++ b/lib/Service/Signing/NativeSigningProvider.php
@@ -280,16 +280,15 @@ class NativeSigningProvider implements SigningProviderInterface
             }
         }
 
-        // Call with full positional arity so it matches the canonical OR
-        // ObjectService::saveObject($object, $extend, $register, $schema, $uuid)
-        // signature.
-        $objectService->saveObject(
-            $session,
-            [],
-            $register,
-            $schema,
-            $uuid
-        );
+        // When updating an existing session row, embed the OR uuid in the
+        // object data so the canonical ObjectService::saveObject(object:,
+        // register:, schema:) can detect and update the existing record
+        // rather than creating a duplicate.
+        if ($uuid !== null) {
+            $session['id'] = $uuid;
+        }
+
+        $objectService->saveObject(object: $session, register: $register, schema: $schema);
 
     }//end persistSession()
 

--- a/lib/Service/SigningAuditService.php
+++ b/lib/Service/SigningAuditService.php
@@ -119,7 +119,13 @@ class SigningAuditService
             'metadata'         => $metadata,
         ];
 
-        return $objectService->saveObject($register, $schema, $entry);
+        $saved = $objectService->saveObject(object: $entry, register: $register, schema: $schema);
+
+        if (is_object($saved) === true && method_exists($saved, 'jsonSerialize') === true) {
+            return $saved->jsonSerialize();
+        }
+
+        return (array) $saved;
 
     }//end logEvent()
 

--- a/lib/Service/SigningService.php
+++ b/lib/Service/SigningService.php
@@ -126,7 +126,7 @@ class SigningService
 
         $register       = $this->config->getValueString('docudesk', 'signingRequest_register', '');
         $schema         = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
-        $createdRequest = $objectService->saveObject($register, $schema, $request);
+        $createdRequest = $objectService->saveObject(object: $request, register: $register, schema: $schema);
 
         $signers        = $data['signers'] ?? [];
         $signerIds      = [];
@@ -143,13 +143,13 @@ class SigningService
                 'status'           => 'PENDING',
             ];
 
-            $created     = $objectService->saveObject($signerRegister, $signerSchema, $signerRecord);
+            $created     = $objectService->saveObject(object: $signerRecord, register: $signerRegister, schema: $signerSchema);
             $signerIds[] = $created['id'] ?? $created['uuid'] ?? '';
         }//end foreach
 
         $requestId = $createdRequest['id'] ?? $createdRequest['uuid'] ?? '';
         $createdRequest['signerIds'] = $signerIds;
-        $objectService->saveObject($register, $schema, $createdRequest);
+        $objectService->saveObject(object: $createdRequest, register: $register, schema: $schema);
 
         $this->auditService->logEvent(
             signingRequestId: $requestId,
@@ -182,12 +182,16 @@ class SigningService
         $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
         $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
 
-        $request = $objectService->getObject($register, $schema, $requestId);
-        if (empty($request) === true) {
+        $object = $objectService->find(id: $requestId, register: $register, schema: $schema);
+        if ($object === null) {
             throw new RuntimeException('Signing request not found: '.$requestId);
         }
 
-        return $request;
+        if (is_object($object) === true && method_exists($object, 'jsonSerialize') === true) {
+            return $object->jsonSerialize();
+        }
+
+        return (array) $object;
 
     }//end getRequest()
 
@@ -204,7 +208,26 @@ class SigningService
         $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
         $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
 
-        return $objectService->getObjects($register, $schema);
+        $results = $objectService->findAll(
+            [
+                'filters' => [
+                    'register' => $register,
+                    'schema'   => $schema,
+                ],
+            ]
+        );
+
+        $requests = [];
+        foreach ($results as $result) {
+            if (is_object($result) === true && method_exists($result, 'jsonSerialize') === true) {
+                $requests[] = $result->jsonSerialize();
+                continue;
+            }
+
+            $requests[] = (array) $result;
+        }
+
+        return $requests;
 
     }//end listRequests()
 
@@ -237,11 +260,15 @@ class SigningService
 
         $signerRegister = $this->config->getValueString('docudesk', 'signerRecord_register', '');
         $signerSchema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
-        $signer         = $objectService->getObject($signerRegister, $signerSchema, $signerId);
+        $signerObject   = $objectService->find(id: $signerId, register: $signerRegister, schema: $signerSchema);
 
-        if (empty($signer) === true) {
+        if ($signerObject === null) {
             throw new RuntimeException('Signer record not found: '.$signerId);
         }
+
+        $signer = is_object($signerObject) === true && method_exists($signerObject, 'jsonSerialize') === true
+            ? $signerObject->jsonSerialize()
+            : (array) $signerObject;
 
         // Security finding #282: ensure the authenticated user is the signer
         // they claim to be. Without this check any authenticated user could
@@ -258,7 +285,7 @@ class SigningService
         $signer['status']    = 'SIGNED';
         $signer['signedAt']  = $now->format(DateTimeInterface::ATOM);
         $signer['ipAddress'] = $this->getClientIp();
-        $objectService->saveObject($signerRegister, $signerSchema, $signer);
+        $objectService->saveObject(object: $signer, register: $signerRegister, schema: $signerSchema);
 
         $this->auditService->logEvent(
             signingRequestId: $requestId,
@@ -297,11 +324,15 @@ class SigningService
         $objectService  = $this->settingsService->getObjectService();
         $signerRegister = $this->config->getValueString('docudesk', 'signerRecord_register', '');
         $signerSchema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
-        $signer         = $objectService->getObject($signerRegister, $signerSchema, $signerId);
+        $signerObject   = $objectService->find(id: $signerId, register: $signerRegister, schema: $signerSchema);
 
-        if (empty($signer) === true) {
+        if ($signerObject === null) {
             throw new RuntimeException('Signer record not found: '.$signerId);
         }
+
+        $signer = is_object($signerObject) === true && method_exists($signerObject, 'jsonSerialize') === true
+            ? $signerObject->jsonSerialize()
+            : (array) $signerObject;
 
         // Security finding #282: ensure the authenticated user is the signer
         // they claim to be before allowing them to decline on its behalf.
@@ -311,17 +342,20 @@ class SigningService
 
         $signer['status']        = 'DECLINED';
         $signer['declineReason'] = $reason;
-        $objectService->saveObject($signerRegister, $signerSchema, $signer);
+        $objectService->saveObject(object: $signer, register: $signerRegister, schema: $signerSchema);
 
-        $register = $this->config->getValueString('docudesk', 'signingRequest_register', '');
-        $schema   = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
-        $request  = $objectService->getObject($register, $schema, $requestId);
+        $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
+        $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
+        $requestObject = $objectService->find(id: $requestId, register: $register, schema: $schema);
+        $request       = $requestObject !== null && is_object($requestObject) === true && method_exists($requestObject, 'jsonSerialize') === true
+            ? $requestObject->jsonSerialize()
+            : (array) $requestObject;
 
         $signatureLevel = $request['signatureLevel'] ?? 'SES';
         $provider       = $request['provider'] ?? 'native';
 
         $request['status'] = 'DECLINED';
-        $objectService->saveObject($register, $schema, $request);
+        $objectService->saveObject(object: $request, register: $register, schema: $schema);
 
         $this->auditService->logEvent(
             signingRequestId: $requestId,
@@ -357,14 +391,17 @@ class SigningService
         $objectService = $this->settingsService->getObjectService();
         $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
         $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
-        $request       = $objectService->getObject($register, $schema, $requestId);
+        $requestObject = $objectService->find(id: $requestId, register: $register, schema: $schema);
+        $request       = $requestObject !== null && is_object($requestObject) === true && method_exists($requestObject, 'jsonSerialize') === true
+            ? $requestObject->jsonSerialize()
+            : (array) $requestObject;
 
         if ($this->isValidTransition(currentStatus: $request['status'] ?? '', newStatus: 'CANCELLED') === false) {
             throw new RuntimeException('Cannot cancel request in status: '.($request['status'] ?? 'unknown'));
         }
 
         $request['status'] = 'CANCELLED';
-        $objectService->saveObject($register, $schema, $request);
+        $objectService->saveObject(object: $request, register: $register, schema: $schema);
 
         $this->auditService->logEvent(
             signingRequestId: $requestId,
@@ -489,21 +526,27 @@ class SigningService
         $allSigned      = true;
 
         foreach ($signerIds as $signerId) {
-            $signer = $objectService->getObject($signerRegister, $signerSchema, $signerId);
+            $signerObj = $objectService->find(id: $signerId, register: $signerRegister, schema: $signerSchema);
+            $signer    = $signerObj !== null && is_object($signerObj) === true && method_exists($signerObj, 'jsonSerialize') === true
+                ? $signerObj->jsonSerialize()
+                : (array) $signerObj;
             if (($signer['status'] ?? '') !== 'SIGNED') {
                 $allSigned = false;
                 break;
             }
         }//end foreach
 
-        $freshRequest = $objectService->getObject($register, $schema, $requestId);
+        $freshObj     = $objectService->find(id: $requestId, register: $register, schema: $schema);
+        $freshRequest = $freshObj !== null && is_object($freshObj) === true && method_exists($freshObj, 'jsonSerialize') === true
+            ? $freshObj->jsonSerialize()
+            : (array) $freshObj;
 
         $freshRequest['status'] = 'IN_PROGRESS';
         if ($allSigned === true) {
             $freshRequest['status'] = 'COMPLETED';
         }
 
-        $objectService->saveObject($register, $schema, $freshRequest);
+        $objectService->saveObject(object: $freshRequest, register: $register, schema: $schema);
 
     }//end updateRequestStatus()
 
@@ -522,7 +565,10 @@ class SigningService
         $signerSchema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
 
         foreach ($signerIds as $signerId) {
-            $signer = $objectService->getObject($signerRegister, $signerSchema, $signerId);
+            $signerObj = $objectService->find(id: $signerId, register: $signerRegister, schema: $signerSchema);
+            $signer    = $signerObj !== null && is_object($signerObj) === true && method_exists($signerObj, 'jsonSerialize') === true
+                ? $signerObj->jsonSerialize()
+                : (array) $signerObj;
             if (($signer['userId'] ?? '') === $userId && ($signer['status'] ?? '') === 'PENDING') {
                 return $signerId;
             }

--- a/tests/stubs/OpenRegisterStubs.php
+++ b/tests/stubs/OpenRegisterStubs.php
@@ -66,6 +66,20 @@ class ObjectService
 
 
     /**
+     * Find all objects matching a set of filters
+     *
+     * @param array<string, mixed> $config Config with 'filters' key
+     *
+     * @return array<mixed>
+     */
+    public function findAll(array $config=[]): array
+    {
+        return [];
+
+    }//end findAll()
+
+
+    /**
      * Delete an object
      *
      * @param string $uuid Object UUID
@@ -327,6 +341,29 @@ interface Emitter
 namespace OCP;
 
 /**
+ * Stub for OCP\IUserSession
+ *
+ * @category Tests
+ * @package  OCP
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ */
+interface IUserSession
+{
+
+    /**
+     * Get the currently logged in user
+     *
+     * @return \OCP\IUser|null
+     */
+    public function getUser(): ?\OCP\IUser;
+
+
+}//end interface
+
+
+/**
  * Stub for OCP\IAppConfig
  *
  * @category Tests
@@ -432,6 +469,29 @@ interface IAppManager
     public function getAppVersion(string $appId, bool $useCache = true): string;
 
 }
+
+namespace OCP\AppFramework;
+
+/**
+ * Stub for OCP\AppFramework\Http constants
+ *
+ * @category Tests
+ * @package  OCP\AppFramework
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ */
+class Http
+{
+    public const STATUS_OK = 200;
+    public const STATUS_CREATED = 201;
+    public const STATUS_NO_CONTENT = 204;
+    public const STATUS_UNAUTHORIZED = 401;
+    public const STATUS_FORBIDDEN = 403;
+    public const STATUS_NOT_FOUND = 404;
+    public const STATUS_INTERNAL_SERVER_ERROR = 500;
+}//end class
+
 
 namespace OCP\AppFramework\Http;
 

--- a/tests/unit/Controller/SigningControllerTest.php
+++ b/tests/unit/Controller/SigningControllerTest.php
@@ -159,38 +159,22 @@ class SigningControllerTest extends TestCase
 
 
     /**
-     * The narrow OR-sidecar-lag fallback still triggers for `\Error`
-     * (e.g. calling a method that doesn't exist on the deployed OR build).
-     * Logged at ERROR level (not warning), still returns an empty list so
-     * the page renders while the sidecar catches up.
+     * A PHP `\Error` (e.g. call to undefined method on a mock) now propagates
+     * as-is since the `\Error` fallback was removed when SigningService was
+     * migrated to the canonical OR API (findAll / find / saveObject).
      *
      * @return void
      */
-    public function testListRequestsCatchesErrorAsNotConfigured(): void
+    public function testListRequestsLetsErrorPropagate(): void
     {
         $this->signingService->method('listRequests')
-            ->willThrowException(new \Error('Call to undefined method ObjectService::getObjects()'));
+            ->willThrowException(new \Error('Call to undefined method'));
 
-        $this->logger->expects($this->once())
-            ->method('error')
-            ->with(
-                $this->stringContains('Likely a missing OpenRegister method'),
-                $this->callback(
-                    function ($context): bool {
-                        return is_array($context) === true && isset($context['exception']);
-                    }
-                )
-            );
+        $this->expectException(\Error::class);
 
-        $response = $this->controller->listRequests();
+        $this->controller->listRequests();
 
-        $this->assertInstanceOf(JSONResponse::class, $response);
-        $this->assertSame(Http::STATUS_OK, $response->getStatus());
-        $data = $response->getData();
-        $this->assertSame([], $data['results']);
-        $this->assertTrue($data['notConfigured']);
-
-    }//end testListRequestsCatchesErrorAsNotConfigured()
+    }//end testListRequestsLetsErrorPropagate()
 
 
     /**


### PR DESCRIPTION
## Summary

- Replace all `saveObject($register, $schema, $data)` positional calls with canonical `saveObject(object:, register:, schema:)` named-arg form
- Replace non-existent `getObject($reg, $schema, $id)` with `find(id:, register:, schema:)` + `jsonSerialize()`
- Replace non-existent `getObjects` with `findAll(['filters'=>[...]])`
- Remove the `\Error` fallback in `SigningController::listRequests`
- Fix `NativeSigningProvider::persistSession` to use canonical API
- Add missing `IUserSession`, `Http`, `findAll` stubs to test harness

Closes finding C1.

## Test plan

- [ ] `php vendor/bin/phpunit --bootstrap tests/bootstrap-standalone.php --no-coverage tests/unit/Controller/SigningControllerTest.php tests/unit/Service/SigningAuditServiceTest.php` → 11/11 pass