### PR TITLE
fix(security): wave-7 critical C1-C5 (signing pipeline mitigation + batch IDOR + jobId CSPRNG + signer IDOR + consent multitenancy)

### DIFF
--- a/lib/Controller/CorrespondenceController.php
+++ b/lib/Controller/CorrespondenceController.php
@@ -332,6 +332,16 @@ class CorrespondenceController extends Controller
                 );
             }
 
+            // C3 security fix: enforce job ownership so an authenticated user
+            // cannot poll another user's job by guessing or brute-forcing the jobId.
+            $jobUserId = (string) ($status['options']['userId'] ?? '');
+            if ($jobUserId !== '' && $jobUserId !== $user->getUID()) {
+                return new JSONResponse(
+                    data: ['error' => $this->l10n->t('Access denied')],
+                    statusCode: Http::STATUS_FORBIDDEN
+                );
+            }
+
             $status['jobId'] = $jobId;
 
             return new JSONResponse(data: $status, statusCode: Http::STATUS_OK);

--- a/lib/Service/BatchStateService.php
+++ b/lib/Service/BatchStateService.php
@@ -25,7 +25,10 @@ namespace OCA\DocuDesk\Service;
 use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\ICache;
+use OCP\IGroupManager;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Read/write store for anonymization batch state backed by the distributed cache.
@@ -55,6 +58,8 @@ class BatchStateService
      * @param ICacheFactory   $cacheFactory Factory used to obtain the distributed cache.
      * @param IAppConfig      $appConfig    App-config lookup for runtime limits.
      * @param LoggerInterface $logger       Logger for lifecycle events.
+     * @param IUserSession    $userSession  User session for ownership checks.
+     * @param IGroupManager   $groupManager Group manager for admin bypass.
      *
      * @return void
      */
@@ -62,6 +67,8 @@ class BatchStateService
         ICacheFactory $cacheFactory,
         private readonly IAppConfig $appConfig,
         private readonly LoggerInterface $logger,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
     ) {
         $this->cache = $cacheFactory->createDistributed('docudesk');
 
@@ -129,6 +136,20 @@ class BatchStateService
         $batch = json_decode($data, true);
         if (is_array($batch) === false) {
             return null;
+        }
+
+        // C2 security fix: enforce batch ownership so an authenticated user
+        // cannot read or drive another user's batch by guessing its ID.
+        // Admins may access any batch for support/audit purposes.
+        $currentUser = $this->userSession->getUser();
+        if ($currentUser !== null) {
+            $currentUid  = $currentUser->getUID();
+            $batchUserId = (string) ($batch['userId'] ?? '');
+            $isAdmin     = $this->groupManager->isAdmin($currentUid);
+
+            if ($isAdmin === false && $batchUserId !== $currentUid) {
+                throw new RuntimeException('Access denied: batch belongs to another user');
+            }
         }
 
         // Reset TTL on read (keep-alive pattern) so active batches don't expire during human review.

--- a/lib/Service/CorrespondenceService.php
+++ b/lib/Service/CorrespondenceService.php
@@ -796,23 +796,20 @@ class CorrespondenceService
     }//end logCorrespondence()
 
     /**
-     * Generate a unique job ID
+     * Generate a unique job ID using a cryptographically secure source
      *
-     * @return string A UUID-like job identifier
+     * Uses random_bytes() (CSPRNG) rather than mt_rand() so job IDs cannot
+     * be predicted by an attacker who knows the approximate creation time
+     * (C3 security fix).
+     *
+     * @return string A RFC-4122 v4 UUID job identifier
      */
     private function generateJobId(): string
     {
-        return sprintf(
-            '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff),
-            (mt_rand(0, 0x0fff) | 0x4000),
-            (mt_rand(0, 0x3fff) | 0x8000),
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff)
-        );
+        $data    = random_bytes(16);
+        $data[6] = chr(ord($data[6]) & 0x0f | 0x40);
+        $data[8] = chr(ord($data[8]) & 0x3f | 0x80);
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
 
     }//end generateJobId()
 }//end class

--- a/lib/Service/Signing/NativeSigningProvider.php
+++ b/lib/Service/Signing/NativeSigningProvider.php
@@ -100,6 +100,17 @@ class NativeSigningProvider implements SigningProviderInterface
         string $level,
         array $options=[]
     ): array {
+        // C1 mitigation (issue #304): the signing pipeline is not yet wired —
+        // SigningService::sign() never invokes the provider, so no document is
+        // ever signed or marked completed. Throw immediately so administrators
+        // who enable signing see the gap at once rather than silently getting a
+        // no-op. Remove this guard when the provider↔request wiring ships.
+        throw new RuntimeException(
+            'Native signing pipeline is not yet integrated — see ConductionNL/docudesk#304. '
+            .'Disable signing_enabled until the request↔provider wiring is complete.'
+        );
+
+        // @phpstan-ignore-next-line (dead code until #304 is resolved)
         if ($this->supportsLevel(level: $level) === false) {
             throw new RuntimeException(
                 'Native provider only supports SES signature level, got: '.$level
@@ -183,10 +194,19 @@ class NativeSigningProvider implements SigningProviderInterface
      */
     public function downloadSignedDocument(string $externalId): string
     {
+        // C1 mitigation (issue #304): the signing pipeline is not yet wired —
+        // no code sets session status to 'completed'. Throw a descriptive error
+        // so the failure mode is loud rather than silently returning an unsigned file.
+        throw new RuntimeException(
+            'Native signing pipeline is not yet integrated — see ConductionNL/docudesk#304. '
+            .'No signed document is available until the request↔provider wiring ships.'
+        );
+
+        // @phpstan-ignore-next-line (dead code until #304 is resolved)
         $session = $this->loadSessionByExternalId(externalId: $externalId);
 
         if (($session['status'] ?? '') !== 'completed') {
-            throw new RuntimeException('Signing session is not completed');
+            throw new RuntimeException('Signing session is not completed (pipeline not yet integrated — see issue #304)');
         }
 
         $signedPath = $session['signedDocumentPath'] ?? null;

--- a/lib/Service/SigningService.php
+++ b/lib/Service/SigningService.php
@@ -272,6 +272,13 @@ class SigningService
             $signer = (array) $signerObject;
         }
 
+        // C4 security fix: verify the signer record belongs to this signing
+        // request. Without this check, an attacker who knows any valid
+        // signerId can sign under an arbitrary requestId they do not own.
+        if (($signer['signingRequestId'] ?? '') !== $requestId) {
+            throw new RuntimeException('Signer record does not belong to this signing request');
+        }
+
         // Security finding #282: ensure the authenticated user is the signer
         // they claim to be. Without this check any authenticated user could
         // sign on behalf of another signer by supplying their signer ID.
@@ -336,6 +343,13 @@ class SigningService
             $signer = $signerObject->jsonSerialize();
         } else {
             $signer = (array) $signerObject;
+        }
+
+        // C4 security fix: verify the signer record belongs to this signing
+        // request. Without this check, an attacker who knows any valid
+        // signerId can decline under an arbitrary requestId they do not own.
+        if (($signer['signingRequestId'] ?? '') !== $requestId) {
+            throw new RuntimeException('Signer record does not belong to this signing request');
         }
 
         // Security finding #282: ensure the authenticated user is the signer

--- a/tests/unit/Service/BatchStateServiceKeepAliveTest.php
+++ b/tests/unit/Service/BatchStateServiceKeepAliveTest.php
@@ -21,6 +21,8 @@ use OCA\DocuDesk\Service\BatchStateService;
 use OCP\IAppConfig;
 use OCP\ICache;
 use OCP\ICacheFactory;
+use OCP\IGroupManager;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -34,7 +36,7 @@ use Psr\Log\LoggerInterface;
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.nl
  *
- * @psalm-suppress PropertyNotSetInConstructor
+ * @psalm-suppress  PropertyNotSetInConstructor
  * @phpstan-extends TestCase
  */
 class BatchStateServiceKeepAliveTest extends TestCase
@@ -54,7 +56,6 @@ class BatchStateServiceKeepAliveTest extends TestCase
      */
     private BatchStateService $service;
 
-
     /**
      * Set up test environment
      *
@@ -64,18 +65,28 @@ class BatchStateServiceKeepAliveTest extends TestCase
     {
         parent::setUp();
 
-        $this->mockCache = $this->createMock(ICache::class);
+        $this->mockCache = $this->createMock(className: ICache::class);
 
-        $mockCacheFactory = $this->createMock(ICacheFactory::class);
+        $mockCacheFactory = $this->createMock(className: ICacheFactory::class);
         $mockCacheFactory->method('createDistributed')->willReturn($this->mockCache);
 
-        $mockAppConfig = $this->createMock(IAppConfig::class);
-        $mockLogger    = $this->createMock(LoggerInterface::class);
+        $mockAppConfig    = $this->createMock(className: IAppConfig::class);
+        $mockLogger       = $this->createMock(className: LoggerInterface::class);
+        $mockUserSession  = $this->createMock(className: IUserSession::class);
+        $mockGroupManager = $this->createMock(className: IGroupManager::class);
 
-        $this->service = new BatchStateService($mockCacheFactory, $mockAppConfig, $mockLogger);
+        // No user session in keep-alive tests — ownership check is skipped.
+        $mockUserSession->method('getUser')->willReturn(null);
+
+        $this->service = new BatchStateService(
+            cacheFactory: $mockCacheFactory,
+            appConfig: $mockAppConfig,
+            logger: $mockLogger,
+            userSession: $mockUserSession,
+            groupManager: $mockGroupManager
+        );
 
     }//end setUp()
-
 
     /**
      * Test that getBatch resets TTL by calling cache set on read
@@ -92,18 +103,17 @@ class BatchStateServiceKeepAliveTest extends TestCase
         $this->mockCache->expects($this->once())
             ->method('set')
             ->with(
-                $this->stringContains('test-123'),
+                $this->stringContains(string: 'test-123'),
                 $batchData,
                 7200
             );
 
         $result = $this->service->getBatch('test-123');
 
-        $this->assertNotNull($result);
-        $this->assertEquals('test-123', $result['batchId']);
+        $this->assertNotNull(actual: $result);
+        $this->assertEquals(expected: 'test-123', actual: $result['batchId']);
 
     }//end testGetBatchResetsTtlOnRead()
-
 
     /**
      * Test that getBatch returns null for missing batch without calling set
@@ -117,10 +127,9 @@ class BatchStateServiceKeepAliveTest extends TestCase
 
         $result = $this->service->getBatch('nonexistent');
 
-        $this->assertNull($result);
+        $this->assertNull(actual: $result);
 
     }//end testGetBatchReturnsNullForMissing()
-
 
     /**
      * Test that getBatch returns null for invalid JSON without calling set
@@ -134,9 +143,7 @@ class BatchStateServiceKeepAliveTest extends TestCase
 
         $result = $this->service->getBatch('bad-data');
 
-        $this->assertNull($result);
+        $this->assertNull(actual: $result);
 
     }//end testGetBatchReturnsNullForInvalidJson()
-
-
 }//end class

--- a/tests/unit/Service/BatchStateServiceTest.php
+++ b/tests/unit/Service/BatchStateServiceTest.php
@@ -21,9 +21,13 @@ use OCA\DocuDesk\Service\BatchStateService;
 use OCP\IAppConfig;
 use OCP\ICache;
 use OCP\ICacheFactory;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Unit tests for BatchStateService
@@ -38,7 +42,7 @@ use Psr\Log\LoggerInterface;
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.nl
  *
- * @psalm-suppress PropertyNotSetInConstructor
+ * @psalm-suppress  PropertyNotSetInConstructor
  * @phpstan-extends TestCase
  */
 class BatchStateServiceTest extends TestCase
@@ -72,6 +76,19 @@ class BatchStateServiceTest extends TestCase
      */
     private LoggerInterface|MockObject $mockLogger;
 
+    /**
+     * Mocked IUserSession
+     *
+     * @var IUserSession|MockObject
+     */
+    private IUserSession|MockObject $mockUserSession;
+
+    /**
+     * Mocked IGroupManager
+     *
+     * @var IGroupManager|MockObject
+     */
+    private IGroupManager|MockObject $mockGroupManager;
 
     /**
      * Set up test environment
@@ -82,23 +99,30 @@ class BatchStateServiceTest extends TestCase
     {
         parent::setUp();
 
-        $this->mockCache     = $this->createMock(ICache::class);
-        $this->mockAppConfig = $this->createMock(IAppConfig::class);
-        $this->mockLogger    = $this->createMock(LoggerInterface::class);
+        $this->mockCache        = $this->createMock(className: ICache::class);
+        $this->mockAppConfig    = $this->createMock(className: IAppConfig::class);
+        $this->mockLogger       = $this->createMock(className: LoggerInterface::class);
+        $this->mockUserSession  = $this->createMock(className: IUserSession::class);
+        $this->mockGroupManager = $this->createMock(className: IGroupManager::class);
 
-        $mockCacheFactory = $this->createMock(ICacheFactory::class);
+        // Default: no user logged in (no ownership check needed for tests
+        // that don't exercise the ownership path).
+        $this->mockUserSession->method('getUser')->willReturn(null);
+
+        $mockCacheFactory = $this->createMock(className: ICacheFactory::class);
         $mockCacheFactory->method('createDistributed')
             ->with('docudesk')
             ->willReturn($this->mockCache);
 
         $this->service = new BatchStateService(
-            $mockCacheFactory,
-            $this->mockAppConfig,
-            $this->mockLogger
+            cacheFactory: $mockCacheFactory,
+            appConfig: $this->mockAppConfig,
+            logger: $this->mockLogger,
+            userSession: $this->mockUserSession,
+            groupManager: $this->mockGroupManager
         );
 
     }//end setUp()
-
 
     /**
      * Test getMaxFiles returns configured value
@@ -113,10 +137,9 @@ class BatchStateServiceTest extends TestCase
 
         $result = $this->service->getMaxFiles();
 
-        $this->assertSame(50, $result);
+        $this->assertSame(expected: 50, actual: $result);
 
     }//end testGetMaxFilesReturnsConfiguredValue()
-
 
     /**
      * Test getMaxFiles returns default 100 when not configured
@@ -130,10 +153,9 @@ class BatchStateServiceTest extends TestCase
 
         $result = $this->service->getMaxFiles();
 
-        $this->assertSame(100, $result);
+        $this->assertSame(expected: 100, actual: $result);
 
     }//end testGetMaxFilesReturnsDefault()
-
 
     /**
      * Test createBatch stores a batch in cache with uploading status
@@ -155,14 +177,13 @@ class BatchStateServiceTest extends TestCase
         $files  = [['fileId' => 1, 'fileName' => 'test.pdf', 'status' => 'uploaded']];
         $result = $this->service->createBatch(userId: 'user1', files: $files);
 
-        $this->assertSame('uploading', $result['status']);
-        $this->assertSame('user1', $result['userId']);
-        $this->assertCount(1, $result['files']);
-        $this->assertArrayHasKey('batchId', $result);
-        $this->assertNotNull($storedJson);
+        $this->assertSame(expected: 'uploading', actual: $result['status']);
+        $this->assertSame(expected: 'user1', actual: $result['userId']);
+        $this->assertCount(expectedCount: 1, haystack: $result['files']);
+        $this->assertArrayHasKey(key: 'batchId', array: $result);
+        $this->assertNotNull(actual: $storedJson);
 
     }//end testCreateBatchStoresBatchWithUploadingStatus()
-
 
     /**
      * Test getBatch returns null when cache miss
@@ -175,30 +196,78 @@ class BatchStateServiceTest extends TestCase
 
         $result = $this->service->getBatch(batchId: 'non-existent');
 
-        $this->assertNull($result);
+        $this->assertNull(actual: $result);
 
     }//end testGetBatchReturnsNullOnCacheMiss()
 
-
     /**
-     * Test getBatch returns decoded array on cache hit
+     * Test getBatch returns decoded array on cache hit (owner accessing own batch)
      *
      * @return void
      */
     public function testGetBatchReturnsBatchArray(): void
     {
-        $batch = ['batchId' => 'abc-123', 'status' => 'uploading', 'files' => []];
+        $mockUser = $this->createMock(className: IUser::class);
+        $mockUser->method('getUID')->willReturn('user1');
+        $this->mockUserSession->method('getUser')->willReturn($mockUser);
+        $this->mockGroupManager->method('isAdmin')->willReturn(false);
+
+        $batch = ['batchId' => 'abc-123', 'userId' => 'user1', 'status' => 'uploading', 'files' => []];
         $this->mockCache->method('get')
             ->willReturn(json_encode($batch));
 
         $result = $this->service->getBatch(batchId: 'abc-123');
 
-        $this->assertIsArray($result);
-        $this->assertSame('abc-123', $result['batchId']);
-        $this->assertSame('uploading', $result['status']);
+        $this->assertIsArray(actual: $result);
+        $this->assertSame(expected: 'abc-123', actual: $result['batchId']);
+        $this->assertSame(expected: 'uploading', actual: $result['status']);
 
     }//end testGetBatchReturnsBatchArray()
 
+    /**
+     * Test getBatch throws when a non-admin user accesses another user's batch (C2)
+     *
+     * @return void
+     */
+    public function testGetBatchThrowsForForeignBatch(): void
+    {
+        $mockUser = $this->createMock(className: IUser::class);
+        $mockUser->method('getUID')->willReturn('attacker');
+        $this->mockUserSession->method('getUser')->willReturn($mockUser);
+        $this->mockGroupManager->method('isAdmin')->willReturn(false);
+
+        $batch = ['batchId' => 'abc-123', 'userId' => 'victim', 'status' => 'uploading', 'files' => []];
+        $this->mockCache->method('get')->willReturn(json_encode($batch));
+
+        $this->expectException(exception: RuntimeException::class);
+        $this->expectExceptionMessage(message: 'Access denied');
+
+        $this->service->getBatch(batchId: 'abc-123');
+
+    }//end testGetBatchThrowsForForeignBatch()
+
+    /**
+     * Test getBatch allows admin to access any batch (C2 admin bypass)
+     *
+     * @return void
+     */
+    public function testGetBatchAllowsAdminToAccessForeignBatch(): void
+    {
+        $mockUser = $this->createMock(className: IUser::class);
+        $mockUser->method('getUID')->willReturn('admin-user');
+        $this->mockUserSession->method('getUser')->willReturn($mockUser);
+        $this->mockGroupManager->method('isAdmin')->willReturn(true);
+
+        $batch = ['batchId' => 'abc-123', 'userId' => 'other-user', 'status' => 'uploading', 'files' => []];
+        $this->mockCache->method('get')->willReturn(json_encode($batch));
+
+        // Admin bypass — should not throw.
+        $result = $this->service->getBatch(batchId: 'abc-123');
+
+        $this->assertIsArray(actual: $result);
+        $this->assertSame(expected: 'abc-123', actual: $result['batchId']);
+
+    }//end testGetBatchAllowsAdminToAccessForeignBatch()
 
     /**
      * Test updateBatch calls cache set with updated batch data
@@ -211,12 +280,11 @@ class BatchStateServiceTest extends TestCase
 
         $this->mockCache->expects($this->once())
             ->method('set')
-            ->with($this->stringContains('abc-123'), $this->anything(), $this->anything());
+            ->with($this->stringContains(string: 'abc-123'), $this->anything(), $this->anything());
 
         $this->service->updateBatch(batchId: 'abc-123', batch: $batch);
 
     }//end testUpdateBatchCallsCacheSet()
-
 
     /**
      * Test deleteBatch calls cache remove with correct key
@@ -227,11 +295,9 @@ class BatchStateServiceTest extends TestCase
     {
         $this->mockCache->expects($this->once())
             ->method('remove')
-            ->with($this->stringContains('abc-123'));
+            ->with($this->stringContains(string: 'abc-123'));
 
         $this->service->deleteBatch(batchId: 'abc-123');
 
     }//end testDeleteBatchCallsCacheRemove()
-
-
 }//end class

--- a/tests/unit/Service/Signing/NativeSigningProviderTest.php
+++ b/tests/unit/Service/Signing/NativeSigningProviderTest.php
@@ -1,13 +1,12 @@
 <?php
 
 /**
- * Unit tests for NativeSigningProvider — finding #287 regression coverage.
+ * Unit tests for NativeSigningProvider — wave-9 C1 mitigation coverage.
  *
- * Asserts that signing sessions are persisted via the OpenRegister
- * ObjectService instead of in a per-request `$sessions` array, so that
- * `checkStatus`, `downloadSignedDocument` and `cancelSigning` running in
- * separate HTTP requests can resolve a session that `initiateSigning`
- * created.
+ * Verifies that `initiateSigning` and `downloadSignedDocument` throw
+ * a descriptive RuntimeException referencing issue #304 until the full
+ * request↔provider wiring ships.  Also guards the `checkStatus` not-found
+ * path retained from finding #287 regression coverage.
  *
  * @category Tests
  * @package  OCA\DocuDesk\Tests\Unit\Service\Signing
@@ -25,7 +24,6 @@ namespace OCA\DocuDesk\Tests\Unit\Service\Signing;
 
 use OCA\DocuDesk\Service\Signing\NativeSigningProvider;
 use OCA\DocuDesk\Service\SettingsService;
-use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\IAppConfig;
 use OCP\IUserSession;
@@ -34,7 +32,7 @@ use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
- * Tests for NativeSigningProvider session persistence
+ * Tests for NativeSigningProvider C1 mitigation (issue #304)
  *
  * @category Tests
  * @package  OCA\DocuDesk\Tests\Unit\Service\Signing
@@ -46,38 +44,24 @@ use RuntimeException;
  */
 class NativeSigningProviderTest extends TestCase
 {
-
     /**
-     * In-memory session store shared between the provider instances under test
-     *
-     * @var array<string, array<string, mixed>>
-     */
-    private array $store = [];
-
-
-    /**
-     * Build a NativeSigningProvider wired to an OR ObjectService fake that
-     * persists rows in `$this->store` keyed by externalId.
+     * Build a minimal NativeSigningProvider for testing the guard paths.
      *
      * @return NativeSigningProvider
      */
     private function buildProvider(): NativeSigningProvider
     {
-        $userSession = $this->createMock(IUserSession::class);
-        $logger      = $this->createMock(LoggerInterface::class);
+        $userSession = $this->createMock(className: IUserSession::class);
+        $logger      = $this->createMock(className: LoggerInterface::class);
 
-        $config = $this->createMock(IAppConfig::class);
+        $config = $this->createMock(className: IAppConfig::class);
         $config->method('getValueString')->willReturnCallback(
-            function (string $app, string $key, string $default = ''): string {
+            function (string $app, string $key, string $default=''): string {
                 return $default;
             }
         );
 
-        // Mock the real OR ObjectService — `findAll` and `saveObject` are
-        // real public methods on the deployed class so `createMock` lets us
-        // stub them. `findAll(array $config)` returns the matching rows;
-        // `saveObject(array $object, ...)` writes to the in-memory store.
-        $objectService = $this->getMockBuilder(ObjectService::class)
+        $objectService = $this->getMockBuilder(className: ObjectService::class)
             ->disableOriginalConstructor()
             ->disableOriginalClone()
             ->disableArgumentCloning()
@@ -85,123 +69,74 @@ class NativeSigningProviderTest extends TestCase
             ->onlyMethods(['findAll', 'saveObject'])
             ->getMock();
 
-        $objectService->method('findAll')->willReturnCallback(
-            function (array $config = []): array {
-                $filters    = $config['filters'] ?? [];
-                $externalId = $filters['externalId'] ?? null;
-                if ($externalId === null) {
-                    return array_values($this->store);
-                }
+        $objectService->method('findAll')->willReturn([]);
 
-                if (isset($this->store[(string) $externalId]) === true) {
-                    return [$this->store[(string) $externalId]];
-                }
-
-                return [];
-            }
-        );
-        $objectService->method('saveObject')->willReturnCallback(
-            function (array | object $object, ?array $extend = [], $register = null, $schema = null, ?string $uuid = null): ObjectEntity {
-                $row = is_array($object) === true ? $object : (array) $object;
-                $key = (string) ($row['externalId'] ?? $uuid ?? '');
-                if ($uuid !== null && $uuid !== '') {
-                    $row['uuid'] = $uuid;
-                }
-
-                $this->store[$key] = $row;
-
-                // Real OR returns an ObjectEntity. The provider only relies
-                // on saveObject side-effects (the store row), not the
-                // return value, so a bare entity wrapping the row keeps
-                // the contract intact.
-                $entity = new ObjectEntity();
-                $entity->setUuid((string) ($row['uuid'] ?? $key));
-                $entity->setObject($row);
-                return $entity;
-            }
-        );
-
-        $settingsService = $this->createMock(SettingsService::class);
+        $settingsService = $this->createMock(className: SettingsService::class);
         $settingsService->method('getObjectService')->willReturn($objectService);
 
         return new NativeSigningProvider(
-            $userSession,
-            $logger,
-            $settingsService,
-            $config
+            userSession: $userSession,
+            logger: $logger,
+            settingsService: $settingsService,
+            config: $config
         );
 
     }//end buildProvider()
 
-
     /**
-     * Reset the shared store before each test
+     * Reset test state before each test
      *
      * @return void
      */
     protected function setUp(): void
     {
         parent::setUp();
-        $this->store = [];
 
     }//end setUp()
 
-
     /**
-     * Initiate persists the session in OR and a subsequent checkStatus
-     * (potentially on a different provider instance) finds it.
+     * C1 mitigation (issue #304): initiateSigning throws immediately with a
+     * descriptive error because the signing pipeline is not yet wired.
+     * Admins who enable signing_enabled=1 see the gap at once.
      *
      * @return void
      */
-    public function testInitiateThenCheckStatusReturnsPersistedState(): void
+    public function testInitiateThrowsBecausePipelineNotIntegrated(): void
     {
         $provider = $this->buildProvider();
 
-        $result = $provider->initiateSigning(
+        $this->expectException(exception: RuntimeException::class);
+        $this->expectExceptionMessage(message: 'ConductionNL/docudesk#304');
+
+        $provider->initiateSigning(
             documentPath: '/foo.pdf',
             documentName: 'foo.pdf',
             signers: [['userId' => 'alice']],
             level: 'SES'
         );
 
-        $this->assertTrue($result['success']);
-        $externalId = $result['externalId'];
-        $this->assertArrayHasKey($externalId, $this->store);
-
-        $status = $provider->checkStatus(externalId: $externalId);
-
-        $this->assertSame('pending', $status['status']);
-        $this->assertSame([['userId' => 'alice']], $status['signers']);
-
-    }//end testInitiateThenCheckStatusReturnsPersistedState()
-
+    }//end testInitiateThrowsBecausePipelineNotIntegrated()
 
     /**
-     * Sessions written by one provider instance are visible to another —
-     * the precise bug from #287 was that a fresh class instance had an
-     * empty array.
+     * C1 mitigation (issue #304): downloadSignedDocument throws immediately
+     * with a descriptive error because no session can ever reach 'completed'
+     * while the pipeline is not yet wired.
      *
      * @return void
      */
-    public function testSessionsSurviveAcrossProviderInstances(): void
+    public function testDownloadThrowsBecausePipelineNotIntegrated(): void
     {
-        $first = $this->buildProvider();
+        $provider = $this->buildProvider();
 
-        $result     = $first->initiateSigning('/foo.pdf', 'foo.pdf', [], 'SES');
-        $externalId = $result['externalId'];
+        $this->expectException(exception: RuntimeException::class);
+        $this->expectExceptionMessage(message: 'ConductionNL/docudesk#304');
 
-        $second = $this->buildProvider();
-        $status = $second->checkStatus(externalId: $externalId);
-        $this->assertSame('pending', $status['status']);
+        $provider->downloadSignedDocument(externalId: 'native-any-id');
 
-        $this->assertTrue($second->cancelSigning(externalId: $externalId));
-        $this->assertSame('cancelled', $this->store[$externalId]['status']);
-
-    }//end testSessionsSurviveAcrossProviderInstances()
-
+    }//end testDownloadThrowsBecausePipelineNotIntegrated()
 
     /**
-     * checkStatus on an unknown externalId throws (not silently returns).
+     * CheckStatus on an unknown externalId throws (not silently returns).
      *
      * @return void
      */
@@ -209,70 +144,8 @@ class NativeSigningProviderTest extends TestCase
     {
         $provider = $this->buildProvider();
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(exception: RuntimeException::class);
         $provider->checkStatus(externalId: 'native-does-not-exist');
 
     }//end testCheckStatusOnMissingSessionThrows()
-
-
-    /**
-     * downloadSignedDocument refuses to return a path while the session
-     * status is still `pending`.
-     *
-     * @return void
-     */
-    public function testDownloadRefusesWhenNotCompleted(): void
-    {
-        $provider = $this->buildProvider();
-
-        $result     = $provider->initiateSigning('/foo.pdf', 'foo.pdf', [], 'SES');
-        $externalId = $result['externalId'];
-
-        $this->expectException(RuntimeException::class);
-        $provider->downloadSignedDocument(externalId: $externalId);
-
-    }//end testDownloadRefusesWhenNotCompleted()
-
-
-    /**
-     * downloadSignedDocument returns the persisted signedDocumentPath when
-     * the session has completed (or falls back to documentPath until the
-     * SES marker writer follow-up to #287 ships).
-     *
-     * @return void
-     */
-    public function testDownloadReturnsPathOnCompletion(): void
-    {
-        $provider = $this->buildProvider();
-
-        $result     = $provider->initiateSigning('/foo.pdf', 'foo.pdf', [], 'SES');
-        $externalId = $result['externalId'];
-
-        // Mark the session completed in the OR-backed fake store.
-        $this->store[$externalId]['status']             = 'completed';
-        $this->store[$externalId]['signedDocumentPath'] = '/foo.signed.pdf';
-
-        $this->assertSame(
-            '/foo.signed.pdf',
-            $provider->downloadSignedDocument(externalId: $externalId)
-        );
-
-    }//end testDownloadReturnsPathOnCompletion()
-
-
-    /**
-     * Non-SES levels are still rejected on initiate.
-     *
-     * @return void
-     */
-    public function testNonSesLevelRejected(): void
-    {
-        $provider = $this->buildProvider();
-
-        $this->expectException(RuntimeException::class);
-        $provider->initiateSigning('/x.pdf', 'x.pdf', [], 'QES');
-
-    }//end testNonSesLevelRejected()
-
-
 }//end class


### PR DESCRIPTION
## Summary

Fixes all 5 wave-7 verified CRITICALs (C1–C5). C5 was already patched on `development`; C1–C4 are new.

- **C1 (structural — tracks #304)**: `NativeSigningProvider::initiateSigning()` and `downloadSignedDocument()` now throw a descriptive `RuntimeException` referencing issue #304. Admins who flip `signing_enabled=1` will see the gap immediately rather than getting a silent no-op. The full request↔provider wiring is the subject of #304 and is too large for this PR.
- **C2 (batch endpoint ownership IDOR)**: `BatchStateService::getBatch()` now enforces ownership — compares `batch['userId']` against the authenticated user's UID. Non-owners get a `RuntimeException`. Admins bypass the check via `IGroupManager::isAdmin()`. Three new unit tests cover owner-access, non-owner rejection, and admin bypass.
- **C3 (jobId CSPRNG + jobStatus IDOR)**: `CorrespondenceService::generateJobId()` now uses `random_bytes(16)` (CSPRNG) to produce a RFC-4122 v4 UUID instead of 8× `mt_rand`. `CorrespondenceController::jobStatus()` now compares `$status['options']['userId']` against the current user UID and returns HTTP 403 on mismatch.
- **C4 (signer IDOR)**: `SigningService::sign()` and `decline()` now verify `$signer['signingRequestId'] === $requestId` before processing, preventing an attacker with a valid signerId from acting under an arbitrary requestId.
- **C5 (consent `_rbac:false`)**: Confirmed already fixed in a prior wave — all 6 cited sites in `ConsentService`, `ConsentUpdateHandler`, `ConsentCrudService`, and `MetadataService` no longer pass `_rbac:false` / `_multitenancy:false`.

## Test plan

- [x] All changed test files pass PHPCS (zero errors)
- [x] `BatchStateServiceTest` — 3 new ownership tests (owner-ok, non-owner-403, admin-bypass)
- [x] `NativeSigningProviderTest` — 2 new C1 guard tests (initiate throws, download throws)
- [x] PHP syntax lint passes on all 8 changed files
- [ ] Full CI run on push

## Tracking

- C1 structural wiring: https://github.com/ConductionNL/docudesk/issues/304

**DO NOT admin-merge** — let CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)