### PR TITLE
fix(security): bump twig/twig to ^3.27.0 (CVE-2026-48805/06/07/08, CVE-2026-46636)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
 		"symfony/uid": "^6.4",
 		"symfony/yaml": "^6.4",
 		"thiagoalessio/tesseract_ocr": "^2.13",
-		"twig/twig": "^3.18"
+		"twig/twig": "^3.27.0"
 	},
 	"require-dev": {
 		"edgedesign/phpqa": "^1.27",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79276ab08be78707cfe0ddceede2caf3",
+    "content-hash": "3edab7077122a0103d7ca0f7121bac58",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -922,16 +922,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6b177d03d2eb04a6c9d01bab9818fb93a30ce7fd"
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6b177d03d2eb04a6c9d01bab9818fb93a30ce7fd",
-                "reference": "6b177d03d2eb04a6c9d01bab9818fb93a30ce7fd",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
                 "shasum": ""
             },
             "require": {
@@ -983,7 +983,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -1003,7 +1003,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T14:08:27+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
@@ -1293,16 +1293,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.26.0",
+            "version": "v3.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
                 "shasum": ""
             },
             "require": {
@@ -1357,7 +1357,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.27.0"
             },
             "funding": [
                 {
@@ -1369,7 +1369,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:31:59+00:00"
+            "time": "2026-05-27T13:05:51+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Security fix

Bumps `twig/twig` from `v3.26.0` to `v3.27.0` to resolve 5 sandbox bypass CVEs disclosed 2026-05-27:

| CVE | Title |
|-----|-------|
| CVE-2026-48805 | Sandbox state regression in deprecated internal wrappers in `src/Resources/core.php` |
| CVE-2026-48806 | Sandbox `__toString()` policy bypass via dynamic mapping keys |
| CVE-2026-48807 | Sandbox `__toString()` policy bypass via `Traversable` in `join`/`replace` and `in`/`not in` operators |
| CVE-2026-48808 | Sandbox property allowlist bypass via the `column` filter under `SourcePolicyInterface` |
| CVE-2026-46636 | Sandbox filter, tag and function allow-list bypass when sandbox state changes between renders |

All five affect `twig/twig >=3.0.0,<3.27.0`. `composer audit` is now clean.

## Changes
- `composer.json`: constraint bumped from `^3.18` to `^3.27.0`
- `composer.lock`: `twig/twig` updated from `v3.26.0` to `v3.27.0`

## Test plan
- [x] `composer audit` — no advisories found
- [x] Version confirmed: `twig/twig v3.27.0`