### PR TITLE
fix(quality): resolve all PHPCS errors — composer check:strict now exits 0

### DIFF
--- a/lib/Service/ConsentCrudService.php
+++ b/lib/Service/ConsentCrudService.php
@@ -85,9 +85,9 @@ class ConsentCrudService
      * server-side so only records whose @self.owner matches the caller are
      * returned. Passing null returns all records (admin callers only).
      *
-     * @param string      $register  The register ID
-     * @param string      $schema    The schema ID
-     * @param string|null $ownerUid  UID to scope results to, or null for all
+     * @param string      $register The register ID
+     * @param string      $schema   The schema ID
+     * @param string|null $ownerUid UID to scope results to, or null for all
      *
      * @return array<int, array<string, mixed>> List of consent records
      *

--- a/lib/Service/ConsentService.php
+++ b/lib/Service/ConsentService.php
@@ -218,9 +218,10 @@ class ConsentService
     /**
      * Get all consent records for a specific document
      *
-     * @param string $documentId The document UUID
-     * @param string $register   The register ID
-     * @param string $schema     The schema ID
+     * @param string      $documentId The document UUID
+     * @param string      $register   The register ID
+     * @param string      $schema     The schema ID
+     * @param string|null $ownerUid   UID to scope results to, or null for all
      *
      * @return array<int, array<string, mixed>> List of consent records
      *

--- a/lib/Service/ConsentUpdateHandler.php
+++ b/lib/Service/ConsentUpdateHandler.php
@@ -158,9 +158,10 @@ class ConsentUpdateHandler
     /**
      * Get all consent records for a specific document
      *
-     * @param string $documentId The document UUID
-     * @param string $register   The register ID
-     * @param string $schema     The schema ID
+     * @param string      $documentId The document UUID
+     * @param string      $register   The register ID
+     * @param string      $schema     The schema ID
+     * @param string|null $ownerUid   UID to scope results to, or null for all
      *
      * @return array<int, array<string, mixed>> List of consent records
      *

--- a/lib/Service/SigningService.php
+++ b/lib/Service/SigningService.php
@@ -266,9 +266,11 @@ class SigningService
             throw new RuntimeException('Signer record not found: '.$signerId);
         }
 
-        $signer = is_object($signerObject) === true && method_exists($signerObject, 'jsonSerialize') === true
-            ? $signerObject->jsonSerialize()
-            : (array) $signerObject;
+        if (is_object($signerObject) === true && method_exists($signerObject, 'jsonSerialize') === true) {
+            $signer = $signerObject->jsonSerialize();
+        } else {
+            $signer = (array) $signerObject;
+        }
 
         // Security finding #282: ensure the authenticated user is the signer
         // they claim to be. Without this check any authenticated user could
@@ -330,9 +332,11 @@ class SigningService
             throw new RuntimeException('Signer record not found: '.$signerId);
         }
 
-        $signer = is_object($signerObject) === true && method_exists($signerObject, 'jsonSerialize') === true
-            ? $signerObject->jsonSerialize()
-            : (array) $signerObject;
+        if (is_object($signerObject) === true && method_exists($signerObject, 'jsonSerialize') === true) {
+            $signer = $signerObject->jsonSerialize();
+        } else {
+            $signer = (array) $signerObject;
+        }
 
         // Security finding #282: ensure the authenticated user is the signer
         // they claim to be before allowing them to decline on its behalf.
@@ -347,9 +351,11 @@ class SigningService
         $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
         $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
         $requestObject = $objectService->find(id: $requestId, register: $register, schema: $schema);
-        $request       = $requestObject !== null && is_object($requestObject) === true && method_exists($requestObject, 'jsonSerialize') === true
-            ? $requestObject->jsonSerialize()
-            : (array) $requestObject;
+        if ($requestObject !== null && is_object($requestObject) === true && method_exists($requestObject, 'jsonSerialize') === true) {
+            $request = $requestObject->jsonSerialize();
+        } else {
+            $request = (array) $requestObject;
+        }
 
         $signatureLevel = $request['signatureLevel'] ?? 'SES';
         $provider       = $request['provider'] ?? 'native';
@@ -392,9 +398,11 @@ class SigningService
         $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
         $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
         $requestObject = $objectService->find(id: $requestId, register: $register, schema: $schema);
-        $request       = $requestObject !== null && is_object($requestObject) === true && method_exists($requestObject, 'jsonSerialize') === true
-            ? $requestObject->jsonSerialize()
-            : (array) $requestObject;
+        if ($requestObject !== null && is_object($requestObject) === true && method_exists($requestObject, 'jsonSerialize') === true) {
+            $request = $requestObject->jsonSerialize();
+        } else {
+            $request = (array) $requestObject;
+        }
 
         if ($this->isValidTransition(currentStatus: $request['status'] ?? '', newStatus: 'CANCELLED') === false) {
             throw new RuntimeException('Cannot cancel request in status: '.($request['status'] ?? 'unknown'));
@@ -527,19 +535,24 @@ class SigningService
 
         foreach ($signerIds as $signerId) {
             $signerObj = $objectService->find(id: $signerId, register: $signerRegister, schema: $signerSchema);
-            $signer    = $signerObj !== null && is_object($signerObj) === true && method_exists($signerObj, 'jsonSerialize') === true
-                ? $signerObj->jsonSerialize()
-                : (array) $signerObj;
+            if ($signerObj !== null && is_object($signerObj) === true && method_exists($signerObj, 'jsonSerialize') === true) {
+                $signer = $signerObj->jsonSerialize();
+            } else {
+                $signer = (array) $signerObj;
+            }
+
             if (($signer['status'] ?? '') !== 'SIGNED') {
                 $allSigned = false;
                 break;
             }
         }//end foreach
 
-        $freshObj     = $objectService->find(id: $requestId, register: $register, schema: $schema);
-        $freshRequest = $freshObj !== null && is_object($freshObj) === true && method_exists($freshObj, 'jsonSerialize') === true
-            ? $freshObj->jsonSerialize()
-            : (array) $freshObj;
+        $freshObj = $objectService->find(id: $requestId, register: $register, schema: $schema);
+        if ($freshObj !== null && is_object($freshObj) === true && method_exists($freshObj, 'jsonSerialize') === true) {
+            $freshRequest = $freshObj->jsonSerialize();
+        } else {
+            $freshRequest = (array) $freshObj;
+        }
 
         $freshRequest['status'] = 'IN_PROGRESS';
         if ($allSigned === true) {
@@ -566,9 +579,12 @@ class SigningService
 
         foreach ($signerIds as $signerId) {
             $signerObj = $objectService->find(id: $signerId, register: $signerRegister, schema: $signerSchema);
-            $signer    = $signerObj !== null && is_object($signerObj) === true && method_exists($signerObj, 'jsonSerialize') === true
-                ? $signerObj->jsonSerialize()
-                : (array) $signerObj;
+            if ($signerObj !== null && is_object($signerObj) === true && method_exists($signerObj, 'jsonSerialize') === true) {
+                $signer = $signerObj->jsonSerialize();
+            } else {
+                $signer = (array) $signerObj;
+            }
+
             if (($signer['userId'] ?? '') === $userId && ($signer['status'] ?? '') === 'PENDING') {
                 return $signerId;
             }

--- a/lib/Service/SigningVerificationService.php
+++ b/lib/Service/SigningVerificationService.php
@@ -212,7 +212,7 @@ class SigningVerificationService
     {
         // Use preg_replace with a literal match (preg_quote) so that any
         // special regex characters in the MAC value are treated as plain text.
-        return preg_replace('/' . preg_quote($mac, '/') . '/', '', $pdfContent) ?? $pdfContent;
+        return preg_replace('/'.preg_quote($mac, '/').'/', '', $pdfContent) ?? $pdfContent;
 
     }//end stripAssertionMac()
 


### PR DESCRIPTION
## Summary

- **SigningVerificationService**: remove spaces around concat operator in `preg_replace` call
- **ConsentCrudService / ConsentService / ConsentUpdateHandler**: add missing `@param string|null \$ownerUid` tag; fix alignment spaces on `@param` lines
- **SigningService**: convert 6 multi-line ternary expressions to explicit `if/else` blocks (Inline IF statements are not allowed by our PHPCS ruleset)

All violations were introduced by recent wave-3 security hardening commits.

## Verification

```
composer check:strict  →  ALL CHECKS PASSED  (exit 0)
```

- lint: 0 errors
- phpcs: 0 errors (was: 28 errors across 5 files)
- phpmd: violations exist but swallowed by `|| echo` fallback (pre-existing architectural debt, not this PR's scope)
- psalm: passes
- phpstan: 0 errors
- test:all: skipped (no Nextcloud server) → exit 0