### PR TITLE
fix(anonymization): validate bases before file-access check to guarantee HTTP 400

### DIFF
--- a/lib/Controller/AnonymizationController.php
+++ b/lib/Controller/AnonymizationController.php
@@ -292,11 +292,8 @@ class AnonymizationController extends Controller
                 return new JSONResponse(['error' => $this->l10n->t('Not authenticated')], Http::STATUS_UNAUTHORIZED);
             }
 
-            $accessError = $this->verifyFileAccess(fileId: $fileId);
-            if ($accessError !== null) {
-                return $accessError;
-            }
-
+            // Validate request body BEFORE file-access checks so that malformed
+            // input always yields HTTP 400 regardless of whether the file exists.
             $params   = $this->request->getParams();
             $entities = $params['entities'] ?? [];
 
@@ -315,6 +312,11 @@ class AnonymizationController extends Controller
             $appendBasisSummary = $this->extractAppendBasisSummary(params: $params);
             if ($appendBasisSummary instanceof JSONResponse) {
                 return $appendBasisSummary;
+            }
+
+            $accessError = $this->verifyFileAccess(fileId: $fileId);
+            if ($accessError !== null) {
+                return $accessError;
             }
 
             $outputFormat = 'pdf';

--- a/tests/unit/Controller/AnonymizationControllerTest.php
+++ b/tests/unit/Controller/AnonymizationControllerTest.php
@@ -344,6 +344,100 @@ class AnonymizationControllerTest extends TestCase
 
 
     /**
+     * Input validation (non-array bases) must return 400 even when the file
+     * does not exist — validation runs before the file-access check.
+     *
+     * This test documents the ordering fix: previously verifyFileAccess ran
+     * first and returned 404 before validation, causing malformed input to
+     * receive 404 instead of 400 (or 500 when the file existed but the
+     * downstream service crashed on the invalid bases value).
+     *
+     * @return void
+     *
+     * @spec openspec/changes/anonymisation-bases-passthrough/tasks.md#task-4
+     */
+    public function testAnonymizeReturns400ForInvalidBasesBeforeFileAccessCheck(): void
+    {
+        $this->mockRequest->method('getParams')->willReturn(
+            [
+                'entities' => [
+                    ['text' => 'Jan Janssen', 'type' => 'PERSON', 'bases' => 'not-an-array'],
+                ],
+            ]
+        );
+
+        // Controller whose root-folder reports no matching files (would return 404).
+        $emptyFolder = $this->createMock(Folder::class);
+        $emptyFolder->method('getById')->willReturn([]);
+        $emptyRootFolder = $this->createMock(IRootFolder::class);
+        $emptyRootFolder->method('getUserFolder')->willReturn($emptyFolder);
+
+        $controller = new AnonymizationController(
+            appName: 'docudesk',
+            request: $this->mockRequest,
+            logger: $this->mockLogger,
+            anonymizationService: $this->mockAnonService,
+            fileListingService: $this->mockFileService,
+            l10n: $this->mockL10n,
+            userSession: $this->mockUserSession,
+            rootFolder: $emptyRootFolder
+        );
+
+        $response = $controller->anonymize(fileId: 999999);
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(400, $response->getStatus());
+        $data = $response->getData();
+        $this->assertArrayHasKey('error', $data);
+
+    }//end testAnonymizeReturns400ForInvalidBasesBeforeFileAccessCheck()
+
+
+    /**
+     * Input validation (non-string bases item) must return 400 even when the
+     * file does not exist.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/anonymisation-bases-passthrough/tasks.md#task-4
+     */
+    public function testAnonymizeReturns400ForNonStringBasesItemBeforeFileAccessCheck(): void
+    {
+        $this->mockRequest->method('getParams')->willReturn(
+            [
+                'entities' => [
+                    ['text' => 'Jan Janssen', 'type' => 'PERSON', 'bases' => [42]],
+                ],
+            ]
+        );
+
+        $emptyFolder = $this->createMock(Folder::class);
+        $emptyFolder->method('getById')->willReturn([]);
+        $emptyRootFolder = $this->createMock(IRootFolder::class);
+        $emptyRootFolder->method('getUserFolder')->willReturn($emptyFolder);
+
+        $controller = new AnonymizationController(
+            appName: 'docudesk',
+            request: $this->mockRequest,
+            logger: $this->mockLogger,
+            anonymizationService: $this->mockAnonService,
+            fileListingService: $this->mockFileService,
+            l10n: $this->mockL10n,
+            userSession: $this->mockUserSession,
+            rootFolder: $emptyRootFolder
+        );
+
+        $response = $controller->anonymize(fileId: 999999);
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(400, $response->getStatus());
+        $data = $response->getData();
+        $this->assertArrayHasKey('error', $data);
+
+    }//end testAnonymizeReturns400ForNonStringBasesItemBeforeFileAccessCheck()
+
+
+    /**
      * Test anonymize succeeds when bases is a valid array of strings
      *
      * @return void


### PR DESCRIPTION
## Summary

- **Bug**: `POST /api/anonymization/anonymize/{fileId}` with a malformed `bases` field returned HTTP 500 (unhandled exception) or HTTP 404 (premature file-access rejection) instead of HTTP 400 with a clear validation error.
- **Root cause**: `verifyFileAccess()` ran before input validation. With a non-existent fileId (e.g. the `999999` used in Newman tests) the 404 returned before `validateEntityBases()` was reached. With a valid fileId, malformed `bases` reached the service layer and caused an unhandled exception.
- **Fix**: Reorder `AnonymizationController::anonymize()` so all request-body validation (`entities` presence + type check, `bases` shape check, `appendBasisSummary` type check) runs **before** `verifyFileAccess()`. Malformed input now always yields HTTP 400 regardless of whether the file exists.
- **Tests**: Two new regression tests added (`testAnonymizeReturns400ForInvalidBasesBeforeFileAccessCheck`, `testAnonymizeReturns400ForNonStringBasesItemBeforeFileAccessCheck`) that use a root-folder mock returning no files, confirming 400 is returned before the file-access gate.

## Test plan

- [ ] `composer check:strict` exits 0 (lint + PHPCS + PHPMD + Psalm + PHPStan + PHPUnit all pass)
- [ ] Newman tests `POST /api/anonymization/anonymize/999999 (invalid bases - non-array)` → 400 ✓
- [ ] Newman tests `POST /api/anonymization/anonymize/999999 (invalid bases - non-string item)` → 400 ✓
- [ ] Existing 404 test (`testAnonymizeReturns404WhenFileNotOwnedByUser`) still passes ✓