### PR TITLE
docs(openspec): 9 market-gap change specs from the 2026-07 deep research

### DIFF
--- a/openspec/changes/anonymization-review-workbench/.openspec.yaml
+++ b/openspec/changes/anonymization-review-workbench/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/anonymization-review-workbench/design.md
+++ b/openspec/changes/anonymization-review-workbench/design.md
@@ -1,0 +1,249 @@
+# Design: anonymization-review-workbench
+
+## Context
+
+Verified at HEAD (worktree `spec/market-gap-2026-07`, docudesk @
+origin/development):
+
+- `src/views/anonymization/EntityReviewTable.vue` already implements search,
+  type filter, selected/total counters, bulk select/deselect of visible rows,
+  a per-entity grondslag (bases) `NcSelect`, a per-entity skip toggle, and an
+  "Apply dossier grondslagen to visible" action. It emits
+  `toggle | bulk-select | bulk-deselect | bases-change | skip-change |
+  confidence-change`.
+- `src/views/anonymization/AddManualEntityModal.vue` posts operator-supplied
+  text to OpenRegister's chunk-aware matcher
+  (`POST /api/files/{fileId}/manual-entities`, OR route
+  `fileText#addManualEntity`, verified present in OR `appinfo/routes.php`);
+  one `EntityRelation` is created per occurrence found.
+- `AnonymizationService::extractAndDetectEntities()` (lib/Service/, line 192)
+  delegates to OR `TextExtractionService::extractFile()` +
+  `EntityRelationMapper::findEntitiesForFile()`, then calls
+  `GrondslagProposalService::applyProposals()` (fill-only-when-empty per
+  entity type, admin config key `docudesk.grondslagen.entity_type_bases` —
+  CB #122 is therefore already implemented server-side) and
+  `attachProhibitionMatches()` via `PolicyMatchService`.
+- `PolicyMatchService::match()` already evaluates BOTH rule kinds and returns
+  `kind: 'prohibition' | 'standing_consent'` (prohibitions win on conflict),
+  but only `matchProhibition()` is consumed today — standing consents are
+  never surfaced during review.
+- `PolicyController` + `PolicyCrudService` provide full CRUD for
+  `publicationProhibition` and standing-consent `publicationConsent`
+  (scope `entity`) objects under `/api/policy/prohibitions` and
+  `/api/policy/standing-consents`; the `ProhibitionIndex` /
+  `StandingConsentIndex` views exist but are deep-link only.
+- `publicationProhibition` schema: required `primaryName`, `entityType`
+  (enum PERSON/ORGANIZATION/OTHER — this is the rule "category"),
+  `matchRules`, `reason`, `active`; optional `legalAuthority`, `severity`,
+  `validFrom/validUntil`, etc. It has NO grondslag linkage today.
+  `publicationConsent` has `scope` (`document`/`entity`), `matchRules`,
+  `legalBasis` (free string) — also no `bases` linkage.
+- The `dossier` schema has `bases` (array of `base` slugs) and `checkedOn`
+  (dossier-level reviewed timestamp; an event listener regenerates the
+  grondslagen summary when it changes). There is NO per-document checked
+  state anywhere.
+- In-app viewers exist: `src/components/viewers/PdfViewer.vue`,
+  `WordViewer.vue`, `TextViewer.vue`, hosted by
+  `src/views/fileViewer/FileViewerPage.vue`.
+- The `anonymizationLink` schema links `sourceFileId` → `anonymizedFileId`,
+  which gives the workbench the right-hand ("anonymized") pane for free.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One review workbench per document composing the verified pieces above.
+- Human-checked gate per document that anonymize-commit and export respect.
+- Pre-application of org rule lists (both policy kinds) during review.
+- Grondslag per rule (`bases` on both policy schemas) and grondslag proposal
+  surfacing/override in the UI.
+
+**Non-Goals:**
+
+- No visual redaction canvas (draw-a-box image redaction) — separate gap,
+  separate change.
+- No changes to detection engines or anonymisation execution — OpenRegister
+  owns `TextExtractionService`, `EntityRelationMapper`,
+  `FileService::anonymizeDocument` (project boundary).
+- No changes to the WOO consent/objection lifecycle (consent-management) or
+  the prohibition gate semantics (`anonymisation-prohibition-gate`) — the
+  workbench consumes both.
+- No batch-scale/queueing work — that is the sibling `redaction-at-scale`
+  change.
+
+## Decisions
+
+### D1 — The org rule lists ARE the existing policy objects, extended
+
+GH #62/#63 ask for org-level "always anonymise" / "never anonymise" lists.
+Verified at HEAD, DocuDesk already has exactly these semantics as OR objects:
+`publicationProhibition` (an entity that must never be published ⇒ always
+anonymise) and standing-consent `publicationConsent` with `scope: entity`
+(entity may stay visible ⇒ never anonymise). **Decision: do not introduce a
+new rule schema.** Extend both schemas with an optional `bases` array
+(grondslag slugs referencing `base` objects, same dialect as
+`dossier.bases`), keep `entityType` as the rule category, and surface both
+lists in the workbench. Rejected alternative: a new `anonymisationRule`
+schema — would duplicate `matchRules` matching, split `PolicyMatchService`
+into two rule stores, and orphan the existing PolicyController surface.
+
+### D2 — Per-document checked state is a new `documentReview` OR object
+
+The gate needs durable, auditable, per-file state. ADR-001 forbids custom
+tables, batch state is ephemeral ICache, and `EntityRelation` rows live in
+OR's own store (not schema-extensible from DocuDesk). **Decision: new
+`documentReview` schema** in `lib/Settings/docudesk_register.json` keyed by
+`fileId` (idempotency key, mirroring `anonymizationLink.sourceFileId`), with
+`checkedOn`, `checkedBy`, `entityCountAtCheck`, `manualEntityCount`, and
+`note`. Editing detections after checking MUST invalidate the check (the
+gate compares current entity-set fingerprint against
+`entityCountAtCheck`/`checkedOn` versus the relations' last change) — a
+stale "checked" mark is worse than none. Mirrors the proven dossier-level
+`checkedOn` pattern one level down.
+
+### D3 — Gate enforcement is server-side, in both commit paths
+
+Blocking only in the UI would be decorative. `POST
+/api/anonymization/anonymize/{fileId}` and `POST
+/api/anonymization/batch/{batchId}/anonymize` MUST return HTTP 409 when the
+target file(s) lack a valid `documentReview` — same enforcement style as the
+existing prohibition gate (`AnonymizationService::runProhibitionGate`).
+Admin escape hatch: `IAppConfig` key `docudesk.review.checked_gate`
+(`enforced` default | `advisory`) so pilots that only do spot-checks are not
+dead-ended; `advisory` still records the gate result in the response.
+
+### D4 — Standing consents pre-apply as excluded-with-badge, prohibitions stay included-and-locked-hint
+
+Extraction already attaches `prohibitionMatch`. Add the symmetric
+`standingConsentMatch` (same `{ruleId, ruleName}` shape, from the same
+`PolicyMatchService::match()` call — one matcher, one pass, prohibitions win
+on conflict as already implemented). Review semantics: prohibition match ⇒
+`included: true` pre-set + warning badge (unchecking requires explicit
+confirmation; the existing prohibition gate still catches it at commit);
+standing-consent match ⇒ `included: false` pre-set + info badge. Both remain
+operator-overridable — the review is the human-in-the-loop mandate, rules are
+defaults, except that prohibition overrides are re-checked by the existing
+commit gate.
+
+### D5 — Selection-to-entity reuses the OR chunk matcher, not offsets
+
+The preview panes render extracted text/PDF, whose coordinates do not map
+1:1 onto OR's chunk offsets across formats. **Decision:** text selection
+pre-fills `AddManualEntityModal` (value = selection, type picker, bases
+picker pre-filled from `GrondslagProposalService` mapping for the chosen
+type) and submits to the existing OR `manual-entities` endpoint, which
+matches occurrences chunk-aware server-side. Rejected: client-computed
+character offsets — fragile across PDF/Word/Text viewers and duplicates OR
+matching logic (ADR-022).
+
+### D6 — Declarative vs imperative (ADR-031)
+
+- `documentReview`, `bases` on the two policy schemas: **declarative** schema
+  additions in `lib/Settings/docudesk_register.json`; `documentReview` gets
+  no lifecycle annotation (it is a single-state marker object, created and
+  invalidated, not a workflow).
+- Gate enforcement, standing-consent match attachment, selection-to-entity:
+  **imperative** — these are lifecycle guards and NLP-adjacent review
+  orchestration, valid ADR-031 exceptions (lifecycle guard, NLP pipeline),
+  implemented in existing services (`AnonymizationService`,
+  `PolicyMatchService`, controllers).
+- No new aggregations/calculations/notifications — nothing else to declare.
+
+### D7 — OpenRegister usage (ADR-001) and frontend (ADR-012)
+
+All persisted state is OR objects via the existing AppHost/ObjectService
+pattern: `documentReview` (new), `publicationProhibition` /
+`publicationConsent` (extended), `base` (read), `anonymizationLink` (read,
+for the anonymized pane), `EntityRelation` rows via
+`EntityRelationMapper` (read) and OR `manual-entities` (write). No custom
+tables. Frontend uses `@conduction/nextcloud-vue` where applicable
+(`CnFormDialog` for modals-style forms; the workbench body is a
+domain-specific split view hosted like `FileViewerPage`, reusing the
+existing `Dd*` components and viewers); NL Design System tokens via NC CSS
+variables only (ADR-003). ADR-011 check: matching, BSN handling and slug
+logic all already live in OR/`PolicyMatchService` — nothing re-implemented.
+
+## Seed Data
+
+Municipality-flavoured examples shipped as register/test seeds:
+
+```json
+// base (existing schema) — grondslag referenced by rules and proposals
+{ "name": "Woo art. 5.1.2.e — eerbiediging persoonlijke levenssfeer",
+  "description": "Uitzonderingsgrond voor persoonsgegevens in Woo-publicaties (AVG art. 4/6)." }
+
+// publicationProhibition — org-level ALWAYS-anonymise rule, now with bases
+{ "primaryName": "Beschermde getuige zaak KG ZA 24/123",
+  "entityType": "PERSON",
+  "matchRules": [ { "type": "normalized", "value": "Beschermde Getuige A" } ],
+  "reason": "gerechtelijk bevel",
+  "legalAuthority": "Rechtbank Den Haag KG ZA 24/123",
+  "bases": [ "woo-art-5-1-2-e" ],
+  "severity": "critical",
+  "active": true }
+
+// publicationConsent (scope: entity) — org-level NEVER-anonymise rule
+{ "scope": "entity",
+  "documentId": "00000000-0000-0000-0000-000000000000",
+  "entityType": "ORGANIZATION",
+  "entityText": "Gemeente Voorbeeldstad",
+  "matchRules": [ { "type": "normalized", "value": "Gemeente Voorbeeldstad" } ],
+  "consentStatus": "consent_given",
+  "legalBasis": "Bestuursorgaan zelf — geen derde-belanghebbende",
+  "bases": [ "woo-art-5-1-2-e" ],
+  "active": true }
+
+// documentReview — the per-document checked gate marker
+{ "fileId": 424242,
+  "checkedOn": "2026-07-16T14:30:00Z",
+  "checkedBy": "w.devries",
+  "entityCountAtCheck": 37,
+  "manualEntityCount": 2,
+  "note": "Twee handmatige BSN-passages toegevoegd op p. 4." }
+```
+
+Seed task: extend the register seed with two `base` grondslagen, one
+prohibition and one standing consent carrying `bases`, so the workbench
+demos rule pre-application on a clean install.
+
+## Risks / Trade-offs
+
+- [Gate friction at volume — 55.000 docs/yr cannot each be hand-checked] →
+  the `advisory` mode (D3) plus the sibling `redaction-at-scale` sampling-QA
+  change; the gate stays per-document truth either way.
+- [Check-then-edit staleness] → D2 invalidation: any entity mutation after
+  `checkedOn` voids the review; scenario-tested.
+- [Preview highlight fidelity in PDF pane] → highlights are best-effort
+  (text-layer matches); the entity TABLE remains the source of truth for
+  decisions, so a missed highlight never hides an entity from review.
+- [Schema additive changes to two shipped policy schemas] → `bases` is
+  optional, absent-safe in `PolicyCrudService`/`PolicyMatchService`
+  (pre-change rules keep matching identically); union-merge the register
+  JSON, never hand-pick (memory: union-merge drops modifications).
+- [Two policy kinds pre-applying could confuse operators] → distinct badges
+  + a legend in the workbench; prohibitions win on conflict exactly as the
+  matcher already implements.
+
+## Migration Plan
+
+1. Register JSON: add `documentReview` schema + `bases` on both policy
+   schemas (additive; imported via `ConfigurationService::importFromApp()` on
+   boot — no data migration, existing rules simply have no `bases`).
+2. Backend: `standingConsentMatch` attachment, `DocumentReviewController`
+   (+ routes), gate checks in both anonymize paths (behind
+   `docudesk.review.checked_gate`).
+3. Frontend workbench + wiring; nav entry.
+4. Rollback: config `advisory` disables gate blocking; the workbench view is
+   additive (existing widget flows keep working untouched).
+
+## Open Questions
+
+- Should the checked gate also block the CSV batch report download
+  (`batchReport`) or only anonymize-commit/export of documents? Provisional:
+  only commit/export block; the report is an audit artifact and stays
+  readable.
+- `publicationProhibition.entityType` enum is `PERSON|ORGANIZATION|OTHER`
+  while detection types are richer (BSN, IBAN, EMAIL…). Widening the enum is
+  a separate, potentially breaking policy change — the workbench maps
+  detection types onto the existing three categories for rule matching
+  (as `PolicyMatchService` already does) and does NOT widen the enum.

--- a/openspec/changes/anonymization-review-workbench/proposal.md
+++ b/openspec/changes/anonymization-review-workbench/proposal.md
@@ -1,0 +1,113 @@
+---
+kind: code
+---
+
+# Proposal: anonymization-review-workbench
+
+## Why
+
+Every serious buyer of anonymisation software demands a human-review surface,
+and DocuDesk does not have one as a coherent workbench yet:
+
+- The **joni-png wish set** (GH #45–#64, mirrored as CB #72–#87) asks for
+  exactly this: side-by-side original/redacted preview, inline entity
+  add/edit/toggle, select-text-to-create-entity, search and counters, and a
+  per-document "checked" gate before anything is exported.
+- The **Arnhem tender 407824** (anonymiseringssoftware for Arnhem + Renkum +
+  Rheden, ~275 Woo dossiers / ~55.000 docs per year) requires automatic AND
+  manual redaction with human control before irreversible blackout.
+- Nine Dutch government **algoritmeregister** entries for anonymisation
+  algorithms (Rotterdam, Zaanstad, Min AZ, mostly Octobox deployments) all
+  mandate human review of machine detections — VNG estimates >50% of documents
+  are partly auto-redactable but ALL need review.
+- Seven competitors (xxllnc Anonimiseren, ZyLAB ONE, Octobox, CaseGuard,
+  Redactable, Adobe Acrobat Pro, iOpenbaar) ship a suggest-then-approve review
+  UI; it is NL-market table stakes. DocuDesk's counter-positioning (fully
+  local, OR-native, EUPL) only lands if the review UX exists.
+
+DocuDesk already has most of the machinery, verified at HEAD: an
+`EntityReviewTable.vue` with search/type-filter/counters/bulk actions and
+per-entity grondslag pickers, an `AddManualEntityModal.vue` posting to
+OpenRegister's chunk-aware `POST /api/files/{fileId}/manual-entities` matcher,
+`GrondslagProposalService` (CB #122 — per-entity-type grondslag auto-proposal,
+fill-only-when-empty, config key `docudesk.grondslagen.entity_type_bases`),
+`PolicyMatchService::match()` returning `prohibition | standing_consent`
+matches, and in-app PDF/Word/Text viewers. What is missing is the workbench
+that composes them: a document preview next to the entity list, selection-to-
+entity, pre-application of BOTH policy kinds (today only `prohibitionMatch`
+is attached at extract time), a per-document human-checked gate, and grondslag
+per org-level rule (GH #62/#63: org-wide "always anonymise" / "never
+anonymise" lists).
+
+## What
+
+- A **review workbench view** per document: original document preview
+  (reusing the existing `PdfViewer`/`WordViewer`/`TextViewer` components)
+  side-by-side with the anonymized result preview (or a pending placeholder
+  before the first anonymisation run), with the existing `EntityReviewTable`
+  as the decision panel — one shared entity state model, no forked state.
+- **Select text in the preview to create a manual entity**: selecting a text
+  range opens the existing `AddManualEntityModal` pre-filled with the
+  selection, plus an entity type picker and a grondslag (bases) picker; the
+  created `EntityRelation` rows appear inline in the review table.
+- **Inline accept/reject/toggle per entity** synced with the existing
+  `included` / `_decisionSkip` / `_decisionBases` model of
+  `EntityReviewTable.vue` — the workbench adds preview-side highlight and
+  click-through, not a second model.
+- **Realtime search, type filters and counters** over detections (the table
+  already has these; the workbench keeps them and adds occurrence counters in
+  the preview).
+- A **per-document "checked" gate**: a reviewer marks a document as reviewed
+  (persisted as a new `documentReview` OR object, mirroring the existing
+  dossier-level `checkedOn` field); anonymize-commit and export for that
+  document are blocked (HTTP 409) until the gate is satisfied. Batch
+  anonymisation refuses to run while any file in the batch is unchecked.
+- **Org-level "always anonymise" and "never anonymise" rule lists**: these ARE
+  the existing policy objects (verified at HEAD) — `publicationProhibition`
+  (= always anonymise, `entityType` is the category) and entity-scope
+  `publicationConsent` standing consents (= never anonymise). Both schemas
+  gain a `bases` array (grondslag per rule, GH #62/#63); both rule kinds are
+  pre-applied during review (prohibition match → included + locked-on hint;
+  standing-consent match → excluded + badge), and the existing
+  `ProhibitionIndex`/`StandingConsentIndex` views become reachable from the
+  workbench.
+- **Grondslag auto-proposal surfaced**: the proposals `GrondslagProposalService`
+  already writes at extract time (CB #122) are shown as pre-filled, overridable
+  values in the workbench's grondslag pickers, including for manual entities.
+
+## Capabilities
+
+### New Capabilities
+
+- `anonymization-review-workbench`: the interactive human-review workbench —
+  side-by-side preview, selection-to-manual-entity, per-document checked gate,
+  org rule-list pre-application, grondslag proposal surfacing.
+
+### Modified Capabilities
+
+- `anonymization-entity-review`: the consolidated-entities response gains a
+  `standingConsentMatch` field (sibling of the existing `prohibitionMatch`),
+  and the batch anonymize commit gains the per-document checked-gate
+  precondition.
+
+## Impact
+
+- **Backend**: new `DocumentReviewController` (+ routes) for the checked gate;
+  `AnonymizationService`/`EntityConsolidationService` attach
+  `standingConsentMatch` next to `prohibitionMatch` (both via the existing
+  `PolicyMatchService`); `BatchAnonymizationController::batchAnonymize` and
+  `AnonymizationController::anonymize` enforce the gate; `PolicyCrudService`
+  accepts the new `bases` property.
+- **Register JSON** (`lib/Settings/docudesk_register.json`): new
+  `documentReview` schema; `bases` array added to `publicationProhibition`
+  and `publicationConsent`.
+- **Frontend**: new `src/views/anonymization/ReviewWorkbench.vue` (+ preview
+  highlight layer), selection-to-entity wiring into `AddManualEntityModal`,
+  checked-gate UI, policy badges in `EntityReviewTable`; policy form modals
+  gain a grondslag picker.
+- **No engine changes**: entity detection, text extraction and anonymisation
+  stay in OpenRegister (`TextExtractionService`, `EntityRelationMapper`,
+  `FileService::anonymizeDocument`); the workbench orchestrates and renders.
+- **Dependencies**: OpenRegister manual-entities endpoint
+  (`fileText#addManualEntity`, verified present at OR HEAD); no new external
+  services; all processing stays local.

--- a/openspec/changes/anonymization-review-workbench/specs/anonymization-entity-review/spec.md
+++ b/openspec/changes/anonymization-review-workbench/specs/anonymization-entity-review/spec.md
@@ -1,0 +1,85 @@
+# anonymization-entity-review Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Extends the consolidated batch entity review with the workbench's policy
+pre-application and checked-gate semantics: the consolidated-entities
+response gains a `standingConsentMatch` field (sibling of the existing
+`prohibitionMatch`), and the batch anonymize commit gains the per-document
+checked-gate precondition (see `anonymization-review-workbench`
+REQ-DDARW-007/008).
+
+## ADDED Requirements
+
+### Requirement: Consolidated entities carry `standingConsentMatch` (REQ-DDARW-010)
+
+The endpoint `GET /api/anonymization/batch/{batchId}/entities` MUST include
+a `standingConsentMatch` field on every entity entry, the standing-consent
+sibling of the existing `prohibitionMatch` field:
+
+- `null` — no active standing-consent rule matches the entity, OR
+- `{ ruleId, ruleName }` — an active standing-consent rule matched.
+
+The matcher consulted MUST be the same `PolicyMatchService::match()` pass
+that produces `prohibitionMatch`; when both kinds match, `prohibitionMatch`
+MUST be set and `standingConsentMatch` MUST be `null` (prohibitions win on
+conflict, existing matcher behaviour). Entities with a
+`standingConsentMatch` MUST be pre-set `included: false` in the response
+(overriding WOO-profile pre-selection for that entity), mirroring the
+review pre-application. The change MUST be additive: pre-change clients
+reading only the existing fields continue to work.
+
+#### Scenario: Standing-consent match pre-excludes a batch entity
+
+- GIVEN an active standing consent for "Gemeente Voorbeeldstad" (ORGANIZATION)
+- AND a batch in review status containing that entity with the WOO profile pre-selecting ORGANIZATION as keep
+- WHEN the consolidated-entities endpoint is called
+- THEN the entity entry has `standingConsentMatch: {ruleId, ruleName}` and `included: false`
+- @e2e exclude batch API response-shape contract; covered by PHPUnit (tests/unit/Controller/BatchAnonymizationControllerTest.php) and Newman batch contracts
+
+#### Scenario: No standing-consent rule matches
+
+- GIVEN a batch entity that no standing-consent rule matches
+- WHEN the endpoint is called
+- THEN the entity entry has `standingConsentMatch: null`
+- @e2e exclude batch API response-shape contract; covered by PHPUnit (tests/unit/Controller/BatchAnonymizationControllerTest.php)
+
+#### Scenario: Prohibition wins over standing consent
+
+- GIVEN a batch entity matched by both an active prohibition and an active standing consent
+- WHEN the endpoint is called
+- THEN `prohibitionMatch` is set and `standingConsentMatch` is `null`
+- AND the entity is pre-set `included: true`
+- @e2e exclude matcher precedence already unit-covered in PolicyMatchService; asserted by PHPUnit, not UI
+
+### Requirement: Batch anonymize respects the per-document checked gate (REQ-DDARW-011)
+
+`POST /api/anonymization/batch/{batchId}/anonymize` MUST evaluate the
+per-document checked gate (`documentReview` objects, gate mode
+`docudesk.review.checked_gate`) for every non-error file in the batch
+before anonymizing anything. In `enforced` mode (default) the endpoint MUST
+return HTTP 409 with `reason: "documents_not_reviewed"` and an
+`uncheckedFiles` array (fileId + fileName) when one or more files lack a
+valid check, committing no file. In `advisory` mode the endpoint MUST
+proceed and include the `checkedGate` verdict in the response. This
+precondition runs in addition to — not instead of — the existing
+prohibition gate.
+
+#### Scenario: Batch with one unchecked file is refused atomically
+
+- GIVEN gate mode `enforced` and a review-status batch of 3 files with 2 checked and 1 unchecked
+- WHEN the batch anonymize endpoint is called with a reviewed entity list
+- THEN the system returns HTTP 409 with `reason: "documents_not_reviewed"` and the unchecked file listed
+- AND no file in the batch is anonymized
+- @e2e exclude batch API gate contract; covered by PHPUnit (tests/unit/Controller/BatchAnonymizationControllerTest.php) and Newman batch contracts
+
+#### Scenario: Fully checked batch proceeds
+
+- GIVEN gate mode `enforced` and a review-status batch whose files are all checked
+- WHEN the batch anonymize endpoint is called
+- THEN anonymization proceeds exactly as before this change
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts

--- a/openspec/changes/anonymization-review-workbench/specs/anonymization-review-workbench/spec.md
+++ b/openspec/changes/anonymization-review-workbench/specs/anonymization-review-workbench/spec.md
@@ -1,0 +1,300 @@
+# anonymization-review-workbench Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+The interactive human-review workbench for anonymisation: a per-document
+split view (original preview | anonymized preview) with the existing
+`EntityReviewTable` as the decision panel, selection-to-manual-entity,
+pre-application of the org-level "always anonymise" (prohibition) and
+"never anonymise" (standing consent) rule lists, grondslag auto-proposal
+surfacing, and a per-document human-checked gate that anonymize-commit and
+export respect. Detection, extraction and anonymisation engines remain in
+OpenRegister; the workbench orchestrates and renders (GDPR Art. 5(1)(d)
+accuracy — human verification of machine detections; Woo Art. 5 grondslag
+per redaction).
+
+## ADDED Requirements
+
+### Requirement: Side-by-side review workbench per document (REQ-DDARW-001)
+
+The system MUST provide a review workbench view for a single document that
+renders the original document preview (reusing the existing
+`PdfViewer`/`WordViewer`/`TextViewer` components by MIME type) side-by-side
+with the anonymized result preview, and hosts the existing
+`EntityReviewTable` as the decision panel. When no anonymized result exists
+yet (no `anonymizationLink` object for the file's `sourceFileId`), the
+anonymized pane MUST show a pending placeholder stating that anonymisation
+has not been committed. The anonymized pane MUST resolve its file via the
+`anonymizationLink` OR object (`sourceFileId` → `anonymizedFileId`). For
+file types no viewer supports, the pane MUST degrade to the existing
+"cannot be previewed" message while the entity table remains fully
+functional.
+
+#### Scenario: Reviewer opens the workbench for an extracted document
+
+- GIVEN a PDF that has been extracted and has detected entities
+- AND no anonymized result exists yet for the file
+- WHEN the reviewer opens the review workbench for the file
+- THEN the left pane shows the original PDF preview
+- AND the right pane shows the pending placeholder
+- AND the entity review table lists the detected entities
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+#### Scenario: Anonymized result appears after a commit
+
+- GIVEN a document with a committed anonymisation run (an `anonymizationLink` object exists)
+- WHEN the reviewer opens the review workbench
+- THEN the right pane previews the file referenced by `anonymizedFileId`
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+### Requirement: One shared entity decision model (REQ-DDARW-002)
+
+The workbench MUST use the existing `EntityReviewTable` entity state model
+(`included`, `_decisionSkip`, `_decisionBases`) as the single source of
+truth for per-entity decisions. Accept/reject/toggle actions performed from
+the preview panes (clicking a highlighted occurrence) MUST mutate the same
+model the table mutates, and MUST NOT introduce a second entity state store.
+The table's existing realtime search, entity-type filter, selected/total
+counters and bulk select/deselect of visible rows MUST remain available
+inside the workbench.
+
+#### Scenario: Toggling from the preview updates the table
+
+- GIVEN the workbench shows a document with the entity "Jan Jansen" (PERSON) included
+- WHEN the reviewer clicks the highlighted "Jan Jansen" occurrence in the original pane and chooses reject
+- THEN the entity's `included` flag becomes false in the review table row
+- AND the selected/total counter decreases by one
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+#### Scenario: Search and type filter operate in the workbench
+
+- GIVEN a document with 40 detected entities of mixed types
+- WHEN the reviewer types "Utrecht" in the search box and selects type ORGANIZATION
+- THEN only ORGANIZATION entities whose value contains "Utrecht" remain visible
+- AND the counter shows the filtered count out of the total
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+### Requirement: Select text in the preview to create a manual entity (REQ-DDARW-003)
+
+The system MUST let the reviewer select a text range in the original
+preview and create a manual entity from it. The selection MUST open the
+existing `AddManualEntityModal` pre-filled with the selected text, an
+entity-type picker, and a grondslag (bases) picker pre-filled from the
+grondslag auto-proposal mapping for the chosen type (see REQ-DDARW-006).
+Submission MUST go to OpenRegister's chunk-aware matcher
+(`POST /api/files/{fileId}/manual-entities`) — the client MUST NOT compute
+or transmit character offsets. Created entity occurrences MUST appear in
+the review table without a full page reload, and a zero-match outcome MUST
+be reported to the reviewer as a non-error notice (existing modal
+behaviour).
+
+#### Scenario: Reviewer creates a manual entity from a selection
+
+- GIVEN the original pane shows extracted text containing "Pieter de Vries"
+- WHEN the reviewer selects "Pieter de Vries" and chooses "Add as entity", picks type PERSON, and submits
+- THEN the modal was pre-filled with the selected text
+- AND one review-table row appears per occurrence matched by OpenRegister
+- AND the row carries the proposed grondslag for PERSON as its pre-filled bases
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+#### Scenario: Selection matches nothing in the extracted chunks
+
+- GIVEN a selection whose normalised text does not occur in the file's extracted chunks
+- WHEN the reviewer submits the manual entity
+- THEN the workbench shows the zero-match notice
+- AND no review-table row is added
+- @e2e exclude zero-match path depends on OR matcher internals; covered by vitest store tests (tests/vitest) and the existing PoC widget contract — no stable UI fixture can force a zero-match deterministically
+
+### Requirement: Org rule lists pre-apply during review (REQ-DDARW-004)
+
+The system MUST pre-apply the org-level rule lists to every entity in the
+review workbench: an entity matching an active `publicationProhibition`
+rule ("always anonymise") MUST be pre-set `included: true` and carry a
+warning badge naming the rule; an entity matching an active standing-consent
+`publicationConsent` rule (scope `entity`, "never anonymise") MUST be
+pre-set `included: false` and carry an info badge naming the rule. Both
+rule kinds MUST be evaluated by the existing `PolicyMatchService::match()`
+in a single pass, with prohibitions winning on conflict (existing
+behaviour). The pre-application is a default: the reviewer MAY override
+either direction, except that overriding a prohibition remains subject to
+the existing prohibition commit gate. Both badges MUST link to the matched
+rule's detail view.
+
+#### Scenario: Prohibited entity arrives pre-included with a badge
+
+- GIVEN an active prohibition rule matching "Beschermde Getuige A" (PERSON)
+- AND a document in which that entity was detected
+- WHEN the reviewer opens the workbench
+- THEN the entity row is pre-set included with a prohibition badge naming the rule
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+#### Scenario: Standing-consent entity arrives pre-excluded with a badge
+
+- GIVEN an active standing consent for "Gemeente Voorbeeldstad" (ORGANIZATION)
+- AND a document in which that entity was detected
+- WHEN the reviewer opens the workbench
+- THEN the entity row is pre-set excluded with a standing-consent badge naming the rule
+- AND the reviewer can still re-include it manually
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+#### Scenario: Entity matching both kinds follows the prohibition
+
+- GIVEN one active prohibition and one active standing consent that both match the same entity text
+- WHEN the entity is pre-applied in the workbench
+- THEN the prohibition wins and the entity is pre-set included with the prohibition badge
+- @e2e exclude conflict precedence is matcher logic already unit-covered in PolicyMatchService; asserted by PHPUnit (tests/unit/Service/PolicyMatchServiceTest.php), not by UI
+
+### Requirement: Grondslag per org rule (REQ-DDARW-005)
+
+The `publicationProhibition` and `publicationConsent` schemas MUST gain an
+optional `bases` array of grondslag slugs referencing `base` objects (the
+same dialect as `dossier.bases`). The policy CRUD endpoints
+(`/api/policy/prohibitions`, `/api/policy/standing-consents`) MUST accept,
+persist and return `bases`; rules without `bases` MUST keep matching
+exactly as before (additive, non-breaking). When a rule with `bases`
+pre-applies to an entity whose decision bases are empty, the rule's `bases`
+MUST be pre-filled as that entity's grondslag (fill-only-when-empty,
+consistent with the existing proposal semantics). The rule category remains
+the existing `entityType` property; the enum is NOT widened by this change.
+
+#### Scenario: Admin adds a grondslag to a prohibition rule
+
+- GIVEN an existing prohibition rule without bases
+- WHEN an admin edits the rule in the prohibition form and picks "Woo art. 5.1.2.e" as grondslag
+- THEN `PUT /api/policy/prohibitions/{id}` persists `bases: ["woo-art-5-1-2-e"]`
+- AND the rule detail shows the grondslag
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+#### Scenario: Rule bases pre-fill the matched entity's grondslag
+
+- GIVEN a prohibition rule with `bases: ["woo-art-5-1-2-e"]` matching a detected entity whose decision bases are empty
+- WHEN the workbench pre-applies the rule
+- THEN the entity row's grondslag picker is pre-filled with "woo-art-5-1-2-e"
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+#### Scenario: Pre-change rule without bases keeps matching
+
+- GIVEN a prohibition rule created before this change (no `bases` property)
+- WHEN `PolicyMatchService` evaluates entities
+- THEN the rule matches exactly as before
+- AND the API returns the rule without error
+- @e2e exclude backwards-compatibility of an optional schema property; covered by PHPUnit (tests/unit/Service/PolicyCrudServiceTest.php, PolicyMatchServiceTest.php)
+
+### Requirement: Grondslag auto-proposal surfaced and overridable (REQ-DDARW-006)
+
+The workbench MUST show the per-entity-type grondslag proposals that
+`GrondslagProposalService` already writes at extraction time (config key
+`docudesk.grondslagen.entity_type_bases`, CB #122) as the pre-filled value
+of each entity row's grondslag picker, visually marked as proposed until
+the reviewer confirms or changes it. The proposal MUST also pre-fill the
+grondslag picker of the manual-entity modal based on the chosen entity
+type. Reviewer overrides MUST always win over proposals and rule `bases`.
+
+#### Scenario: Proposal appears pre-filled for a detected BSN
+
+- GIVEN the admin mapping assigns grondslag "woo-art-5-1-2-e" to entity type BSN
+- AND a document in which a BSN was detected
+- WHEN the reviewer opens the workbench
+- THEN the BSN row's grondslag picker is pre-filled with "woo-art-5-1-2-e" and marked as proposed
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+#### Scenario: Reviewer override wins
+
+- GIVEN an entity row with a proposed grondslag
+- WHEN the reviewer picks a different grondslag
+- THEN the reviewer's choice is what is sent on the anonymise request
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+### Requirement: Per-document checked gate (REQ-DDARW-007)
+
+The system MUST provide a per-document "reviewed" mark persisted as a
+`documentReview` OR object (`fileId` as idempotency key, `checkedOn`,
+`checkedBy`, `entityCountAtCheck`, `manualEntityCount`, optional `note`)
+via `POST /api/review/{fileId}/check` and `DELETE /api/review/{fileId}/check`
+(uncheck), readable via `GET /api/review/{fileId}`. Marking a document
+checked MUST require that extraction has completed for the file. Any
+mutation of the file's entity decisions after `checkedOn` (toggle, manual
+entity added, bases changed) MUST invalidate the check: the gate MUST treat
+the document as unchecked until re-checked.
+
+#### Scenario: Reviewer marks a document as checked
+
+- GIVEN an extracted document whose entities the reviewer has reviewed
+- WHEN the reviewer clicks "Mark as reviewed" in the workbench
+- THEN a `documentReview` object is created with `checkedBy` = the reviewer and `checkedOn` = now
+- AND the workbench shows the document as reviewed
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+#### Scenario: Editing entities invalidates the check
+
+- GIVEN a document marked checked
+- WHEN the reviewer adds a manual entity to the document
+- THEN the document reverts to unchecked
+- AND the workbench prompts for re-review
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+### Requirement: Checked gate blocks anonymize-commit and export (REQ-DDARW-008)
+
+The system MUST enforce the checked gate at commit time while the admin
+setting `docudesk.review.checked_gate` is `enforced` (default):
+`POST /api/anonymization/anonymize/{fileId}` MUST return HTTP 409 with a
+machine-readable reason when the file has no valid `documentReview`, and
+`POST /api/anonymization/batch/{batchId}/anonymize` MUST return HTTP 409
+listing every unchecked file in the batch, committing nothing. Export/download surfaces for anonymized results produced by this
+flow MUST be blocked by the same predicate. When the setting is
+`advisory`, the operations MUST proceed but the response MUST include the
+gate verdict (`checkedGate: { passed: false, uncheckedFiles: [...] }`).
+Only admins MAY change the setting.
+
+#### Scenario: Single-file commit blocked while unchecked
+
+- GIVEN gate mode `enforced` and an extracted, unchecked document
+- WHEN `POST /api/anonymization/anonymize/{fileId}` is called
+- THEN the system returns HTTP 409 with reason `document_not_reviewed`
+- AND no anonymized file is produced
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+#### Scenario: Batch commit blocked listing unchecked files
+
+- GIVEN gate mode `enforced` and a batch of 3 files of which 1 is unchecked
+- WHEN `POST /api/anonymization/batch/{batchId}/anonymize` is called
+- THEN the system returns HTTP 409 listing the unchecked file
+- AND no file in the batch is anonymized
+- @e2e exclude batch API contract without stable UI surface for partial-checked batches; covered by PHPUnit + Newman (tests/newman /api/anonymization/batch contracts)
+
+#### Scenario: Advisory mode proceeds with verdict
+
+- GIVEN gate mode `advisory` and an unchecked document
+- WHEN the anonymise commit is called
+- THEN the operation succeeds
+- AND the response contains `checkedGate.passed: false`
+- @e2e exclude admin-config branch of an API contract; covered by PHPUnit (tests/unit/Controller/AnonymizationControllerTest.php)
+
+### Requirement: Rule lists reachable and manageable from the workbench (REQ-DDARW-009)
+
+The workbench MUST link to the org rule lists (the existing
+`ProhibitionIndex` and `StandingConsentIndex` views), and those views MUST
+be reachable from the app navigation (today they are deep-link only,
+verified at HEAD). The prohibition and standing-consent form modals MUST
+include the grondslag (`bases`) picker and continue to show the rule
+category (`entityType`). Creating or updating a rule MUST invalidate the
+policy matcher cache so the next review pass uses the new rule (existing
+`PolicyMatchService::invalidateCache()` seam).
+
+#### Scenario: Reviewer navigates from a badge to the rule list
+
+- GIVEN a workbench entity carrying a prohibition badge
+- WHEN the reviewer clicks the badge
+- THEN the prohibition detail/list view opens showing the matched rule
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts
+
+#### Scenario: New rule applies to the next review
+
+- GIVEN a reviewer-created standing consent for "Stichting Voorbeeld"
+- WHEN a new document containing "Stichting Voorbeeld" is extracted and opened in the workbench
+- THEN the entity is pre-excluded with the standing-consent badge
+- @e2e tests/e2e/spec-coverage/review-workbench.spec.ts

--- a/openspec/changes/anonymization-review-workbench/tasks.md
+++ b/openspec/changes/anonymization-review-workbench/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: anonymization-review-workbench
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 16.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Register & seed data
+
+- [ ] 1.1 Add the `documentReview` schema and the optional `bases` array on `publicationProhibition` and `publicationConsent` to `lib/Settings/docudesk_register.json`
+  - Additive only; union-merge, never hand-pick; existing objects stay valid without `bases`.
+  - `documentReview`: `fileId` (integer, idempotency key), `checkedOn`, `checkedBy`, `entityCountAtCheck`, `manualEntityCount`, `note`.
+- [ ] 1.2 Extend the register seed with workbench demo data (two `base` grondslagen, one prohibition and one standing consent carrying `bases`) per the design.md Seed Data section
+  - A clean install demos rule pre-application without manual setup.
+
+## 2. Backend
+
+- [ ] 2.1 Attach `standingConsentMatch` next to `prohibitionMatch` in `AnonymizationService::extractAndDetectEntities()` and in the batch consolidated-entities path, from the single existing `PolicyMatchService::match()` pass (REQ-DDARW-010)
+  - Prohibition wins on conflict; standing-consent match pre-sets `included: false`; additive response shape.
+- [ ] 2.2 Accept/persist/return `bases` in `PolicyCrudService` + `PolicyController` for both rule kinds; invalidate the matcher cache on rule writes (REQ-DDARW-005, REQ-DDARW-009)
+  - Pre-change rules without `bases` match unchanged (regression test).
+- [ ] 2.3 Add `DocumentReviewController` with routes `GET /api/review/{fileId}`, `POST /api/review/{fileId}/check`, `DELETE /api/review/{fileId}/check`, storing `documentReview` OR objects; invalidate the check on any post-check entity mutation (REQ-DDARW-007)
+  - Auth attributes on every method (route-auth gate); per-object authorization guard (no-admin-idor gate).
+- [ ] 2.4 Enforce the checked gate in `AnonymizationController::anonymize` and `BatchAnonymizationController::batchAnonymize` behind `IAppConfig` key `docudesk.review.checked_gate` (`enforced` default | `advisory`) (REQ-DDARW-008, REQ-DDARW-011)
+  - HTTP 409 with machine-readable reason + `uncheckedFiles`; advisory mode returns `checkedGate` verdict; runs in addition to the prohibition gate.
+
+## 3. Frontend
+
+- [ ] 3.1 Build `src/views/anonymization/ReviewWorkbench.vue`: original/anonymized split view reusing the existing viewers, `EntityReviewTable` as decision panel, anonymized pane resolved via `anonymizationLink` (REQ-DDARW-001, REQ-DDARW-002)
+  - One shared entity state model; pending placeholder when no anonymized result; unsupported types degrade to the existing message.
+- [ ] 3.2 Implement preview text-selection → pre-filled `AddManualEntityModal` (value, type picker, grondslag pre-fill from the proposal mapping), submitting to the existing OR manual-entities endpoint (REQ-DDARW-003)
+  - No client-side offsets; new rows appear without reload; zero-match notice preserved.
+- [ ] 3.3 Render prohibition/standing-consent badges with rule links and pre-applied include/exclude state; show proposed grondslag as pre-filled + marked, reviewer override wins (REQ-DDARW-004, REQ-DDARW-006)
+- [ ] 3.4 Add checked-gate UI (mark reviewed / re-review prompt on invalidation) and wire nav entries for the workbench and the existing `ProhibitionIndex`/`StandingConsentIndex` views; add the `bases` picker to both policy form modals (REQ-DDARW-007, REQ-DDARW-009)
+  - NcSelect fields carry `inputLabel`; modals stay in their own files (modal-isolation gate).
+
+## 4. Quality
+
+- [ ] 4.1 PHPUnit unit tests for gate logic, `standingConsentMatch` attachment, policy `bases` CRUD and check-invalidation — minimum 75% coverage on new code (ADR-009)
+  - Run in container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`.
+  - End-to-end verify with OpenRegister on Postgres (8080): detection → pre-application → gate → commit.
+- [ ] 4.2 Playwright spec `tests/e2e/spec-coverage/review-workbench.spec.ts` covering the `@e2e`-referenced scenarios
+- [ ] 4.3 Vitest coverage for the workbench store wiring (shared entity model, selection pre-fill)
+- [ ] 4.4 i18n: EN + NL translations for all new UI strings (keys in English) (ADR-005)
+  - Test with the nldesign theme enabled for accessibility compliance.
+- [ ] 4.5 Docs: `docs/features/review-workbench.md` with Playwright MCP screenshots of the split view, badges, grondslag pickers and the checked gate (ADR-010)
+- [ ] 4.6 Validate: `openspec validate anonymization-review-workbench --strict` passes; hydra gates green on the branch

--- a/openspec/changes/document-waarmerk-certification/.openspec.yaml
+++ b/openspec/changes/document-waarmerk-certification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/document-waarmerk-certification/design.md
+++ b/openspec/changes/document-waarmerk-certification/design.md
@@ -1,0 +1,295 @@
+# Design: document-waarmerk-certification
+
+## Context
+
+Verified current state (HEAD of this worktree):
+
+- `SigningVerificationService::verifyDocument(fileId, userId)` verifies
+  embedded `/DocuDesk-Signature(...)` assertions with an HMAC-SHA256 over a
+  canonicalised document using a server-held secret
+  (`docudesk.signing_verification_secret`), **fail-closed** after security
+  finding #284 (self-asserted blobs report `valid => false`). Real PAdES/CMS
+  validation is not implemented. Route: `GET api/signing/verify/{fileId}`
+  (authenticated, user-folder scoped).
+- The `signing` register (v1.1.0) holds `signingRequest`, `signerRecord`,
+  `signingAuditEntry`, `signingSession` — all *personal-signature* flow
+  records. Providers: `NativeSigningProvider`, `ValidSignProvider`
+  (`lib/Service/Signing/`).
+- Every successful anonymization writes an `anonymizationLink` object
+  (register `document`) with verified fields: `sourceFileId/Name/Path`,
+  `anonymizedFileId/Name/Path`, `outputFormat`, `status`,
+  `replacementCount` (derived from real replacements since GH #286),
+  `runCount`, `anonymizedAt`, `anonymizedBy`. Batch flows additionally
+  produce a CSV audit report (`BatchReportService::generateReport`).
+- `PdfService::renderPdf()` renders Twig→HTML→mPDF (PDF/A-3B capable via
+  `pdfa` option); `PdfConversionService` converts arbitrary files to PDF.
+- No credential/crypto custody code exists in DocuDesk today (verified: no
+  `credentialRef`/`ICrypto` usage under `lib/`).
+
+Fleet context: ADR-064 (hydra#107) fixes custody — secrets are never stored
+in a register schema; objects carry a `credentialRef` and the secret lives
+with the credential broker (`mint()` in OpenRegister, or#440). GH #289
+(audit immutability) informs the record design: waarmerk records are
+write-once evidence.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- An organisation seals an anonymized/published PDF with its own
+  certificate; anyone holding the document can verify authenticity and
+  integrity without a Nextcloud account.
+- The seal is honest: it claims exactly what it can prove (integrity +
+  origin under the configured org certificate), fails closed, and never
+  reports "valid" for anything unverifiable — the #282/#284 signing lessons
+  applied from day one.
+- Anonymization runs can be certified with a data-minimised evidence PDF.
+- Private key custody follows ADR-064 — no key material in schemas, app
+  config, or logs.
+
+**Non-Goals:**
+
+- Not a *qualified* seal (eIDAS QSeal requires a QTSP-managed QSCD; the
+  gap-shortlist explicitly defers QTSP partnerships as a business decision).
+  The waarmerk is an **advanced-level electronic seal at most**, and the UI/
+  docs MUST say so.
+- No change to the personal-signature flow (`document-signing` capability),
+  its providers, or `signing#verify`'s contract.
+- No embedded PAdES/ISO 32000 incremental-update signature inside the PDF
+  structure this wave (see D2).
+- No timestamping authority (RFC 3161) integration this wave — `sealedAt`
+  is server time, recorded in the sealed record.
+
+## Decisions
+
+### D1 — The waarmerk is an organisation seal, not a signature
+
+Terminology and data model separate it from `signingRequest`: a new
+`certification` register with a `waarmerk` schema. Rationale: the signing
+register models a *workflow between persons* (signers, order, decline);
+sealing is a single organisational act on an artifact. Mixing them would
+overload `signingRequest` semantics and its portal exposure
+(portal-contribution reads `signing`). eIDAS grounding: Art. 3(25) electronic
+seal = data attached by a *legal person* to ensure origin and integrity.
+
+### D2 — Seal format: detached CMS (PKCS#7) + visible stamp page, not embedded PAdES
+
+**Chosen:** compute `sha256` over the **sealed payload** (original PDF bytes
++ appended stamp page, with the verification-code field canonicalised the
+same way `SigningVerificationService::canonicaliseForAssertion()` blanks
+marker payloads); sign the hash as a detached CMS structure with
+`openssl_cms_sign()` (fallback `openssl_pkcs7_sign()` on older OpenSSL) using
+the org certificate; store the CMS blob and hash on the `waarmerk` record;
+append a visible stamp page to the output PDF carrying the waarmerk mark,
+the organisation name, `sealedAt`, the verification code, and a QR encoding
+the public verification URL.
+
+**Rejected alternatives:**
+
+- *True embedded PAdES signature*: requires incremental-update writing with
+  `/ByteRange` placeholder arithmetic; pure-PHP support means adopting
+  SetaPDF (commercial) or TCPDF's signing (would replace mPDF for this
+  path). Cost/risk is out of proportion for a v1 whose verification surface
+  is DocuDesk's own page — and Adobe-validatable embedded seals can be added
+  later without breaking the record model (the CMS + hash stay valid).
+- *Reusing the HMAC `/DocuDesk-Signature` marker*: an HMAC proves only "this
+  server knew its own secret" — it is not attributable to an organisation
+  certificate and cannot be verified by a third party even in principle.
+  Asymmetric CMS is the honest primitive for a waarmerk.
+
+Trade-off accepted: PDF viewers will not show a signature panel; the
+verification story is the QR/verification page. This matches how Redactable
+certificates and Zynyo deed-of-signing PDFs are consumed in practice.
+
+### D3 — Key custody: `credentialRef` per ADR-064, fail-closed
+
+Admin settings store: the org **certificate** (public, PEM — safe in app
+config), its fingerprint, and a **`credentialRef`** string pointing at the
+private key held by the fleet credential broker (ADR-064; broker `mint()`
+contract from or#440). At seal time `WaarmerkService` resolves the key
+material through the broker, uses it in-memory, and never persists or logs
+it. If the ref cannot be resolved (broker absent, ref revoked), sealing MUST
+fail with a clear 503-style error — **never** fall back to an unsealed "best
+effort" artifact.
+
+**Documented uncertainty:** the broker resolution API surface available to a
+leaf app at implementation time must be verified against the then-current
+OpenRegister release; as an interim custody fallback the design allows the
+key encrypted-at-rest via Nextcloud `ICrypto` in app config **only** behind
+the same resolver interface, flagged in admin UI as "local custody
+(interim)". The register schema carries only `credentialRef`-shaped
+references either way — never key material (ADR-064 hard rule).
+
+### D4 — Verification: public, code-scoped, fail-closed, no oracles
+
+Two public surfaces (`#[PublicPage]`, brute-force rate-limited via
+`AnonRateThrottle`):
+
+- `GET /verify/{code}` — human page: shows waarmerk status (valid / revoked
+  / unknown), organisation, sealedAt, document *name only* — no content, no
+  file download (the citizen already holds the document).
+- `POST /api/waarmerk/verify` — accepts `{code, sha256}` (the verifier's
+  locally computed document hash — the UI computes it client-side from a
+  user-selected file via WebCrypto so the **document bytes never leave the
+  verifier's machine**); the server compares against the recorded hash and
+  validates the stored CMS against the stored certificate chain
+  (`openssl_cms_verify`), returning `valid|hash-mismatch|revoked|unknown`.
+
+Verification codes are high-entropy (UUIDv4 + check-part), so the endpoint
+is not enumerable (CB #100 existence-oracle lesson: `unknown` and
+`revoked-but-wrong-hash` responses are indistinguishable in timing and
+identical in shape for non-matching codes). NC user-folder access is not
+involved — the record lookup is by code over the `certification` register
+via ObjectService with a system-operation context.
+
+### D5 — Stamp page + QR composition
+
+The stamp page is rendered with the existing `PdfService` (Twig template in
+the templates register, namespace `docudesk`, so the mark is
+huisstijl-brandable) and appended to the source PDF; the QR is generated
+locally as an SVG (small pure-PHP QR encoder vendored under `lib/`, or —
+ADR-011 reuse check — OpenRegister's existing QR utility if one exists at
+implementation time; verified: DocuDesk has none today). No external QR API
+(local-only rule).
+
+### D6 — Processing certificate grounded in `anonymizationLink`
+
+`ProcessingCertificateService` builds the anonymization certificate PDF from
+**already-recorded** data only: the `anonymizationLink` fields listed in
+Context, per-entity-type counts from the run result (types + counts, never
+values), the configured detection backend identifier (from the OR
+anonymizer-backend state DocuDesk already reads for its admin warning), and
+the acting user (`anonymizedBy`). The certificate PDF is then sealed via the
+same `WaarmerkService` path (`sealType: processing-certificate`,
+`anonymizationLinkId` on the record). Nothing is re-derived from document
+content at certificate time — the certificate attests the *record*, which is
+the honest claim (Redactable's model). GDPR: AVG Art. 5(1)(c)
+data-minimisation, Art. 5(2) accountability — the certificate is
+accountability evidence, and contains no personal data beyond the acting
+user id.
+
+### D7 — Declarative vs imperative (ADR-031)
+
+Imperative, with justification: cryptographic sealing, CMS/OpenSSL calls,
+PDF composition, and broker resolution are external-integration/
+document-generation work — listed valid exceptions. Declarative parts stay
+declarative: the `certification` register + `waarmerk` schema are pure
+`docudesk_register.json` additions. **No lifecycle annotation** on
+`waarmerk.status`: the only transition is `active → revoked` and it needs an
+authorization guard (admin or sealer) — a lifecycle-guard imperative
+exception; the guard lives in the controller/service, and the record is
+otherwise write-once (GH #289 immutability: sealed fields are never mutated
+after creation; revocation only sets `status`, `revokedAt`, `revokedBy`,
+`revocationReason`).
+
+### D8 — Frontend (ADR-012)
+
+- Document surfaces (My Documents / anonymization results): "Waarmerk
+  toevoegen" action + waarmerk badge, via existing view integration points.
+- Public verification page: minimal standalone Vue entry (no app shell),
+  NL Design System tokens, WCAG AA (it is citizen-facing).
+- Admin settings: certificate panel in the existing DocuDesk admin settings
+  (`lib/Settings/DocuDeskAdmin.php` section) — upload PEM, show fingerprint/
+  expiry, set `credentialRef`, test-seal button. Registered via the settings
+  framework, NOT the vue-router (hydra-gate-admin-router rule).
+- Dialogs as separate components in `src/modals/` (modal-isolation).
+
+## OpenRegister usage (ADR-001)
+
+| Operation | OR service |
+|---|---|
+| `waarmerk` record CRUD (create/find/list/revoke-update) | `ObjectService` via the same resolver pattern as existing services |
+| Public verification lookup by code | `ObjectService` search with system-operation context (no user folder) |
+| Evidence source | existing `anonymizationLink` objects (read-only) |
+| Register/schema definition | `certification` register in `docudesk_register.json`, imported on boot via `ConfigurationService::importFromApp()` |
+
+No custom tables. `waarmerk` schema (all evidence fields write-once):
+`documentFileId`, `documentName`, `documentHash` (sha256 hex),
+`sealType` (`waarmerk` | `processing-certificate`), `cmsSignature` (base64
+detached CMS), `certificateFingerprint`, `certificateSubject`,
+`verificationCode`, `sealedAt`, `sealedBy`, `status`
+(`active` | `revoked`), `revokedAt`, `revokedBy`, `revocationReason`,
+`anonymizationLinkId` (optional relation, UUID).
+
+## Seed Data
+
+Demo objects (nil-UUID pattern, Demostad flavour; no realistic secrets —
+placeholders only):
+
+```json
+{
+  "waarmerk": {
+    "id": "00000000-0000-0000-0000-000000000201",
+    "documentFileId": 0,
+    "documentName": "woo-besluit-2025-017-geanonimiseerd.pdf",
+    "documentHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "sealType": "waarmerk",
+    "cmsSignature": "PLACEHOLDER_BASE64_CMS",
+    "certificateFingerprint": "00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF",
+    "certificateSubject": "O=Gemeente Demostad, C=NL",
+    "verificationCode": "00000000-0000-0000-0000-000000000202",
+    "sealedAt": "2026-07-16T12:00:00+02:00",
+    "sealedBy": "demo-woo-officer",
+    "status": "active",
+    "anonymizationLinkId": "00000000-0000-0000-0000-000000000203"
+  }
+}
+```
+
+Unit tests generate a **throwaway self-signed org certificate at test
+runtime** (openssl in the test bootstrap) — no PEM/key fixture is ever
+committed (gitleaks). Admin-settings seed uses `credentialRef:
+"doriath://org/demostad/waarmerk-seal"`-style opaque refs with placeholder
+ids.
+
+## Security Considerations
+
+- Private key: resolved per D3, held only in memory during
+  `openssl_cms_sign`, zeroised reference after; never logged (log the
+  fingerprint, never the PEM).
+- Fail-closed everywhere: unresolvable key → seal refused; unknown code /
+  wrong hash / revoked / broken CMS → never `valid` (finding #284 posture).
+- Public endpoints: `#[PublicPage]` + `#[NoCSRFRequired]` on the POST verify
+  (stateless, no session mutation), brute-force protection, response-shape
+  parity to avoid oracles (CB #100), no document content served.
+- Sealing authorization: authenticated users with access to the file;
+  revocation restricted to admins or the sealer (guard in method body —
+  no-admin-idor gate).
+- Certificate expiry: sealing with an expired certificate is refused;
+  verification of seals made while the certificate was valid reports valid
+  with an `certificateExpired: true` advisory (standard long-term-validation
+  compromise, documented on the verification page).
+
+## Risks / Trade-offs
+
+- [No embedded PAdES → Adobe shows no signature panel] → QR/verification
+  page is the product story (D2); record model is forward-compatible with a
+  later embedded-seal upgrade.
+- [ADR-064 broker API surface for leaf apps may shift] → resolver interface
+  isolates it; interim ICrypto custody path behind the same interface,
+  admin-visible (D3). Open question logged.
+- [Stamp page changes document pagination/layout] → stamp is appended as a
+  final page only, never overlaid; the *hash covers the sealed artifact*, so
+  what is verified is exactly what circulates.
+- [Clock trust for `sealedAt`] → documented limitation (no RFC 3161 TSA this
+  wave); `sealedAt` additionally covered by the CMS signed attributes.
+- [Public endpoint abuse] → rate limiting + high-entropy codes; no
+  enumeration, no content exposure.
+
+## Migration Plan
+
+1. Register addition ships first (additive; new register import on boot).
+2. Backend + admin settings; sealing usable via API.
+3. Public verification page + document-view actions.
+4. Rollback = revert release; existing waarmerk records remain readable
+   (they are plain OR objects), verification page disappears with the app.
+
+## Open Questions
+
+- Exact broker-resolution call for leaf apps under ADR-064 at build time
+  (or#440 `mint()` is sessionless — confirm leaf-app read path); interim
+  ICrypto custody acceptable? (Provisional: yes, behind the resolver
+  interface, flagged in admin UI.)
+- Should batch anonymization auto-seal every output (per-dossier toggle)?
+  (Provisional: manual + per-batch opt-in checkbox; auto-seal default off to
+  keep seals meaningful.)

--- a/openspec/changes/document-waarmerk-certification/proposal.md
+++ b/openspec/changes/document-waarmerk-certification/proposal.md
@@ -1,0 +1,100 @@
+---
+kind: code
+---
+
+# Proposal: document-waarmerk-certification
+
+## Why
+
+Dutch government buyers ask for proof that a published document is the
+authentic, unaltered output of a controlled process — a **waarmerk** applied
+with an *organisation* certificate (the eIDAS *electronic seal* concept,
+Regulation 910/2014 Art. 3(25)/(27): a seal is attached by a legal person,
+distinct from a natural person's signature):
+
+- **De Connectie 391449** (market consultation, REQ2): anonymise **and
+  waarmerk** documents before active publication.
+- **Dordrecht/Drechtsteden 407973 VPB-11**: certification of published
+  documents with an organisation certificate.
+- **Zynyo** productises an embedded ETSI "Deed of Signing"; **Redactable**
+  sells *redaction certificates* (what was redacted, when, by whom);
+  ValidSign ships an "evidence summary" — evidence artifacts are a
+  6-competitor feature theme (research-competitors.md theme #4).
+- User-wishes #10 ranks "document certification/waarmerk + immutable audit"
+  in the deduplicated top-10.
+
+DocuDesk already produces the two artifact families worth certifying —
+anonymized/published PDFs (`AnonymizationService`, which records every run as
+an `anonymizationLink` object with real, verified replacement counts, closing
+GH #286) and generated documents — and already owns a fail-closed
+verification primitive (`SigningVerificationService::verifyDocument`, HMAC
+over a canonicalised document, hardened after finding #284). What is missing
+is the organisation-level seal: a cryptographic waarmerk with a visible
+mark + QR, a public verification surface, processing certificates as
+evidence artifacts, and admin-side organisation-certificate management. No
+Nextcloud ecosystem app offers this (research-nc-ecosystem.md: LibreSign is
+personal-signature-oriented; nobody does org sealing of processed
+documents).
+
+## What Changes
+
+- **Organisation certificate management** in DocuDesk admin settings: upload/
+  reference an X.509 organisation certificate for sealing. The private key is
+  NEVER stored in a register schema or app config — the seal service resolves
+  it at signing time via a `credentialRef` per the ADR-064 custody model
+  (master-data authority = OpenRegister, secret custody = credential broker).
+- **Waarmerk sealing**: certify a processed/published PDF with a detached
+  CMS (PKCS#7) signature over the document hash, made by the organisation
+  certificate; a visible waarmerk stamp page (mark + QR + verification code)
+  is appended to the sealed PDF; a `waarmerk` record is stored via
+  OpenRegister.
+- **Processing certificates** as evidence artifacts: an anonymization
+  certificate PDF generated from the existing `anonymizationLink` +
+  anonymization-run data (entity-type counts, backend, timestamps, acting
+  user — never entity values), itself sealed with the waarmerk.
+- **Verification**: a public verification page + endpoint that validates a
+  waarmerk by verification code and uploaded/recomputed document hash,
+  fail-closed (mirroring the finding-#284 posture of the existing verify
+  path). Existing `signing#verify` stays untouched; waarmerk verification is
+  a separate, org-seal-specific surface.
+- **Revocation**: a waarmerk can be revoked (with reason); verification of a
+  revoked waarmerk reports revoked, never valid.
+
+## Capabilities
+
+### New Capabilities
+
+- `document-waarmerk-certification`: organisation-certificate waarmerk
+  (eIDAS electronic-seal concept) on processed/published PDFs — sealing with
+  visible mark + QR, processing certificates as sealed evidence artifacts,
+  public fail-closed verification, revocation, and admin certificate
+  management with credentialRef key custody.
+
+### Modified Capabilities
+
+<!-- none — document-signing requirements are unchanged; the waarmerk is a
+     separate organisational surface. SigningVerificationService is reused
+     as a pattern, not modified in contract. -->
+
+## Impact
+
+- **Backend**: new `WaarmerkService` (hashing, CMS sealing via OpenSSL,
+  stamp-page composition, QR), new `ProcessingCertificateService` (evidence
+  PDF from anonymization data via the existing `PdfService`), new
+  `WaarmerkController`; admin settings section for the org certificate.
+- **Register**: new `certification` register in
+  `lib/Settings/docudesk_register.json` with a `waarmerk` schema (record of
+  each seal: document refs, hash, certificate fingerprint, verification
+  code, status).
+- **Routes**: seal/list/show/revoke endpoints (authenticated) + public
+  verification endpoints (`#[PublicPage]`) in `appinfo/routes.php`.
+- **Frontend**: waarmerk actions on document views, a public verification
+  page, admin settings panel (ADR-012 Cn components).
+- **Dependencies**: PHP OpenSSL extension (already required by Nextcloud);
+  a QR code is rendered without new heavy deps (design.md D5). Credential
+  custody depends on the ADR-064 broker contract (`credentialRef`); the
+  design documents the dependency and the fail-closed behaviour when no key
+  is resolvable.
+- **GDPR**: certificates are data-minimised (AVG Art. 5(1)(c)) — entity
+  *types and counts* only, never detected values; verification exposes no
+  document content.

--- a/openspec/changes/document-waarmerk-certification/specs/document-waarmerk-certification/spec.md
+++ b/openspec/changes/document-waarmerk-certification/specs/document-waarmerk-certification/spec.md
@@ -1,0 +1,178 @@
+# document-waarmerk-certification Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Certify processed/published documents with an organisation certificate — a
+cryptographic **waarmerk** (eIDAS electronic-seal concept, Regulation
+910/2014 Art. 3(25)/(27): attached by a legal person, distinct from a
+personal signature). Covers sealing with a visible mark + QR, processing
+certificates as data-minimised evidence artifacts grounded in the recorded
+anonymization data, a public fail-closed verification surface, revocation,
+and admin-side organisation-certificate management with ADR-064 key custody.
+
+## ADDED Requirements
+
+### Requirement: Organisation certificate is managed in admin settings with credentialRef key custody (REQ-DDWMK-001)
+
+The app MUST provide an admin-settings section to configure the waarmerk
+organisation certificate: upload/paste the X.509 certificate (PEM, public
+material), display its subject, fingerprint, and expiry, and store a
+`credentialRef` reference to the private key. Private key material MUST
+NEVER be stored in a register schema, in plain app config, or written to
+logs (ADR-064 custody model); the key MUST be resolved through a custody
+resolver at seal time only and held only in memory. When no interim local
+custody is configured, the resolver MUST use the fleet credential broker via
+the stored `credentialRef`; an interim encrypted-at-rest local custody mode
+(Nextcloud `ICrypto`) MAY be offered behind the same resolver interface and
+MUST be visibly labelled as local custody in the admin UI. Sealing with an
+expired certificate MUST be refused.
+
+#### Scenario: Admin configures the organisation certificate
+
+- GIVEN a Nextcloud admin on the DocuDesk admin settings page
+- WHEN they upload the organisation certificate PEM and set the private-key `credentialRef`
+- THEN the panel shows the certificate subject, fingerprint, and expiry
+- AND no private-key material appears in any register object, app-config value, or log line
+- @e2e tests/e2e/spec-coverage/document-waarmerk-certification.spec.ts
+
+#### Scenario: Unresolvable key fails sealing closed
+
+- GIVEN a configured certificate whose `credentialRef` cannot be resolved
+- WHEN a user attempts to seal a document
+- THEN the request fails with a clear service-unavailable error naming key resolution
+- AND no unsealed or partially sealed artifact is produced
+- @e2e exclude broker-outage fault injection is not browser-drivable; covered by PHPUnit (tests/unit/Service/WaarmerkServiceTest.php)
+
+### Requirement: A processed PDF can be sealed with a waarmerk (REQ-DDWMK-002)
+
+The app MUST let an authenticated user with access to a processed/published
+PDF apply a waarmerk via `POST /api/waarmerk/seal`: compose the sealed
+artifact by appending a visible stamp page (waarmerk mark, organisation
+name, `sealedAt`, verification code, and a QR encoding the public
+verification URL — QR generated locally, no external service), compute the
+sha256 over the sealed artifact (verification-code field canonicalised), and
+sign that hash as a **detached CMS (PKCS#7)** structure with the
+organisation certificate via OpenSSL. A `waarmerk` record MUST be stored via
+OpenRegister in the new `certification` register carrying the document
+references, `documentHash`, `sealType`, the CMS signature, certificate
+fingerprint and subject, a high-entropy `verificationCode`, `sealedAt`,
+`sealedBy`, and `status: active`. All evidence fields MUST be write-once:
+after creation only the revocation fields of REQ-DDWMK-005 may change. The
+stamp page MUST be appended as a final page and MUST NOT overlay or alter
+existing pages. The UI and documentation MUST describe the waarmerk as an
+organisation seal (advanced level at most) and MUST NOT claim a qualified
+seal.
+
+#### Scenario: WOO officer seals an anonymized PDF
+
+- GIVEN an anonymized PDF the user can access
+- WHEN they trigger "Waarmerk toevoegen" on the document
+- THEN a sealed PDF is produced whose final page shows the waarmerk mark, organisation name, verification code, and QR
+- AND a `waarmerk` object exists with `status: active`, the sha256 of the sealed artifact, and the detached CMS signature
+- @e2e tests/e2e/spec-coverage/document-waarmerk-certification.spec.ts
+
+#### Scenario: Evidence fields are write-once
+
+- GIVEN an existing `waarmerk` record
+- WHEN any API attempts to modify `documentHash`, `cmsSignature`, `verificationCode`, or `sealedAt`
+- THEN the modification is rejected
+- AND the stored evidence fields are byte-identical to their values at creation
+- @e2e exclude immutability contract is an API/service invariant; covered by PHPUnit (tests/unit/Service/WaarmerkServiceTest.php)
+
+### Requirement: Anonymization runs can be certified with a sealed processing certificate (REQ-DDWMK-003)
+
+The app MUST generate an anonymization **processing certificate** as a PDF
+evidence artifact from already-recorded data only: the `anonymizationLink`
+fields (source and anonymized file name/path, `outputFormat`,
+`replacementCount`, `runCount`, `anonymizedAt`, `anonymizedBy`), the
+per-entity-type detection/redaction counts of the run, and the configured
+detection-backend identifier. The certificate MUST contain entity **types
+and counts only — never detected entity values or document text** (AVG Art.
+5(1)(c) data minimisation; Art. 5(2) accountability). The certificate PDF
+MUST itself be sealed through REQ-DDWMK-002 with `sealType:
+processing-certificate` and the `waarmerk` record MUST reference the
+`anonymizationLinkId`. Nothing SHALL be re-derived from document content at
+certificate time — the certificate attests the recorded run.
+
+#### Scenario: Processing certificate for an anonymization run
+
+- GIVEN a completed anonymization with an `anonymizationLink` record
+- WHEN the user requests an anonymization certificate for it
+- THEN a sealed certificate PDF is produced stating what was detected/redacted per entity type (counts), when, by which backend, and by whom
+- AND the certificate contains no entity values and no document text
+- AND its `waarmerk` record carries `sealType: processing-certificate` and the `anonymizationLinkId`
+- @e2e tests/e2e/spec-coverage/document-waarmerk-certification.spec.ts
+
+### Requirement: A waarmerk is publicly verifiable, fail-closed (REQ-DDWMK-004)
+
+The app MUST expose a public verification surface requiring no Nextcloud
+account: `GET /verify/{code}` (human page showing status, organisation,
+seal timestamp, and document name only) and `POST /api/waarmerk/verify`
+accepting `{code, sha256}` where the sha256 is computed by the verifier —
+the verification page MUST compute it client-side (WebCrypto) from a
+locally selected file so document bytes never leave the verifier's machine.
+The server MUST compare the submitted hash with the recorded
+`documentHash` AND validate the stored CMS signature against the stored
+certificate, returning exactly one of `valid`, `hash-mismatch`, `revoked`,
+`unknown`. Verification MUST be fail-closed: any unverifiable state
+(unknown code, broken CMS, certificate mismatch) MUST NOT report `valid`.
+Public endpoints MUST be rate-limited against brute force; verification
+codes MUST be high-entropy and non-enumerable, and response shape for
+non-matching codes MUST NOT act as an existence oracle. The page MUST serve
+no document content and offer no file download. A seal made while the
+certificate was valid but verified after its expiry MUST report `valid`
+with a `certificateExpired: true` advisory.
+
+#### Scenario: Citizen verifies a sealed document via the QR
+
+- GIVEN a citizen holding a sealed PDF and scanning its QR code
+- WHEN they open the verification page and select their local copy of the file
+- THEN the page computes the hash locally and reports `valid` with the organisation name and seal timestamp
+- AND the file is not uploaded to the server
+- @e2e tests/e2e/spec-coverage/document-waarmerk-certification.spec.ts
+
+#### Scenario: Tampered document is detected
+
+- GIVEN a sealed document whose bytes were modified after sealing
+- WHEN it is verified against its waarmerk code
+- THEN the result is `hash-mismatch`
+- AND the result is never `valid`
+- @e2e tests/e2e/spec-coverage/document-waarmerk-certification.spec.ts
+
+#### Scenario: Unknown code yields no oracle
+
+- GIVEN a syntactically plausible but non-existent verification code
+- WHEN verification is attempted
+- THEN the result is `unknown` with a response shape identical to other non-valid outcomes
+- AND repeated attempts are rate-limited
+- @e2e exclude timing/oracle parity and throttling assertions are not reliably browser-testable; covered by PHPUnit (tests/unit/Controller/WaarmerkControllerTest.php)
+
+### Requirement: A waarmerk can be revoked and revocation dominates verification (REQ-DDWMK-005)
+
+The app MUST allow revoking a waarmerk via `POST /api/waarmerk/{id}/revoke`
+with a mandatory reason. Revocation MUST be restricted by an in-method
+authorization guard to admins or the original sealer. Revocation sets only
+`status: revoked`, `revokedAt`, `revokedBy`, `revocationReason`; every
+other field stays immutable. Verification of a revoked waarmerk MUST return
+`revoked` regardless of hash match and MUST NEVER return `valid`.
+Revocation MUST be irreversible via the API.
+
+#### Scenario: Revoked seal never verifies as valid
+
+- GIVEN a waarmerk revoked with reason "document withdrawn after objection"
+- WHEN the (unmodified) sealed document is verified with the correct code and hash
+- THEN the result is `revoked`
+- AND the human page shows the revocation date but not internal notes beyond the recorded reason
+- @e2e tests/e2e/spec-coverage/document-waarmerk-certification.spec.ts
+
+#### Scenario: Non-sealer non-admin cannot revoke
+
+- GIVEN an authenticated user who is neither an admin nor the sealer of a waarmerk
+- WHEN they call the revoke endpoint for it
+- THEN the request is rejected with 403
+- AND the waarmerk remains `active`
+- @e2e exclude authorization-guard negative path; covered by PHPUnit (tests/unit/Controller/WaarmerkControllerTest.php)

--- a/openspec/changes/document-waarmerk-certification/tasks.md
+++ b/openspec/changes/document-waarmerk-certification/tasks.md
@@ -1,0 +1,51 @@
+# Tasks: document-waarmerk-certification
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 14.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Register & data model
+
+- [ ] 1.1 Add the `certification` register + `waarmerk` schema to `lib/Settings/docudesk_register.json` (fields per design.md: document refs, `documentHash`, `sealType` enum, `cmsSignature`, certificate fingerprint/subject, `verificationCode`, `sealedAt`/`sealedBy`, `status` enum, revocation fields, optional `anonymizationLinkId` relation)
+  - Additive import on boot; `tests/validate-manifest.js` passes; NO key material fields anywhere (ADR-064)
+
+- [ ] 1.2 Seed data: demo `waarmerk` object (nil-UUID, Demostad, placeholder CMS/fingerprint per design.md Seed Data); test bootstrap generates a throwaway self-signed org certificate at runtime — no PEM/key fixture committed
+
+## 2. Backend
+
+- [ ] 2.1 Custody resolver + admin settings: certificate PEM storage (public material), fingerprint/expiry display, `credentialRef` storage; broker resolution with interim `ICrypto` local-custody mode behind the same interface, labelled in UI; expired-cert seal refusal; key never persisted or logged (REQ-DDWMK-001)
+
+- [ ] 2.2 `WaarmerkService::seal()`: stamp-page composition via `PdfService` (Twig template, brandable) + local QR SVG, canonicalised sha256 over sealed artifact, detached CMS via `openssl_cms_sign` (pkcs7 fallback), write-once `waarmerk` record via ObjectService (REQ-DDWMK-002)
+  - Stamp appended as final page only; fail-closed on unresolvable key (503, no artifact)
+
+- [ ] 2.3 `ProcessingCertificateService`: anonymization certificate PDF from `anonymizationLink` + run entity-type counts + backend id + acting user; types/counts only — never entity values; sealed with `sealType: processing-certificate` + `anonymizationLinkId` (REQ-DDWMK-003)
+
+- [ ] 2.4 Verification: `POST /api/waarmerk/verify` (`{code, sha256}` → `valid|hash-mismatch|revoked|unknown`, CMS validation via `openssl_cms_verify`, fail-closed, oracle-free response parity, rate-limited) and revocation endpoint with in-method admin-or-sealer guard, reason mandatory, irreversible (REQ-DDWMK-004/005)
+
+## 3. Routes & controller
+
+- [ ] 3.1 `WaarmerkController` + routes in `appinfo/routes.php`: seal, list/show, revoke (authenticated, explicit attributes); `GET /verify/{code}` page + `POST /api/waarmerk/verify` as `#[PublicPage]` with brute-force protection
+  - route-auth/semantic-auth/no-admin-idor gates pass; public endpoints serve no document content
+
+## 4. Frontend (ADR-012)
+
+- [ ] 4.1 Document surfaces: "Waarmerk toevoegen" action + waarmerk badge on My Documents/anonymization results; anonymization-certificate action on runs; dialogs in `src/modals/`
+
+- [ ] 4.2 Public verification page: standalone entry, client-side WebCrypto hash of a locally selected file (bytes never uploaded), status rendering incl. `certificateExpired` advisory; NL Design System tokens, WCAG AA (citizen-facing)
+
+- [ ] 4.3 Admin settings panel (settings framework, NOT vue-router): PEM upload, fingerprint/expiry, `credentialRef`, custody-mode label, test-seal button
+
+## 5. Quality, i18n, docs
+
+- [ ] 5.1 Unit tests ≥75% on new code (seal/verify round-trip with runtime-generated cert, tamper detection, revocation dominance, write-once invariant, oracle parity, key-never-logged assertion); run in container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`
+
+- [ ] 5.2 Playwright e2e `tests/e2e/spec-coverage/document-waarmerk-certification.spec.ts` (seal → QR page → verify valid / tampered / revoked); verify on Postgres (8080); test with nldesign theme enabled
+
+- [ ] 5.3 i18n EN source + NL translations for all new strings, incl. the public page (citizen-facing Dutch first-class)
+
+- [ ] 5.4 Docs in `docs/features/` (waarmerk, processing certificate, verification; explicit "organisation seal, not qualified seal" wording) with Playwright screenshots (ADR-010); `openspec validate document-waarmerk-certification --strict` passes
+
+## Quality checklist
+
+- ADR-064: no secret in schema/appconfig/logs — reviewer greps for PEM headers and `credentialRef` misuse
+- Fail-closed verified by mutation-style tests (flip hash byte, strip CMS, revoke) — never `valid`
+- `composer check:strict` green; hydra gates pass; end-to-end verified against OpenRegister on Postgres dev instance

--- a/openspec/changes/ocr-trigger-surface/.openspec.yaml
+++ b/openspec/changes/ocr-trigger-surface/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/ocr-trigger-surface/design.md
+++ b/openspec/changes/ocr-trigger-surface/design.md
@@ -1,0 +1,219 @@
+# Design: ocr-trigger-surface
+
+## Context
+
+Verified at HEAD:
+
+- `OcrService` public seams: `isTesseractAvailable()`,
+  `getTesseractVersion()`, `needsOcr(string $mimeType, ?string
+  $existingText)`, `isOcrEnabled()` (`ocr_enabled`, default on),
+  `getOcrLanguages()` (`ocr.default_languages` with legacy
+  `ocr_languages` fallback, default `nld+eng`), `getOcrDpi()`
+  (`ocr.default_dpi` / legacy `ocr_dpi`, default 300),
+  `extractTextFromImage()`, `extractTextFromPdf()`, and
+  `processFile(int $fileId): array{text, confidence, ocrProcessed}` —
+  which already handles disabled-OCR, missing Tesseract, missing file and
+  non-candidate MIME by returning `ocrProcessed: false` absent-safely.
+- Callers: exactly one — `FinancialExtractionService::resolveText()`
+  (scan-en-herken). No route, no UI, no anonymisation-pipeline use.
+- `AnonymizationService::extractAndDetectEntities(int $fileId)` calls OR
+  `TextExtractionService::extractFile($fileId, true)` then
+  `EntityRelationMapper::findEntitiesForFile($fileId)`.
+- OpenRegister does NO OCR (zero OCR/Tesseract references in
+  `TextExtractionService` + `lib/Service/TextExtraction/` handlers,
+  verified against the local openregister checkout). OR's pipeline is:
+  extract (FileHandler/PdfExtractor/WordExtractor/...) → `textToChunks`
+  → `persistChunksForSource` (private) →
+  `EntityRecognitionHandler::processSourceChunks`. There is **no public
+  seam to ingest externally-supplied text for a fileId** at HEAD.
+- `FileListingService::buildFileInfo()` returns `ocrProcessed` =
+  (OCR-candidate MIME && status !== 'uploaded') and `ocrConfidence` =
+  `null` — a heuristic, not a record; the canonical
+  `ocr-document-scanning` spec's REQ-OCR-05 and its Architecture note
+  ("Called by `AnonymizationService::extractAndDetectEntities()`") do not
+  match the code. This change makes the spec true instead of leaving it
+  aspirational.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give the existing OCR engine an invocation surface: route, UI action,
+  and automatic anonymisation-pipeline fallback.
+- Make per-file OCR status honest and persistent.
+- Pin the DocuDesk↔OpenRegister OCR division of labour in a spec.
+
+**Non-Goals:**
+
+- No OCR engine work (Tesseract wrapping, rasterisation, confidence —
+  all exist and stay as-is).
+- No searchable-PDF ("sandwich PDF") output, no image redaction/blackout
+  of scans — scans get *detection and review*; visual redaction of image
+  content is a separate future change.
+- No change to scan-en-herken (`FinancialExtractionService` keeps its own
+  `resolveText()` path).
+- No background/bulk OCR queue — bulk behaviour arrives via
+  `redaction-at-scale` work units, which call the same pipeline.
+
+## Decisions
+
+### D1 — OCR stays in DocuDesk; OR ingests text (the boundary decision)
+
+Per the project boundaries, extraction/detection engines live in
+OpenRegister — but OCR is a *text acquisition* step OR deliberately does
+not perform, and DocuDesk already owns a hardened local Tesseract path
+used by scan-en-herken. **Decision:** DocuDesk remains the OCR provider;
+OpenRegister remains the single owner of chunking + entity detection. The
+recovered OCR text must therefore enter OR's pipeline, which requires an
+OR-side ingestion seam (D2). Rejected alternatives: (a) moving OcrService
+into OR — right long-term home, but a cross-app engine migration is out
+of this change's scope and would orphan the scan-en-herken caller; (b)
+DocuDesk running its own entity detection over OCR text — duplicates the
+engine (ADR-022 violation) and forks entity storage.
+
+### D2 — Cross-app dependency: an OR provided-text ingestion seam
+
+OR has no public API to persist chunks for externally-supplied text
+(`persistChunksForSource` is private; `chunkDocument()` is public but
+returns arrays without persisting). **Decision:** this change declares an
+explicit OpenRegister dependency — an `extractFile()` overload or sibling
+(e.g. `extractFromProvidedText(int $fileId, string $text)`) that chunks,
+persists and runs entity recognition for a fileId using caller-provided
+text; filed as an OR issue and implemented as a small OR PR before this
+change's task 2.3 can complete. **Degraded behaviour until it lands
+(fail-flagged, never fail-silent):** the extract response and review UI
+mark the file `ocrDetectionPending` — OCR ran, text was recovered, but
+entity detection could not consume it. The requirement (REQ-DDOCR-004)
+scenarios cover both states. Rejected: DocuDesk writing OR `Chunk` rows
+via container-resolved mappers — reaching into another app's private
+persistence dialect is how silent drift defects happen.
+
+### D3 — Fallback placement: inside `extractAndDetectEntities()`, after OR extraction
+
+**Decision:** the fallback branch runs in
+`AnonymizationService::extractAndDetectEntities()`: call OR
+`extractFile()` first (cheap for born-digital files, unchanged behaviour),
+then consult `OcrService::needsOcr(mime, extractedText)` — for candidate
+files whose extraction yielded empty/near-empty text, run
+`OcrService::processFile()` and ingest via D2. This keeps the trigger at
+the orchestration layer where prohibition matching and grondslag proposals
+already hang, so OCR-recovered entities flow through the SAME
+post-processing (proposals, prohibition/standing-consent matches, risk
+level) with zero extra wiring. "Low text" uses `needsOcr()`'s existing
+empty-after-trim semantics for PDFs — no new heuristic invented in v1.
+
+### D4 — Honest OCR status: a new `ocrResult` OR object
+
+`FileListingService`'s heuristic must go. Options: NC file metadata
+(non-queryable, lost on rescan), extending `anonymizationLink` (wrong
+lifecycle — OCR happens before/without anonymisation), or a dedicated OR
+object. **Decision:** new `ocrResult` schema keyed by `fileId`
+(idempotency key; re-running OCR updates the object): `confidence`,
+`languages`, `dpi`, `textLength`, `ocrProcessedAt`, `triggeredBy`
+(`manual` | `fallback`), `engineVersion` (Tesseract version string).
+`FileListingService.buildFileInfo()` returns `ocrProcessed: true` +
+`ocrConfidence` only when an `ocrResult` exists; candidates without one
+return `ocrProcessed: false, ocrAvailable: true` so the UI can offer the
+action. GDPR note: `ocrResult` stores metadata only — never the OCR text
+itself (the text lives in OR chunks like all other extracted text; data
+minimisation, no second PII store).
+
+### D5 — Route/UI contract mirrors the admin settings exactly
+
+`POST /api/ocr/{fileId}`: 200 with the result on success; **409** when
+OCR is disabled by the admin toggle (client error, actionable); **503**
+when enabled but Tesseract is not installed (server-side capability
+missing, matches the settings-page status display); **404** unknown file;
+**400** non-candidate MIME. The UI action renders only when the file
+listing says `ocrAvailable` and settings say enabled+installed — but the
+server checks again (UI visibility is not authorization). Response never
+includes the extracted text (it goes to OR chunks; the API returns
+`textLength` + confidence).
+
+### D6 — Declarative vs imperative (ADR-031)
+
+- `ocrResult` schema: **declarative** register addition; no lifecycle
+  annotation (single-state metadata record).
+- Controller, fallback branch, OR ingestion call: **imperative** — NLP
+  pipeline orchestration and external-engine invocation are valid ADR-031
+  exception categories. No aggregations/notifications/relations dialects
+  involved.
+
+### D7 — OpenRegister usage (ADR-001) and frontend (ADR-012)
+
+`ocrResult` persisted via the existing AppHost/ObjectService pattern (no
+custom tables). OR services consumed: `TextExtractionService` (extract +
+the D2 ingestion seam), `EntityRelationMapper` (unchanged reads). ADR-011
+check: no new validation/formatting utilities; Tesseract wrapping already
+exists in `OcrService`. Frontend: the Run-OCR action joins the existing
+MyDocuments action menus and file-viewer header; confidence badge uses NC
+CSS variables (ADR-003); strings EN-keyed with NL translations (ADR-005).
+
+## Seed Data
+
+```json
+// ocrResult — a scanned municipal letter, manually OCR'd
+{ "fileId": 812004,
+  "confidence": 91.4,
+  "languages": "nld+eng",
+  "dpi": 300,
+  "textLength": 4231,
+  "ocrProcessedAt": "2026-07-16T10:05:00Z",
+  "triggeredBy": "manual",
+  "engineVersion": "tesseract 5.3.0" }
+
+// ocrResult — a scan swept up by the anonymisation fallback
+{ "fileId": 812005,
+  "confidence": 78.9,
+  "languages": "nld+eng",
+  "dpi": 300,
+  "textLength": 1876,
+  "ocrProcessedAt": "2026-07-16T10:06:12Z",
+  "triggeredBy": "fallback",
+  "engineVersion": "tesseract 5.3.0" }
+```
+
+Seed task: include one scanned-PDF sample document (tests/sample-documents
+already exists) + its `ocrResult` so the badge and status render on a
+clean install.
+
+## Risks / Trade-offs
+
+- [OR ingestion seam is cross-app and may lag] → D2 degraded-but-flagged
+  behaviour; the DocuDesk surface (route, UI, status, settings) is
+  independently shippable and testable; the fallback's detection leg
+  activates when the seam lands.
+- [OCR on large PDFs is slow (Imagick rasterisation at 300 DPI)] → the
+  route is synchronous per file (matches the existing extract-one-file
+  interaction); bulk OCR flows through `redaction-at-scale` ticks;
+  the UI shows a busy state and the route enforces one concurrent OCR per
+  user (same fail-fast style as the soffice lock).
+- [Low-confidence OCR yields garbage entities] → confidence is persisted
+  and surfaced on the review workbench (low-confidence visual flag
+  already exists in the entity-review capability); no auto-commit ever
+  happens without the human gate.
+- [ocrProcessed semantics change for existing UI consumers
+  (FileEntitiesDashboardWidget reads it)] → the field keeps its name and
+  boolean type; only its truth improves. `ocrConfidence` goes from
+  always-null to sometimes-set — additive.
+
+## Migration Plan
+
+1. Register JSON: add `ocrResult` (additive, union-merge).
+2. Ship `OcrController` + routes + UI action + honest FileListingService
+   reads (independently valuable: manual OCR works end-to-end minus
+   detection).
+3. Land the OR ingestion seam (cross-app PR); flip the fallback's
+   detection leg from `ocrDetectionPending` to full ingestion.
+4. Rollback: the admin `ocr_enabled` toggle disables the whole surface
+   (route 409s, UI hides); no data migration to unwind.
+
+## Open Questions
+
+- Should `triggeredBy: fallback` OCR runs be rate-limited per batch to
+  protect ticks (a 480-file scan dossier = 480 OCR runs)? Provisional:
+  bounded by `redaction-at-scale`'s `seconds_per_tick` budget; no
+  separate OCR budget in v1.
+- Long-term: migrate `OcrService` into OpenRegister as a text-extraction
+  handler so ALL OR consumers get OCR? Logged as the architectural
+  follow-up in the OR issue of D2 — explicitly out of scope here.

--- a/openspec/changes/ocr-trigger-surface/proposal.md
+++ b/openspec/changes/ocr-trigger-surface/proposal.md
@@ -1,0 +1,102 @@
+---
+kind: code
+tracking_issue: https://github.com/ConductionNL/docudesk/issues/85
+---
+
+# Proposal: ocr-trigger-surface
+
+## Why
+
+DocuDesk ships a complete local OCR engine that the anonymisation product
+cannot reach. Verified at HEAD:
+
+- `lib/Service/OcrService.php` (634 LOC, Tesseract via
+  `thiagoalessio/tesseract_ocr` + Imagick page rasterisation) implements
+  availability probing, MIME/text-based `needsOcr()` detection, image and
+  scanned-PDF extraction with confidence, admin-config languages/DPI and
+  an enable toggle, and a ready-made `processFile(int $fileId)` entry
+  point.
+- Its ONLY caller is `FinancialExtractionService` (the scan-en-herken
+  invoice pipeline). The anonymisation pipeline
+  (`AnonymizationService::extractAndDetectEntities()`) delegates straight
+  to OpenRegister's `TextExtractionService::extractFile()`, which does
+  **no OCR** (verified: zero OCR/Tesseract references in OR's
+  TextExtractionService and its handlers). A scanned PDF therefore
+  extracts empty text, yields zero entities, and sails through review as
+  "nothing to redact" — a silent privacy failure, the exact class GH #285
+  documented for numeric PII.
+- There is no OCR route in `appinfo/routes.php`, no UI trigger, and
+  `FileListingService` fakes the `ocrProcessed` flag (it returns "is an
+  OCR-candidate MIME and not status uploaded", with `ocrConfidence`
+  hardcoded `null`) — while the canonical `ocr-document-scanning` spec
+  (REQ-OCR-05, marked Implemented) claims real per-file OCR metadata, and
+  its Architecture section claims `AnonymizationService` integration that
+  does not exist. This is the orphaned-capability defect class: spec done,
+  engine green, nothing invokes it.
+
+Demand is concrete: **GH #85** (this change's tracking issue) asks for OCR
+in the anonymisation flow; the **algoritmeregister profile** (9 orgs incl.
+Rotterdam, Zaanstad, Min AZ) lists OCR of scans as a standard capability
+of deployed anonymisation systems; the Arnhem tender volume (~55.000
+docs/yr) is heavy on scanned correspondence.
+
+## What
+
+- An **OCR API surface**: `OcrController` with
+  `POST /api/ocr/{fileId}` (run OCR, returns text length, confidence,
+  `ocrProcessed`, language/DPI used) and `GET /api/ocr/{fileId}` (status),
+  wrapping the existing `OcrService::processFile()`.
+- A **"Run OCR" UI action** on scanned/image documents (OCR-candidate
+  MIME types) in the MyDocuments listing and the file viewer, visible only
+  when OCR is enabled and Tesseract is available.
+- **Automatic OCR fallback in the anonymisation extract pipeline**: when
+  OR text extraction yields empty/low text for a PDF/image
+  (`OcrService::needsOcr()` semantics), the pipeline runs OCR and feeds
+  the recovered text into OpenRegister chunking + entity detection, so
+  scans get entity detection instead of silently skipping. Files where
+  OCR is unavailable/disabled are flagged, never silently passed.
+- **Honest OCR status on files**: a new `ocrResult` OR object per file
+  (confidence, languages, DPI, text length, `ocrProcessedAt`);
+  `FileListingService` returns real `ocrProcessed`/`ocrConfidence` from it
+  instead of the MIME heuristic.
+- **Admin settings respected end-to-end**: enable toggle hides the UI
+  action and turns the route into a 409; languages
+  (`ocr.default_languages`, legacy `ocr_languages` fallback) and DPI
+  (`ocr.default_dpi`, legacy `ocr_dpi`) drive every run (existing
+  `OcrService` config reads).
+- **Documented OR relationship**: OpenRegister owns text extraction,
+  chunking and entity detection and does no OCR; DocuDesk's Tesseract path
+  is the local OCR provider that hands recovered text to OR. The OR-side
+  ingestion seam for externally-provided text is specified as this
+  change's cross-app dependency.
+
+## Capabilities
+
+### New Capabilities
+
+- `ocr-trigger-surface`: the OCR invocation surface — API route, UI
+  action, automatic anonymisation-pipeline fallback, honest per-file OCR
+  status, admin-setting enforcement.
+
+### Modified Capabilities
+
+- `ocr-document-scanning`: REQ-OCR-05 (OCR metadata) is corrected from
+  the heuristic to real persisted per-file results; the capability's
+  claimed-but-absent `AnonymizationService` integration becomes a real,
+  specified requirement.
+
+## Impact
+
+- **Backend**: new `OcrController` + routes; `AnonymizationService::
+  extractAndDetectEntities()` gains the fallback branch;
+  `FileListingService::buildFileInfo()` reads `ocrResult` objects;
+  `OcrService` itself is unchanged (it already has every needed seam).
+- **Register JSON**: new `ocrResult` schema (additive).
+- **Frontend**: "Run OCR" action in MyDocuments/file viewer; OCR badge
+  with confidence; existing OCR admin settings section untouched.
+- **Cross-app dependency (OpenRegister)**: an ingestion seam for
+  externally-supplied text per fileId (so OCR text enters OR chunking +
+  entity detection); tracked as an explicit task with a degraded-but-
+  flagged behaviour until it lands.
+- **No external services**: Tesseract runs on the server; processing
+  stays 100% local (algoritmeregister/EDPB posture).

--- a/openspec/changes/ocr-trigger-surface/specs/ocr-document-scanning/spec.md
+++ b/openspec/changes/ocr-trigger-surface/specs/ocr-document-scanning/spec.md
@@ -1,0 +1,45 @@
+# ocr-document-scanning Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Corrects the OCR metadata requirement to match reality and this change's
+wiring: at HEAD, `FileListingService` fabricates `ocrProcessed` from a
+MIME heuristic with `ocrConfidence` hardcoded null, and the capability's
+claimed integration with `AnonymizationService::extractAndDetectEntities()`
+does not exist (OcrService's only caller is the scan-en-herken financial
+pipeline). With `ocr-trigger-surface`, per-file OCR metadata becomes a
+persisted record and the anonymisation integration becomes real
+(REQ-DDOCR-003/004/005).
+
+## MODIFIED Requirements
+
+### Requirement: OCR Metadata (REQ-OCR-05)
+
+**Priority:** MUST
+
+The system SHALL report OCR confidence scores and track an ocrProcessed flag per file, derived from a persisted per-file `ocrResult` OpenRegister object written by every completed OCR run (manual trigger or anonymisation-pipeline fallback — see `ocr-trigger-surface` REQ-DDOCR-005). The file listing SHALL NOT infer OCR status from MIME type or processing status: `ocrProcessed` SHALL be true only when an `ocrResult` exists for the file, and `ocrConfidence` SHALL be the recorded Tesseract mean confidence (0-100) from that object. OCR-candidate files without an `ocrResult` SHALL report `ocrProcessed: false` with no confidence score and `ocrAvailable: true`.
+
+#### Scenario: Report confidence score
+- GIVEN OCR was performed on a file
+- WHEN the file listing is queried
+- THEN a confidence score (0-100) reflecting Tesseract mean confidence SHALL be reported from the file's persisted `ocrResult`
+- AND the ocrProcessed flag SHALL be true
+- @e2e tests/e2e/spec-coverage/ocr-trigger.spec.ts
+
+#### Scenario: Non-OCR files
+- GIVEN a file that did not require OCR
+- WHEN the file listing is queried
+- THEN ocrProcessed SHALL be false
+- AND no confidence score SHALL be reported
+- @e2e exclude listing-shape contract; covered by PHPUnit (tests/unit/Service/FileListingServiceTest.php)
+
+#### Scenario: OCR candidate not yet processed is not faked
+- GIVEN a scanned PDF that has been uploaded but never OCR'd
+- WHEN the file listing is queried
+- THEN ocrProcessed SHALL be false and ocrAvailable SHALL be true
+- AND no confidence score SHALL be reported
+- @e2e exclude listing-shape contract; covered by PHPUnit (tests/unit/Service/FileListingServiceTest.php)

--- a/openspec/changes/ocr-trigger-surface/specs/ocr-trigger-surface/spec.md
+++ b/openspec/changes/ocr-trigger-surface/specs/ocr-trigger-surface/spec.md
@@ -1,0 +1,212 @@
+# ocr-trigger-surface Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+The invocation surface for DocuDesk's existing local Tesseract OCR engine
+(`OcrService`): an API route, a "Run OCR" UI action on scanned/image
+documents, an automatic OCR fallback inside the anonymisation extract
+pipeline (so scans get entity detection instead of silently skipping —
+GDPR Art. 5(1)(f) integrity: undetected PII in scans is unprotected PII),
+honest persisted per-file OCR status, and end-to-end enforcement of the
+existing admin settings (enable toggle, languages, DPI). OpenRegister
+remains the single owner of chunking and entity detection and performs no
+OCR; DocuDesk's Tesseract path is the local OCR provider. All OCR runs
+100% on the server (no external services).
+
+## ADDED Requirements
+
+### Requirement: OCR API route (REQ-DDOCR-001)
+
+The system MUST provide `POST /api/ocr/{fileId}` running OCR on the given
+file via the existing `OcrService::processFile()`, and
+`GET /api/ocr/{fileId}` returning the file's persisted OCR status. The
+POST response MUST include `ocrProcessed`, `confidence`, `textLength`,
+and the `languages`/`dpi` used, and MUST NOT include the extracted text
+itself. Error contract: HTTP 409 when OCR is disabled by the admin
+toggle; HTTP 503 when OCR is enabled but Tesseract is not installed;
+HTTP 404 for an unknown/inaccessible file; HTTP 400 for a MIME type that
+is not an OCR candidate (`needsOcr()` semantics). Both routes MUST
+declare their auth posture and MUST resolve the file through the
+requesting user's folder (no cross-user file access).
+
+#### Scenario: Manual OCR of a scanned PDF succeeds
+
+- GIVEN OCR enabled, Tesseract installed, and a scanned PDF in the user's files
+- WHEN `POST /api/ocr/{fileId}` is called
+- THEN the response reports `ocrProcessed: true` with a confidence score and text length
+- AND the response contains no extracted text body
+- @e2e tests/e2e/spec-coverage/ocr-trigger.spec.ts
+
+#### Scenario: Disabled toggle blocks the route
+
+- GIVEN the admin has set `ocr_enabled` to off
+- WHEN `POST /api/ocr/{fileId}` is called
+- THEN the system returns HTTP 409 stating OCR is disabled
+- @e2e exclude admin-config API error contract; covered by PHPUnit (tests/unit/Controller/OcrControllerTest.php)
+
+#### Scenario: Missing Tesseract yields 503
+
+- GIVEN OCR enabled but no Tesseract binary on the host
+- WHEN `POST /api/ocr/{fileId}` is called
+- THEN the system returns HTTP 503 naming the missing capability
+- @e2e exclude host-capability error contract; covered by PHPUnit (tests/unit/Controller/OcrControllerTest.php)
+
+#### Scenario: Non-candidate MIME is rejected
+
+- GIVEN a `.docx` file (not an OCR-candidate MIME)
+- WHEN `POST /api/ocr/{fileId}` is called
+- THEN the system returns HTTP 400
+- @e2e exclude API validation contract; covered by PHPUnit (tests/unit/Controller/OcrControllerTest.php)
+
+### Requirement: "Run OCR" UI action (REQ-DDOCR-002)
+
+The system MUST offer a "Run OCR" action on OCR-candidate documents
+(image MIME types and PDFs) in the MyDocuments file listing and the
+in-app file viewer. The action MUST be rendered only when OCR is enabled
+and Tesseract is available (server-verified again on invocation — UI
+visibility is not authorization). While running, the action MUST show a
+busy state; on completion the file's OCR badge (status + confidence) MUST
+update without a page reload; on failure the error reason MUST be shown
+to the user.
+
+#### Scenario: User runs OCR from MyDocuments
+
+- GIVEN a scanned PDF listed in MyDocuments with `ocrProcessed: false`
+- WHEN the user triggers "Run OCR" on the file
+- THEN a busy state is shown while OCR runs
+- AND on completion the file row shows an OCR badge with the confidence score
+- @e2e tests/e2e/spec-coverage/ocr-trigger.spec.ts
+
+#### Scenario: Action hidden when OCR is disabled
+
+- GIVEN the admin has disabled OCR
+- WHEN the user opens MyDocuments
+- THEN no "Run OCR" action is offered on any file
+- @e2e tests/e2e/spec-coverage/ocr-trigger.spec.ts
+
+### Requirement: Automatic OCR fallback in the anonymisation extract pipeline (REQ-DDOCR-003)
+
+`AnonymizationService::extractAndDetectEntities()` MUST, after
+OpenRegister text extraction completes, evaluate
+`OcrService::needsOcr(mimeType, extractedText)` for the file; when it
+returns true (image MIME, or PDF whose extraction yielded empty text) and
+OCR is enabled and available, the pipeline MUST run
+`OcrService::processFile()` and hand the recovered text to OpenRegister
+for chunking and entity detection (REQ-DDOCR-004), so that
+OCR-recovered entities flow through the SAME post-processing as native
+extractions (grondslag proposals, prohibition/standing-consent matching,
+risk level). Born-digital files whose extraction yielded text MUST NOT
+trigger OCR (no behaviour change). A candidate file for which OCR cannot
+run (disabled, unavailable, or zero text recovered) MUST be explicitly
+flagged in the extract response (`ocrSkipped` with a reason) — never
+silently reported as "no entities".
+
+#### Scenario: Scanned PDF gets entity detection via fallback
+
+- GIVEN OCR enabled and a scanned PDF containing a name and a BSN, uploaded to the anonymisation flow
+- WHEN extraction runs
+- THEN OR extraction yields empty text, the OCR fallback runs, and the recovered text is ingested
+- AND the review shows the detected PERSON and BSN entities with proposals and policy matches applied
+- @e2e tests/e2e/spec-coverage/ocr-trigger.spec.ts
+
+#### Scenario: Born-digital PDF skips OCR
+
+- GIVEN a born-digital PDF with embedded text
+- WHEN extraction runs
+- THEN no OCR is performed and extraction behaves exactly as before this change
+- @e2e exclude no-op regression path; covered by PHPUnit (tests/unit/Service/AnonymizationServiceTest.php)
+
+#### Scenario: Scan with OCR unavailable is flagged, not silent
+
+- GIVEN Tesseract not installed and a scanned PDF in the anonymisation flow
+- WHEN extraction runs
+- THEN the extract response carries `ocrSkipped` with reason `tesseract_unavailable`
+- AND the review UI shows a warning that the document could not be scanned for entities
+- @e2e tests/e2e/spec-coverage/ocr-trigger.spec.ts
+
+### Requirement: OCR text enters OpenRegister detection via the ingestion seam (REQ-DDOCR-004)
+
+Recovered OCR text MUST be handed to OpenRegister through a provided-text
+ingestion seam (an `extractFromProvidedText(int $fileId, string $text)`
+style API on OR's `TextExtractionService`) that chunks, persists and runs
+entity recognition for the file, keeping OpenRegister the single owner of
+chunk storage and entity detection. DocuDesk MUST NOT write OR chunk
+persistence directly and MUST NOT run its own entity detection over OCR
+text. Until the OR seam is available at runtime, the pipeline MUST
+degrade fail-flagged: the extract response and review UI mark the file
+`ocrDetectionPending` (OCR ran; detection could not consume the text),
+and the file MUST NOT be reported as reviewed-clean.
+
+#### Scenario: Ingested OCR text produces OR-detected entities
+
+- GIVEN the OR provided-text seam available and a scanned PDF whose OCR recovered text
+- WHEN the fallback ingests the text
+- THEN OR persists chunks for the file and `EntityRelationMapper::findEntitiesForFile()` returns the detected entities
+- @e2e exclude cross-app seam integration; covered by PHPUnit integration tests with OpenRegister installed (tests/integration)
+
+#### Scenario: Seam absent degrades fail-flagged
+
+- GIVEN an OpenRegister version without the provided-text seam
+- WHEN the fallback runs OCR on a scan
+- THEN the extract response carries `ocrDetectionPending: true`
+- AND the review UI shows the pending-detection warning for the document
+- @e2e exclude version-skew degradation branch; covered by PHPUnit (tests/unit/Service/AnonymizationServiceTest.php)
+
+### Requirement: Honest persisted OCR status per file (REQ-DDOCR-005)
+
+Every completed OCR run (manual or fallback) MUST persist an `ocrResult`
+OpenRegister object keyed by `fileId` (re-runs update it) recording
+`confidence`, `languages`, `dpi`, `textLength`, `ocrProcessedAt`,
+`triggeredBy` (`manual` | `fallback`) and `engineVersion`. The object
+MUST NOT store the OCR text itself (data minimisation — the text lives in
+OR chunks like all extracted text). `FileListingService` MUST derive
+`ocrProcessed` and `ocrConfidence` from the `ocrResult` object — the
+MIME-heuristic fabrication of these fields MUST be removed. Files that
+are OCR candidates without an `ocrResult` MUST report
+`ocrProcessed: false` plus `ocrAvailable: true` so the UI can offer the
+action.
+
+#### Scenario: File listing reflects a real OCR run
+
+- GIVEN a scanned PDF that was OCR'd at confidence 91.4
+- WHEN the file listing is queried
+- THEN the file reports `ocrProcessed: true` and `ocrConfidence: 91.4`
+- @e2e tests/e2e/spec-coverage/ocr-trigger.spec.ts
+
+#### Scenario: Candidate without a run is no longer faked
+
+- GIVEN an extracted (non-OCR'd) born-digital PDF
+- WHEN the file listing is queried
+- THEN the file reports `ocrProcessed: false` and `ocrConfidence: null`
+- AND `ocrAvailable: true`
+- @e2e exclude listing-shape regression contract; covered by PHPUnit (tests/unit/Service/FileListingServiceTest.php)
+
+### Requirement: Admin settings drive every OCR run (REQ-DDOCR-006)
+
+The system MUST apply the existing admin settings to every OCR invocation
+on every surface (route, UI action, pipeline fallback) via the existing
+`OcrService` reads: the enable toggle (`ocr_enabled`), the language
+models (`ocr.default_languages`, legacy `ocr_languages` fallback, default
+`nld+eng`) and the DPI (`ocr.default_dpi`, legacy `ocr_dpi` fallback,
+default 300). Changed settings MUST take effect on the next run without
+restart. The persisted `ocrResult` MUST record the languages and DPI
+actually used.
+
+#### Scenario: Custom languages are applied and recorded
+
+- GIVEN the admin sets the OCR languages to `nld+deu`
+- WHEN a user runs OCR on a scan
+- THEN Tesseract runs with `nld+deu`
+- AND the file's `ocrResult` records `languages: "nld+deu"`
+- @e2e exclude settings pass-through; covered by PHPUnit (tests/unit/Service/OcrServiceTest.php, OcrControllerTest.php)
+
+#### Scenario: Toggle change takes effect immediately
+
+- GIVEN OCR was enabled and a user has MyDocuments open
+- WHEN the admin disables OCR and the user triggers a (stale) Run OCR action
+- THEN the server returns HTTP 409 and the UI surfaces the disabled state
+- @e2e tests/e2e/spec-coverage/ocr-trigger.spec.ts

--- a/openspec/changes/ocr-trigger-surface/tasks.md
+++ b/openspec/changes/ocr-trigger-surface/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: ocr-trigger-surface
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 13.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Register & seed data
+
+- [ ] 1.1 Add the `ocrResult` schema (`fileId` idempotency key, `confidence`, `languages`, `dpi`, `textLength`, `ocrProcessedAt`, `triggeredBy`, `engineVersion`) to `lib/Settings/docudesk_register.json` — additive, union-merge only; never stores OCR text
+- [ ] 1.2 Seed one scanned-PDF sample (tests/sample-documents) with its `ocrResult` so badge/status render on a clean install
+
+## 2. Backend
+
+- [ ] 2.1 Add `OcrController` with `POST /api/ocr/{fileId}` and `GET /api/ocr/{fileId}` wrapping `OcrService::processFile()`, persisting `ocrResult`, with the 409/503/404/400 error contract (REQ-DDOCR-001)
+  - Auth attributes on every method (route-auth gate); file resolved via the requesting user's folder only (no-admin-idor gate); response carries `textLength`, never the text.
+- [ ] 2.2 File an OpenRegister issue + PR for the provided-text ingestion seam (`extractFromProvidedText(int $fileId, string $text)`) that chunks, persists and runs entity recognition (REQ-DDOCR-004)
+  - Cross-app dependency; verify against OR HEAD at apply time — do not assume it landed.
+- [ ] 2.3 Add the OCR fallback branch to `AnonymizationService::extractAndDetectEntities()`: `needsOcr()` after OR extraction → `processFile()` → ingest via the OR seam; fail-flagged degradation (`ocrSkipped` reasons, `ocrDetectionPending` when the seam is absent) (REQ-DDOCR-003, REQ-DDOCR-004)
+  - OCR-recovered entities flow through the existing proposals/policy-match/risk post-processing unchanged.
+- [ ] 2.4 Replace the `FileListingService` MIME heuristic with `ocrResult`-derived `ocrProcessed`/`ocrConfidence` + `ocrAvailable` (REQ-DDOCR-005)
+  - `FileEntitiesDashboardWidget` keeps working (field names/types unchanged).
+
+## 3. Frontend
+
+- [ ] 3.1 "Run OCR" action in MyDocuments and the file viewer with busy state, badge update without reload, and error surfacing; hidden when disabled/unavailable but always server-re-checked (REQ-DDOCR-002, REQ-DDOCR-006)
+- [ ] 3.2 Review-flow warnings for `ocrSkipped` and `ocrDetectionPending` documents so scans are never silently "clean" (REQ-DDOCR-003, REQ-DDOCR-004)
+
+## 4. Quality
+
+- [ ] 4.1 PHPUnit for controller error contract, fallback branching, degradation flags, `ocrResult` persistence and listing derivation — 75% coverage on new code (ADR-009)
+  - Run in container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`.
+  - Live-verify on Postgres (8080) with OpenRegister + Tesseract in the container: upload scan → fallback OCR → entities in review; and the manual Run-OCR path.
+- [ ] 4.2 Playwright spec `tests/e2e/spec-coverage/ocr-trigger.spec.ts` for the `@e2e`-referenced scenarios
+- [ ] 4.3 i18n EN + NL for all new UI strings (keys in English); nldesign theme check (ADR-005, ADR-003)
+- [ ] 4.4 Docs: `docs/features/ocr.md` with Playwright screenshots (Run OCR action, badge, review warnings, admin settings) and the DocuDesk↔OpenRegister OCR division of labour (ADR-010)
+- [ ] 4.5 Validate: `openspec validate ocr-trigger-surface --strict` passes; hydra gates green (orphaned-write gate should now pass for OcrService)

--- a/openspec/changes/office-template-authoring/.openspec.yaml
+++ b/openspec/changes/office-template-authoring/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/office-template-authoring/design.md
+++ b/openspec/changes/office-template-authoring/design.md
@@ -1,0 +1,309 @@
+# Design: office-template-authoring
+
+## Context
+
+Verified current state (HEAD of this worktree):
+
+- Templates are OpenRegister objects in the `templates` register (v2.0.0),
+  schemas `template` + `templateVersion`
+  (`lib/Settings/docudesk_register.json`). `template.content` is a Twig/HTML
+  string (`format: html`); required fields are `name`, `content`,
+  `namespace`.
+- `TemplateService` (CRUD, advisory lock, duplicate), `TemplateVersionService`
+  (snapshot per content change, paginated history, diff, restore),
+  `TemplatePreviewService` (Twig → HTML preview), `TemplateRenderer`
+  (sandboxed Twig) — all resolve register/schema via `OpenRegisterResolver`
+  and store exclusively through OR `ObjectService` (ADR-001, no custom
+  tables).
+- `PdfConversionService` walks an ordered backend cascade
+  (`lib/Service/Conversion/`): OfficeApp → LibreOffice headless → PhpWord →
+  mPDF → EML; `LibreOfficeHeadlessBackend` accepts DOCX/ODT/RTF/… (verified
+  `SUPPORTED_MIMES`) and emits PDF via
+  `pdf:writer_pdf_Export:UseTaggedPDF=true,SelectPdfVersion=2`.
+- `DocumentService::generateDocument()` renders a Twig template + resolved
+  `dataRefs` (`DataResolverService`) to pdf/odf/html and logs a
+  `generatedDocument` object.
+- `composer.json` already requires `phpoffice/phpword: ^1.2` (used by
+  `PhpWordBackend`), `mpdf/mpdf: ^8.2`, `twig/twig: ^3.27`.
+- UI: `src/views/templates/TemplateIndex.vue` + `TemplateDetail.vue`.
+
+Constraint (openspec/config.yaml): all document processing stays local — no
+external API calls. GDPR note: template *data* filling happens at generation
+time with the same data-resolution path as today; this change introduces no
+new personal-data storage (templates and fragments are content, not subject
+data).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A communications-department user uploads a DOCX with `${field}` tags and it
+  becomes a working, versioned, previewable template — no developer involved.
+- Tag errors are caught at upload time, against the register schema the
+  template is bound to, not at first failed generation.
+- Bulk migration of an existing house-style estate (hundreds of DOCX files +
+  text fragments) is a supported, reportable operation.
+- Text fragments (bouwstenen) are managed once and reused across templates.
+- Every existing template feature (versions, diff, restore, lock, duplicate,
+  preview, namespaces) works identically for office templates.
+
+**Non-Goals:**
+
+- No in-browser WYSIWYG DOCX editor — authoring happens in Word/LibreOffice/
+  Collabora; DocuDesk manages, validates, and renders. (Collabora editing of
+  the stored source file is a natural follow-up, not this change.)
+- No charts/dynamic-image modules (competitor theme #9) this wave.
+- No change to the Twig template type, the Twig sandbox, or `PdfService`.
+- No guided-interview wizard (separate gap; SmartDocuments/docassemble
+  territory).
+- No multi-format simultaneous output (XLSX/PPTX) — DOCX and PDF only.
+
+## Decisions
+
+### D1 — Merge-tag syntax: PhpWord `${field}` macros (TemplateProcessor)
+
+**Chosen:** the `${field}` macro syntax processed by
+`\PhpOffice\PhpWord\TemplateProcessor` — `getVariables()` for extraction,
+`setValue()`/`cloneRow()`/`cloneBlock()` for filling. Dotted paths
+(`${applicant.name}`) are supported by treating the full dotted string as the
+macro name and resolving it against the data context with the existing
+`adbario/php-dot-notation` dependency. Repeating content uses
+TemplateProcessor's native block/row cloning with `${block}`…`${/block}`
+delimiters.
+
+**Rejected alternatives:**
+
+- *Carbone `{d.field}`*: Carbone's renderer is a Node.js engine (open-core,
+  CCL); embedding it means a Node sidecar or their SaaS API — the latter
+  violates the local-only processing rule outright, the former adds an ExApp
+  for something PHP already does.
+- *docxtemplater `{tag}`*: browser/Node JS library (MIT core + paid modules);
+  server-side rendering in a PHP Nextcloud app would push template filling
+  into the client or a sidecar, and paid modules gate loops/images.
+- *Word content controls (structured document tags)*: robust but authorable
+  only via Word's developer ribbon — precisely the developer dependency this
+  change removes; PhpWord also has no first-class content-control API.
+
+`${field}` is visible plain text any Word/LibreOffice user can type, it
+survives ODT→DOCX conversion, and the processor is an existing, already-vetted
+dependency. This satisfies ADR-011 (reuse before build): PhpWord is already in
+`composer.json` and no OpenRegister `lib/Formats/`/`lib/Service/` utility
+covers DOCX templating (checked — OR owns text *extraction*, not document
+*assembly*).
+
+### D2 — Office source storage: Nextcloud file referenced by `sourceFileId`
+
+The DOCX source is binary; OR object properties are JSON. **Chosen:** store
+the uploaded source in an app-managed folder (same pattern as anonymization
+outputs — `anonymizationLink` stores `sourceFileId`/`anonymizedFileId`
+NC file ids, verified in the register), and reference it from the template
+object as `sourceFileId` plus a `contentHash` (sha256) for version integrity.
+`template.content` for office templates holds the extracted *text projection*
+(for search/diff display), not the binary.
+
+**Rejected:** base64-embedding the DOCX in `template.content` (bloats every
+list/search response and version snapshot; OR objects are not blob stores).
+
+Version snapshots (`templateVersion`) gain `sourceFileId` + `contentHash` so a
+restore can re-point to the exact office revision; the version service keeps
+one immutable copy per version in the app folder (office sources are small —
+tens of KB — and Den Helder-scale estates are hundreds, not millions).
+
+### D3 — ODT handling: accepted at upload, normalised to DOCX
+
+`TemplateProcessor` operates on DOCX (Word2007) only. ODT uploads are
+accepted and converted to DOCX once, at upload time, via the existing
+LibreOffice headless backend (which supports ODT input, verified); the DOCX
+becomes the canonical source, the original ODT is retained alongside for
+provenance. The upload response flags the conversion so the author can check
+fidelity. Rationale: one canonical fill path instead of two engines; LO
+round-trips `${field}` text runs losslessly.
+
+### D4 — Tag validation against a bound schema
+
+Templates gain optional `boundRegister`/`boundSchema` (slugs). On upload (and
+on every new office version) the service extracts tags with `getVariables()`
+and classifies each against the bound schema's `properties` (read through
+OR's schema API via the container, same access pattern as
+`OpenRegisterResolver`): `known` (property or dotted sub-path exists),
+`fragment` (`fragment:` prefix), `unknown`. Unknown tags produce a structured
+report on the template object (`tagReport`). Whether unknown tags block or
+warn is admin-configurable (`docudesk.templates.unknown_tag_severity`,
+default `warning` — migration estates must be importable before mapping).
+Templates without a binding get a `not validated against a schema` notice,
+never a block (Twig templates today have no binding either).
+
+### D5 — Rendering path: fill, then cascade
+
+`DocumentService::generateDocument()` branches on `templateType`:
+
+- `twig` (existing): Twig render → HTML → `PdfService`/mPDF — unchanged.
+- `office` (new): resolve data (same `DataResolverService` + fragments
+  pre-pass) → `TemplateProcessor` fill into a temp DOCX → output `docx`
+  as-is, or `pdf`/`pdfa` via `PdfConversionService::convertToPdf()` (the
+  LibreOffice cascade). Huisstijl for office templates is the document's own
+  house style (that is the point of office-native authoring); the
+  `huisstijlId` option is ignored for `office` templates with a warning.
+
+**Declarative vs imperative (ADR-031):** document generation is an explicitly
+listed valid imperative exception (external-binary conversion, file
+assembly), matching how the existing generation/conversion services already
+work — no `x-openregister-*` behaviour annotation can express "run soffice".
+The *data* side stays declarative: the schema extensions, the new
+`textFragment` schema, and the register bump are pure `docudesk_register.json`
+edits; no lifecycle/aggregation/notification annotations are added or needed.
+
+### D6 — Text fragments (bouwstenen): schema + pre-pass resolution
+
+New `textFragment` schema in the `templates` register: `name`, `slug`
+(unique per namespace), `content` (plain text/limited HTML), `namespace`,
+`category`, `tags`, `language`. A template references a fragment as
+`${fragment:slug}`. Resolution is a **pre-processing pass** in the render
+path (office: `setValue('fragment:slug', …)` before field filling; Twig: a
+string substitution before `TemplateRenderer::renderTemplate()` so the Twig
+sandbox's fixed function whitelist is untouched). Fragments may contain
+`${field}` tags themselves (one level — no recursive fragment nesting, cycle
+risk). Missing fragments render as a visible `[ontbrekende bouwsteen: slug]`
+marker and a generation warning, never silent emptiness.
+
+### D7 — Bulk import: async job + interactive mapping, OR-native state
+
+`POST /api/templates/import` accepts a ZIP (or a Files-app folder path). An
+import job (queued via `IJobList`, same pattern as
+`DocumentService::generateBulk()` jobs) unpacks, creates one `office`
+template per DOCX/ODT (namespace, category from folder structure), runs tag
+extraction/validation per file, and writes a per-file import report. Job
+state and the report live on a new `templateImportJob` schema (templates
+register) — not in memory (lesson: GH #287 in-memory sessions). The UI wizard
+then walks unresolved tags: the operator maps tag → schema property (stored
+as `fieldMap` on the template, applied as an aliasing layer at fill time) or
+accepts them as ad-hoc data fields. `.txt`/`.html` files in a `fragments/`
+ZIP folder import as `textFragment` objects (Den Helder: 433 fragments).
+
+### D8 — Security: no macro execution, escaped values, sandbox parity
+
+- Macro-enabled uploads (`.docm`, `.dotm`, or a DOCX containing
+  `vbaProject.bin`) are **rejected** at upload (a template store must never
+  become a macro-distribution vector).
+- Filled values are inserted with `setValue()` (XML-escaped by
+  TemplateProcessor) — data can never inject WordprocessingML or trigger the
+  Twig path.
+- The fill step executes no template-authored logic (unlike Twig): the office
+  path is data-substitution only, so it needs no sandbox — conditionality
+  stays declarative via block cloning.
+- Uploads are size-capped (`docudesk.templates.max_upload_bytes`, default
+  20 MB) and mime-sniffed (reuse the extension/mime approach proven in
+  `DocumentValidationService`).
+
+### D9 — Frontend (ADR-012)
+
+`TemplateIndex.vue` gains a type column/filter and the import-wizard entry;
+`TemplateDetail.vue` gains office-specific panels (source download, tag
+report, field mapping, preview via cascade). All new UI uses
+`@conduction/nextcloud-vue` components (`CnIndexPage`, `CnDataTable`,
+`CnFormDialog`) and NL Design System tokens via NC CSS variables (ADR-003);
+dialogs live in `src/modals/` per modal-isolation rules. Fragment management
+is a tab on the template index (same `CnDataTable` pattern).
+
+## OpenRegister usage (ADR-001)
+
+| Operation | OR service |
+|---|---|
+| Template/fragment/import-job CRUD | `ObjectService` (`saveObject`/`find`/`searchObjectsPaginated`/`deleteObject`) via `OpenRegisterResolver`, exactly as `TemplateService` does today |
+| Office source + version binaries | NC app folder files referenced by file id (pattern of `anonymizationLink.sourceFileId`) |
+| Bound-schema property lookup (tag validation) | OR schema read via the container (no schema duplication in DocuDesk) |
+| Generation audit | existing `generatedDocument` objects — `templateType` is added to the logged metadata |
+
+No custom database tables. Register import stays via
+`ConfigurationService::importFromApp()` on boot; templates register version
+bumps `2.0.0 → 2.1.0`.
+
+## Seed Data
+
+Shipped as demo/seed objects (municipality-flavoured, nil-UUID pattern):
+
+```json
+{
+  "template": {
+    "id": "00000000-0000-0000-0000-000000000101",
+    "name": "Beschikking parkeervergunning",
+    "namespace": "docudesk",
+    "templateType": "office",
+    "sourceFileId": 0,
+    "contentHash": "<sha256-of-seed-docx>",
+    "boundRegister": "dossier",
+    "boundSchema": "dossier",
+    "mergeFields": ["aanvrager.naam", "aanvrager.adres", "besluit.datum", "fragment:ondertekening-burgemeester"],
+    "fieldMap": {},
+    "category": "beschikkingen",
+    "tags": ["parkeren", "huisstijl-2026"]
+  },
+  "textFragment": {
+    "id": "00000000-0000-0000-0000-000000000102",
+    "name": "Ondertekening burgemeester",
+    "slug": "ondertekening-burgemeester",
+    "namespace": "docudesk",
+    "content": "Hoogachtend,\nde burgemeester van Demostad,\nnamens deze,",
+    "category": "ondertekening",
+    "language": "nl"
+  },
+  "templateImportJob": {
+    "id": "00000000-0000-0000-0000-000000000103",
+    "status": "completed",
+    "totalFiles": 3,
+    "imported": 3,
+    "failed": 0,
+    "startedBy": "demo-communicatie",
+    "report": [{"file": "beschikking-parkeervergunning.docx", "tags": 4, "unknownTags": 0}]
+  }
+}
+```
+
+A seed DOCX with the four tags above ships under `tests/sample-documents/`
+(also used by unit tests). Seeding follows the existing register-import
+mechanism; the demo consultancy flavour ("Demostad") matches the shipped
+dossier demo data (`demostad-woo-2025-017` etc., verified in the register).
+
+## Risks / Trade-offs
+
+- [Word splits `${field}` across XML runs when authors edit tag text
+  incrementally] → TemplateProcessor's `fixBrokenMacros()` handles the common
+  cases; the upload tag report is the safety net — a tag the author expects
+  but extraction misses is visible immediately. Documented in the user docs.
+- [ODT→DOCX normalisation can shift layout] → conversion is flagged in the
+  upload response + preview is one click; original ODT retained.
+- [LibreOffice fidelity for exotic house styles] → preview via the same
+  cascade used at generation time, so what the author previews is what
+  citizens get; OfficeApp (Collabora) backend ranks above LO in the cascade
+  when installed.
+- [Bulk import of hundreds of files under the serialized soffice lock is
+  slow] → import validates tags (PhpWord, no soffice) synchronously per file
+  but renders nothing; conversion only happens on preview/generation. ODT
+  normalisation is the only soffice work at import and is queued.
+- [Fragment changes silently alter future renders of many templates] →
+  generation metadata logs fragment slugs + their object versions
+  (`generatedDocument.dataRefs` already records sources); fragment edits are
+  OR-audited.
+- [`content` text projection drifts from binary source] → `contentHash`
+  recomputed on every upload; version restore re-points both together.
+
+## Migration Plan
+
+1. Register bump ships the schema extensions (additive, no data migration —
+   existing templates read as `templateType: twig` via default).
+2. Backend services + routes land behind no flag (new endpoints, no changed
+   contracts).
+3. UI ships last; until then office endpoints are API-only (parity with how
+   template management itself shipped).
+4. Rollback = revert app release; additive schema fields are inert for old
+   code.
+
+## Open Questions
+
+- Should `boundSchema` binding be *required* for office templates once an
+  organisation enables blocking tag validation? (Provisional: no — ad-hoc
+  data templates stay legal; the admin severity knob only governs unknown
+  tags on *bound* templates.)
+- Whether Collabora in-place editing of the stored source (richdocuments
+  integration) lands as a fast-follow — depends on ecosystem priority, not
+  this spec.

--- a/openspec/changes/office-template-authoring/proposal.md
+++ b/openspec/changes/office-template-authoring/proposal.md
@@ -1,0 +1,111 @@
+---
+kind: code
+---
+
+# Proposal: office-template-authoring
+
+## Why
+
+DocuDesk templates today are Twig/HTML strings (`template.content`, `format:
+html` — verified in `lib/Settings/docudesk_register.json` and
+`lib/Service/TemplateRenderer.php`). That makes template authoring a
+developer activity, while the market baseline is office-file-native
+authoring: **8+ competitors** let the communications department own templates
+inside real Word/LibreOffice files — Xential, SmartDocuments (drag-drop
+editor, 150+ gemeenten), iWRITER/Templafy, Docmosis, Carbone, docxtemplater,
+Templater and Fluent all author in `.docx`/`.odt` with merge tags
+(research-competitors.md, feature theme #1: "Template authoring IN
+Word/Office/LO files — 8+ competitors. Twig/HTML = developer-facing").
+
+Dutch-government demand is concrete and tendered:
+
+- **Den Helder 306597/297564**: document-generator tender requiring migration
+  of **486 existing house-style templates + 433 text fragments** (wens
+  3.3.4.3 adds version rollback), i.e. bulk import of office files is an
+  award criterion, not a nicety.
+- **Noord-Brabant 422049** (2026-04-21): "sjabloonvoorziening" explicitly
+  including template migration.
+- User-wishes #7: central library, versioning/rollback, huisstijl, and
+  **migration tooling** rank as a top-10 deduplicated wish (GH #82, NC forum
+  threads).
+
+DocuDesk already has the two halves this change joins: a template register
+with versioning/diff/restore/lock/duplicate/preview
+(`TemplateService`/`TemplateVersionService`/`TemplatesController`, spec
+`template-management` REQ-TMPL-01..12) and a file-to-PDF conversion cascade
+(`PdfConversionService` walking OfficeApp → LibreOffice headless → PhpWord →
+mPDF → EML, verified in `lib/Service/Conversion/`). What is missing is the
+bridge: accepting a real DOCX/ODT with merge tags as a first-class template,
+validating its tags against a bound register schema, rendering it through the
+cascade, and importing existing template estates in bulk.
+
+## What Changes
+
+- **Office-file templates as a first-class template type.** The `template`
+  schema gains `templateType` (`twig` | `office`), a reference to the stored
+  office source file, extracted merge-field metadata, and an optional bound
+  register/schema. Existing Twig/HTML templates are untouched (`templateType`
+  defaults to `twig`); no breaking change.
+- **Merge-tag syntax: PhpWord `${field}` macros.** Tags are authored in Word/
+  LibreOffice as plain `${field}` / `${block}` text runs and processed with
+  `phpoffice/phpword`'s `TemplateProcessor` (already a composer dependency,
+  `^1.2`). Rationale vs Carbone `{d.field}` / docxtemplater in design.md —
+  short version: fully local PHP, zero new dependencies, no Node sidecar, no
+  external API (config.yaml local-only rule).
+- **Tag validation + error reporting on upload**: extracted tags are checked
+  against the bound register schema's properties; unknown tags produce a
+  structured validation report (block or warn, admin-configurable).
+- **Rendering through the existing conversion cascade**: fill tags with
+  `TemplateProcessor`, then convert the filled DOCX via `PdfConversionService`
+  (LibreOffice headless etc.) for PDF/PDF-A output; DOCX passthrough output is
+  also supported.
+- **Reusable text fragments (bouwstenen)**: a new `textFragment` schema in the
+  templates register; fragments are referenced from office templates
+  (`${fragment:slug}`) and resolved in a pre-processing pass.
+- **Bulk import / migration tooling**: upload a ZIP (or point at a folder) of
+  DOCX/ODT house-style templates; an async job creates office templates,
+  extracts tags, and produces an import report; an interactive mapping step
+  lets the operator map unknown tags to schema properties (Den Helder-scale:
+  hundreds of templates).
+- **Versioning / lock / preview / duplicate parity**: the existing
+  `template-management` capabilities keep working for office templates
+  (version snapshots reference the office source revision; preview renders
+  via the cascade).
+
+## Capabilities
+
+### New Capabilities
+
+- `office-template-authoring`: DOCX/ODT files with `${field}` merge tags as
+  first-class templates — upload, tag extraction and validation against a
+  bound register schema, rendering through the conversion cascade, reusable
+  text fragments (bouwstenen), and bulk import/migration tooling.
+
+### Modified Capabilities
+
+- `template-management`: the template data model is extended with
+  `templateType`, office-source references, merge-field metadata, and schema
+  binding; versioning, locking, preview, and duplication requirements are
+  extended to cover office templates. Existing Twig/HTML requirements are
+  unchanged.
+
+## Impact
+
+- **Backend**: new `OfficeTemplateService` (tag extraction/validation/fill via
+  PhpWord `TemplateProcessor`), new `TemplateImportService` (ZIP/folder bulk
+  import job), extensions to `TemplateService`/`TemplateVersionService`/
+  `TemplatePreviewService`; render path reuses `PdfConversionService` and
+  `DocumentService`.
+- **Register**: `lib/Settings/docudesk_register.json` — `template` and
+  `templateVersion` schema extensions, new `textFragment` schema, templates
+  register version bump (currently `2.0.0`).
+- **Routes**: new upload/validate/import endpoints under `api/templates/…`
+  (`appinfo/routes.php`).
+- **Frontend**: template index/detail (`src/views/templates/`) gain office
+  upload, tag report, fragment management, and import wizard using
+  `@conduction/nextcloud-vue` components (ADR-012).
+- **Dependencies**: none new — `phpoffice/phpword ^1.2` already shipped
+  (verified in `composer.json`); LibreOffice headless already the conversion
+  backbone.
+- **Sibling boundaries**: no OpenRegister/OpenConnector changes; data
+  resolution keeps using the existing `DataResolverService` contract.

--- a/openspec/changes/office-template-authoring/specs/office-template-authoring/spec.md
+++ b/openspec/changes/office-template-authoring/specs/office-template-authoring/spec.md
@@ -1,0 +1,193 @@
+# office-template-authoring Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Accept real DOCX/ODT office files with `${field}` merge tags as first-class
+DocuDesk templates alongside the existing Twig/HTML type: upload with tag
+extraction and validation against a bound register schema, rendering through
+the existing PDF conversion cascade, reusable text fragments (bouwstenen),
+and bulk import/migration tooling for existing house-style template estates.
+The goal is that the communications department owns templates without
+developer help.
+
+## ADDED Requirements
+
+### Requirement: Office files are accepted as first-class templates (REQ-DDOTA-001)
+
+The app MUST accept a DOCX or ODT file upload as a template of
+`templateType: office` via `POST /api/templates/office` (multipart), storing
+the office source as a Nextcloud file referenced from the template object by
+`sourceFileId` together with a sha256 `contentHash`. Merge tags MUST use the
+PhpWord macro syntax `${field}` (dotted paths such as `${aanvrager.naam}`
+allowed; repeating regions via `${block}`…`${/block}`); the upload MUST
+extract all tags with PhpWord `TemplateProcessor::getVariables()` and persist
+them as `mergeFields` on the template. ODT uploads MUST be normalised to DOCX
+via the LibreOffice headless backend at upload time (the original ODT
+retained; the response MUST flag the conversion). Uploads MUST be rejected
+with HTTP 422 when macro-enabled (`.docm`/`.dotm` or containing
+`vbaProject.bin`), when exceeding the configured size cap, or when the
+sniffed mime type contradicts the extension. Existing Twig/HTML templates
+MUST be unaffected: absent `templateType` MUST read as `twig`.
+
+#### Scenario: Communications officer uploads a DOCX house-style template
+
+- GIVEN an authenticated user with a DOCX containing `${aanvrager.naam}` and `${besluit.datum}`
+- WHEN the file is uploaded to `POST /api/templates/office` with `name` and `namespace`
+- THEN a template object is created with `templateType: office`, a `sourceFileId`, a `contentHash`, and `mergeFields` containing both tags
+- AND the template appears in `GET /api/templates` alongside Twig templates
+- @e2e tests/e2e/spec-coverage/office-template-authoring.spec.ts
+
+#### Scenario: Macro-enabled upload is rejected
+
+- GIVEN a `.docm` file (or a DOCX whose package contains `vbaProject.bin`)
+- WHEN it is uploaded as an office template
+- THEN the response is HTTP 422 naming the macro rejection reason
+- AND no template object and no stored file is created
+- @e2e exclude negative-path file forging (crafting a macro container) is not browser-drivable in Playwright; covered by PHPUnit (tests/unit/Service/OfficeTemplateServiceTest.php) against fixture files in tests/sample-documents/
+
+#### Scenario: ODT upload is normalised and flagged
+
+- GIVEN an ODT template containing `${zaaknummer}`
+- WHEN it is uploaded
+- THEN the canonical source stored is a DOCX with the tag intact and the original ODT is retained
+- AND the upload response carries a `converted: true` flag
+- @e2e exclude conversion fidelity requires the LibreOffice binary in the test container; covered by PHPUnit integration test gated on soffice availability (tests/unit/Service/OfficeTemplateServiceTest.php)
+
+### Requirement: Uploaded tags are validated against the bound register schema (REQ-DDOTA-002)
+
+The app MUST validate extracted merge tags against the bound register schema.
+A template MAY declare `boundRegister` and `boundSchema` (OpenRegister
+slugs). On every office upload (create and new-version), the service MUST
+classify each extracted tag as `known` (matches a property or dotted
+sub-path of the bound schema), `fragment` (`fragment:` prefix), or `unknown`,
+and MUST persist the structured result as `tagReport` on the template.
+Unknown tags on a bound template MUST be reported at the severity configured
+in `docudesk.templates.unknown_tag_severity` (`warning` default, `blocking`
+optional); at `blocking` the upload MUST be refused with HTTP 422 listing the
+unknown tags. A template without a schema binding MUST never be blocked on
+tag validation and its report MUST state that no schema validation was
+performed. The schema properties MUST be read from OpenRegister (no property
+list duplicated in DocuDesk).
+
+#### Scenario: Unknown tag is reported on upload
+
+- GIVEN a template bound to register `dossier` / schema `dossier`
+- AND an uploaded DOCX containing the tag `${aanvraagr.naam}` (typo) which matches no schema property
+- WHEN the upload completes under the default `warning` severity
+- THEN the template is created and its `tagReport` lists `aanvraagr.naam` as `unknown`
+- AND the template detail UI shows the unknown-tag warning
+- @e2e tests/e2e/spec-coverage/office-template-authoring.spec.ts
+
+#### Scenario: Blocking severity refuses the upload
+
+- GIVEN `docudesk.templates.unknown_tag_severity` set to `blocking`
+- AND an upload for a bound template containing an unknown tag
+- WHEN the upload is processed
+- THEN the response is HTTP 422 listing each unknown tag
+- AND no template object is created
+- @e2e exclude admin-config permutation of the same validation path; covered by PHPUnit (tests/unit/Service/OfficeTemplateServiceTest.php)
+
+### Requirement: Office templates render through the conversion cascade (REQ-DDOTA-003)
+
+Document generation MUST render office templates through the existing
+conversion cascade. `DocumentService::generateDocument()` (and the
+corresponding `documents/generate`, `preview`, and `bulk` endpoints) MUST support
+`templateType: office`: resolve data through the existing
+`DataResolverService` contract, fill tags with PhpWord `TemplateProcessor`
+(`setValue` for scalars — XML-escaped, `cloneBlock`/`cloneRow` for arrays),
+and produce output as `docx` (the filled file) or `pdf`/`pdfa` by converting
+the filled DOCX through `PdfConversionService::convertToPdf()` (the existing
+backend cascade). Tags with no value in the resolved data MUST render as
+empty with a generation warning naming the tag. Filling MUST execute no
+template-authored logic and MUST make no external network call. Each office
+generation MUST log a `generatedDocument` object recording the template type.
+
+#### Scenario: Office template generates a PDF via the cascade
+
+- GIVEN an office template with tags `${aanvrager.naam}` and `${besluit.datum}` and a dataRef resolving both
+- WHEN `POST /api/documents/generate` is called with `format: "pdf"`
+- THEN the filled DOCX is converted by the conversion cascade and a PDF is returned
+- AND a `generatedDocument` object is logged with the template id, version, and type
+- @e2e tests/e2e/spec-coverage/office-template-authoring.spec.ts
+
+#### Scenario: Missing data yields a warning, not silent loss
+
+- GIVEN a generation whose resolved data lacks `besluit.datum`
+- WHEN the document is generated
+- THEN the output renders the tag position as empty
+- AND the response `warnings` name `besluit.datum`
+- @e2e exclude warning-payload assertion on the generation API; covered by PHPUnit (tests/unit/Service/DocumentServiceTest.php)
+
+### Requirement: Reusable text fragments (bouwstenen) resolve in templates (REQ-DDOTA-004)
+
+The app MUST provide CRUD for `textFragment` objects (name, unique
+per-namespace `slug`, `content`, `namespace`, `category`, `tags`,
+`language`) stored in the templates register via OpenRegister. A template —
+office or Twig — MUST be able to reference a fragment as `${fragment:slug}`;
+rendering MUST resolve fragment references in a pre-processing pass before
+field filling (fragments MAY themselves contain `${field}` tags, one level
+deep — no recursive fragment nesting). A missing fragment MUST render a
+visible `[ontbrekende bouwsteen: <slug>]` marker and produce a generation
+warning, never silent omission. The Twig sandbox whitelist MUST NOT be
+extended for fragment support.
+
+#### Scenario: Fragment content is rendered into a generated document
+
+- GIVEN a fragment `ondertekening-burgemeester` and an office template referencing `${fragment:ondertekening-burgemeester}`
+- WHEN a document is generated
+- THEN the fragment's content appears at the reference position
+- AND `${field}` tags inside the fragment are filled from the same data context
+- @e2e tests/e2e/spec-coverage/office-template-authoring.spec.ts
+
+#### Scenario: Missing fragment is visible and warned
+
+- GIVEN a template referencing `${fragment:bestaat-niet}`
+- WHEN a document is generated
+- THEN the output contains `[ontbrekende bouwsteen: bestaat-niet]`
+- AND the generation response carries a warning naming the slug
+- @e2e exclude negative-path rendering assertion; covered by PHPUnit (tests/unit/Service/OfficeTemplateServiceTest.php)
+
+### Requirement: Bulk import migrates existing template estates (REQ-DDOTA-005)
+
+The app MUST provide `POST /api/templates/import` accepting a ZIP upload (or
+a Files-app folder path) of DOCX/ODT templates and optional text fragments,
+processed as an asynchronous job whose state is persisted as a
+`templateImportJob` object via OpenRegister (never in memory). The job MUST
+create one office template per office file (running tag
+extraction/validation per REQ-DDOTA-001/002), import `fragments/` entries as
+`textFragment` objects, and record a per-file report (created id, tag
+counts, unknown tags, failures — failures skip the file and continue). Job
+progress MUST be queryable via `GET /api/templates/import/{jobId}`. The UI
+MUST provide an interactive mapping step where the operator maps unknown
+tags to bound-schema properties, persisted as `fieldMap` on the template and
+applied as a tag→property aliasing layer at fill time. The flow MUST handle
+estates of hundreds of files (Den Helder scale: 486 templates + 433
+fragments).
+
+#### Scenario: ZIP of house-style templates imports with a report
+
+- GIVEN a ZIP containing three DOCX templates and a `fragments/` folder with two text fragments
+- WHEN it is posted to `POST /api/templates/import`
+- THEN a `templateImportJob` is created and progresses to `completed`
+- AND three office templates and two fragments exist, each report row naming its tags and unknown tags
+- @e2e tests/e2e/spec-coverage/office-template-authoring.spec.ts
+
+#### Scenario: Operator maps an unknown tag interactively
+
+- GIVEN an imported template whose `tagReport` lists `naam_aanvrager` as unknown against bound schema `dossier`
+- WHEN the operator maps `naam_aanvrager` to the schema property `aanvrager.naam` in the import wizard
+- THEN the mapping is stored in the template's `fieldMap`
+- AND a subsequent generation fills `${naam_aanvrager}` from `aanvrager.naam`
+- @e2e tests/e2e/spec-coverage/office-template-authoring.spec.ts
+
+#### Scenario: A corrupt file does not abort the import
+
+- GIVEN a ZIP where one of three files is not a valid DOCX
+- WHEN the import job runs
+- THEN the two valid files import normally
+- AND the report marks the corrupt file as failed with a reason
+- @e2e exclude corrupt-fixture negative path; covered by PHPUnit (tests/unit/Service/TemplateImportServiceTest.php)

--- a/openspec/changes/office-template-authoring/specs/template-management/spec.md
+++ b/openspec/changes/office-template-authoring/specs/template-management/spec.md
@@ -1,0 +1,94 @@
+# template-management Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Extend the existing template-management capability (Twig/HTML templates as
+OpenRegister objects with versioning, diff/restore, locking, duplication, and
+preview — REQ-TMPL-01..12) so the same data model and lifecycle features
+cover `office` templates introduced by the `office-template-authoring`
+change. Existing Twig/HTML requirements are unchanged; this delta only ADDs
+requirements.
+
+## ADDED Requirements
+
+### Requirement: Template data model carries the office-template extension (REQ-DDOTA-006)
+
+The `template` schema in `lib/Settings/docudesk_register.json` MUST be
+extended (templates register version `2.0.0` → `2.1.0`, additive only) with:
+`templateType` (enum `twig` | `office`, default `twig`), `sourceFileId`
+(integer, NC file id of the office source), `contentHash` (string, sha256 of
+the source), `boundRegister` / `boundSchema` (strings, OpenRegister slugs),
+`mergeFields` (array of extracted tag names), `fieldMap` (object, tag →
+schema-property aliases), and `tagReport` (object, last validation result).
+The `templateVersion` schema MUST gain `sourceFileId` and `contentHash` so a
+version snapshot pins the exact office revision. All new properties MUST be
+optional so every existing template object remains valid, and an absent
+`templateType` MUST be interpreted as `twig` everywhere. For `office`
+templates, `content` holds the extracted text projection of the source (for
+search and diff display), never the binary.
+
+#### Scenario: Existing Twig templates are untouched by the schema bump
+
+- GIVEN a template object created before this change (no `templateType`)
+- WHEN the register import runs on boot and the template is listed and rendered
+- THEN the object validates against the extended schema
+- AND it behaves as `templateType: twig` in every code path
+- @e2e exclude schema-migration compatibility is not browser-observable; covered by PHPUnit register-drift tests (tests/unit/Service/TemplateServiceTest.php) and tests/validate-manifest.js
+
+#### Scenario: Office template object carries source reference and hash
+
+- GIVEN an uploaded office template
+- WHEN its object is fetched via `GET /api/templates/{id}`
+- THEN it contains `templateType: office`, an integer `sourceFileId`, a `contentHash`, and its `mergeFields`
+- @e2e tests/e2e/spec-coverage/templates.spec.ts
+
+### Requirement: Versioning, locking, preview, and duplication work for office templates (REQ-DDOTA-007)
+
+The existing template lifecycle features MUST apply to `office` templates
+with identical contracts:
+
+- **Versioning**: each new office source upload for an existing template
+  MUST create a `templateVersion` snapshot (via `TemplateVersionService`)
+  whose `sourceFileId`/`contentHash` reference an immutable copy of the
+  prior source; restore MUST re-point the template to the target version's
+  source and text projection using the existing auto-snapshot-then-restore
+  behaviour (REQ-TMPL-08).
+- **Diff**: `GET /api/templates/{id}/versions/diff` MUST return the two
+  versions' text projections for client-side diff (binary sources are not
+  diffed).
+- **Locking**: the advisory lock (REQ-TMPL-11) MUST gate office source
+  re-upload exactly as it gates content updates.
+- **Preview**: `POST /api/templates/{id}/preview` for an office template
+  MUST fill the tags with provided (or seed) data and return a rendered
+  preview produced through the conversion cascade.
+- **Duplication**: `POST /api/templates/{id}/duplicate` MUST copy the office
+  source to a new file, preserving `templateType`, `mergeFields`,
+  `fieldMap`, and schema binding, with the existing " (kopie)" naming and no
+  version history (REQ-TMPL-10).
+
+#### Scenario: New source upload creates a version and restore brings it back
+
+- GIVEN an office template with source revision A
+- WHEN revision B is uploaded and then version A is restored via `POST /api/templates/{id}/versions/{versionId}/restore`
+- THEN a snapshot of A existed before B took effect, an auto-snapshot of B is written on restore
+- AND the template's `sourceFileId`/`contentHash` again reference revision A's content
+- @e2e tests/e2e/spec-coverage/templates.spec.ts
+
+#### Scenario: Office template preview renders through the cascade
+
+- GIVEN an office template with `${aanvrager.naam}` and preview data `{"aanvrager": {"naam": "A. de Vries"}}`
+- WHEN the preview endpoint is called
+- THEN the returned preview shows "A. de Vries" at the tag position
+- @e2e tests/e2e/spec-coverage/templates.spec.ts
+
+#### Scenario: Duplicate copies the source file
+
+- GIVEN an office template
+- WHEN it is duplicated
+- THEN the duplicate references a NEW `sourceFileId` whose content hash equals the original's `contentHash`
+- AND the duplicate has no version history and no lock
+- @e2e exclude file-copy integrity assertion; covered by PHPUnit (tests/unit/Service/TemplateServiceTest.php)

--- a/openspec/changes/office-template-authoring/tasks.md
+++ b/openspec/changes/office-template-authoring/tasks.md
@@ -1,0 +1,59 @@
+# Tasks: office-template-authoring
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 16.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Register & data model
+
+- [ ] 1.1 Extend `lib/Settings/docudesk_register.json`: `template` schema (+`templateType`, `sourceFileId`, `contentHash`, `boundRegister`, `boundSchema`, `mergeFields`, `fieldMap`, `tagReport`), `templateVersion` (+`sourceFileId`, `contentHash`), new `textFragment` and `templateImportJob` schemas; bump templates register to 2.1.0
+  - All new properties optional; absent `templateType` reads as `twig`; schema refs by slug (not PascalCase)
+  - `tests/validate-manifest.js` and register import on boot both pass
+
+- [ ] 1.2 Ship seed data: demo office template object + seed DOCX in `tests/sample-documents/`, demo `textFragment`, demo `templateImportJob` (nil-UUID pattern, Demostad flavour per design.md Seed Data)
+  - Seed imports cleanly via the existing register-import mechanism
+
+## 2. Backend services
+
+- [ ] 2.1 `OfficeTemplateService`: upload intake (multipart), macro/`vbaProject.bin` rejection, size cap + mime sniff, ODT→DOCX normalisation via `LibreOfficeHeadlessBackend`, source storage in app folder + `sourceFileId`/`contentHash`, tag extraction via PhpWord `TemplateProcessor::getVariables()` (REQ-DDOTA-001)
+  - HTTP 422 paths for macro/size/mime; `converted: true` flag on ODT normalisation
+
+- [ ] 2.2 Tag validation against bound schema: classify known/fragment/unknown by reading schema properties from OpenRegister; persist `tagReport`; honour `docudesk.templates.unknown_tag_severity` (warning default, blocking refuses upload) (REQ-DDOTA-002)
+
+- [ ] 2.3 Office render path in `DocumentService::generateDocument()`/`generatePreview()`: fragments pre-pass → `TemplateProcessor` fill (setValue/cloneBlock/cloneRow, `fieldMap` aliasing) → `docx` output or `PdfConversionService::convertToPdf()` for pdf/pdfa; missing-data warnings; `generatedDocument` logging with template type (REQ-DDOTA-003)
+  - `huisstijlId` ignored for office templates with a warning
+
+- [ ] 2.4 `textFragment` CRUD + fragment resolution pre-pass for both office and Twig paths, missing-fragment marker + warning; NO change to the Twig sandbox whitelists (REQ-DDOTA-004)
+
+- [ ] 2.5 `TemplateImportService` + background job: ZIP/folder unpack, per-file template+fragment creation, per-file report, skip-and-continue on failure; `templateImportJob` state via ObjectService (REQ-DDOTA-005)
+
+- [ ] 2.6 Lifecycle parity: version snapshot + restore re-pointing `sourceFileId`/`contentHash`, lock gating source re-upload, preview via cascade, duplicate copying the source file (REQ-DDOTA-006/007)
+
+## 3. Routes & controller
+
+- [ ] 3.1 Routes + `TemplatesController` actions: `POST api/templates/office`, `POST api/templates/{id}/office` (new source version), `POST api/templates/import`, `GET api/templates/import/{jobId}`, fragment CRUD routes; explicit auth attributes on every method; error shaping via `TemplateRequestHandler`
+  - Every route registered in `appinfo/routes.php`; gate route-reachability/route-auth pass
+
+## 4. Frontend (ADR-012)
+
+- [ ] 4.1 `TemplateIndex.vue`: type column/filter, office-upload entry, fragments tab (`CnDataTable`), import-wizard entry; dialogs as separate components in `src/modals/`
+
+- [ ] 4.2 `TemplateDetail.vue`: office panels — source download, tag report with unknown-tag warnings, field-mapping editor, cascade preview; NL Design System tokens only (ADR-003)
+
+- [ ] 4.3 Import wizard: ZIP upload, job progress, per-file report, interactive unknown-tag → schema-property mapping persisted to `fieldMap`
+
+## 5. Quality, i18n, docs
+
+- [ ] 5.1 Unit tests (≥75% coverage on new code) incl. register-drift pins for the new schema fields; run in container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`
+  - Fixtures: valid DOCX, macro DOCX, corrupt DOCX, ODT in `tests/sample-documents/`
+
+- [ ] 5.2 Playwright e2e `tests/e2e/spec-coverage/office-template-authoring.spec.ts` + extend `templates.spec.ts` for the parity scenarios; verify on Postgres (8080), test with nldesign theme enabled
+
+- [ ] 5.3 i18n: all new UI strings with English source keys + NL translations (ADR-005)
+
+- [ ] 5.4 Docs in `docs/features/` (office templates, fragments, bulk import) with Playwright MCP screenshots (ADR-010); `openspec validate office-template-authoring --strict` passes
+
+## Quality checklist
+
+- No sed/awk/scripted code edits; Edit tool or full-file writes only
+- `composer check:strict` green; hydra gates (spdx, route-auth, spec-coverage, manifest-validation 28/30/51/52) pass
+- End-to-end verified against OpenRegister on the Postgres dev instance, not SQLite

--- a/openspec/changes/pdfua-accessible-output/.openspec.yaml
+++ b/openspec/changes/pdfua-accessible-output/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/pdfua-accessible-output/design.md
+++ b/openspec/changes/pdfua-accessible-output/design.md
@@ -1,0 +1,255 @@
+# Design: pdfua-accessible-output
+
+## Context
+
+Verified current state (HEAD of this worktree):
+
+- `PdfService::renderPdf()` renders Twig→HTML→**mPDF**; `pdfa: true`
+  configures mPDF `PDFA`/`PDFAversion '3-B'`. mPDF cannot emit structure
+  tags — its output is untagged by construction; the shipped
+  `pdf-generation` spec already records "PDF accessibility (tagged PDF) not
+  currently enforced".
+- `LibreOfficeHeadlessBackend::convert()` (the cascade's workhorse) already
+  exports `pdf:writer_pdf_Export:UseTaggedPDF=true,SelectPdfVersion=2` — so
+  cascade output is *tagged* today, but carries no PDF/UA identifier, no
+  enforced document language, and tag quality is whatever the source
+  provides.
+- `DocumentValidationService` (pure computation, ADR-031 calculation
+  pattern) has 6 check ids with per-profile severities
+  (`off|warning|blocking`), heuristic parser-free content checks
+  (`/Encrypt` trailer scan, `Tj/TJ` operator counting), verdict aggregation,
+  and an on-demand `POST /api/validation/validate` endpoint. Findings never
+  embed content.
+- Validation UI: `src/modals/ValidationResultModal.vue`, verdict chips per
+  the `document-validation-checks` spec; profile editor is a spec'd
+  follow-up.
+- `TemplatePreviewService::preview()` renders Twig→HTML for the template
+  editor.
+- Publication hand-off: DocuDesk prepares documents; publication endpoints
+  live in OpenCatalogi/OpenWoo (research boundary). The in-flight
+  `woo-publicatie-pipeline` change owns the pipeline itself; this change
+  only supplies the per-document accessibility signal it (and any future
+  publisher) consults.
+
+Statutory frame: Besluit digitale toegankelijkheid overheid → EN 301 549
+§10 (documents) → WCAG 2.1 AA; PDF/UA-1 = ISO 14289-1. DocuDesk targets
+**PDF/UA-1 for generated documents** and honest reporting where a backend
+cannot reach it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Generated documents (templates → PDF) can be produced tagged with correct
+  language, title, and structural semantics — PDF/UA-1 as the target
+  profile.
+- Accessibility problems are *visible*: per-document findings in the
+  existing validation surface, and a warning at publication hand-off.
+- Template authors get lint feedback (alt text, heading order, language) in
+  preview, where fixing is cheap.
+- Honesty over box-ticking: a path that cannot produce tagged output says
+  so; DocuDesk never labels an untagged PDF accessible.
+
+**Non-Goals:**
+
+- Not a full PDF/UA *validator*: Matterhorn-protocol/veraPDF-grade checking
+  (31 checkpoints, 136 failure conditions) is out of scope; our checks are
+  presence heuristics, and the docs say so. (External veraPDF integration is
+  a potential follow-up, same track as the CB #182 PDF/A validation issue.)
+- No remediation of *ingested* third-party PDFs (no auto-tagging of scans —
+  that is an OCR + authoring problem).
+- No change to anonymization outputs' pipeline (they inherit cascade tagging
+  but their sources are scans/uploads; certifying their accessibility would
+  be false).
+- No claim of certified conformance — the UI wording is "accessibility
+  checks passed", never "PDF/UA certified".
+
+## Decisions
+
+### D1 — Accessible generation routes through LibreOffice, not mPDF
+
+**Chosen:** an `accessible: true` option on the generation path
+(`DocumentService` options → `pdfOptions`). When set:
+
+- **Office templates** (with `office-template-authoring` in place) and any
+  path already using `PdfConversionService`: extend
+  `LibreOfficeHeadlessBackend` with an accessible-export mode adding
+  `PDFUACompliance=true` (and keeping `UseTaggedPDF=true`) to the filter
+  options, driven by a per-call option threaded through
+  `PdfConversionService::convertToPdf($source, $opts)` (the `$opts`
+  parameter exists and is currently unused — verified).
+- **Twig/HTML templates**: the rendered HTML is written to a temp `.html`
+  file and converted via the same LO accessible mode (LO's HTML import
+  preserves headings/alt/lang), **instead of** mPDF.
+
+**Rejected alternatives:**
+
+- *Make mPDF emit tagged PDF*: mPDF has no structure-tree support; forking
+  it is out of the question.
+- *Switch PDF engine to a tagged-capable HTML engine (WeasyPrint/Prince)*:
+  new runtime (Python/commercial) for something LO already does; violates
+  the reuse instinct and adds an ExApp for v1.
+- *Post-process tagging*: auto-tagging untagged PDFs is exactly the
+  low-quality box-ticking this change avoids.
+
+Consequence (accepted): accessible rendering requires the soffice binary;
+when LO is unavailable the generation MUST fail the `accessible` request
+with a structured error (attempt records exist in
+`ConversionFailedException`) rather than silently falling back to untagged
+mPDF output. `SelectPdfVersion` interplay: PDF/A-2+ and PDF/UA can coexist;
+the accessible mode keeps PDF/A when both are requested and the docs note
+LO's conformance limits.
+
+### D2 — Language and title are mandatory inputs to accessible output
+
+PDF/UA requires a document language and title. The accessible path MUST set
+`Lang` (from an explicit option, the template's language variant
+(register-i18n), or the instance default locale — in that precedence) and
+the document title metadata (existing `title` option / template name). A
+missing resolvable language is a generation-time error for `accessible:
+true`, not a silent default to nothing.
+
+### D3 — Validation: four heuristic, parser-free accessibility checks
+
+New check ids in `DocumentValidationService`, same catalogue/profile/
+severity machinery (no new mechanism):
+
+| checkId | Heuristic (PDF byte-level, cheap, no new deps) |
+|---|---|
+| `pdf-not-tagged` | no `/StructTreeRoot` reference, or `/MarkInfo` without `/Marked true` |
+| `pdf-language-missing` | catalog carries no `/Lang` entry |
+| `pdf-title-missing` | no XMP `dc:title`/Info `/Title` with non-empty value |
+| `pdfua-identifier-missing` | XMP lacks `pdfuaid:part` (only meaningful when tagging is present; suppressed when `pdf-not-tagged` already fired) |
+
+Style-matched to the existing `isPdfEncrypted` (`/Encrypt` scan) and
+`textLayerMissing` (operator counting) heuristics: string/regex scans over
+the PDF bytes, findings carry `checkId`/`severity`/`message`/`params`,
+never content. All four default to `warning` in every shipped profile
+(consistent with "default deployment never blocks") and are grouped as
+category `accessibility` (a new optional `category` key on findings so the
+UI can group — additive, existing findings default to `document`).
+`aggregate()` is untouched.
+
+**Rejected:** bundling veraPDF (JVM dependency; belongs to a dedicated
+validator integration), and DOM-level PDF parsing (a real PDF parser dep for
+marginal heuristic gain).
+
+### D4 — Publication-readiness is a signal DocuDesk computes, a gate the pipeline consults
+
+This change adds a `publicationReadiness` helper on the validation surface:
+"has open `accessibility`-category findings" → the UI shows a warning on
+publication-facing actions (the Woo hand-off action, when the
+`woo-publicatie-pipeline` change lands, plus today's print/publish-adjacent
+surfaces). The design deliberately does NOT hard-block hand-off from within
+this change: severity escalation to `blocking` via the existing profile
+mechanism is the admin's instrument (then the standard 422 gate of
+`document-validation-checks` REQ applies). This keeps a single
+gating mechanism, avoids a second policy system, and respects the sibling
+boundary (OpenCatalogi/OpenWoo own publication endpoints).
+
+### D5 — Template lint in preview: HTML-level checks at authoring time
+
+`TemplatePreviewService` gains a lint pass over the rendered preview HTML
+(and, for office templates, over the DOCX text/XML projection):
+
+- `img` without non-empty `alt` (or DOCX drawing without `wp:docPr` descr),
+- heading-order jump (`h1 → h3` without `h2`; DOCX Heading styles
+  analogous),
+- no language resolvable (template has no language variant and no explicit
+  lang),
+- `table` without `th` header cells (HTML path only).
+
+Lint results return alongside the preview response and render as a
+non-blocking checklist in the template editor. Lint NEVER blocks saving —
+it is authoring guidance (the enforcement point stays document validation).
+
+### D6 — Declarative vs imperative (ADR-031)
+
+Imperative with justification: PDF rendering/conversion is document
+generation via an external binary (listed valid exception), and the new
+checks extend `DocumentValidationService`, which is already the ADR-031
+**calculation** backend invoked by OR's calculation runtime / listener
+fallback — the accessibility findings flow into `validationStatus`/
+`validationFindings` exactly as existing checks do, with **no new storage
+mechanism and no schema change** (`docudesk_register.json` untouched; the
+verdict fields are already spec'd by `document-validation-checks`). No
+lifecycle/notification annotations are added.
+
+### D7 — Frontend (ADR-012)
+
+- `ValidationResultModal` / findings panel: group by `category`, an
+  `accessibility` section with localised messages; verdict chip unchanged.
+- Publication-facing actions: warning banner ("dit document heeft openstaande
+  toegankelijkheidsbevindingen") with a link to the findings.
+- Template editor preview: lint checklist panel (`CnDataTable`-style list),
+  non-blocking.
+- Admin: the accessibility checks appear automatically in the (spec'd)
+  profile editor since they ride the same profile config; a short
+  DigiToegankelijk note is added to the validation settings section.
+- All strings EN-source + NL; nldesign-theme tested (the accessibility
+  feature itself must be accessible — WCAG AA on all new UI).
+
+## OpenRegister usage (ADR-001)
+
+No schema or register changes. Findings/verdicts persist through the
+already-specified `document-validation-checks` calculation path (OR
+calculation runtime / event-listener fallback invoking the same service);
+on-demand endpoint stays non-persisting. Template lint is ephemeral
+(preview response only). This change is code-only against
+`lib/Service/DocumentValidationService.php`, `lib/Service/Conversion/`,
+`PdfService`/`DocumentService`, `TemplatePreviewService`, and UI.
+
+## Seed Data
+
+No new schemas → no new seed objects. Test fixtures (committed under
+`tests/sample-documents/`, generated content, no personal data):
+
+- `tagged-pdfua.pdf` — minimal tagged PDF with `/StructTreeRoot`,
+  `/Lang (nl-NL)`, title, and `pdfuaid:part 1` XMP (generated by LO from a
+  seed ODT at fixture-build time; committed as a stable binary).
+- `untagged.pdf` — mPDF-produced equivalent (fires `pdf-not-tagged`).
+- `tagged-no-lang.pdf` — tagged but `/Lang` stripped.
+- Seed template with a deliberate lint trap (image without alt + `h1→h3`
+  jump) for the preview-lint tests, Demostad-flavoured content
+  ("Besluit parkeervergunning Demostad").
+
+## Risks / Trade-offs
+
+- [LO's PDF/UA export quality depends on source semantics] → that is exactly
+  what D5 lint + D2 mandatory language address at the controllable end (our
+  templates); the docs state that conformance depends on template quality,
+  and the checks report what actually shipped.
+- [Heuristic checks can false-negative (tag soup passes)] → documented
+  honestly: checks are presence heuristics, category label is
+  "accessibility checks", not "PDF/UA certified"; veraPDF-grade validation
+  is the named follow-up.
+- [`accessible: true` fails when soffice is absent] → deliberate (D1) —
+  fail-closed beats silently inaccessible output; the error carries the
+  cascade attempt records so admins see why.
+- [Twig-template HTML→LO import fidelity vs mPDF rendering differences] →
+  accessible mode is opt-in per generation; visual diffs surface in
+  preview, which uses the same path when `accessible` is requested.
+- [Publication warning depends on a pipeline that is itself in-flight] →
+  the signal is computed locally and also surfaces on existing validation
+  UI; the pipeline consumes it when it lands (loose coupling by design,
+  D4).
+
+## Migration Plan
+
+1. Validation checks land first (pure additive service change — findings
+   appear on next validation, old records stay "not yet validated" per the
+   existing spec).
+2. LO accessible-export mode + generation option.
+3. UI grouping, publication warning, template lint.
+4. Rollback = revert release; no data migration in either direction (no
+   schema changes).
+
+## Open Questions
+
+- Default language precedence when a template has multiple language
+  variants and the call passes none (provisional: the variant actually
+  rendered wins; error only when nothing is resolvable).
+- Whether anonymization PDF outputs should *report* (not enforce)
+  accessibility findings by default (provisional: yes — they run through
+  validation like any document; scan-sourced files will warn, which is the
+  truthful state).

--- a/openspec/changes/pdfua-accessible-output/proposal.md
+++ b/openspec/changes/pdfua-accessible-output/proposal.md
@@ -1,0 +1,90 @@
+---
+kind: code
+---
+
+# Proposal: pdfua-accessible-output
+
+## Why
+
+Accessible PDF output is a **statutory requirement** for Dutch government —
+the Besluit digitale toegankelijkheid overheid (implementing EU Directive
+2016/2102) mandates EN 301 549 conformance, which for PDFs means tagged,
+accessible documents (PDF/UA-1, ISO 14289-1 / WCAG 2.1 AA). It is a hard
+procurement gate (Forum Standaardisatie / DigiToegankelijk), Xential
+actively positions "WCAG templates" as a differentiator
+(research-competitors.md), and user-wishes #15 flags it as a fully
+**unspecced gap**: "hard procurement gate … 0 issues". The NC-ecosystem scan
+(research-nc-ecosystem.md, gap 4) confirms **zero coverage**: no Nextcloud
+app produces or validates PDF/UA — DocuDesk already ships PDF/A-3
+(`pdfa3-conversion`, `render-pdfa`), so accessibility is the missing half of
+its archival/compliance output story.
+
+Every document DocuDesk generates for a citizen or publishes under Woo is in
+scope of the Besluit. Verified current state: the mPDF path
+(`PdfService::renderPdf`) produces **untagged** PDFs (the existing
+`pdf-generation` spec itself notes "PDF accessibility (tagged PDF) not
+currently enforced"); the LibreOffice headless backend already exports with
+`UseTaggedPDF=true` (verified in `LibreOfficeHeadlessBackend`, filter string
+`pdf:writer_pdf_Export:UseTaggedPDF=true,SelectPdfVersion=2`) but without
+PDF/UA identification or language metadata; and
+`DocumentValidationService` has six check ids, none touching accessibility.
+
+## What Changes
+
+- **Tagged, accessible PDF generation (PDF/UA-1 target)** from the template
+  rendering pipeline: an `accessible` output option routes rendering through
+  a backend capable of tagged output (LibreOffice headless with
+  `PDFUACompliance` + `UseTaggedPDF`), sets document language and title
+  metadata, and preserves semantic structure (heading hierarchy, alt text,
+  table headers, reading order) from the template HTML/DOCX. The mPDF path
+  cannot produce tagged PDFs and MUST honestly report non-conformance
+  instead of silently emitting untagged output.
+- **Accessibility as a new check category in `DocumentValidationService`**:
+  new heuristic, parser-free check ids (`pdf-not-tagged`,
+  `pdf-language-missing`, `pdf-title-missing`, `pdfua-identifier-missing`)
+  reporting PDF/UA/WCAG findings per document through the existing
+  profile/severity/verdict mechanism.
+- **Accessibility status surfaced** in the validation UI (verdict chip +
+  findings panel already spec'd by `document-validation-checks`) and as a
+  **publication-readiness warning**: a document with open accessibility
+  findings warns before Woo publication hand-off.
+- **Template-level accessibility lint** in template preview: missing alt
+  text, heading-order jumps, missing language — caught at authoring time,
+  not at the published document.
+
+## Capabilities
+
+### New Capabilities
+
+- `pdfua-accessible-output`: the cross-cutting accessibility surface —
+  accessibility status in UI and publication-readiness, template-level
+  accessibility lint in preview, and the statutory conformance framing
+  (Besluit digitale toegankelijkheid / EN 301 549).
+
+### Modified Capabilities
+
+- `pdf-generation`: gains the accessible/tagged output requirement (backend
+  routing, language/title metadata, honest conformance reporting on the
+  mPDF path).
+- `document-validation-checks`: gains the accessibility check category
+  (new check ids in the existing catalogue/profile/severity mechanism).
+
+## Impact
+
+- **Backend**: `PdfService`/`DocumentService` output-option plumbing; a
+  PDF/UA-capable export path on `LibreOfficeHeadlessBackend` (filter options
+  extension); new accessibility checks in
+  `lib/Service/DocumentValidationService.php`; template lint in
+  `TemplatePreviewService`.
+- **Frontend**: findings already render via `ValidationResultModal` /
+  validation UI; adds the accessibility category, the publication-readiness
+  warning, and lint results in template preview (ADR-012 components).
+- **Config**: accessibility checks ride the existing
+  `docudesk.validation.profiles` severity mechanism (default `warning`,
+  admin-escalatable to `blocking`).
+- **No new dependencies**: heuristics are parser-free (same style as the
+  existing `isPdfEncrypted`/`textLayerMissing` checks); veraPDF-grade
+  external validation is explicitly out of scope (tracked separately, CB
+  #182 pattern).
+- **Sibling boundaries**: publication endpoints remain
+  OpenCatalogi/OpenWoo's; DocuDesk only gates its own hand-off readiness.

--- a/openspec/changes/pdfua-accessible-output/specs/document-validation-checks/spec.md
+++ b/openspec/changes/pdfua-accessible-output/specs/document-validation-checks/spec.md
@@ -1,0 +1,71 @@
+# document-validation-checks Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Extend the document validation check catalogue with an accessibility
+category: heuristic, parser-free PDF/UA/WCAG presence checks reported per
+document through the existing profile/severity/verdict mechanism. Existing
+requirements (catalogue, profiles, calculation storage, on-demand endpoint,
+422 gate, UI) are unchanged; this delta only ADDs requirements.
+
+## ADDED Requirements
+
+### Requirement: The check catalogue MUST include an accessibility category (REQ-DDPUA-003)
+
+`DocumentValidationService` MUST implement four additional checks, grouped
+under a new optional finding key `category: "accessibility"` (existing
+findings default to category `document`; the aggregation of
+`validationStatus` is unchanged):
+
+- `pdf-not-tagged` — the PDF carries no `/StructTreeRoot` reference, or its
+  `/MarkInfo` lacks `/Marked true`.
+- `pdf-language-missing` — the PDF catalog carries no `/Lang` entry.
+- `pdf-title-missing` — neither XMP `dc:title` nor Info `/Title` has a
+  non-empty value.
+- `pdfua-identifier-missing` — the XMP metadata lacks a `pdfuaid:part`
+  identifier; this finding MUST be suppressed when `pdf-not-tagged` already
+  fired for the same document.
+
+The checks MUST be heuristic byte-level scans in the style of the existing
+`pdf-encrypted`/`text-layer-missing` checks (no new parsing dependency),
+MUST apply only to PDF content, MUST ride the existing
+`docudesk.validation.profiles` per-check severity mechanism
+(`off|warning|blocking`), MUST default to `warning` in every shipped
+profile, and — like all findings — MUST never embed document content. The
+service and its documentation MUST describe these as accessibility presence
+heuristics, not certified PDF/UA (Matterhorn/veraPDF-grade) validation.
+
+#### Scenario: Untagged PDF fires the accessibility findings
+
+- GIVEN an untagged PDF generated via mPDF
+- WHEN validation runs under a default profile
+- THEN the findings contain `{checkId: "pdf-not-tagged", severity: "warning", category: "accessibility"}`
+- AND no `pdfua-identifier-missing` finding is produced for it
+- @e2e tests/e2e/spec-coverage/pdfua-accessible-output.spec.ts
+
+#### Scenario: Tagged PDF without language fires only the language check
+
+- GIVEN a tagged PDF fixture whose catalog lacks `/Lang`
+- WHEN validation runs
+- THEN the findings contain `pdf-language-missing`
+- AND contain neither `pdf-not-tagged` nor a false `pdf-title-missing` when a title is present
+- @e2e exclude fixture-permutation matrix; covered by PHPUnit (tests/unit/Service/DocumentValidationServiceTest.php)
+
+#### Scenario: Accessible fixture passes the accessibility category
+
+- GIVEN the tagged PDF/UA fixture with `/StructTreeRoot`, `/Lang`, a title, and `pdfuaid:part`
+- WHEN validation runs
+- THEN no accessibility-category finding is produced
+- @e2e exclude pure service computation; covered by PHPUnit (tests/unit/Service/DocumentValidationServiceTest.php)
+
+#### Scenario: Admin escalates an accessibility check to blocking
+
+- GIVEN a profile setting `pdf-not-tagged` to `blocking`
+- WHEN an untagged PDF is validated
+- THEN `validationStatus` is `failed` via the existing aggregation
+- AND the existing intake 422 gate applies without any new gating mechanism
+- @e2e exclude severity-escalation config permutation; covered by PHPUnit (tests/unit/Service/DocumentValidationServiceTest.php)

--- a/openspec/changes/pdfua-accessible-output/specs/pdf-generation/spec.md
+++ b/openspec/changes/pdfua-accessible-output/specs/pdf-generation/spec.md
@@ -1,0 +1,86 @@
+# PDF Generation Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Extend the PDF generation capability with tagged, accessible output
+(PDF/UA-1 target, ISO 14289-1 / EN 301 549 / WCAG 2.1 AA): an `accessible`
+output option that routes rendering through a tagged-capable backend with
+mandatory language and title metadata, and honest non-conformance reporting
+on paths that cannot produce tagged output. Existing REQ-PDF-01..07
+requirements are unchanged; this delta only ADDs requirements.
+
+## ADDED Requirements
+
+### Requirement: Accessible output routes through a tagged-capable backend (REQ-DDPUA-001)
+
+The generation pipeline MUST support an `accessible: true` output option for
+PDF output. When set, rendering MUST be produced by a backend capable of
+tagged PDF: `LibreOfficeHeadlessBackend` MUST gain an accessible-export mode
+adding `PDFUACompliance=true` to its `writer_pdf_Export` filter options
+(keeping `UseTaggedPDF=true`), selected via the per-call options of
+`PdfConversionService::convertToPdf()`. For Twig/HTML templates the rendered
+HTML MUST be converted through this LibreOffice accessible mode instead of
+mPDF; for office templates the filled DOCX takes the same path. Because mPDF
+cannot emit structure tags, the mPDF path MUST NOT be used to satisfy an
+`accessible: true` request and MUST NOT silently substitute untagged output:
+when no tagged-capable backend is available the request MUST fail with a
+structured conversion error carrying the per-backend attempt records. When
+both `accessible` and PDF/A are requested the export MUST retain PDF/A
+conformance alongside tagging.
+
+#### Scenario: Accessible generation produces a tagged PDF
+
+- GIVEN LibreOffice headless is available
+- AND a template rendered with `accessible: true`
+- WHEN the PDF is generated
+- THEN the output contains a structure tree (`/StructTreeRoot`) and `/MarkInfo` with `/Marked true`
+- AND the export used the `PDFUACompliance=true` filter mode
+- @e2e tests/e2e/spec-coverage/pdfua-accessible-output.spec.ts
+
+#### Scenario: Accessible request fails closed without a tagged-capable backend
+
+- GIVEN LibreOffice headless is unavailable
+- WHEN a generation with `accessible: true` is requested
+- THEN the request fails with a structured error listing the attempted backends
+- AND no untagged PDF is returned for the request
+- @e2e exclude backend-outage fault injection is not browser-drivable; covered by PHPUnit (tests/unit/Service/PdfConversionServiceTest.php)
+
+### Requirement: Accessible output carries mandatory language and title metadata (REQ-DDPUA-002)
+
+Accessible PDF output MUST set the document language (`/Lang`) and the
+document title metadata. The language MUST be resolved in this precedence:
+an explicit per-call language option, the rendered template's language
+variant, then the instance default locale; when no language is resolvable
+the `accessible: true` generation MUST fail with a descriptive error rather
+than emit output without `/Lang`. The title MUST come from the existing
+`title` option or fall back to the template name. Semantic structure present
+in the source (heading hierarchy, image alternative text, table headers)
+MUST be preserved into the tagged output rather than flattened.
+
+#### Scenario: Language and title are present in accessible output
+
+- GIVEN a Dutch template rendered with `accessible: true` and title "Besluit parkeervergunning"
+- WHEN the PDF is generated
+- THEN the PDF catalog carries `/Lang` with the Dutch language tag
+- AND the document title metadata equals "Besluit parkeervergunning"
+- @e2e tests/e2e/spec-coverage/pdfua-accessible-output.spec.ts
+
+#### Scenario: Unresolvable language fails the accessible request
+
+- GIVEN a template with no language variant, no explicit language option, and no resolvable instance locale
+- WHEN generation with `accessible: true` is requested
+- THEN the request fails naming the missing language
+- AND no PDF without `/Lang` is produced for the request
+- @e2e exclude locale-resolution permutation; covered by PHPUnit (tests/unit/Service/PdfServiceTest.php)
+
+#### Scenario: Heading structure survives into the tag tree
+
+- GIVEN a template whose content uses h1/h2 headings and an image with alt text
+- WHEN an accessible PDF is generated
+- THEN the structure tree contains corresponding heading elements in order
+- AND the image carries the alternative text
+- @e2e exclude tag-tree introspection requires a PDF parser in the test harness; covered by PHPUnit against the tagged fixture set (tests/unit/Service/PdfConversionServiceTest.php)

--- a/openspec/changes/pdfua-accessible-output/specs/pdfua-accessible-output/spec.md
+++ b/openspec/changes/pdfua-accessible-output/specs/pdfua-accessible-output/spec.md
@@ -1,0 +1,91 @@
+# pdfua-accessible-output Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+The cross-cutting accessibility surface on top of accessible generation
+(pdf-generation delta) and the accessibility check category
+(document-validation-checks delta): accessibility status surfaced in the
+validation UI, a publication-readiness warning before Woo hand-off, and
+template-level accessibility lint in preview. Statutory frame: Besluit
+digitale toegankelijkheid overheid / EU Directive 2016/2102 / EN 301 549 →
+WCAG 2.1 AA; target output profile PDF/UA-1 (ISO 14289-1).
+
+## ADDED Requirements
+
+### Requirement: Accessibility status is surfaced in the validation UI (REQ-DDPUA-004)
+
+The validation findings UI MUST group findings by category and MUST render
+an `accessibility` section with localised messages when accessibility
+findings exist; the existing verdict chip semantics stay unchanged. The
+wording MUST describe the state as accessibility checks (e.g. "accessibility
+checks passed" / "openstaande toegankelijkheidsbevindingen") and MUST NOT
+claim PDF/UA certification. All new UI MUST itself satisfy WCAG 2.1 AA and
+use NL Design System tokens via Nextcloud CSS variables.
+
+#### Scenario: Operator sees grouped accessibility findings
+
+- GIVEN a document with `pdf-not-tagged` and `pdf-language-missing` findings
+- WHEN the operator opens its validation results
+- THEN an "Accessibility" group lists both findings with localised explanations
+- AND the verdict chip reflects the existing aggregation
+- @e2e tests/e2e/spec-coverage/pdfua-accessible-output.spec.ts
+
+### Requirement: Open accessibility findings warn before Woo publication hand-off (REQ-DDPUA-005)
+
+Publication-facing actions in DocuDesk MUST consult a
+publication-readiness signal derived from the document's stored validation
+findings: when open `accessibility`-category findings exist, the action MUST
+show a warning naming the findings (with a link to the validation detail)
+before the user proceeds. The warning MUST NOT hard-block by itself —
+blocking remains the domain of the existing profile severity mechanism
+(escalating a check to `blocking` engages the standard intake/verdict gate).
+The signal MUST be computed within DocuDesk; publication endpoints remain
+owned by OpenCatalogi/OpenWoo and any publication pipeline consumes the same
+signal.
+
+#### Scenario: Inaccessible document warns before publication
+
+- GIVEN a document prepared for Woo publication whose findings include `pdf-not-tagged`
+- WHEN the user triggers the publication hand-off action
+- THEN a warning states the document has open accessibility findings and links to them
+- AND the user can still proceed unless a blocking severity applies
+- @e2e tests/e2e/spec-coverage/pdfua-accessible-output.spec.ts
+
+#### Scenario: Clean document proceeds without warning
+
+- GIVEN a document whose accessibility-category findings are empty
+- WHEN the publication hand-off action is triggered
+- THEN no accessibility warning is shown
+- @e2e tests/e2e/spec-coverage/pdfua-accessible-output.spec.ts
+
+### Requirement: Template preview lints accessibility at authoring time (REQ-DDPUA-006)
+
+Template preview MUST run an accessibility lint over the rendered preview
+(HTML for Twig templates; the text/XML projection for office templates) and
+MUST return the lint results alongside the preview: images without
+non-empty alternative text, heading-order jumps (e.g. h1 followed by h3
+without h2), no resolvable document language, and (HTML path) tables
+without header cells. Lint results MUST render as a non-blocking checklist
+in the template editor and MUST NOT prevent saving or previewing — document
+validation remains the enforcement point. Lint findings MUST reference the
+offending element positionally (e.g. nth image, heading text) and MUST NOT
+require the author to read generated output to locate the problem.
+
+#### Scenario: Author sees a missing-alt lint in preview
+
+- GIVEN a template containing an image without alt text and an h1→h3 heading jump
+- WHEN the author opens the template preview
+- THEN the lint checklist reports the missing alternative text and the heading-order jump, each locating the offending element
+- AND the template can still be saved and previewed
+- @e2e tests/e2e/spec-coverage/pdfua-accessible-output.spec.ts
+
+#### Scenario: Clean template lints empty
+
+- GIVEN a template with alt-texted images, ordered headings, and a language variant
+- WHEN preview runs
+- THEN the lint checklist is empty
+- @e2e exclude lint-computation permutations; covered by PHPUnit (tests/unit/Service/TemplatePreviewServiceTest.php)

--- a/openspec/changes/pdfua-accessible-output/tasks.md
+++ b/openspec/changes/pdfua-accessible-output/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: pdfua-accessible-output
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 13.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Accessible generation backend
+
+- [ ] 1.1 Extend `LibreOfficeHeadlessBackend` with an accessible-export mode (`PDFUACompliance=true` + `UseTaggedPDF=true` filter options) selected via the per-call `$opts` of `PdfConversionService::convertToPdf()`; keep PDF/A when both requested (REQ-DDPUA-001)
+  - Fail-closed with structured attempt records when soffice is unavailable; never silent mPDF fallback for `accessible: true`
+
+- [ ] 1.2 Thread the `accessible` option through `DocumentService`/`PdfService` generation paths: Twig/HTML → temp `.html` → LO accessible mode; office templates → filled DOCX → same path (REQ-DDPUA-001)
+
+- [ ] 1.3 Mandatory metadata: `/Lang` resolution (explicit option → template language variant → instance locale, else descriptive failure) and title metadata (option → template name); semantic structure preserved (REQ-DDPUA-002)
+
+## 2. Validation checks
+
+- [ ] 2.1 Add the four accessibility checks to `lib/Service/DocumentValidationService.php` (`pdf-not-tagged`, `pdf-language-missing`, `pdf-title-missing`, `pdfua-identifier-missing` with suppression rule), byte-level heuristics, `category: "accessibility"` on findings (existing findings default `document`), riding the existing profile/severity mechanism, default `warning` (REQ-DDPUA-003)
+  - No new parsing dependency; findings never embed content; `aggregate()` unchanged
+
+- [ ] 2.2 Build the PDF fixture set in `tests/sample-documents/` (tagged PDF/UA, untagged, tagged-no-lang, no-title) per design.md Seed Data — generated content only, no personal data
+
+## 3. UI surfaces (ADR-012)
+
+- [ ] 3.1 Validation findings UI: category grouping with an "Accessibility" section and localised messages in `ValidationResultModal`/findings panel; "checks passed" wording — never "PDF/UA certified" (REQ-DDPUA-004)
+
+- [ ] 3.2 Publication-readiness warning: helper deriving "open accessibility findings" from stored findings; warning + link on publication-facing actions; no new gating mechanism (REQ-DDPUA-005)
+
+- [ ] 3.3 Template preview lint: lint pass in `TemplatePreviewService` (missing alt, heading-order jump, unresolvable language, table without headers) returned with the preview; non-blocking checklist panel in the template editor with positional references (REQ-DDPUA-006)
+
+## 4. Quality, i18n, docs
+
+- [ ] 4.1 Unit tests ≥75% on new code: filter-option selection, fail-closed path, lang/title resolution matrix, all four checks against the fixture set incl. suppression rule and blocking escalation, lint permutations; run in container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`
+
+- [ ] 4.2 Playwright e2e `tests/e2e/spec-coverage/pdfua-accessible-output.spec.ts` (accessible generation → findings grouping → publication warning → template lint); verify on Postgres (8080); test with nldesign theme enabled — new UI itself WCAG AA
+
+- [ ] 4.3 i18n: EN source keys + NL translations for findings messages, warning banner, lint checklist
+
+- [ ] 4.4 Docs in `docs/features/` (accessible output, accessibility checks incl. "presence heuristics, not certified PDF/UA validation" framing, DigiToegankelijk/EN 301 549 context) with Playwright screenshots (ADR-010)
+
+- [ ] 4.5 `openspec validate pdfua-accessible-output --strict` passes; run gates on the touched capability specs
+
+## Quality checklist
+
+- No schema/register change in this change — verify `docudesk_register.json` untouched in the diff
+- Honesty invariants mutation-tested: untagged output never labelled accessible; `accessible: true` never silently downgraded
+- `composer check:strict` green; hydra gates pass; verified end-to-end against OpenRegister on the Postgres dev instance

--- a/openspec/changes/redaction-at-scale/.openspec.yaml
+++ b/openspec/changes/redaction-at-scale/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/redaction-at-scale/design.md
+++ b/openspec/changes/redaction-at-scale/design.md
@@ -1,0 +1,222 @@
+# Design: redaction-at-scale
+
+## Context
+
+Verified at HEAD:
+
+- `BatchStateService` stores batch state in `ICache` (TTL 7200s, prefix
+  `docudesk_batch_`, `DEFAULT_MAX_FILES = 100`); TTL is refreshed on writes
+  and status polls.
+- `BatchAnonymizationController::batchExtract` extracts one file per HTTP
+  call; `::batchAnonymize` → `BatchAnonymizeService::anonymizeBatch` loops
+  over ALL files synchronously in one request.
+- `FolderExtractionJob extends QueuedJob` processes every file of a folder
+  batch sequentially in a single run; no cancellation, no per-run budget,
+  no resume.
+- `LibreOfficeHeadlessBackend` serializes soffice via a global
+  `ILockingProvider` lock (`soffice:headless:convert`) and fails fast when
+  the lock is held — the only existing resource guard.
+- The canonical `batch-anonymization` spec already mandates (REQ-BANON-00,
+  status implementing, change `docudesk-adopt-or-abstractions`): batch
+  state as `batchAnonymizationJob` OR objects with per-file child objects
+  and lifecycle annotations, scheduled via OR Background Jobs, with the
+  cap promoted to `IAppConfig docudesk.batch.max_files_per_run`. Those
+  schemas are NOT yet present in `lib/Settings/docudesk_register.json` —
+  the migration is in flight.
+- Sibling change `anonymization-review-workbench` introduces the
+  per-document `documentReview` checked gate this change's sampling QA
+  routes into.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Process dossier/folder batches sized for 25.000–55.000 docs/year and
+  50–200 users without HTTP timeouts, lost state or instance starvation.
+- Operator control: progress, cancel, resume, throughput/failure insight.
+- Statistical trust: sampling QA over auto-redacted output.
+
+**Non-Goals:**
+
+- No distributed workers / external queue (Redis queues, Horizon-style) —
+  NC cron + OR background jobs are the platform primitives (ADR-001/022).
+- No change to detection quality or anonymisation semantics (OR-owned).
+- No review-UI work beyond routing QA samples into the existing workbench.
+- No multi-tenant scheduling fairness (single-org assumption for v1).
+
+## Decisions
+
+### D1 — Complete and extend REQ-BANON-00, don't fork it
+
+Durable state is a precondition for scale, and the canonical spec already
+mandates OR-object batch state. **Decision:** this change depends on and
+completes that migration — `batchAnonymizationJob` (+ per-file
+`batchAnonymizationFile` children) become the source of truth, ICache is
+demoted to an optional read-through cache for hot status polls. The
+existing wire statuses stay unchanged (`pending/processing/success/error`
+per file; batch adds `cancelling/cancelled` — see D3). Rejected: a second,
+parallel "large batch" store — two state machines for one domain object is
+the orphaned-capability pattern this fleet keeps paying for.
+
+### D2 — Chunked work units under a cron coordinator
+
+**Decision:** a `BatchJobCoordinator` cron job (NC `TimedJob`, interval ≤ 5
+min) claims pending batches and processes bounded **work units**: at most
+`docudesk.batch.files_per_tick` files (default 25) AND at most
+`docudesk.batch.seconds_per_tick` wall seconds (default 120) per run,
+whichever ends first, then yields. Progress is written per file, so the
+unit boundary is also the crash-recovery boundary — resume is "by
+construction" (D4). Both extract and anonymize phases run through the same
+work-unit mechanic. Rejected alternatives: one QueuedJob per file (job-table
+bloat at 5k-file dossiers, no ordering); keeping the single-run
+QueuedJob (crash strands the batch; a 5.000-file run in one cron slot
+starves other NC jobs — memory: NC34 double bg-jobs incidents).
+
+### D3 — Cooperative cancellation between files
+
+**Decision:** `POST /api/anonymization/batch/{batchId}/cancel` sets the
+batch to `cancelling`; the worker checks the flag between files and
+transitions to `cancelled`, never killing mid-file (a half-written
+anonymized file is worse than one extra file). Already-produced outputs are
+kept and reported. Cancel of a completed/errored batch is a 409.
+
+### D4 — Resume = re-enqueue only non-succeeded files, idempotently
+
+**Decision:** `POST /api/anonymization/batch/{batchId}/resume` on an
+`error` or `cancelled` batch re-queues only files not in `success`.
+Idempotency per file: the anonymize step keys on the existing
+`anonymizationLink.sourceFileId` (unique per source; `runCount` increments
+on re-anonymisation) so a file that succeeded between crash and resume is
+skipped, not double-processed. Extraction idempotency is OR-side
+(`TextExtractionService::extractFile` re-extract semantics).
+
+### D5 — Sampling QA routes into the workbench checked gate
+
+**Decision:** at batch anonymize completion, a uniform random sample of
+`docudesk.batch.qa_sample_rate` percent (default 5, min 1 file when the
+batch is non-empty and the rate > 0) of successfully auto-anonymized files
+is marked `qaSampled: true` on their per-file objects. Sampled files
+REQUIRE human review: they surface in the review workbench queue, and the
+batch report records per-sample outcome (`pending/confirmed/corrected`).
+Selection uses a seeded PRNG with the seed stored on the batch so the
+sample is reproducible for audit (algoritmeregister expectation).
+Rejected: confidence-weighted sampling — better statistically but
+unexplainable to auditors in v1; noted as future work.
+
+### D6 — Resource guards compose, they don't replace
+
+**Decision:** (a) per-tick file and time budgets (D2); (b) extraction
+concurrency: the coordinator processes files sequentially within a tick
+(concurrency 1 — matching today's serialized reality) and respects the
+existing soffice `ILockingProvider` lock by treating a fail-fast lock miss
+as a retryable per-file outcome, not an error; (c) load-aware backoff: if
+a tick exhausts its time budget on fewer than 20% of its file budget, the
+coordinator marks the batch `throttled` in progress metadata and continues
+next tick — visible, not silent. No PHP `sys_getloadavg()` gating in v1
+(container-dependent, flaky signal).
+
+### D7 — Two caps: synchronous stays 100, background gets 1000
+
+**Decision:** the existing synchronous upload/extract path keeps
+`docudesk.batch.max_files_per_run` (default 100). Batches above it are not
+rejected anymore but require the background path
+(`docudesk.batch.max_files_background`, default 1000; hard server-side
+clamp). Folder batches route by the same thresholds. Arnhem-scale yearly
+volume (55.000 docs ≈ 220/working day) fits comfortably; single mega-dossiers
+beyond 1000 files must be split (explicit product decision — an unbounded
+cap invites an unbounded outage).
+
+### D8 — Declarative vs imperative (ADR-031)
+
+- Batch/per-file state, lifecycle transitions
+  (`pending → extracting → review → anonymizing → completed | error` +
+  `cancelling/cancelled`), progress fields, QA flags: **declarative** —
+  schemas + `x-openregister-lifecycle` in `lib/Settings/docudesk_register.json`
+  (extending the REQ-BANON-00 schemas).
+- The coordinator job, work-unit loop, cancellation checks, sampler and
+  throughput aggregation: **imperative** — scheduled bulk work is an
+  explicit ADR-031 exception category.
+- Report aggregation (docs/hour, failure grouping) is computed in
+  `BatchReportService` at read time, not stored — avoids denormalised
+  counters drifting from child-object truth.
+
+### D9 — OpenRegister services (ADR-001) and frontend (ADR-012)
+
+All state via OR ObjectService (batch job + file child objects,
+`anonymizationLink` reads, `documentReview` for QA routing); no custom
+tables; extraction/detection/anonymisation via the existing container-
+resolved OR services (`TextExtractionService`, `EntityRelationMapper`,
+`FileService::anonymizeDocument`). Frontend: batch operations view built
+on `CnIndexPage`/`CnDataTable` with the existing store pattern; progress
+via status polling (no websockets in v1). ADR-011: no new
+validation/formatting utilities — reuse OR formats.
+
+## Seed Data
+
+```json
+// batchAnonymizationJob — a folder batch mid-flight (municipal dossier)
+{ "name": "Woo-dossier Subsidietoekenningen 2025",
+  "sourceType": "folder",
+  "folderId": 731001,
+  "folderPath": "/Dossiers/Woo-2025-014",
+  "status": "anonymizing",
+  "totalFiles": 480,
+  "filesSucceeded": 213,
+  "filesFailed": 2,
+  "qaSampleRate": 5,
+  "qaSampleSeed": "00000000-0000-0000-0000-000000000000",
+  "requestedBy": "w.devries",
+  "startedAt": "2026-07-16T08:10:00Z",
+  "throttled": false }
+
+// batchAnonymizationFile — child object, one per file
+{ "batchId": "00000000-0000-0000-0000-000000000001",
+  "fileId": 731245,
+  "fileName": "besluit-subsidie-0042.pdf",
+  "status": "success",
+  "entityCount": 31,
+  "replacementCount": 29,
+  "qaSampled": true,
+  "qaOutcome": "pending",
+  "durationMs": 5400,
+  "error": null }
+```
+
+Seed task: one demo batch (12 files, 1 error, 1 QA sample) so the
+operations view and report render meaningfully on a clean install.
+
+## Risks / Trade-offs
+
+- [REQ-BANON-00 migration is in flight in another change] → this change
+  declares the dependency explicitly and lands after (or absorbs) the
+  OR-state migration; tasks include a HEAD re-verify before apply
+  (memory: spec-says-done ≠ feature runs).
+- [Cron cadence caps throughput (~25 files/5 min/instance by default)] →
+  budgets are admin-tunable; the report exposes docs/hour so operators see
+  the ceiling; documented sizing guidance in docs task.
+- [Sequential-within-tick underuses big hosts] → deliberate v1 safety
+  choice (soffice serialization makes >1 extraction concurrency mostly
+  false parallelism anyway); revisit with real pilot numbers (CB #148).
+- [Sampling QA can be perceived as blocking throughput] → only sampled
+  files require review; the batch completes regardless, report shows QA
+  debt.
+- [ICache read-through can serve stale status] → OR objects are
+  authoritative; cache entries carry the batch version and are invalidated
+  on every write.
+
+## Migration Plan
+
+1. Land/absorb the REQ-BANON-00 OR-state schemas; add progress,
+   cancellation and QA fields (additive).
+2. Ship coordinator + work units behind config `docudesk.batch.engine`
+   (`background` default | `legacy-sync` kill switch, one release).
+3. Ship cancel/resume/report/ops-view + QA sampler.
+4. Rollback: `legacy-sync` restores in-request behaviour; OR batch objects
+   remain readable (no data loss either direction).
+
+## Open Questions
+
+- Should QA sample outcomes feed back into detection-confidence tuning
+  (OR-side)? Deferred — cross-app contract with OR entity detection.
+- Should the ops view be admin-only or visible to all batch owners?
+  Provisional: owners see their batches, admins see all.

--- a/openspec/changes/redaction-at-scale/proposal.md
+++ b/openspec/changes/redaction-at-scale/proposal.md
@@ -1,0 +1,112 @@
+---
+kind: code
+tracking_issue: https://github.com/ConductionNL/docudesk/issues/236
+---
+
+# Proposal: redaction-at-scale
+
+## Why
+
+The tenders DocuDesk is being measured against are municipal-scale:
+
+- **Arnhem 407824** (with Renkum + Rheden): ~275 Woo dossiers and ~55.000
+  documents per year, ~50 staff, irreversible blackout, "SaaS tenzij".
+- **Groningen 421583**: laksoftware for ~200 users, 25.000–35.000 documents
+  per year.
+- **CB #148** tracks a municipal pilot at this volume; **GH #236** (the
+  tracking issue for this change) and the intelligence-DB backlog item
+  `redaction-at-scale` record the same demand. GH #84 asks for async dossier
+  processing.
+
+Verified at HEAD, DocuDesk's batch pipeline cannot carry that load:
+
+- Batch state lives in **ICache** (`BatchStateService`, TTL 7200s, prefix
+  `docudesk_batch_`) — a cache eviction or restart loses a running batch.
+- `POST /api/anonymization/batch/{batchId}/extract` processes **one file per
+  HTTP call** (client-driven polling loop).
+- `POST /api/anonymization/batch/{batchId}/anonymize` runs a **synchronous
+  foreach over every file inside a single HTTP request**
+  (`BatchAnonymizeService::anonymizeBatch`) — at hundreds of files this hits
+  PHP/webserver timeouts.
+- `FolderExtractionJob` (QueuedJob) processes an entire folder batch
+  **sequentially in one run** with no cancellation, no resume and no
+  per-run budget; a mid-run crash strands the batch.
+- The only resource guard is the LibreOffice lock
+  (`LibreOfficeHeadlessBackend`, global `ILockingProvider` lock
+  `soffice:headless:convert`); nothing bounds extraction fan-out or job run
+  time, so a big batch can starve the instance.
+- Batch size is capped at 100 files (`DEFAULT_MAX_FILES`) — a single Woo
+  dossier at Arnhem scale exceeds it.
+
+The existing `batch-anonymization` spec (REQ-BANON-00, status implementing)
+already points the way: OR-object batch state with lifecycle child objects
+and OR Background Jobs. This change builds the scale layer on that
+foundation. VNG's finding that >50% of documents are partly auto-redactable
+but ALL need review also makes a **sampling QA** loop (random N% of
+auto-redacted documents routed to human review) a hard requirement for
+trustworthy volume processing.
+
+## What
+
+- **Durable, chunked background processing**: batches above the synchronous
+  threshold are processed by cron-scheduled background jobs in bounded work
+  units (N files per tick, run-time budget per tick), with batch and
+  per-file state persisted as OR objects (extending REQ-BANON-00) so a
+  restart never loses a batch.
+- **Progress, cancellation and resume**: per-batch progress
+  (files done/total, current phase, throughput), `POST
+  /api/anonymization/batch/{batchId}/cancel` (graceful, between files) and
+  `POST /api/anonymization/batch/{batchId}/resume` (re-enqueue only
+  non-succeeded files; idempotent per file).
+- **Throughput and failure reporting**: the batch report gains
+  documents/hour, per-phase durations and failures grouped by reason; an
+  operations view lists active/recent batches.
+- **Sampling QA**: an admin-configurable random sample (default 5%) of
+  auto-anonymized documents per batch is routed to human review (the
+  `anonymization-review-workbench` checked gate), with sample outcomes
+  recorded on the batch report.
+- **Rate/resource guards**: bounded files-per-tick and seconds-per-tick,
+  extraction concurrency cap, reuse of the existing serialized LibreOffice
+  lock, and load-aware backoff so extract/convert backends do not starve
+  the Nextcloud instance.
+- **Scale limits**: a separate, larger admin-configurable cap for
+  background batches (default 1000 files; synchronous path keeps its
+  existing cap), sized for 25.000–55.000 docs/year and 50–200 users.
+
+## Capabilities
+
+### New Capabilities
+
+- `redaction-at-scale`: the municipal-scale batch layer — chunked
+  background processing, progress/cancel/resume, throughput + failure
+  reporting, sampling QA, resource guards, background-scale limits.
+
+### Modified Capabilities
+
+- `batch-anonymization`: the batch anonymize step becomes a background
+  operation above the synchronous threshold (the endpoint enqueues instead
+  of looping in-request).
+- `folder-batch-analysis`: folder batches gain optional recursive
+  enumeration and chunked background extraction with cancellation checks
+  (replacing the single-run-processes-all job behaviour).
+
+## Impact
+
+- **Backend**: new `BatchJobCoordinator` (cron `TimedJob`) + work-unit
+  processing in `BatchAnonymizeService`/`BatchExtractionService`; new
+  cancel/resume/list controller actions on `BatchAnonymizationController`;
+  `BatchStateService` backed by OR objects (completing the REQ-BANON-00
+  direction) with ICache retained only as a read-through cache;
+  `BatchReportService` extended with throughput/failure aggregation; QA
+  sampler.
+- **Register JSON**: `batchAnonymizationJob` + `batchAnonymizationFile`
+  schemas (declared by the in-flight REQ-BANON-00; this change depends on
+  and completes them) gain progress/cancellation/QA fields.
+- **Frontend**: batch progress view with cancel/resume actions and an
+  operations list; QA-sample badge linking to the review workbench.
+- **Admin settings**: `docudesk.batch.max_files_background`,
+  `docudesk.batch.files_per_tick`, `docudesk.batch.seconds_per_tick`,
+  `docudesk.batch.qa_sample_rate`.
+- **Engines untouched**: extraction/detection/anonymisation remain
+  OpenRegister services; LibreOffice serialization stays as-is and is
+  respected, not bypassed.

--- a/openspec/changes/redaction-at-scale/specs/batch-anonymization/spec.md
+++ b/openspec/changes/redaction-at-scale/specs/batch-anonymization/spec.md
@@ -1,0 +1,48 @@
+# batch-anonymization Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Scales the batch anonymize step for municipal volume: above the
+synchronous threshold the anonymize endpoint enqueues a background batch
+(processed per `redaction-at-scale` REQ-DDRAS-002) instead of looping over
+every file inside one HTTP request. Below the threshold behaviour is
+unchanged.
+
+## MODIFIED Requirements
+
+### Requirement: Batch anonymization
+The system SHALL anonymize all extracted files in a batch via `POST /api/anonymization/batch/{batchId}/anonymize`. The request body SHALL include an `entities` array of entity values/types to anonymize (from the review step). The system SHALL apply the entity list to each file using OpenRegister's FileService::anonymizeDocument(). Per GDPR Article 4(5), entity replacements SHALL use unique UUID pseudonyms per entity value (consistent across all files in the batch). Batches whose file count exceeds the synchronous cap (`docudesk.batch.max_files_per_run`, default 100) SHALL NOT be anonymized in-request: the endpoint SHALL persist the reviewed entity list on the batch job object, transition the batch to `anonymizing`, and return HTTP 202 with the batch progress location; the files are then processed in background work units (see `redaction-at-scale` REQ-DDRAS-002), preserving the same per-file anonymization semantics and pseudonym consistency across the whole batch. Batches at or below the cap SHALL keep the existing synchronous behaviour and response shape.
+
+#### Scenario: Anonymize batch with reviewed entities
+- **WHEN** `POST /api/anonymization/batch/{batchId}/anonymize` is called with 10 selected entities
+- **THEN** each extracted file in the batch is anonymized using the provided entity list
+- **AND** each file's status updates to "anonymized" with replacementCount
+- **AND** the same entity value receives the same UUID pseudonym across all files
+- **AND** the batch status changes to "completed"
+
+#### Scenario: Anonymize batch with empty entity list
+- **WHEN** the entities array is empty
+- **THEN** the system returns HTTP 400 with error "No entities provided for anonymization"
+
+#### Scenario: Skip error files during batch anonymization
+- **WHEN** a batch contains files with status "error" from extraction
+- **THEN** those files are skipped during anonymization
+- **AND** the response includes a skippedFiles array listing the skipped file IDs and reasons
+
+#### Scenario: Large batch is enqueued instead of processed in-request (REQ-DDRAS-009)
+- **GIVEN** a review-status batch of 480 files (above the synchronous cap of 100)
+- **WHEN** `POST /api/anonymization/batch/{batchId}/anonymize` is called with the reviewed entity list
+- **THEN** the system returns HTTP 202 with the batch progress location
+- **AND** the reviewed entity list is persisted on the batch job object
+- **AND** the files are anonymized in background work units with the same pseudonym consistency across the batch
+- @e2e tests/e2e/spec-coverage/redaction-at-scale.spec.ts
+
+#### Scenario: Small batch keeps the synchronous contract
+- **GIVEN** a review-status batch of 20 files
+- **WHEN** the anonymize endpoint is called
+- **THEN** the files are anonymized in-request and the pre-change response shape is returned
+- @e2e exclude backwards-compatible API contract; covered by PHPUnit (tests/unit/Controller/BatchAnonymizationControllerTest.php) and Newman batch contracts

--- a/openspec/changes/redaction-at-scale/specs/folder-batch-analysis/spec.md
+++ b/openspec/changes/redaction-at-scale/specs/folder-batch-analysis/spec.md
@@ -1,0 +1,79 @@
+# folder-batch-analysis Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Scales folder batches for municipal dossiers: the single-run
+`FolderExtractionJob` (which processes every file of the batch in one
+QueuedJob execution) is replaced by the chunked, cancellable work-unit
+processing of `redaction-at-scale` REQ-DDRAS-002, and folder enumeration
+gains an optional recursive mode for dossier trees.
+
+## MODIFIED Requirements
+
+### Requirement: Background extraction via QueuedJob
+The system SHALL process folder-batch extraction in background work units under the `redaction-at-scale` coordinator (REQ-DDRAS-002): per run, at most `docudesk.batch.files_per_tick` files and at most `docudesk.batch.seconds_per_tick` wall seconds, processing files sequentially and calling `AnonymizationService::extractAndDetectEntities()` for each file. After each file is processed, the per-file OR child object SHALL be updated (status "extracted" or "error") before the next file begins. Between files the worker SHALL honour a pending cancellation (`redaction-at-scale` REQ-DDRAS-004). When all files have been attempted, the batch status SHALL change to "review". Individual file failures SHALL NOT abort the batch; processing SHALL continue with the remaining files.
+
+#### Scenario: Background job processes 3 files sequentially
+- **WHEN** a folder-batch work unit runs for a batch with 3 files
+- **THEN** file 1 is extracted and its status updated to "extracted" before file 2 begins
+- **AND** file 2 is extracted and its status updated before file 3 begins
+- **AND** after all 3 files are processed, the batch status changes to "review"
+
+#### Scenario: One file fails during background extraction
+- **WHEN** extraction fails for file 2 of 3
+- **THEN** file 2's status is set to "error" with the error message
+- **AND** file 3 is still processed normally
+- **AND** the batch status still transitions to "review" when all files have been attempted
+
+#### Scenario: Batch state reflects progress during extraction
+- **WHEN** the background processing has completed 2 of 5 files
+- **THEN** a poll of `GET /api/anonymization/batch/{batchId}/status` shows batchStatus "extracting", 2 files with status "extracted", and 3 files with status "uploaded"
+- **AND** progress is reported as 40%
+
+#### Scenario: Extraction spanning multiple work units (REQ-DDRAS-010)
+- **GIVEN** a folder batch of 60 files and `files_per_tick = 25`
+- **WHEN** the coordinator runs until the batch is done
+- **THEN** extraction completes across three work units with per-file state persisted at each file boundary
+- AND a cancellation requested between units stops the batch before the next unit starts
+- @e2e exclude cron work-unit scheduling not drivable from UI; covered by PHPUnit (tests/unit/BackgroundJob/BatchJobCoordinatorTest.php)
+
+## ADDED Requirements
+
+### Requirement: Optional recursive folder enumeration (REQ-DDRAS-011)
+
+`POST /api/anonymization/batch/folder` MUST accept an optional boolean
+`recursive` parameter (default `false`, preserving the existing flat-scan
+behaviour). When `recursive: true`, the system MUST enumerate file nodes
+depth-first through all subfolders of the resolved folder, still skipping
+non-file nodes, and MUST record each file's path relative to the batch
+root so the report and review views can display dossier structure. The
+applicable batch size cap (synchronous or background, per
+`redaction-at-scale` REQ-DDRAS-008) MUST be enforced against the total
+recursive file count before any processing starts.
+
+#### Scenario: Recursive dossier folder becomes one batch
+
+- GIVEN a dossier folder `/Dossiers/Woo-2025-014` with 3 subfolders containing 480 files in total
+- WHEN a folder batch is created with `recursive: true`
+- THEN the batch contains all 480 files with their relative paths recorded
+- AND the batch is routed to the background path (above the synchronous cap)
+- @e2e tests/e2e/spec-coverage/redaction-at-scale.spec.ts
+
+#### Scenario: Default remains a flat scan
+
+- GIVEN a folder with 5 direct files and a subfolder containing 10 more
+- WHEN a folder batch is created without the `recursive` parameter
+- THEN the batch contains only the 5 direct files (existing behaviour)
+- @e2e exclude backwards-compatible enumeration contract; covered by PHPUnit (tests/unit/Service/FolderBatchServiceTest.php)
+
+#### Scenario: Recursive count above the background cap is refused
+
+- GIVEN a recursive enumeration totalling 1200 files and a background cap of 1000
+- WHEN batch creation is attempted
+- THEN the system returns HTTP 400 naming the configured maximum
+- AND no batch is created
+- @e2e exclude API limit contract; covered by PHPUnit + Newman batch contracts

--- a/openspec/changes/redaction-at-scale/specs/redaction-at-scale/spec.md
+++ b/openspec/changes/redaction-at-scale/specs/redaction-at-scale/spec.md
@@ -1,0 +1,239 @@
+# redaction-at-scale Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+The municipal-scale batch layer over the existing batch-anonymization and
+folder-batch capabilities: durable OR-backed batch state processed in
+bounded background work units under NC cron, with per-batch progress,
+cooperative cancellation, idempotent resume, throughput + failure
+reporting, sampling QA routed to human review, and resource guards so the
+extract/convert backends (LibreOffice, OR text extraction) never starve
+the instance. Sized for 25.000–55.000 documents/year and 50–200 users
+(Arnhem 407824, Groningen 421583). All processing stays local.
+
+## ADDED Requirements
+
+### Requirement: Durable batch state as OR objects (REQ-DDRAS-001)
+
+Batch and per-file processing state MUST be persisted as OpenRegister
+objects (`batchAnonymizationJob` with `batchAnonymizationFile` child
+objects, completing the direction set by REQ-BANON-00) and MUST survive a
+PHP restart, cache flush or cron interruption. `ICache` MAY be used only
+as a read-through cache for status polls and MUST be invalidated on every
+state write; the OR objects are authoritative. Existing per-file wire
+statuses (`pending`, `processing`, `success`, `error`) MUST be preserved.
+
+#### Scenario: Batch survives a cache flush
+
+- GIVEN a background batch in status `anonymizing` with 200 of 480 files succeeded
+- WHEN the distributed cache is flushed and the batch status endpoint is called
+- THEN the response reports the batch and per-file state unchanged, read from OR objects
+- @e2e exclude infrastructure resilience contract (cache flush) not drivable from UI; covered by PHPUnit (tests/unit/Service/BatchStateServiceTest.php)
+
+#### Scenario: State writes invalidate the read-through cache
+
+- GIVEN a cached batch status entry
+- WHEN a per-file child object transitions to `success`
+- THEN the next status poll reflects the transition, not the cached value
+- @e2e exclude cache-coherence contract; covered by PHPUnit (tests/unit/Service/BatchStateServiceTest.php)
+
+### Requirement: Chunked background processing under cron (REQ-DDRAS-002)
+
+Batches on the background path MUST be processed by a cron-scheduled
+coordinator job in bounded work units: at most
+`docudesk.batch.files_per_tick` files (default 25) AND at most
+`docudesk.batch.seconds_per_tick` wall seconds (default 120) per run,
+whichever limit is reached first, after which the coordinator MUST yield
+and continue in a later run. Per-file state MUST be written after each
+file so the work-unit boundary is the crash-recovery boundary. Both the
+extraction phase and the anonymize phase MUST run through this work-unit
+mechanic. Files within a work unit MUST be processed sequentially (v1
+concurrency = 1).
+
+#### Scenario: Large batch is processed across multiple ticks
+
+- GIVEN a background batch of 60 files and `files_per_tick = 25`
+- WHEN the coordinator runs three times
+- THEN the first two runs process 25 files each and the third processes the remaining 10
+- AND after each run the batch progress reflects the files completed so far
+- @e2e exclude cron work-unit scheduling not drivable from UI; covered by PHPUnit (tests/unit/BackgroundJob/BatchJobCoordinatorTest.php)
+
+#### Scenario: Time budget ends a tick early
+
+- GIVEN a tick whose processed files consume the `seconds_per_tick` budget after 8 of 25 files
+- WHEN the budget is exhausted
+- THEN the coordinator finishes the current file, persists progress, and yields
+- AND the remaining files are processed in subsequent ticks
+- @e2e exclude time-budget behaviour requires clock control; covered by PHPUnit with injected clock
+
+### Requirement: Per-batch progress reporting (REQ-DDRAS-003)
+
+The batch status endpoint MUST report, for background batches: current
+phase, `totalFiles`, files succeeded/failed/pending, percentage complete,
+`startedAt`, an updating throughput figure (documents per hour over the
+batch so far), and a `throttled` flag (set when a tick exhausts its time
+budget on fewer than 20% of its file budget). The frontend batch
+operations view MUST render this progress and MUST list active and recent
+batches of the current user (admins see all batches).
+
+#### Scenario: Operator watches batch progress
+
+- GIVEN a running background batch
+- WHEN the operator opens the batch operations view
+- THEN the batch row shows phase, progress percentage, throughput and any throttled indicator
+- AND the view updates as polling continues
+- @e2e tests/e2e/spec-coverage/redaction-at-scale.spec.ts
+
+#### Scenario: Throttling is visible, not silent
+
+- GIVEN a tick that processed 4 of 25 budgeted files before its time budget expired
+- WHEN the batch status is next read
+- THEN `throttled: true` is reported on the batch progress
+- @e2e exclude throttle-flag computation covered by PHPUnit (tests/unit/BackgroundJob/BatchJobCoordinatorTest.php)
+
+### Requirement: Cooperative cancellation (REQ-DDRAS-004)
+
+The system MUST provide `POST /api/anonymization/batch/{batchId}/cancel`
+for background batches: the batch transitions to `cancelling`; the worker
+MUST check the flag between files and MUST complete (never truncate) the
+file in progress before transitioning the batch to `cancelled`. Outputs
+already produced MUST be kept and reported. Cancelling a batch that is
+`completed`, `error` or already `cancelled` MUST return HTTP 409. Only the
+batch owner or an admin MAY cancel.
+
+#### Scenario: Cancel takes effect between files
+
+- GIVEN a background batch processing file 12 of 60
+- WHEN the owner calls the cancel endpoint
+- THEN file 12 finishes normally and no further file is started
+- AND the batch ends in status `cancelled` with 12 files succeeded
+- @e2e tests/e2e/spec-coverage/redaction-at-scale.spec.ts
+
+#### Scenario: Cancel of a completed batch is refused
+
+- GIVEN a batch in status `completed`
+- WHEN the cancel endpoint is called
+- THEN the system returns HTTP 409
+- @e2e exclude API error contract; covered by PHPUnit + Newman batch contracts
+
+### Requirement: Idempotent resume (REQ-DDRAS-005)
+
+The system MUST provide `POST /api/anonymization/batch/{batchId}/resume`
+for batches in status `error` or `cancelled`: only files not in `success`
+are re-queued. Per-file processing MUST be idempotent — the anonymize step
+MUST key on the existing `anonymizationLink.sourceFileId` linkage so a
+file that already produced its output is skipped rather than re-processed,
+and a resumed run MUST NOT duplicate anonymized output files. Resume of a
+running or completed batch MUST return HTTP 409.
+
+#### Scenario: Resume after a mid-batch failure
+
+- GIVEN a batch that errored with 40 of 60 files succeeded
+- WHEN the owner calls the resume endpoint
+- THEN only the 20 non-succeeded files are re-queued
+- AND the batch completes with 60 succeeded files and no duplicate output files
+- @e2e tests/e2e/spec-coverage/redaction-at-scale.spec.ts
+
+#### Scenario: File that succeeded out-of-band is skipped
+
+- GIVEN a resumed batch containing a file whose `anonymizationLink` already records a successful output
+- WHEN the worker reaches that file
+- THEN the file is marked `success` without re-anonymizing
+- @e2e exclude idempotency-key behaviour; covered by PHPUnit (tests/unit/Service/BatchAnonymizeServiceTest.php)
+
+### Requirement: Throughput and failure reporting (REQ-DDRAS-006)
+
+The batch report (`GET /api/anonymization/batch/{batchId}/report`) MUST be
+extended with: overall documents/hour, per-phase durations
+(extract/anonymize), and failures grouped by reason (exception class or
+mapped error category) with per-file detail. Aggregations MUST be computed
+at read time from the per-file child objects (no stored counters that can
+drift). Entity values MUST remain excluded from the report (GDPR data
+minimisation, Recital 26 — existing behaviour).
+
+#### Scenario: Report groups failures by reason
+
+- GIVEN a completed batch with 3 files failed by conversion lock timeouts and 1 by extraction error
+- WHEN the report is downloaded
+- THEN the failure summary shows the two reason groups with counts 3 and 1
+- AND per-file rows carry their individual reason
+- @e2e exclude CSV report content contract; covered by PHPUnit (tests/unit/Service/BatchReportServiceTest.php) and Newman
+
+#### Scenario: Throughput appears on the report
+
+- GIVEN a completed 480-file batch that ran for 6 hours
+- WHEN the report is downloaded
+- THEN it states the overall documents/hour for the batch
+- @e2e exclude report aggregation covered by PHPUnit (tests/unit/Service/BatchReportServiceTest.php)
+
+### Requirement: Sampling QA routed to human review (REQ-DDRAS-007)
+
+On completion of a background batch's anonymize phase, the system MUST
+select a uniform random sample of `docudesk.batch.qa_sample_rate` percent
+(default 5; minimum 1 file when the rate > 0 and the batch has successful
+files; rate 0 disables sampling) of successfully auto-anonymized files,
+mark them `qaSampled: true`, and route them to human review via the
+review-workbench checked gate (`documentReview`). Sample selection MUST be
+reproducible: the PRNG seed MUST be stored on the batch object. The batch
+report MUST record each sample's outcome (`pending`, `confirmed`,
+`corrected`). Sampling MUST NOT block batch completion.
+
+#### Scenario: Five percent of a batch is sampled
+
+- GIVEN a completed background batch with 200 succeeded files and a 5% sample rate
+- WHEN sampling runs
+- THEN 10 files are marked `qaSampled: true` and appear in the review queue
+- AND the batch report lists 10 samples with outcome `pending`
+- @e2e tests/e2e/spec-coverage/redaction-at-scale.spec.ts
+
+#### Scenario: Sample is reproducible from the stored seed
+
+- GIVEN a batch with a stored `qaSampleSeed`
+- WHEN the sample selection is recomputed from the seed for audit
+- THEN the same file set is selected
+- @e2e exclude deterministic-sampling audit property; covered by PHPUnit (tests/unit/Service/BatchQaSamplerTest.php)
+
+#### Scenario: Rate zero disables sampling
+
+- GIVEN `docudesk.batch.qa_sample_rate = 0`
+- WHEN a batch completes
+- THEN no file is marked `qaSampled` and the report shows sampling disabled
+- @e2e exclude admin-config branch; covered by PHPUnit (tests/unit/Service/BatchQaSamplerTest.php)
+
+### Requirement: Resource guards on extract/convert backends (REQ-DDRAS-008)
+
+Background processing MUST respect the existing LibreOffice serialization
+lock (`soffice:headless:convert`): a fail-fast lock miss MUST be treated
+as a retryable per-file outcome (retried in a later tick, bounded retry
+count) rather than a file error. The coordinator MUST never process more
+than one batch work unit concurrently per instance. Background batch size
+MUST be clamped server-side to `docudesk.batch.max_files_background`
+(default 1000); the synchronous path keeps its existing
+`docudesk.batch.max_files_per_run` cap (default 100), and batches between
+the two caps MUST be routed to the background path instead of rejected.
+
+#### Scenario: Lock miss is retried, not failed
+
+- GIVEN a file whose PDF conversion hits a held soffice lock
+- WHEN the work unit processes it
+- THEN the file returns to `pending` with a retry count incremented
+- AND it is retried in a later tick, becoming `error` only after the bounded retries are exhausted
+- @e2e exclude lock-contention behaviour requires concurrency control; covered by PHPUnit (tests/unit/Service/BatchAnonymizeServiceTest.php)
+
+#### Scenario: Oversized batch routes to background instead of 400
+
+- GIVEN a folder batch of 480 files, a sync cap of 100 and a background cap of 1000
+- WHEN the batch is created
+- THEN it is accepted and marked for background processing
+- @e2e tests/e2e/spec-coverage/redaction-at-scale.spec.ts
+
+#### Scenario: Batch above the background cap is refused
+
+- GIVEN a folder containing 1200 files and a background cap of 1000
+- WHEN batch creation is attempted
+- THEN the system returns HTTP 400 naming the configured maximum
+- @e2e exclude API limit contract; covered by PHPUnit + Newman batch contracts

--- a/openspec/changes/redaction-at-scale/tasks.md
+++ b/openspec/changes/redaction-at-scale/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: redaction-at-scale
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 17.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Register & seed data
+
+- [ ] 1.1 Re-verify against HEAD whether the REQ-BANON-00 OR-state migration (`docudesk-adopt-or-abstractions`) has landed; land or absorb the `batchAnonymizationJob` + `batchAnonymizationFile` schemas in `lib/Settings/docudesk_register.json`
+  - Spec-says-done is not proof — check the register JSON and `BatchStateService` on the apply branch.
+- [ ] 1.2 Extend the batch schemas with progress, cancellation and QA fields (`totalFiles`, succeeded/failed counters at read time, `qaSampleRate`, `qaSampleSeed`, `throttled`; per-file `qaSampled`, `qaOutcome`, `durationMs`, retry count) — additive, union-merge only
+- [ ] 1.3 Seed one demo batch (12 files, 1 error, 1 QA sample) per design.md Seed Data
+
+## 2. Backend — durable state & work units
+
+- [ ] 2.1 Rebase `BatchStateService` onto OR objects as the source of truth with ICache as an invalidated read-through cache (REQ-DDRAS-001)
+  - Wire statuses unchanged; cache entries carry batch version.
+- [ ] 2.2 Implement `BatchJobCoordinator` (cron `TimedJob`) with `files_per_tick`/`seconds_per_tick` budgets, sequential per-file processing, per-file state writes, throttled-flag computation (REQ-DDRAS-002, REQ-DDRAS-003)
+  - One work unit per instance at a time; injected clock for tests.
+- [ ] 2.3 Route batches between sync and background paths by the two caps; server-side clamp `docudesk.batch.max_files_background` (default 1000) (REQ-DDRAS-008, REQ-DDRAS-009)
+  - Anonymize endpoint returns HTTP 202 + persisted entity list above the sync cap; pre-change contract below it.
+- [ ] 2.4 Implement cancel and resume endpoints + worker-side cooperative cancellation and `anonymizationLink`-keyed idempotent resume (REQ-DDRAS-004, REQ-DDRAS-005)
+  - Auth attributes + owner/admin guards on every new route (route-auth, no-admin-idor gates).
+- [ ] 2.5 Treat soffice lock misses as bounded-retry per-file outcomes; migrate `FolderExtractionJob` processing into the coordinator work units; add `recursive` folder enumeration with relative paths (REQ-DDRAS-008, REQ-DDRAS-010, REQ-DDRAS-011)
+
+## 3. Backend — reporting & QA
+
+- [ ] 3.1 Extend `BatchReportService` with read-time throughput, per-phase durations and failure grouping; keep entity values out of the report (REQ-DDRAS-006)
+- [ ] 3.2 Implement the seeded-PRNG QA sampler marking N% of succeeded files `qaSampled` and creating their review-queue routing via the `documentReview` gate; record outcomes on the report (REQ-DDRAS-007)
+  - Depends on `anonymization-review-workbench` (documentReview schema); coordinate landing order.
+
+## 4. Frontend
+
+- [ ] 4.1 Batch operations view (`CnIndexPage`/`CnDataTable`): active/recent batches, phase, progress %, throughput, throttled indicator; owner-scoped with admin overview (REQ-DDRAS-003)
+- [ ] 4.2 Cancel/resume actions with confirmation dialogs (own modal files) and QA-sample badges linking to the review workbench (REQ-DDRAS-004, REQ-DDRAS-005, REQ-DDRAS-007)
+
+## 5. Quality
+
+- [ ] 5.1 PHPUnit for coordinator budgets, cancellation, resume idempotency, sampler determinism, report aggregation, cap routing — 75% coverage on new code (ADR-009)
+  - Run in container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`.
+  - Live-verify a 150+ file folder batch end-to-end on Postgres (8080) with OpenRegister: enqueue → ticks → cancel → resume → report.
+- [ ] 5.2 Playwright spec `tests/e2e/spec-coverage/redaction-at-scale.spec.ts` for the `@e2e`-referenced scenarios; Newman contracts for cancel/resume/report
+- [ ] 5.3 i18n EN + NL for all new UI strings (keys in English); nldesign theme check (ADR-005, ADR-003)
+- [ ] 5.4 Docs: `docs/features/redaction-at-scale.md` with Playwright screenshots (ops view, cancel/resume, QA badges) + sizing guidance (files_per_tick vs cron cadence vs docs/hour) (ADR-010)
+- [ ] 5.5 Validate: `openspec validate redaction-at-scale --strict` passes; hydra gates green

--- a/openspec/changes/woo-publicatie-pipeline/.openspec.yaml
+++ b/openspec/changes/woo-publicatie-pipeline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/woo-publicatie-pipeline/design.md
+++ b/openspec/changes/woo-publicatie-pipeline/design.md
@@ -1,0 +1,306 @@
+# Design: woo-publicatie-pipeline
+
+## Context
+
+Verified at DocuDesk HEAD:
+
+- `publicationConsent` (register `consent`) carries `consentStatus`
+  (`pending` | `consent_given` | `objection_received` | `no_response` |
+  `anonymized`), `objectionDeadline`, `publicationDecision` (`pending` |
+  `anonymize` | `publish_with_consent` | `publish_anonymized` | `reject`),
+  scoped `document`/`entity`. `ObjectionDeadlineChecker` computes the
+  configurable WOO objection window (default 28 days,
+  `publication_objection_period_days`) — the publication-consent spec forbids
+  delegating this to OR's GDPR Art-12(3) helper.
+- `publicationProhibition` (register `consent`) models active prohibitions
+  with `matchRules`, `active`, `validFrom/validUntil`;
+  `PolicyMatchService`/`PolicyCrudService` exist.
+- The `document` register already hosts processing artifacts
+  (`generatedDocument`, `correspondence`, `anonymizationLink`, ...); the
+  anonymisation pipeline records source↔anonymised file mapping in
+  `anonymizationLink` (`status`, `anonymizedFileId`).
+- Dossiers (`dossier` register) carry `bases[]` grondslagen + `checkedOn`
+  review timestamp.
+- OR access pattern: `SettingsService::getObjectService()` →
+  `searchObjects(['@self' => ['register' => ..., 'schema' => ...]])` /
+  `saveObject()`.
+
+Verified at OpenCatalogi HEAD
+(`opencatalogi/lib/Settings/publication_register.json` + openspec):
+
+- Register slug `publication`, schema slug `publication` with properties
+  `title`, `summary`, `description`, `organization`, `themes`,
+  `publicatiedatum` (past date ⇒ live via OR published-predicate),
+  `depublicatiedatum` (past ⇒ withdrawn; future ⇒ scheduled),
+  `retentionTermMonths`, `retentionExpiresAt` (manual override requires
+  `retentionNote`, RET-003), `retentionCategory`, `retentionAction`,
+  `status` (lifecycle incl. `archived`, RET-006).
+- DiWoo/Woo-index emission is OpenCatalogi's: sitemaps per informatiecategorie
+  (WOO-001..005), `diwoo:Document` field mapping (WOO-006/010), TOOI value-list
+  binding for informatiecategorie/publisher (WOO-TOOI-001/002) resolved by
+  `TooiVocabularyService` from bundled `tooi_waardelijsten.json`.
+
+Boundary (shared brief): DocuDesk prepares + hands off + tracks state;
+OpenCatalogi/OpenWoo is the publication endpoint; DocuDesk builds no portal.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One auditable pipeline object per publication with a readiness gate that
+  cannot be bypassed.
+- DiWoo metadata assembled once, on the DocuDesk side, from operator input +
+  document metadata, in the vocabulary OpenCatalogi validates.
+- Handoff, de-publication and destruction-date propagation as first-class,
+  logged operations against the OpenCatalogi `publication` object.
+
+**Non-Goals:**
+
+- No public portal, sitemap, search or DCAT surface (OpenCatalogi/OpenWoo own
+  these).
+- No change to the objection-window computation or consent CRUD.
+- No automatic publication without an operator release (human-in-the-loop is
+  the market's hard requirement).
+- No TMLO/MDTO or full Archiefwet retention engine (next wave, per gap
+  shortlist) — only recording + propagating a supplied destruction date.
+
+## Decisions
+
+### D1 — `publicationRecord` + `publicationLogEntry` in the `document` register
+
+New schemas (no new register — the `document` register already models
+processing artifacts, and a new register slug near "publication" would court
+the cross-app slug collision with OpenCatalogi's `publication` register):
+
+- **`publicationRecord`**: `subjectType` (`document` | `dossier`),
+  `documentFileRef`, `dossierRef`, `redactedFileRef` (the derivative that
+  will be published — the original is never handed off), readiness block
+  (`entitiesReviewed`, `consentClear`, `prohibitionsClear` booleans +
+  `readinessEvaluatedAt`), DiWoo block (`wooCategory` — TOOI informatiecategorie
+  code e.g. `c_8c840238`, `documentsoort`, `publisher` — TOOI organisatie URI,
+  `officieleTitel`, `creatiedatum`, `publicatiedatum`), `status` (lifecycle,
+  D3), `endpointPublicationRef` (UUID of the OpenCatalogi publication object),
+  `handoffAt`, `depublicationReason`, `depublicationRequestedAt`,
+  `destructionDate`, `destructionDateSource`.
+- **`publicationLogEntry`**: `publicationRecordRef`, `action` (enum
+  `created` | `readiness_evaluated` | `metadata_assembled` | `handed_off` |
+  `published` | `depublication_requested` | `depublished` |
+  `destruction_date_propagated`), `actor`, `timestamp`, `details` (string),
+  `snapshot` (JSON of the readiness/DiWoo state at that moment). Append-only:
+  no update/delete route exists and the schema is flagged immutable.
+
+### D2 — Readiness is service-evaluated, persisted with timestamp; the gate is a lifecycle guard
+
+`PublicationPipelineService::evaluateReadiness()` computes three verdicts:
+
+1. **Entities reviewed** — every entity detected for the document(s) has a
+   review decision (source: the anonymisation entity-review state; for a
+   dossier: the dossier's `checkedOn` is set and the batch report exists).
+2. **Consent clear** — the new clearance query on the consent side (D6): every
+   `publicationConsent` for the document is in a publication-permitting
+   terminal state: `consent_given`, `anonymized`, or `no_response` with
+   `objectionDeadline` in the past; no record has `consentStatus =
+   objection_received` unresolved and none has `publicationDecision = reject`.
+   (WOO objection window; personal-data handling per AVG Art. 6(1)(e) — the
+   readiness snapshot stores only verdicts + record UUIDs, no entity text.)
+3. **Prohibitions clear** — `PolicyMatchService` finds no active
+   `publicationProhibition` matching the document's entities.
+
+Declarative-vs-imperative: this is a **cross-object aggregation over three
+registers with date arithmetic and policy matching** — beyond the
+`x-openregister-calculations` dialect; imperative evaluation is a justified
+ADR-031 exception (same class as `document-validation-checks`' fallback).
+The *gate itself* is declarative where it can be: the `publicationRecord`
+lifecycle (D3) declares `draft → ready` guarded on the three booleans, and
+handoff requires status `ready`, so a stale/false readiness can never be
+bypassed by a direct status write.
+
+Readiness is re-evaluated (and the record demoted to `draft` if it regresses)
+on every handoff attempt — evaluation results carry `readinessEvaluatedAt` and
+are never trusted beyond that instant.
+
+### D3 — Publication lifecycle
+
+```
+draft ──> ready ──> handed_off ──> published ──> depublication_requested ──> depublished
+  ^         │
+  └─────────┘ (readiness regression)
+```
+
+Declared as `x-openregister-lifecycle` (canonical `initial: draft`).
+`published` is set when the endpoint publication goes live
+(`publicatiedatum` in the past — checked on read, confirmed by a lightweight
+status sync when the record is opened); `depublished` when
+`depublicatiedatum` has passed.
+
+### D4 — Handoff writes an OpenCatalogi `publication` object via OR (endpoint addressing, verified)
+
+`PublicationPipelineService::handoff()`:
+
+1. Re-evaluates readiness (D2); aborts unless `ready`.
+2. Creates (or updates, when `endpointPublicationRef` exists) an OR object
+   addressed `['@self' => ['register' => 'publication', 'schema' =>
+   'publication']]` — the OpenCatalogi register/schema slugs verified at HEAD —
+   mapping `officieleTitel → title`, summary/description from the record,
+   `publicatiedatum`, and the DiWoo block. The redacted derivative file
+   (`redactedFileRef`, never the original) is attached as the publication's
+   file/attachment following OpenCatalogi's attachment convention.
+3. Stores `endpointPublicationRef` + `handoffAt`, transitions to
+   `handed_off`, appends a `handed_off` log entry.
+
+If OpenCatalogi is not installed (register absent), handoff is disabled with
+an explanatory UI state — no silent no-op. Rejected alternative: calling
+OpenCatalogi's REST API — the OR object write is the fleet pattern
+(ADR-022-consistent, works cross-app via slugs, RBAC/audit for free) and
+avoids an HTTP dependency inside one instance.
+
+**Uncertainty, stated**: the exact attachment convention for publication files
+(file-attach via OR file handling vs. an `attachments` property) follows
+OpenCatalogi's `publication-attachment-defaults` spec at apply time; if the
+convention requires an OpenCatalogi-side helper, attachment is routed through
+it rather than duplicated.
+
+### D5 — De-publication and destruction-date propagation reuse endpoint semantics
+
+- **Withdraw**: operator supplies a mandatory reason; DocuDesk sets
+  `depublicatiedatum = now` on the endpoint publication object (past date ⇒
+  withdrawn from all public surfaces per OpenCatalogi's published-predicate),
+  transitions the record `depublication_requested → depublished` once the
+  date has passed, and logs both steps with the reason. The endpoint object is
+  never deleted — Woo accountability requires the trace.
+- **Destruction date**: when the source system supplies a destruction date
+  (Archiefwet/selectielijst — e.g. via the zgw-document-bridge metadata or
+  operator entry), DocuDesk records it on `publicationRecord.destructionDate`
+  and propagates it to the endpoint publication as a manual
+  `retentionExpiresAt` override **with** a `retentionNote` naming the source
+  ("Vernietigingsdatum uit zaaksysteem, Archiefwet 1995/selectielijst"), as
+  OpenCatalogi RET-003 requires for overrides. Actual disposal is
+  OpenCatalogi's retention job (RET-005/006) — DocuDesk propagates, never
+  destroys.
+
+### D6 — Consent-clearance signal (the publication-consent modification)
+
+A read-only query, exposed as
+`ConsentService::isDocumentConsentClear(string $documentId): array`
+(verdict + per-record reasons) and consumed by D2. It changes **no** consent
+behaviour: the objection window stays `ObjectionDeadlineChecker`'s, creation
+stays programmatic, the app-owned boundary from the publication-consent spec
+is untouched. Spec-wise this is an ADDED requirement on the
+publication-consent capability (adding a new concern, not modifying existing
+requirements — safe for archive).
+
+### D7 — Frontend per ADR-012
+
+- **Publications index + detail** (manifest pages): `CnIndexPage` +
+  `CnDataTable` listing publication records with status chips; detail shows
+  the readiness checklist (three verdicts with reasons), the DiWoo metadata
+  form (`CnFormDialog`; wooCategory select bound to the 17 TOOI
+  informatiecategorieën), the publication log timeline, and
+  withdraw/destruction-date actions.
+- **Publish wizard entry**: "Publiceren" action on document detail (MyDocuments)
+  and dossier context creating a `publicationRecord` and walking anonymize →
+  consent → publish state (each step deep-links to the existing capability
+  surfaces; the wizard orchestrates, never reimplements).
+- NL Design tokens via NC CSS variables (ADR-003); no hardcoded colors.
+
+## OpenRegister service usage (ADR-001)
+
+| Operation | OR service |
+|---|---|
+| Publication records + log CRUD | `ObjectService::saveObject()` / `searchObjects()` on `document` register (no custom tables) |
+| Consent clearance query | `searchObjects()` on `consent`/`publicationConsent` filtered by `documentId` |
+| Prohibition check | existing `PolicyMatchService` (consent register) |
+| Endpoint handoff | `saveObject()` addressed to OpenCatalogi's `publication`/`publication` (cross-register slugs) |
+| Lifecycle gates | declarative `x-openregister-lifecycle` on `publicationRecord` |
+| Audit | OR audit trail + append-only `publicationLogEntry` |
+
+ADR-011 check: date arithmetic reuses `ObjectionDeadlineChecker` outputs; no
+new validation/formatting utilities; TOOI codes are passed as opaque values
+(OpenCatalogi's `TooiVocabularyService` is the authority — the 17-category
+list used in the UI select is sourced from its bundled value list, not
+re-declared).
+
+## Declarative-vs-imperative decision (ADR-031)
+
+- **Declarative**: `publicationRecord` lifecycle + guard
+  (`x-openregister-lifecycle`, canonical `initial:`); log schema immutability;
+  endpoint live/withdrawn semantics ride OpenCatalogi's OR
+  published-predicate (`publicatiedatum`/`depublicatiedatum`).
+- **Imperative (justified exceptions)**: readiness evaluation (cross-register
+  aggregation + date/policy logic — beyond the calculations dialect); handoff
+  (cross-app object write + file attachment = external integration in ADR-031
+  terms); destruction-date propagation (writes another app's object with a
+  RET-003 note). Each imperative path appends a `publicationLogEntry`, keeping
+  accountability declarative-readable.
+
+## Seed Data
+
+Shipped in `docudesk_register.json` `objects[]` (demo-municipality flavour,
+placeholder identifiers only):
+
+```json
+{
+  "@self": {"register": "document", "schema": "publicationRecord", "slug": "demostad-woo-2025-017-besluit"},
+  "subjectType": "document",
+  "documentFileRef": "seed-file-demostad-besluit-subsidie",
+  "redactedFileRef": "seed-file-demostad-besluit-subsidie-geanonimiseerd",
+  "dossierRef": "demostad-woo-2025-017",
+  "entitiesReviewed": true,
+  "consentClear": true,
+  "prohibitionsClear": true,
+  "readinessEvaluatedAt": "2026-07-01T09:15:00+00:00",
+  "wooCategory": "c_8c840238",
+  "documentsoort": "besluit",
+  "publisher": "https://identifier.overheid.nl/tooi/id/gemeente/gm0000",
+  "officieleTitel": "Besluit subsidietoekenning cultuur 2024-088 (geanonimiseerd)",
+  "creatiedatum": "2024-11-03",
+  "publicatiedatum": "2026-07-02",
+  "status": "published",
+  "endpointPublicationRef": "00000000-0000-0000-0000-000000000000",
+  "handoffAt": "2026-07-01T09:20:00+00:00",
+  "destructionDate": "2034-11-03",
+  "destructionDateSource": "selectielijst 2020, procestype 6"
+}
+```
+
+Plus a `draft` record with `consentClear: false` (objection window still
+open) and matching `publicationLogEntry` rows (`created`,
+`readiness_evaluated`, `handed_off`, `published`,
+`destruction_date_propagated`) so demos show the full accountability trail.
+
+## Risks / Trade-offs
+
+- [OpenCatalogi schema drift (property renames on `publication`)] → the
+  handoff field map lives in one service constant + a drift-pin unit test
+  against a fixture of the OpenCatalogi register JSON; gate 28/30-style
+  cross-ref at review.
+- [Readiness snapshot staleness] → re-evaluation on every handoff attempt +
+  lifecycle demotion on regression (D2); `readinessEvaluatedAt` always shown
+  in UI.
+- [Consent taxonomy ambiguity: `no_response` + elapsed deadline] → the
+  clearance rule follows the existing consent lifecycle semantics
+  (no_response after deadline = publish permitted under WOO active-disclosure;
+  `publicationDecision = reject` always blocks); rule is a single pure
+  function, unit-tested exhaustively.
+- [Cross-app write authorization] → handoff runs under the acting operator's
+  OR permissions on the OpenCatalogi register; a 403 is surfaced as
+  "publication endpoint declined" with the OR error, never swallowed.
+- [Dutch-only DiWoo vocabulary vs EN UI] → labels i18n'd EN+NL; codes stay
+  TOOI-canonical.
+
+## Migration Plan
+
+Additive: schemas + seeds (register version bump, boot import), new
+service/controller/routes/views. No existing schema or consent behaviour
+changes. Rollback = drop routes/UI; records remain readable. Publications
+already handed off live in OpenCatalogi and are unaffected by rollback.
+
+## Open Questions
+
+- Dossier-level publication fan-out (one record per dossier vs per document
+  inside it): this change ships one record per handed-off unit (document, or
+  dossier published as a bundle); per-document fan-out inside a dossier is a
+  follow-up once volume demands it.
+- Whether `published`/`depublished` confirmation should be event-driven
+  (OpenCatalogi → DocuDesk notification) instead of checked-on-read — deferred
+  until OpenCatalogi emits such events.

--- a/openspec/changes/woo-publicatie-pipeline/proposal.md
+++ b/openspec/changes/woo-publicatie-pipeline/proposal.md
@@ -1,0 +1,97 @@
+---
+kind: code
+tracking_issue: https://github.com/ConductionNL/docudesk/issues/238
+---
+
+# Proposal: woo-publicatie-pipeline
+
+## Why
+
+Active publication under the Wet open overheid is the single biggest volume
+driver in the current market window: Dordrecht/Drechtsteden 407973 specifies a
+Woo publicatietool in **224 requirements** — Woo-index discoverability, DiWoo
+metadata, de-publication, destruction-date propagation; De Connectie 391449
+asks for an active-publication scale-up where publication is reusable beyond
+Woo; GH #238 tracks the Woo pipeline; 96% of municipalities already met the
+first five Woo categories and more categories are coming (structural volume
+growth), while GPP-Woo (16 gemeenten, EUPL) is building the rival open-source
+publication stack.
+
+DocuDesk already owns the two upstream steps — anonymisation (single, batch,
+folder) and publication consent (WOO objection lifecycle, 28-day window,
+prohibitions/standing consents) — and the sibling apps own the endpoint:
+OpenCatalogi publishes OR `publication` objects with DiWoo/TOOI-validated
+Woo-index sitemaps (WOO-001..010, WOO-TOOI-001..004) and a retention
+lifecycle. What is missing is the **pipeline that chains them**: nothing today
+answers "is this document ready to publish?", assembles the DiWoo metadata,
+hands the redacted result off to the publication endpoint, withdraws it again,
+or accounts for any of it. Operators would have to hand-copy files into
+OpenCatalogi and hand-check consent deadlines — which is exactly the gap the
+tenders score on.
+
+## What Changes
+
+- Two new schemas in the existing `document` register:
+  - `publicationRecord` — one per document/dossier being published: readiness
+    state (entities reviewed, consent clear, prohibitions clear), DiWoo
+    metadata block (Woo informatiecategorie, documentsoort, publisher,
+    dates), handoff bookkeeping (endpoint publication reference), publication
+    lifecycle status, destruction date, de-publication reason.
+  - `publicationLogEntry` — append-only accountability log of every pipeline
+    action.
+- **Publication readiness** evaluation: a document/dossier is `ready` only
+  when all detected entities are reviewed, the consent gate is clear (consent
+  given, or objection window elapsed without objection, per existing
+  publication-consent rules) and no active publication prohibition matches.
+- **DiWoo metadata assembly** on the publication record (TOOI-bound Woo
+  category, documentsoort, publisher, creatiedatum) — OpenCatalogi validates
+  TOOI binding at sitemap render; DocuDesk assembles and passes.
+- **Handoff to OpenCatalogi** as the publication endpoint: create an OR
+  `publication` object (register slug `publication`, schema `publication` —
+  verified at OpenCatalogi HEAD) with the redacted derivative attached;
+  DocuDesk does NOT build its own portal.
+- **De-publication flow**: withdraw with a mandatory reason; propagated to the
+  endpoint by setting `depublicatiedatum` on the publication object; logged.
+- **Destruction-date propagation**: a destruction date from the source
+  (Archiefwet/selectielijst) is recorded on the endpoint publication object
+  via its retention fields (`retentionExpiresAt` + mandatory
+  `retentionNote`, per OpenCatalogi RET-003).
+- **Publication log** UI on the publication record detail; publish wizard
+  chaining anonymize → consent → publish from document/dossier context.
+
+## Capabilities
+
+### New Capabilities
+
+- `woo-publicatie-pipeline`: readiness-gated active-publication pipeline —
+  publication records with readiness evaluation, DiWoo metadata assembly,
+  handoff to OpenCatalogi, de-publication with reason, destruction-date
+  propagation and an append-only publication log.
+
+### Modified Capabilities
+
+- `publication-consent`: adds a machine-readable **consent-clearance signal**
+  per document (all consent records in a publication-permitting terminal
+  state, objection window handling unchanged) that the pipeline's readiness
+  gate consumes. No change to the objection-window rules or the app-owned
+  consent boundary.
+
+## Impact
+
+- `lib/Settings/docudesk_register.json`: `publicationRecord` +
+  `publicationLogEntry` schemas in the `document` register, seed data,
+  register version bump.
+- New `lib/Service/PublicationPipelineService.php` (readiness evaluation,
+  handoff, withdraw, destruction-date propagation, logging) +
+  `lib/Controller/PublicationController.php` with `api/publications/*` routes.
+- `ConsentService`/`ConsentCrudService`: new read-only clearance query (no
+  behaviour change to existing consent CRUD).
+- `src/manifest.json` + new views: Publications index/detail, publish wizard
+  entry points on document/dossier surfaces.
+- Cross-app runtime dependency (soft): OpenCatalogi installed for the
+  endpoint; without it, handoff is disabled with an explanatory state.
+  Addressing verified: OpenCatalogi register slug `publication`, schema
+  `publication` with `publicatiedatum`, `depublicatiedatum`,
+  `retentionTermMonths`, `retentionExpiresAt`, `retentionNote`, `status`.
+- Evidence: Dordrecht 407973 (224 reqs), De Connectie 391449, GH #238,
+  Tilburg ×2, GPP-Woo rivalry (ecosystem report).

--- a/openspec/changes/woo-publicatie-pipeline/specs/publication-consent/spec.md
+++ b/openspec/changes/woo-publicatie-pipeline/specs/publication-consent/spec.md
@@ -1,0 +1,58 @@
+# publication-consent Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Adds a machine-readable **consent-clearance signal** per document to the
+existing publication-consent capability, for consumption by the
+woo-publicatie-pipeline readiness gate. This is an additive concern: the
+app-owned consent boundary, the consent CRUD surface and the configurable WOO
+objection window (`ObjectionDeadlineChecker`,
+`publication_objection_period_days`, default 28 days) are unchanged.
+
+## ADDED Requirements
+
+### Requirement: Document consent-clearance signal (REQ-DDWPP-020)
+
+`ConsentService` MUST expose a read-only clearance query
+`isDocumentConsentClear(string $documentId): array` returning a boolean
+verdict plus per-record reasons. A document is consent-clear if and only if
+every `publicationConsent` record for it satisfies one of: `consentStatus =
+consent_given`; `consentStatus = anonymized`; or `consentStatus =
+no_response` with `objectionDeadline` in the past (WOO active-disclosure
+objection window elapsed). A document is NOT clear while any record has
+`consentStatus` `pending` or `objection_received`, or `publicationDecision =
+reject`. A document with zero consent records is clear (no affected entities
+require consent). The query MUST NOT modify any consent record and MUST NOT
+alter how `objectionDeadline` is computed.
+
+#### Scenario: All consents terminal and permitting
+
+- GIVEN a document with two consent records: one `consent_given` and one `no_response` whose `objectionDeadline` was yesterday
+- WHEN the clearance query runs
+- THEN the verdict is clear
+- @e2e exclude pure read-only query consumed by the pipeline UI — covered exhaustively by PHPUnit table tests (tests/unit/Service/ConsentServiceTest.php); the consuming surface is covered by REQ-DDWPP-002 scenarios
+
+#### Scenario: Unresolved objection blocks clearance
+
+- GIVEN a document with a consent record in `objection_received` and `publicationDecision` `pending`
+- WHEN the clearance query runs
+- THEN the verdict is not clear and the reasons name that record's UUID and status
+- @e2e exclude pure read-only query — covered by PHPUnit (tests/unit/Service/ConsentServiceTest.php); UI consumption covered under REQ-DDWPP-002
+
+#### Scenario: Rejection decision blocks clearance regardless of status
+
+- GIVEN a document with a consent record whose `publicationDecision` is `reject`
+- WHEN the clearance query runs
+- THEN the verdict is not clear
+- @e2e exclude pure read-only query — covered by PHPUnit (tests/unit/Service/ConsentServiceTest.php)
+
+#### Scenario: Objection window computation is untouched
+
+- GIVEN the clearance query implementation
+- WHEN it evaluates `no_response` records
+- THEN it compares against the stored `objectionDeadline` computed by `ObjectionDeadlineChecker` and introduces no alternative deadline computation
+- @e2e exclude architectural boundary assertion — covered by PHPUnit and code review, not a browser flow

--- a/openspec/changes/woo-publicatie-pipeline/specs/woo-publicatie-pipeline/spec.md
+++ b/openspec/changes/woo-publicatie-pipeline/specs/woo-publicatie-pipeline/spec.md
@@ -1,0 +1,234 @@
+# woo-publicatie-pipeline Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Readiness-gated active-publication pipeline chaining DocuDesk's existing
+anonymisation and publication-consent capabilities into a handoff to
+OpenCatalogi as the publication endpoint (Woo active disclosure / Woo-index,
+DiWoo). One `publicationRecord` per published unit carries the readiness
+state (entities reviewed, consent clear, prohibitions clear), the assembled
+DiWoo metadata, the endpoint reference, the destruction date and the
+lifecycle; every pipeline action lands in an append-only publication log.
+DocuDesk prepares, hands off and tracks state — it builds no portal, sitemap
+or search surface (OpenCatalogi/OpenWoo own those).
+
+## ADDED Requirements
+
+### Requirement: Publication record and log schemas (REQ-DDWPP-001)
+
+The app MUST declare two schemas in the `document` register:
+`publicationRecord` (`subjectType` enum `document`|`dossier`,
+`documentFileRef`, `dossierRef`, `redactedFileRef`, readiness booleans
+`entitiesReviewed`/`consentClear`/`prohibitionsClear` +
+`readinessEvaluatedAt`, DiWoo block `wooCategory`/`documentsoort`/
+`publisher`/`officieleTitel`/`creatiedatum`/`publicatiedatum`, `status`,
+`endpointPublicationRef`, `handoffAt`, `depublicationReason`,
+`depublicationRequestedAt`, `destructionDate`, `destructionDateSource`) and
+`publicationLogEntry` (`publicationRecordRef`, `action` enum, `actor`,
+`timestamp`, `details`, `snapshot`). All data MUST be stored as OpenRegister
+objects (ADR-001), with a register version bump for boot import.
+
+#### Scenario: Register import creates the pipeline schemas
+
+- GIVEN DocuDesk and OpenRegister installed
+- WHEN `ConfigurationService::importFromApp()` runs on boot
+- THEN `publicationRecord` and `publicationLogEntry` exist in the `document` register with the seeded demo objects queryable
+- @e2e exclude boot-time register import with no UI surface of its own — covered by PHPUnit register-import assertions (tests/unit/Settings/)
+
+### Requirement: Publication readiness evaluation (REQ-DDWPP-002)
+
+`PublicationPipelineService::evaluateReadiness()` MUST compute and persist
+three verdicts on the publication record, with `readinessEvaluatedAt`:
+`entitiesReviewed` (every detected entity for the subject has a review
+decision; for a dossier additionally `checkedOn` is set), `consentClear` (per
+the consent-clearance signal, REQ-DDWPP-020) and `prohibitionsClear` (no
+active `publicationProhibition` matches, via the existing
+`PolicyMatchService`). The readiness snapshot MUST store only verdicts and
+record UUIDs — never entity text or other personal data (data minimisation,
+AVG Art. 5(1)(c)).
+
+#### Scenario: Ready when all three gates are clear
+
+- GIVEN a document whose entities are all reviewed, whose consents are all publication-permitting and which matches no active prohibition
+- WHEN readiness is evaluated
+- THEN all three booleans are true and `readinessEvaluatedAt` is set
+- AND the record may transition to `ready`
+- @e2e tests/e2e/workflows/woo-publicatie-pipeline.spec.ts
+
+#### Scenario: Open objection window blocks readiness
+
+- GIVEN a document with a `publicationConsent` in status `pending` whose `objectionDeadline` lies in the future
+- WHEN readiness is evaluated
+- THEN `consentClear` is false and the record cannot reach `ready`
+- AND the UI shows the blocking consent record as the reason
+- @e2e tests/e2e/workflows/woo-publicatie-pipeline.spec.ts
+
+### Requirement: Readiness gate is enforced by the record lifecycle (REQ-DDWPP-003)
+
+The `publicationRecord` schema MUST declare an `x-openregister-lifecycle`
+annotation (canonical `initial: draft`) with transitions `draft → ready`,
+`ready → draft` (readiness regression), `ready → handed_off`, `handed_off →
+published`, `published → depublication_requested`,
+`depublication_requested → depublished`. The `draft → ready` transition MUST
+be guarded on all three readiness booleans being true, and handoff MUST only
+be possible from `ready`, so the gate cannot be bypassed by a direct status
+write. Readiness MUST be re-evaluated on every handoff attempt and the record
+demoted to `draft` when it has regressed.
+
+#### Scenario: Direct status write cannot skip the gate
+
+- GIVEN a publication record in `draft` with `consentClear` false
+- WHEN a save attempts `status = handed_off`
+- THEN OpenRegister's lifecycle guard rejects the transition
+- @e2e exclude server-side lifecycle guard — covered by PHPUnit transition tests (tests/unit/Service/PublicationPipelineServiceTest.php)
+
+#### Scenario: Regressed readiness demotes the record at handoff
+
+- GIVEN a record in `ready` for which a new objection has since been received
+- WHEN handoff is attempted
+- THEN readiness is re-evaluated, `consentClear` becomes false, the record returns to `draft` and no endpoint object is written
+- @e2e tests/e2e/workflows/woo-publicatie-pipeline.spec.ts
+
+### Requirement: DiWoo metadata assembly (REQ-DDWPP-004)
+
+The publication record MUST carry an operator-completed DiWoo metadata block
+before handoff: `wooCategory` (one of the 17 TOOI Woo informatiecategorie
+codes, selected from OpenCatalogi's bundled TOOI value list — never free
+text), `documentsoort`, `publisher` (TOOI organisatie URI), `officieleTitel`,
+`creatiedatum` and `publicatiedatum`. Handoff MUST be blocked while any
+mandatory DiWoo field is missing. DocuDesk assembles and passes these values;
+TOOI validation and `diwoo:Document` emission remain OpenCatalogi's
+(WOO-TOOI-001/002).
+
+#### Scenario: Missing Woo category blocks handoff
+
+- GIVEN a `ready` record without a `wooCategory`
+- WHEN the operator attempts handoff
+- THEN handoff is refused with a message naming the missing DiWoo fields
+- @e2e tests/e2e/spec-coverage/woo-publications.spec.ts
+
+#### Scenario: Category is selected from the TOOI list
+
+- GIVEN the DiWoo metadata form
+- WHEN the operator opens the Woo-categorie field
+- THEN it offers exactly the 17 TOOI informatiecategorieën (code + label) and no free-text entry
+- @e2e tests/e2e/spec-coverage/woo-publications.spec.ts
+
+### Requirement: Handoff to OpenCatalogi as the publication endpoint (REQ-DDWPP-005)
+
+On handoff of a `ready` record, the app MUST create (or update, when
+`endpointPublicationRef` already exists) an OpenRegister object addressed to
+OpenCatalogi's register slug `publication`, schema slug `publication`,
+mapping the record's title/summary/dates/DiWoo block, and attach the redacted
+derivative (`redactedFileRef`) — NEVER the original file. It MUST store
+`endpointPublicationRef` + `handoffAt`, transition to `handed_off` and append
+a `handed_off` log entry. DocuDesk MUST NOT render any public
+portal/sitemap/search surface. When OpenCatalogi is not installed, handoff
+MUST be disabled with an explanatory state — never a silent no-op. An OR
+authorization failure on the endpoint write MUST surface to the operator.
+
+#### Scenario: Successful handoff creates the endpoint publication
+
+- GIVEN a `ready` record with complete DiWoo metadata and a redacted derivative
+- WHEN the operator confirms handoff
+- THEN an OpenCatalogi `publication` object exists carrying the mapped metadata with the redacted file attached
+- AND the record shows `handed_off` with `endpointPublicationRef` set and a `handed_off` log entry
+- @e2e tests/e2e/workflows/woo-publicatie-pipeline.spec.ts
+
+#### Scenario: Endpoint absent
+
+- GIVEN an instance without OpenCatalogi
+- WHEN the operator views a `ready` record
+- THEN the handoff action is disabled with an explanation that OpenCatalogi provides the publication endpoint
+- @e2e tests/e2e/spec-coverage/woo-publications.spec.ts
+
+### Requirement: De-publication with mandatory reason (REQ-DDWPP-006)
+
+An operator MUST be able to withdraw a published record only with a
+non-empty `depublicationReason`. Withdrawal MUST set `depublicatiedatum` on
+the endpoint publication object (OpenCatalogi's published-predicate removes
+it from all public surfaces), transition the record through
+`depublication_requested` to `depublished`, and append log entries carrying
+the reason. The endpoint object MUST NOT be deleted — the accountability
+trace is retained.
+
+#### Scenario: Withdraw a publication
+
+- GIVEN a record in `published`
+- WHEN the operator withdraws it with reason "Onterecht gepubliceerd: lopend bezwaar"
+- THEN the endpoint publication's `depublicatiedatum` is set and the record reaches `depublished`
+- AND the log shows `depublication_requested` and `depublished` entries with the reason
+- @e2e tests/e2e/workflows/woo-publicatie-pipeline.spec.ts
+
+#### Scenario: Empty reason is refused
+
+- GIVEN a record in `published`
+- WHEN withdrawal is attempted without a reason
+- THEN the action is refused and nothing changes on the endpoint
+- @e2e tests/e2e/spec-coverage/woo-publications.spec.ts
+
+### Requirement: Destruction-date propagation (REQ-DDWPP-007)
+
+The app MUST propagate a destruction date recorded on a publication record
+(`destructionDate` + `destructionDateSource` — e.g. supplied via the
+zgw-document-bridge metadata or operator entry, per Archiefwet/selectielijst)
+to the endpoint publication object as a
+`retentionExpiresAt` override accompanied by a `retentionNote` naming the
+source, as OpenCatalogi RET-003 requires. Actual disposal remains
+OpenCatalogi's retention job; DocuDesk MUST NOT delete or archive endpoint
+publications itself. Propagation MUST append a `destruction_date_propagated`
+log entry.
+
+#### Scenario: Destruction date reaches the endpoint
+
+- GIVEN a published record with destruction date 2034-11-03 from "selectielijst 2020, procestype 6"
+- WHEN the destruction date is propagated
+- THEN the endpoint publication carries `retentionExpiresAt` 2034-11-03 and a `retentionNote` naming the source
+- AND the record's log shows a `destruction_date_propagated` entry
+- @e2e exclude endpoint-side retention fields are not rendered in DocuDesk UI — covered by PHPUnit handoff-mapping tests (tests/unit/Service/PublicationPipelineServiceTest.php); the log entry is covered under REQ-DDWPP-008
+
+### Requirement: Append-only publication log (REQ-DDWPP-008)
+
+The app MUST append a `publicationLogEntry` for every pipeline action
+(create, readiness evaluation, metadata assembly, handoff, publication,
+de-publication request/completion, destruction-date
+propagation) with actor, timestamp,
+details and a state snapshot. The app MUST expose no update or delete route
+for log entries, and the record detail MUST render the log as a timeline for
+accountability (Woo Art. 3.3 verantwoording; AVG Art. 5(2) accountability).
+
+#### Scenario: Log timeline shows the full trail
+
+- GIVEN the seeded published demo record
+- WHEN its detail page renders
+- THEN the log timeline shows `created`, `readiness_evaluated`, `handed_off`, `published` and `destruction_date_propagated` entries in order with actors and timestamps
+- @e2e tests/e2e/spec-coverage/woo-publications.spec.ts
+
+#### Scenario: Log entries cannot be mutated via the API
+
+- GIVEN an existing log entry
+- WHEN the route table is inspected for `publicationLogEntry` update/delete endpoints
+- THEN none exist
+- @e2e exclude route-surface property — covered by a PHPUnit route-table assertion, not a browser flow
+
+### Requirement: Publish wizard chains the pipeline from document and dossier context (REQ-DDWPP-009)
+
+MyDocuments document detail and dossier context MUST offer a "Publiceren"
+action that creates (or opens) the publication record and presents the chain
+anonymize → consent → publish as a stepped wizard: each step shows its gate
+state and deep-links to the existing capability surface (anonymisation
+review, consent records, this pipeline) — the wizard orchestrates and MUST
+NOT reimplement those capabilities. Views use `@conduction/nextcloud-vue`
+components (ADR-012) with NL Design tokens via Nextcloud CSS variables
+(ADR-003).
+
+#### Scenario: Wizard reflects gate state
+
+- GIVEN a document with unreviewed entities
+- WHEN the operator opens the publish wizard
+- THEN the anonymisation step shows as blocking with a deep-link to the entity review, and the publish step is disabled
+- @e2e tests/e2e/workflows/woo-publicatie-pipeline.spec.ts

--- a/openspec/changes/woo-publicatie-pipeline/tasks.md
+++ b/openspec/changes/woo-publicatie-pipeline/tasks.md
@@ -1,0 +1,60 @@
+# Tasks: woo-publicatie-pipeline
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 15.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Register + seed data
+
+- [ ] 1.1 Add `publicationRecord` and `publicationLogEntry` schemas to the `document` register in `lib/Settings/docudesk_register.json` (REQ-DDWPP-001, REQ-DDWPP-003)
+  - All properties per design.md D1; `x-openregister-lifecycle` on `publicationRecord` with canonical `initial: draft` and the REQ-DDWPP-003 transitions guarded on the readiness booleans; log schema immutable; register version bump with changelog entry.
+
+- [ ] 1.2 Add seed data: one `published` record with full log trail, one `draft` record blocked on an open objection window (design.md Seed Data)
+  - Placeholder identifiers only (nil UUID / `seed-*`); validates on boot import.
+
+## 2. Backend
+
+- [ ] 2.1 Add the consent-clearance query `ConsentService::isDocumentConsentClear()` (REQ-DDWPP-020)
+  - Pure read-only; verdict + per-record reasons; exhaustive PHPUnit table test over all `consentStatus` × `publicationDecision` × deadline combinations; `ObjectionDeadlineChecker` untouched.
+
+- [ ] 2.2 Implement `lib/Service/PublicationPipelineService.php`: readiness evaluation (REQ-DDWPP-002) + re-evaluation/demotion on handoff (REQ-DDWPP-003)
+  - Entities-reviewed check from anonymisation review state (+ dossier `checkedOn`); prohibitions via existing `PolicyMatchService`; snapshot stores verdicts + UUIDs only, never entity text.
+
+- [ ] 2.3 Implement handoff to OpenCatalogi (REQ-DDWPP-005)
+  - OR `saveObject()` addressed to register slug `publication` / schema `publication`; field map in one service constant; redacted derivative attached per OpenCatalogi's publication-attachment convention (verify `publication-attachment-defaults` at apply); endpoint-absent → disabled state; OR 403 surfaced.
+
+- [ ] 2.4 Implement de-publication (REQ-DDWPP-006) and destruction-date propagation (REQ-DDWPP-007)
+  - Mandatory reason; `depublicatiedatum` set on the endpoint object, never deleted; `retentionExpiresAt` + `retentionNote` per RET-003; log entries for every step.
+
+- [ ] 2.5 Implement append-only logging + `lib/Controller/PublicationController.php` with `api/publications/*` routes (REQ-DDWPP-008)
+  - No update/delete route for log entries (PHPUnit route-table assertion); every controller method carries explicit auth attributes and guards.
+
+- [ ] 2.6 Add an OpenCatalogi schema drift-pin unit test
+  - Fixture of OpenCatalogi's `publication` schema properties; handoff field map validated against it so endpoint renames fail the suite, not production.
+
+## 3. Frontend
+
+- [ ] 3.1 Publications index + detail manifest pages (REQ-DDWPP-004, REQ-DDWPP-008)
+  - `CnIndexPage`/`CnDataTable` with status chips; detail: readiness checklist with reasons, DiWoo form (`CnFormDialog`, wooCategory select limited to the 17 TOOI informatiecategorieën sourced from OpenCatalogi's value list), log timeline, withdraw + destruction-date actions; manifest schema refs use slugs.
+
+- [ ] 3.2 Publish wizard entries on MyDocuments document detail and dossier context (REQ-DDWPP-009)
+  - Stepped anonymize → consent → publish view; deep-links only, no capability reimplementation; NL Design tokens via NC CSS variables.
+
+## 4. Spec maintenance
+
+- [ ] 4.1 Update `openspec/specs/publication-consent/spec.md`: set Status in-progress and append this change to its OpenSpec changes list
+  - Delta REQ-DDWPP-020 merges into the canonical spec at archive time.
+
+## 5. Quality
+
+- [ ] 5.1 PHPUnit unit tests for pipeline service, clearance query, controller and lifecycle guards — minimum 75% coverage on new code
+  - Run inside the container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`.
+  - Consent transitions validated against the GDPR/WOO lifecycle; PUT-semantic saves verified (a non-changed field survives).
+
+- [ ] 5.2 Playwright e2e specs `tests/e2e/workflows/woo-publicatie-pipeline.spec.ts` + `tests/e2e/spec-coverage/woo-publications.spec.ts` covering the `@e2e`-referenced scenarios end-to-end with OpenRegister + OpenCatalogi on the Postgres dev instance
+  - Includes the nldesign-theme accessibility pass on the new views.
+
+- [ ] 5.3 i18n: EN + NL for all new UI strings (readiness reasons, DiWoo labels, wizard steps, log actions)
+  - Keys in English.
+
+- [ ] 5.4 Documentation `docs/features/woo-publicatie-pipeline.md` with Playwright MCP screenshots (ADR-010); run `openspec validate woo-publicatie-pipeline --strict`
+  - Documents the OpenCatalogi endpoint boundary and the readiness gate semantics.

--- a/openspec/changes/woo-request-workflow/.openspec.yaml
+++ b/openspec/changes/woo-request-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/woo-request-workflow/design.md
+++ b/openspec/changes/woo-request-workflow/design.md
@@ -1,0 +1,296 @@
+# Design: woo-request-workflow
+
+## Context
+
+Verified at DocuDesk HEAD:
+
+- The `dossier` register holds `dossier` (binds a Nextcloud folder via
+  `@self.folder`; `name`, `description`, `bases[]` — array of `base` slugs —
+  and `checkedOn`) and `base` (Woo Art. 5 uitzonderingsgrond: `name`,
+  `description`, both required; **six canonical grounds seeded**:
+  `persoonsgegevens`, `bijzondere-persoonsgegevens`, `strafrechtelijk`,
+  `bedrijfs-fabricagegegevens`, `onevenredige-benadeling`,
+  `nationale-veiligheid` — each description cites the Woo/AVG articles).
+  `BasesResolverService`, `GrondslagProposalService` and
+  `GrondslagenSummaryService` already resolve/propose grounds.
+- Batch anonymisation exposes per-batch entity review
+  (`api/anonymization/batch/{batchId}/entities`), reports, and manual entity
+  handling; the entity-review data model carries per-entity grondslag
+  (CB #122 auto-proposal in the sibling anonymization-review-workbench
+  change).
+- Document generation is backend-complete (`api/documents/generate`,
+  `generatedDocument` schema, TemplateService/TemplateRenderer with seeded
+  templates); correspondence generation produces letters
+  (`api/correspondence/generate`, `correspondence` schema).
+- The zgw-document-bridge change (sibling, this wave) defines
+  `externalDocument` staging objects and dossier pick-up.
+- The woo-publicatie-pipeline change (sibling, this wave) defines
+  `publicationRecord` handoff to OpenCatalogi.
+- OR access: `SettingsService::getObjectService()` with `@self.register` /
+  `@self.schema` addressing; no custom tables anywhere (ADR-001).
+
+Statutory frame: Woo Art. 4.4 — decision within 4 weeks of receipt, one
+extension of at most 2 weeks with notified reason; disclosure to the
+requester, then active publication of the disclosed set.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One case object per Woo-verzoek with statutory deadline arithmetic and a
+  guarded lifecycle.
+- Candidate collection from both Nextcloud folders and bridge-staged case
+  system documents, deduped by content hash before assessment.
+- Per-document assessment + per-passage exemption tagging that reuses the
+  existing grondslagen register — one taxonomy across anonymisation and
+  disclosure.
+- Inventarislijst and disclosure package produced by the existing generation
+  capabilities, never by new renderers.
+
+**Non-Goals:**
+
+- No cross-system enterprise *search* to discover candidate documents
+  (INDICA's category) — collection starts from folders/zaak selections the
+  operator provides.
+- No email-thread / near-duplicate detection (hash-identical only; threading
+  noted as future work).
+- No requester portal or intake form for citizens (portaliq/portal-contribution
+  territory; intake here is operator-side).
+- No new anonymisation, generation or publication engines — orchestration
+  only.
+- No case-system write-back of disclosure decisions (bridge write-back covers
+  redacted derivatives only).
+
+## Decisions
+
+### D1 — `wooRequest` + `requestDocument` schemas in the `dossier` register
+
+- **`wooRequest`**: `requestNumber` (human key, e.g. "WOO-2026-021"),
+  `subject`, `scopeDescription`, `requesterReference` (opaque operator-side
+  reference to the requester's case/contact — **no requester name/email on
+  the schema**, data minimisation AVG Art. 5(1)(c); identity stays in the NC
+  contact/zaak the reference points at), `receivedAt`, `decisionDeadlineAt`,
+  `extendedAt`, `extensionReason`, `status` (lifecycle, D3), `dossierRef`
+  (the collection dossier), `inventoryFileRef`, `decisionFileRef`,
+  `packageFolderRef`, `publicationRecordRef` (optional link to the
+  woo-publicatie-pipeline record), `closedAt`.
+- **`requestDocument`**: `wooRequestRef`, `origin` (enum `nc-folder` |
+  `zgw-bridge`), `fileRef` (Nextcloud file id of the collected copy),
+  `externalDocumentRef` (bridge staging object UUID when origin is
+  `zgw-bridge`), `title`, `documentDate`, `contentHash` (sha256),
+  `dedupeStatus` (enum `unique` | `duplicate`), `duplicateOfRef`,
+  `assessment` (enum `pending` | `disclose` | `partially_disclose` |
+  `withhold`), `exemptionGrounds[]` (array of `base` slugs),
+  `passageTags[]` (array of objects `{locator, ground, note}` — locator is a
+  page/passage reference; per-entity tags ride the anonymisation entity
+  review, D5), `redactedFileRef`, `inventoryNumber`.
+
+Both live in the `dossier` register: a Woo request is case/dossier domain,
+and the grondslagen it references are already there. Rejected alternative: a
+new `wooRequest` register — more surface, no isolation benefit, and the
+request wants `maxDepth` relations into `dossier`/`base` anyway.
+
+### D2 — Statutory deadline arithmetic (Woo Art. 4.4)
+
+`decisionDeadlineAt = receivedAt + 4 weeks` computed at intake by
+`WooRequestService` (clock-injected). One extension allowed: `extend()`
+requires a reason, adds at most 2 weeks, sets `extendedAt`/`extensionReason`,
+recomputes the deadline, and is refused on a second attempt. The UI shows a
+deadline chip (on-track / due within 5 working days / overdue). This is
+date arithmetic + a legal control ⇒ service-owned and exhaustively
+unit-tested, mirroring how `ObjectionDeadlineChecker` owns the WOO objection
+window (and per the publication-consent precedent: statutory terms are never
+delegated to a generic helper with different legal semantics). ADR-011 check:
+no OR helper models Woo Art. 4.4 terms (OR's `DataSubjectDeadline` is GDPR
+Art. 12(3) — one month + two-month extension — explicitly the wrong law).
+
+### D3 — Request lifecycle (declarative guard)
+
+```
+registered ──> collecting ──> assessing ──> decision ──> disclosed ──> published ──> closed
+                   ^               │                          │
+                   └───────────────┘ (reopen collection)      └──────────────> closed (no active publication)
+```
+
+Declared as `x-openregister-lifecycle` on `wooRequest` (canonical
+`initial: registered`). Guards: `assessing → decision` requires every
+non-duplicate `requestDocument` to have a non-`pending` assessment;
+`decision → disclosed` requires `inventoryFileRef` + `decisionFileRef`;
+`disclosed → published` requires a `publicationRecordRef`. The cross-object
+guard conditions are evaluated imperatively in `WooRequestService` before it
+requests the transition (ADR-031 exception: lifecycle guard over a
+cross-schema aggregate), while OR's declarative lifecycle still rejects any
+out-of-order transition written directly.
+
+### D4 — Collection + hash dedupe
+
+`collect()` accepts a Nextcloud folder selection and/or a set of
+bridge-staged `externalDocument` objects (when the zgw-document-bridge is
+installed; the option is hidden otherwise). Each collected file is copied
+into the request's dossier folder (the existing dossier/folder unit, so
+folder-batch anonymisation runs unchanged), a `requestDocument` row is
+created with `contentHash = sha256(content)`, and dedupe runs within the
+request: rows sharing a hash collapse to one `unique` row (first collected)
+with the rest marked `duplicate` + `duplicateOfRef`. Duplicates are excluded
+from assessment and the inventory but stay listed (accountability: the
+requester may cite them). Email threading / near-duplicate detection is
+explicitly out of scope and recorded as future work in the spec.
+
+### D5 — Exemption-ground tagging reuses the `base` register (verified)
+
+Three tagging levels, one taxonomy:
+
+1. **Per document**: `assessment` + `exemptionGrounds[]` (base slugs).
+2. **Per passage**: `passageTags[]` entries `{locator, ground, note}` for
+   grounds that apply to a passage rather than the whole document (ZyLAB's
+   per-passage annotation, the category's table-stakes feature).
+3. **Per entity**: the existing anonymisation entity review already carries
+   per-entity grondslag (GrondslagProposalService / CB #122); the workflow
+   deep-links into the batch entity review for the dossier rather than
+   duplicating it.
+
+The `base` schema is **not modified**; the additional Woo Art. 5.1/5.2
+grounds the assessment needs beyond the six seeded categories ship as new
+seed `base` objects with article references in name/description (e.g.
+"Art. 5.1.2e — Eerbiediging van de persoonlijke levenssfeer",
+"Art. 5.1.2b — Economische of financiële belangen", "Art. 5.1.1c —
+Vertrouwelijk verstrekte bedrijfs- en fabricagegegevens" where it refines an
+existing category, "Art. 5.2 — Persoonlijke beleidsopvattingen in documenten
+voor intern beraad"). Adding an explicit `article` property to `base` is
+logged as a deferred question (it would touch the dossier-register
+capability, not assigned to this change).
+
+### D6 — Inventarislijst and disclosure package reuse existing generators
+
+- **Inventarislijst**: a seeded template `woo-inventarislijst` (templates
+  register) rendered through the existing `api/documents/generate` with the
+  request + its `unique` documents (inventory number, title, date,
+  assessment, grounds) as data; output stored, `inventoryFileRef` set.
+  Inventory numbers are assigned stably (collection order) on first
+  generation.
+- **Besluit letter**: generated through the existing correspondence
+  capability from a seeded `woo-besluit` template; `decisionFileRef` set.
+- **Package**: `assemblePackage()` creates the package folder containing the
+  redacted PDFs (each `disclose`/`partially_disclose` document's
+  `redactedFileRef` produced by the existing dossier anonymisation flow — the
+  package MUST refuse unredacted originals for `partially_disclose` items),
+  the inventarislijst and the besluit; `packageFolderRef` set. Delivery of
+  the package (mail/portal) stays out of scope (NC Mail / OR email leaf per
+  the app boundary).
+
+### D7 — Frontend per ADR-012
+
+- **Woo-verzoeken index** (manifest page): `CnIndexPage` + `CnDataTable` —
+  request number, subject, status chip, deadline chip.
+- **Request detail**: header with lifecycle + deadline (extension action with
+  mandatory reason); tabs/sections for Collection (add-from-folder,
+  add-from-zaaksysteem when bridge present, dedupe results), Assessment
+  (per-document assessment + grounds multi-select bound to the `base`
+  register, passage tags editor, deep-link to batch entity review),
+  Documents (inventory preview, generate inventarislijst/besluit, assemble
+  package), and the request timeline.
+- Modals/dialogs in their own files under `src/modals/`/`src/dialogs/`;
+  `NcSelect` usages carry `inputLabel`; NL Design tokens via NC CSS
+  variables (ADR-003).
+
+## OpenRegister service usage (ADR-001)
+
+| Operation | OR service |
+|---|---|
+| Request/requestDocument CRUD | `ObjectService::saveObject()` / `searchObjects()` on the `dossier` register (no custom tables) |
+| Grounds lookup | `searchObjects()` on `dossier`/`base` (existing `BasesResolverService` reused) |
+| Lifecycle | declarative `x-openregister-lifecycle` on `wooRequest` |
+| Collection folder | existing dossier folder binding (`@self.folder`) |
+| Inventory/besluit rendering | existing TemplateService / document + correspondence generation (their OR usage unchanged) |
+| Audit | OR object audit trail |
+
+ADR-011 check: hashing via PHP `hash('sha256', ...)`; deadline arithmetic is
+app-owned by legal necessity (D2); no BSN/date/slug utilities duplicated.
+
+## Declarative-vs-imperative decision (ADR-031)
+
+- **Declarative**: `wooRequest` lifecycle (`x-openregister-lifecycle`,
+  canonical `initial:`); grounds as register data (`base` objects);
+  register-i18n on new user-facing string fields (matching the v5.4/v5.5
+  pattern on dossier/base).
+- **Imperative (justified exceptions)**: statutory deadline computation +
+  extension control (legal control, exhaustively unit-tested — same class as
+  `ObjectionDeadlineChecker`); collection + dedupe (file-system side effects
+  + content hashing); cross-object lifecycle guard conditions (aggregate over
+  `requestDocument` rows before transition); inventarislijst/package assembly
+  (document generation — a named ADR-031 exception).
+
+## Seed Data
+
+Shipped in `docudesk_register.json` `objects[]` (demo-municipality flavour,
+placeholder identifiers only):
+
+```json
+{
+  "@self": {"register": "dossier", "schema": "wooRequest", "slug": "demostad-woo-2026-021"},
+  "requestNumber": "WOO-2026-021",
+  "subject": "Handhavingsbesluiten horeca 2024-2025",
+  "scopeDescription": "Alle handhavingsbesluiten en bijbehorende inspectierapporten voor horecagelegenheden in het centrum, januari 2024 t/m december 2025.",
+  "requesterReference": "zaak-00000000-0000-0000-0000-000000000000",
+  "receivedAt": "2026-06-20",
+  "decisionDeadlineAt": "2026-07-18",
+  "status": "assessing",
+  "dossierRef": "demostad-woo-2025-017"
+}
+```
+
+```json
+{
+  "@self": {"register": "dossier", "schema": "requestDocument", "slug": "demostad-woo-2026-021-doc-001"},
+  "wooRequestRef": "demostad-woo-2026-021",
+  "origin": "nc-folder",
+  "fileRef": "seed-file-handhavingsbesluit-2024-113",
+  "title": "Handhavingsbesluit 2024-113 Café De Kroon",
+  "documentDate": "2024-09-12",
+  "contentHash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "dedupeStatus": "unique",
+  "assessment": "partially_disclose",
+  "exemptionGrounds": ["persoonsgegevens", "art-5-1-2e-persoonlijke-levenssfeer"],
+  "passageTags": [
+    {"locator": "p. 2, alinea 3", "ground": "art-5-1-2e-persoonlijke-levenssfeer", "note": "Naam en adres exploitant"}
+  ],
+  "inventoryNumber": 1
+}
+```
+
+Plus: a `duplicate` requestDocument pointing at doc-001; the additional Woo
+Art. 5.1/5.2 `base` seed objects (D5); a `woo-inventarislijst` and a
+`woo-besluit` template seed in the templates register.
+
+## Risks / Trade-offs
+
+- [Statutory-term errors are legal risk] → single clock-injected service,
+  exhaustive unit tests incl. extension refusal; deadline always displayed,
+  never enforced silently (the operator decides, DocuDesk tracks).
+- [Hash dedupe misses near-duplicates/email threads] → explicitly scoped
+  future work; verdict field is an enum so a `near_duplicate` value can be
+  added without migration.
+- [Package could leak unredacted content] → assembly refuses
+  `partially_disclose` items without `redactedFileRef`; spec scenario pins
+  it; package folder inherits dossier ACLs.
+- [Grounds slug drift between seeds and tags] → tags store `base` slugs and
+  render via `BasesResolverService`; unknown slugs render as warnings, never
+  silently dropped.
+- [Sibling-change coupling (bridge, pipeline)] → both integrations are
+  presence-gated (option hidden / step skipped when absent); this change
+  applies standalone.
+
+## Migration Plan
+
+Additive: schemas + seeds + templates (register version bump, boot import),
+new service/controller/routes/views. No existing schema changes. Rollback =
+remove routes/UI; request objects remain readable. No data migration.
+
+## Open Questions
+
+- Explicit `article` property on the `base` schema (vs article-in-name seed
+  convention) — deferred to a dossier-register follow-up.
+- Requester-facing intake/status via portaliq (portal-contribution A6
+  actions) — deferred; this change is operator-side only.
+- `near_duplicate`/email-threading detection — future wave, needs an
+  OR-side text-similarity capability decision.

--- a/openspec/changes/woo-request-workflow/proposal.md
+++ b/openspec/changes/woo-request-workflow/proposal.md
@@ -1,0 +1,99 @@
+---
+kind: code
+---
+
+# Proposal: woo-request-workflow
+
+## Why
+
+Passive disclosure — handling a Woo-verzoek end-to-end — is the competitive
+category where municipalities spend the most painful money: ZyLAB ONE
+(eDiscovery-grade Woo request handling with per-passage exemption-ground
+annotation, dedupe and email threading, used by ministries), INDICA Woo
+(cross-system search to find Woo-relevant content) and OCTOBOX (EIFFEL's
+Woo-desk software+staffing at BZK, OCW, AZ, claiming 60% time saving vs
+Adobe) all monetise exactly this workflow (research-competitors.md category
+3/theme 8). De Connectie 391449 asks for an integraal Woo-proces; VNG
+estimates >50% of documents partly auto-redactable but ALL needing review,
+with ~€25k acquisition budgets for medium/large orgs.
+
+DocuDesk already owns every processing primitive the workflow needs —
+dossier register with Woo Art. 5 grondslagen (`base` schema, six canonical
+uitzonderingsgronden seeded at HEAD), batch/folder anonymisation with entity
+review and CSV audit reports, template-driven document generation
+(`api/documents/generate`), correspondence/letter generation, PDF/A output —
+but has **no request object**: no intake with statutory deadlines, no
+candidate-document collection, no dedupe, no per-document exemption
+assessment, no inventarislijst, no disclosure package, no lifecycle. An
+operator today would juggle folders and spreadsheets around DocuDesk, which
+is exactly what the ZyLAB category sells against.
+
+## What Changes
+
+- Two new schemas in the existing `dossier` register:
+  - `wooRequest` — the Woo-verzoek case: subject/scope, receipt date,
+    statutory decision deadline (Woo Art. 4.4: 4 weeks, one extension of at
+    most 2 weeks with reason), lifecycle status, links to the collection
+    dossier, decision letter, inventory document and disclosure package.
+  - `requestDocument` — one row per candidate document in the request
+    dossier: origin (Nextcloud folder, or case system via the
+    zgw-document-bridge when present), content hash, dedupe verdict,
+    per-document disclosure assessment (disclose / partially disclose /
+    withhold) and exemption grounds.
+- **Intake**: register a request with subject, scope and received date;
+  deadline and extension tracked against the statutory terms with a
+  deadline indicator.
+- **Collection**: attach candidate documents from Nextcloud folders and — via
+  the zgw-document-bridge when installed — from case systems, into a request
+  dossier (reusing the existing `dossier` schema and folder binding).
+- **Dedupe**: hash-based duplicate detection across the collected set
+  (identical content collapses to one assessable document; near-identical
+  email-thread dedupe is noted as future work).
+- **Exemption-ground tagging**: per-document assessment plus per-passage/
+  per-entity tagging using the Woo Art. 5.1/5.2 uitzonderingsgronden — reusing
+  the existing `base` grondslagen register (verified at HEAD: six canonical
+  grounds seeded; additional grounds added as seed data, schema unchanged).
+- **Inventarislijst**: generate the inventory-list document (per-document
+  number, title, date, assessment, grounds) from a seeded template through
+  the existing document-generation capability.
+- **Disclosure package**: assemble redacted PDFs + inventarislijst + besluit
+  letter (via the existing correspondence generation) into a package folder.
+- **Lifecycle**: registered → collecting → assessing → decision → disclosed
+  → published → closed, with the publication step handing off to the
+  woo-publicatie-pipeline where installed.
+
+## Capabilities
+
+### New Capabilities
+
+- `woo-request-workflow`: passive-disclosure case workflow — Woo-verzoek
+  intake with statutory deadline tracking, candidate-document collection
+  (folders + zgw-document-bridge), hash-based dedupe, per-document and
+  per-passage exemption-ground tagging on the existing grondslagen register,
+  inventarislijst generation, disclosure-package assembly and request
+  lifecycle.
+
+### Modified Capabilities
+
+<!-- none — dossier-register, batch-anonymization, document generation and
+     correspondence capabilities are consumed unchanged; new grounds ship as
+     additional seed objects of the existing base schema. -->
+
+## Impact
+
+- `lib/Settings/docudesk_register.json`: `wooRequest` + `requestDocument`
+  schemas in the `dossier` register; additional Woo Art. 5.1/5.2 `base` seed
+  objects; a seeded `woo-inventarislijst` template; register version bump.
+- New `lib/Service/WooRequestService.php` (intake, deadlines, collection,
+  dedupe, assessment, package assembly) +
+  `lib/Controller/WooRequestController.php` with `api/woo-requests/*` routes.
+- `src/manifest.json` + new views: Woo-verzoeken index/detail with deadline
+  indicators, collection and assessment surfaces.
+- Consumes (unchanged): dossier register + folder batch anonymisation,
+  `api/documents/generate` (inventory), correspondence generation (besluit),
+  zgw-document-bridge staging objects (optional), woo-publicatie-pipeline
+  handoff (optional).
+- Evidence: research-competitors.md category 3 (ZyLAB/INDICA/Octobox), De
+  Connectie 391449 integraal Woo-proces, VNG review mandate, Arnhem 407824
+  (275 Woo dossiers/~55k docs/yr shows the volume this workflow must
+  organise).

--- a/openspec/changes/woo-request-workflow/specs/woo-request-workflow/spec.md
+++ b/openspec/changes/woo-request-workflow/specs/woo-request-workflow/spec.md
@@ -1,0 +1,243 @@
+# woo-request-workflow Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Passive-disclosure (Woo-verzoek) case workflow: intake a Woo request with
+statutory deadline tracking (Woo Art. 4.4), collect candidate documents into
+a request dossier from Nextcloud folders and — via the zgw-document-bridge
+when present — case systems, dedupe identical documents by content hash, tag
+per-document and per-passage exemption grounds against the existing Woo
+Art. 5 grondslagen (`base`) register, generate the inventarislijst from a
+template, assemble the disclosure package (redacted PDFs + inventory +
+besluit letter via correspondence generation), and track the request
+lifecycle through decision, disclosure and publication. This is the
+ZyLAB/INDICA/Octobox competitive category; DocuDesk orchestrates its existing
+anonymisation, generation and publication capabilities — it adds no new
+engines.
+
+## ADDED Requirements
+
+### Requirement: Woo-request and request-document schemas (REQ-DDWRW-001)
+
+The app MUST declare two schemas in the `dossier` register: `wooRequest`
+(`requestNumber`, `subject`, `scopeDescription`, `requesterReference` —
+an opaque case/contact reference; the schema MUST NOT carry requester name,
+email or address fields (data minimisation, AVG Art. 5(1)(c)) —
+`receivedAt`, `decisionDeadlineAt`, `extendedAt`, `extensionReason`,
+`status`, `dossierRef`, `inventoryFileRef`, `decisionFileRef`,
+`packageFolderRef`, `publicationRecordRef`, `closedAt`) and `requestDocument`
+(`wooRequestRef`, `origin` enum `nc-folder`|`zgw-bridge`, `fileRef`,
+`externalDocumentRef`, `title`, `documentDate`, `contentHash`,
+`dedupeStatus` enum `unique`|`duplicate`, `duplicateOfRef`, `assessment`
+enum `pending`|`disclose`|`partially_disclose`|`withhold`,
+`exemptionGrounds[]` of `base` slugs, `passageTags[]` of
+`{locator, ground, note}`, `redactedFileRef`, `inventoryNumber`). All data
+MUST be stored as OpenRegister objects (ADR-001) with a register version
+bump for boot import.
+
+#### Scenario: Register import creates the workflow schemas
+
+- GIVEN DocuDesk and OpenRegister installed
+- WHEN `ConfigurationService::importFromApp()` runs on boot
+- THEN `wooRequest` and `requestDocument` exist in the `dossier` register and the seeded demo request is queryable
+- AND neither schema declares a requester name, email or address property
+- @e2e exclude boot-time register import with no UI surface of its own — covered by PHPUnit register-import assertions (tests/unit/Settings/)
+
+### Requirement: Intake with statutory deadline (Woo Art. 4.4) (REQ-DDWRW-002)
+
+Registering a Woo request MUST compute `decisionDeadlineAt = receivedAt + 4
+weeks` (Woo Art. 4.4). Exactly one extension MUST be possible, requiring a
+non-empty reason and adding at most 2 weeks (Woo Art. 4.4 lid 2), recording
+`extendedAt` + `extensionReason`; a second extension attempt MUST be
+refused. The computation MUST be clock-injected and app-owned — it MUST NOT
+be delegated to OpenRegister's GDPR Art. 12(3) deadline helper, whose terms
+belong to a different law. The UI MUST show a deadline indicator (on-track /
+due soon / overdue) on index and detail.
+
+#### Scenario: Deadline computed at intake
+
+- GIVEN an operator registering a request received on 2026-06-20
+- WHEN the request is created
+- THEN `decisionDeadlineAt` is 2026-07-18 and the detail shows the deadline indicator
+- @e2e tests/e2e/workflows/woo-request-workflow.spec.ts
+
+#### Scenario: Second extension refused
+
+- GIVEN a request already extended by 2 weeks with reason
+- WHEN a second extension is attempted
+- THEN it is refused and the deadline is unchanged
+- @e2e exclude single-guard date arithmetic — covered exhaustively by clock-injected PHPUnit tests (tests/unit/Service/WooRequestServiceTest.php); the extension UI happy path is covered in the workflow e2e
+
+### Requirement: Candidate-document collection into a request dossier (REQ-DDWRW-003)
+
+An operator MUST be able to collect candidate documents into the request's
+dossier folder from Nextcloud folder selections and, when the
+zgw-document-bridge is installed, from staged `externalDocument` objects
+(recorded with `origin = zgw-bridge` + `externalDocumentRef`). Each
+collected file MUST produce a `requestDocument` row with a sha256
+`contentHash`, and the copy MUST land in the request's dossier folder so the
+existing folder-batch anonymisation runs unchanged. Without the bridge, the
+case-system option MUST be hidden (not broken).
+
+#### Scenario: Collect from a Nextcloud folder
+
+- GIVEN a request in `collecting` and a folder with three documents
+- WHEN the operator collects the folder
+- THEN three `requestDocument` rows exist with hashes and copies in the request dossier folder
+- @e2e tests/e2e/workflows/woo-request-workflow.spec.ts
+
+#### Scenario: Bridge option is presence-gated
+
+- GIVEN an instance without the zgw-document-bridge configured
+- WHEN the collection surface renders
+- THEN only the folder option is offered
+- @e2e tests/e2e/spec-coverage/woo-requests.spec.ts
+
+### Requirement: Hash-based dedupe of the collected set (REQ-DDWRW-004)
+
+Collection MUST deduplicate within the request by content hash: rows sharing
+a `contentHash` collapse to one `unique` row (first collected) with the
+others marked `duplicate` + `duplicateOfRef`. Duplicates MUST be excluded
+from assessment, the inventarislijst and the disclosure package, but MUST
+remain listed on the request for accountability. Near-identical and
+email-thread deduplication is out of scope for this change and MUST be
+recorded as future work (the `dedupeStatus` enum remains extensible).
+
+#### Scenario: Identical documents collapse
+
+- GIVEN two collected files with identical content
+- WHEN dedupe runs
+- THEN one row is `unique` and the other is `duplicate` pointing at it
+- AND the duplicate is not offered for assessment
+- @e2e tests/e2e/workflows/woo-request-workflow.spec.ts
+
+### Requirement: Exemption-ground tagging reuses the grondslagen register (REQ-DDWRW-005)
+
+Per-document assessment MUST record `assessment`
+(`disclose`/`partially_disclose`/`withhold`) with `exemptionGrounds[]`
+referencing `base` objects by slug — the existing Woo Art. 5 grondslagen
+register, not a new taxonomy. Per-passage tagging MUST be possible via
+`passageTags[]` entries `{locator, ground, note}` whose `ground` is a `base`
+slug. A `withhold` or `partially_disclose` assessment MUST require at least
+one exemption ground. Grounds MUST render via the existing
+`BasesResolverService`; an unknown slug MUST render as a visible warning,
+never be silently dropped. The `base` schema itself MUST NOT be modified;
+the additional Woo Art. 5.1/5.2 grounds ship as new seed `base` objects with
+article references in name and description.
+
+#### Scenario: Withholding requires a ground
+
+- GIVEN a unique request document under assessment
+- WHEN the operator sets `withhold` without selecting a ground
+- THEN the assessment is refused with a message requiring an exemption ground
+- @e2e tests/e2e/spec-coverage/woo-requests.spec.ts
+
+#### Scenario: Per-passage tag with a seeded Art. 5 ground
+
+- GIVEN a document assessed `partially_disclose`
+- WHEN the operator adds a passage tag "p. 2, alinea 3" with ground "Art. 5.1.2e — Eerbiediging van de persoonlijke levenssfeer"
+- THEN the tag is stored with the `base` slug and rendered with the ground's name
+- @e2e tests/e2e/workflows/woo-request-workflow.spec.ts
+
+#### Scenario: Entity-level grounds deep-link to the existing review
+
+- GIVEN a request dossier with a completed batch extraction
+- WHEN the operator opens entity-level tagging
+- THEN they are deep-linked to the existing batch entity review for the dossier and no duplicate entity-review UI is rendered
+- @e2e tests/e2e/spec-coverage/woo-requests.spec.ts
+
+### Requirement: Inventarislijst generation from a template (REQ-DDWRW-006)
+
+The app MUST generate the inventarislijst through the existing
+document-generation capability (`api/documents/generate`) from a seeded
+`woo-inventarislijst` template, listing every `unique` request document with
+a stable `inventoryNumber` (assigned in collection order on first
+generation), title, document date, assessment and exemption grounds. The
+output MUST be stored and recorded in `inventoryFileRef`. No new rendering
+engine may be introduced.
+
+#### Scenario: Generate the inventory
+
+- GIVEN a request in `assessing` with three unique assessed documents
+- WHEN the operator generates the inventarislijst
+- THEN a document is produced listing the three documents with numbers, assessments and grounds, and `inventoryFileRef` is set
+- @e2e tests/e2e/workflows/woo-request-workflow.spec.ts
+
+### Requirement: Disclosure-package assembly (REQ-DDWRW-007)
+
+The app MUST assemble the disclosure package into a package folder
+(`packageFolderRef`): the redacted PDFs of every `disclose` and
+`partially_disclose` document, the inventarislijst and the besluit letter
+(generated via the existing correspondence capability from a seeded
+`woo-besluit` template, recorded in `decisionFileRef`). Assembly MUST refuse
+to include a `partially_disclose` document without a `redactedFileRef`
+(never the unredacted original), and MUST exclude `withhold` documents and
+duplicates. Package delivery (mail/portal) is out of scope (NC Mail / OR
+email leaf boundary).
+
+#### Scenario: Package refuses unredacted partial disclosures
+
+- GIVEN a `partially_disclose` document without a redacted derivative
+- WHEN package assembly is attempted
+- THEN assembly is refused naming the document, and no package folder is produced
+- @e2e tests/e2e/workflows/woo-request-workflow.spec.ts
+
+#### Scenario: Complete package
+
+- GIVEN all disclosable documents have redacted derivatives and inventory + besluit exist
+- WHEN the package is assembled
+- THEN the package folder contains the redacted PDFs, the inventarislijst and the besluit, and `packageFolderRef` is set
+- @e2e tests/e2e/workflows/woo-request-workflow.spec.ts
+
+### Requirement: Guarded request lifecycle (REQ-DDWRW-008)
+
+The `wooRequest` schema MUST declare an `x-openregister-lifecycle`
+annotation (canonical `initial: registered`) with transitions
+`registered → collecting`, `collecting → assessing`, `assessing →
+collecting` (reopen), `assessing → decision`, `decision → disclosed`,
+`disclosed → published`, `disclosed → closed`, `published → closed`.
+Guard conditions MUST hold before the service requests a transition:
+`assessing → decision` requires every `unique` document to have a
+non-`pending` assessment; `decision → disclosed` requires
+`inventoryFileRef` and `decisionFileRef`; `disclosed → published` requires a
+`publicationRecordRef` (woo-publicatie-pipeline handoff; the step MUST be
+skippable to `closed` when the pipeline is not installed). Direct
+out-of-order status writes MUST be rejected by OpenRegister's lifecycle
+guard.
+
+#### Scenario: Decision blocked while assessments are pending
+
+- GIVEN a request in `assessing` with one unique document still `pending`
+- WHEN the operator attempts to move to `decision`
+- THEN the transition is refused naming the unassessed document
+- @e2e tests/e2e/workflows/woo-request-workflow.spec.ts
+
+#### Scenario: Direct status write cannot skip stages
+
+- GIVEN a request in `collecting`
+- WHEN a save attempts `status = disclosed`
+- THEN OpenRegister rejects the transition
+- @e2e exclude server-side lifecycle guard — covered by PHPUnit transition tests (tests/unit/Service/WooRequestServiceTest.php)
+
+### Requirement: Woo-verzoeken UI (REQ-DDWRW-009)
+
+The app MUST provide a Woo-verzoeken index (manifest page; `CnIndexPage` +
+`CnDataTable` with request number, subject, status chip and deadline chip)
+and a request detail with collection, assessment (grounds multi-select bound
+to the `base` register, passage-tag editor), document/package actions and
+the lifecycle header, per ADR-012 (`@conduction/nextcloud-vue` components)
+and ADR-003 (NL Design tokens via Nextcloud CSS variables, no hardcoded
+colors). Modals/dialogs MUST live in their own files under
+`src/modals/`/`src/dialogs/`, and every `NcSelect` MUST carry an
+`inputLabel`.
+
+#### Scenario: Index shows deadline state
+
+- GIVEN the seeded demo request due within a week
+- WHEN the Woo-verzoeken index renders
+- THEN the request row shows its status chip and a "due soon" deadline chip
+- @e2e tests/e2e/spec-coverage/woo-requests.spec.ts

--- a/openspec/changes/woo-request-workflow/tasks.md
+++ b/openspec/changes/woo-request-workflow/tasks.md
@@ -1,0 +1,55 @@
+# Tasks: woo-request-workflow
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 14.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Register + seed data
+
+- [ ] 1.1 Add `wooRequest` and `requestDocument` schemas to the `dossier` register in `lib/Settings/docudesk_register.json` (REQ-DDWRW-001, REQ-DDWRW-008)
+  - All properties per design.md D1 (no requester name/email/address fields); `x-openregister-lifecycle` on `wooRequest` with canonical `initial: registered` and the REQ-DDWRW-008 transitions; register-i18n tags on new user-facing string fields; register version bump with changelog entry.
+
+- [ ] 1.2 Add seed data: demo `wooRequest` + unique/duplicate `requestDocument` rows, the additional Woo Art. 5.1/5.2 `base` ground objects, and `woo-inventarislijst` + `woo-besluit` template seeds (design.md Seed Data, REQ-DDWRW-005/006/007)
+  - `base` schema untouched; article references carried in ground names/descriptions; placeholder identifiers only.
+
+## 2. Backend
+
+- [ ] 2.1 Implement intake + statutory deadline logic in `lib/Service/WooRequestService.php` (REQ-DDWRW-002)
+  - Clock-injected; 4-week deadline; single 2-week-max extension with mandatory reason, second attempt refused; no delegation to OR's Art. 12(3) helper.
+
+- [ ] 2.2 Implement collection + hash dedupe (REQ-DDWRW-003, REQ-DDWRW-004)
+  - Folder + bridge-staged sources (bridge presence-gated); copies into the dossier folder; sha256 hashing; duplicate collapse with `duplicateOfRef`; duplicates excluded from assessment/inventory/package but listed.
+
+- [ ] 2.3 Implement assessment + exemption-ground tagging (REQ-DDWRW-005)
+  - `withhold`/`partially_disclose` require ≥1 ground; passage tags store `base` slugs; rendering via existing `BasesResolverService` with visible unknown-slug warnings.
+
+- [ ] 2.4 Implement inventarislijst generation and disclosure-package assembly (REQ-DDWRW-006, REQ-DDWRW-007)
+  - Inventory via existing `api/documents/generate` + seeded template with stable inventory numbers; besluit via existing correspondence generation; package refuses `partially_disclose` items without `redactedFileRef`; excludes `withhold` + duplicates.
+
+- [ ] 2.5 Implement lifecycle guard conditions + `lib/Controller/WooRequestController.php` with `api/woo-requests/*` routes (REQ-DDWRW-008)
+  - Cross-object guards evaluated before transitions; every controller method carries explicit auth attributes and per-object guards; routes registered before the catch-all.
+
+## 3. Frontend
+
+- [ ] 3.1 Woo-verzoeken index manifest page (REQ-DDWRW-009)
+  - `CnIndexPage`/`CnDataTable`; status + deadline chips; manifest schema refs use slugs.
+
+- [ ] 3.2 Request detail: lifecycle header + extension dialog, collection surface, assessment surface with grounds multi-select and passage-tag editor, document/package actions (REQ-DDWRW-002..007, REQ-DDWRW-009)
+  - Deep-link to batch entity review (no duplicate review UI); modals/dialogs in own files; `NcSelect` with `inputLabel`; NL Design tokens.
+
+## 4. Quality
+
+- [ ] 4.1 PHPUnit unit tests for WooRequestService (deadlines, dedupe, guards, package refusal) and controller — minimum 75% coverage on new code
+  - Run inside the container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`.
+  - PUT-semantic saves verified (a non-changed field survives a status transition).
+
+- [ ] 4.2 Playwright e2e specs `tests/e2e/workflows/woo-request-workflow.spec.ts` + `tests/e2e/spec-coverage/woo-requests.spec.ts` covering the `@e2e`-referenced scenarios end-to-end with OpenRegister on the Postgres dev instance
+  - Test through the UI; includes the nldesign-theme accessibility pass.
+
+- [ ] 4.3 Verify the anonymize → assess → package chain end-to-end with OpenRegister entity detection on a seeded request dossier
+  - Redacted derivatives produced by the existing folder-batch flow land in the package; consent transitions remain valid per GDPR/WOO lifecycle.
+
+- [ ] 4.4 i18n: EN + NL for all new UI strings (statuses, chips, assessment labels, dialogs)
+  - Keys in English.
+
+- [ ] 4.5 Documentation `docs/features/woo-request-workflow.md` with Playwright MCP screenshots (ADR-010); run `openspec validate woo-request-workflow --strict`
+  - Documents the statutory-term semantics, the grondslagen reuse and the ZyLAB-category positioning.

--- a/openspec/changes/zgw-document-bridge/.openspec.yaml
+++ b/openspec/changes/zgw-document-bridge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/zgw-document-bridge/design.md
+++ b/openspec/changes/zgw-document-bridge/design.md
@@ -1,0 +1,292 @@
+# Design: zgw-document-bridge
+
+## Context
+
+DocuDesk today only processes files that already live in Nextcloud. Verified at
+HEAD:
+
+- `lib/Settings/docudesk_register.json` declares five registers (`consent`,
+  `signing`, `templates`, `document`, `dossier`); none models external-system
+  provenance or staging.
+- The `dossier` register's `dossier` schema binds a Nextcloud folder
+  (`@self.folder`) to Woo grondslagen (`bases[]`) and a review timestamp
+  (`checkedOn`) — the natural pick-up unit for bridge documents.
+- All OR access goes through `SettingsService::getObjectService()` returning
+  `OCA\OpenRegister\Service\ObjectService`, queried with
+  `['@self' => ['register' => ..., 'schema' => ...]]` (pattern:
+  `ConsentCrudService::listConsents()`).
+- Admin settings render via `lib/Settings/DocuDeskAdmin.php` +
+  `src/views/settings/`; the SPA is manifest-driven (`src/manifest.json`,
+  pages incl. `MyDocuments`, `Dashboard`).
+
+On the platform side, OpenConnector owns external connectivity (shared brief
+boundary): its `synchronization-engine` spec defines the Source →
+Synchronization → SynchronizationContract triad, bidirectional
+(extern→intern pull, intern→extern push), with file handling and dedup; its
+`stuf-adapter` spec covers StUF messaging; its `synced-from-tab` spec renders
+per-object sync provenance inside OpenRegister. DocuDesk therefore specifies
+**only the target-side contract**: which OR objects OpenConnector reads/writes,
+what the status fields mean, and what DocuDesk's UI shows.
+
+Stakeholders: gemeente Woo/anonymisation teams (Dordrecht 407973, Arnhem
+407824, Den Helder 306597) whose documents are mastered in Rx.Enterprise,
+Djuma, zaaksysteem.nl or a generic ZGW DRC.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- An OR-backed staging model (`bridge` register) that OpenConnector can sync
+  ZGW/StUF documents + metadata into, ≤24h fresh.
+- A processing-status state machine that lets DocuDesk process staged copies
+  and hand redaction results back for write-back — with the zaaksysteem
+  remaining the master record at all times.
+- Per-source connection health in admin settings; source provenance visible on
+  documents.
+
+**Non-Goals:**
+
+- No ZGW/StUF client code in DocuDesk (no HTTP calls to a DRC, no SOAP) — that
+  is OpenConnector's synchronization configuration.
+- No zaak management (starting/updating zaken) — only documents and their
+  metadata.
+- No conflict resolution UI for concurrent edits: staged copies are read-only
+  inputs; DocuDesk output is always a *new* derivative.
+- No hard `info.xml` dependency on OpenConnector.
+
+## Decisions
+
+### D1 — Staging lives in a new `bridge` OR register (ADR-001)
+
+Two schemas, no custom tables:
+
+- **`bridgeSource`** — one object per configured case-system source:
+  `name`, `sourceType` (enum `zgw-drc` | `stuf-zds`), `vendor` (free label:
+  "Rx.Enterprise", "Djuma", "zaaksysteem.nl"), `synchronizationId` (UUID of the
+  OpenConnector Synchronization serving this source), `syncIntervalMinutes`,
+  `lastSyncAt` (date-time), `lastSyncStatus` (enum `success` | `error`),
+  `lastSyncError` (string), `active` (boolean).
+- **`externalDocument`** — one staging record per synced informatieobject:
+  `sourceId` (bridgeSource ref), `externalId` (informatieobject
+  identificatie/URL in the source system), `zaakIdentificatie`, `title`,
+  `filename`, `format`, `creatiedatum`, `vertrouwelijkheidaanduiding`,
+  `versie`, `stagedFileRef` (Nextcloud file id of the staged copy),
+  `contentHash` (sha256 of staged content), `syncedAt`, `processingStatus`
+  (see D3), `dossierRef` (dossier object UUID, empty until picked up),
+  `resultFileRef` (redacted derivative file id), `resultExternalId`
+  (identificatie of the informatieobject created by write-back),
+  `writeBackError`.
+
+Rationale: OpenConnector's engine already writes OR objects as sync targets and
+tracks per-object provenance; a register is queryable, RBAC-guarded, audited
+and MCP-exposed for free. Alternative (staging in plain NC folders only) loses
+metadata, status and provenance. Register slug `bridge` collides with no
+sibling app register at HEAD.
+
+### D2 — Bridge contract: OpenConnector writes objects, DocuDesk writes status
+
+Inbound leg: an admin configures, in OpenConnector, one Synchronization per
+source with target = OR register `bridge`, schema `externalDocument` (mapping
+ZGW `EnkelvoudigInformatieObject` / StUF-ZDS document fields to the properties
+above; the file itself lands in a per-source staging folder via OpenConnector's
+file handling, and the mapping sets `stagedFileRef`). OpenConnector updates
+`bridgeSource.lastSyncAt/lastSyncStatus/lastSyncError` at the end of each run
+(a small post-sync mapping step; the alternative — DocuDesk polling
+OpenConnector's log API — couples DocuDesk to OpenConnector's REST surface and
+breaks when OpenConnector is absent).
+
+Outbound leg: a second, push-direction Synchronization watches `bridge` /
+`externalDocument` objects with `processingStatus = ready_for_writeback` and
+performs the DRC/StUF write; on success it sets `processingStatus =
+written_back` + `resultExternalId`, on failure `writeback_failed` +
+`writeBackError`.
+
+DocuDesk only ever transitions statuses on its side of the fence
+(`staged → in_processing → processed → ready_for_writeback`) and never calls
+the case system.
+
+**Uncertainty, stated per the brief**: OpenConnector's engine demonstrably
+supports intern→extern push and file handling (synchronization-engine spec),
+but the exact mapping features needed for "create new informatieobject +
+relate to zaak" may need an OpenConnector-side mapping/rule addition. This
+change pins the *contract* (the status fields and their semantics); if a gap
+surfaces during apply, it is filed as an OpenConnector issue and the outbound
+leg degrades to `ready_for_writeback` objects waiting (visible in the admin
+panel), never to DocuDesk calling ZGW itself.
+
+### D3 — Processing-status state machine (single source of truth)
+
+```
+staged ──> in_processing ──> processed ──> ready_for_writeback ──> written_back
+   ^              │                                   │
+   └── (reset) ───┘                                   └──> writeback_failed ──> ready_for_writeback (retry)
+```
+
+- `staged` — synced, untouched (set by OpenConnector on create/update).
+- `in_processing` — attached to a dossier / an anonymisation run started.
+- `processed` — a redaction/consent/publish flow produced `resultFileRef`.
+- `ready_for_writeback` — operator (or auto-policy) released the result.
+- `written_back` / `writeback_failed` — set by OpenConnector's push leg.
+
+Declared as `x-openregister-lifecycle` on the `externalDocument` schema with
+canonical `initial: staged` and the transition list above, so the guard is
+declarative (ADR-031 default) and invalid transitions are rejected by OR — no
+imperative state machine in DocuDesk.
+
+### D4 — Write-back = NEW informatieobject; original untouched (decided)
+
+The redacted derivative goes back to the DRC as a **new
+EnkelvoudigInformatieObject** related to the same zaak (via a new
+zaakinformatieobject relation), with metadata carrying: a title suffixed
+"(geanonimiseerd)", the relation to the original's identificatie, and DocuDesk
+processing metadata (processing date, DocuDesk version, anonymisation profile)
+in the beschrijving/kenmerken mapping. The original informatieobject is never
+updated, re-versioned or deleted.
+
+Rationale: Arnhem 407824 and the master-record principle — a metadata update
+or new *version* of the original would make DocuDesk a co-master of the
+original record and break the zaaksysteem's audit trail; a sibling
+informatieobject preserves the original bit-for-bit and is the pattern
+Woo-publication tooling downstream expects (publish the derivative, never the
+original). Rejected alternative: metadata-only update on the original
+(insufficient — the derivative file itself must reach the DRC so the
+zaaksysteem holds the published rendition too).
+
+### D5 — Freshness health is computed, not stored
+
+Health per source = function of `active`, `lastSyncStatus` and
+`now − lastSyncAt` against the 24h SLA (Dordrecht ≤24h):
+
+- `fresh` — last successful sync < 24h ago,
+- `stale` — active but last successful sync ≥ 24h ago,
+- `failing` — `lastSyncStatus = error`,
+- `inactive` — `active = false`.
+
+Computed in `BridgeService::getSourceHealth()` at read time (no cron writing a
+derived field; storing it would just create a second freshness problem).
+Surfaced by `GET api/bridge/sources` and rendered in the admin panel. This is
+imperative but is *presentation aggregation*, not persisted state — no ADR-031
+exception needed because nothing is written.
+
+### D6 — Dossier pick-up reuses the dossier register unchanged
+
+"Attach to dossier" copies/links the staged file into the dossier's Nextcloud
+folder (the unit the existing folder-batch anonymisation and grondslagen
+capabilities operate on) and sets `externalDocument.dossierRef` +
+`processingStatus = in_processing`. The dossier schema is not modified; the
+back-link lives on `externalDocument`, keeping the bridge concern out of the
+dossier capability.
+
+### D7 — Frontend per ADR-012
+
+- **Bridge status panel**: a section in DocuDesk admin settings
+  (`src/views/settings/`) listing sources with `CnDataTable` (name, vendor,
+  type, last sync, health chip) — colors via Nextcloud CSS variables/NL Design
+  tokens (ADR-003), no hardcoded colors.
+- **Source badge**: MyDocuments rows and the document detail header show a
+  badge "Zaaksysteem: {vendor}" when a file id matches an
+  `externalDocument.stagedFileRef` (lookup batched per listing). Provenance
+  detail (sync timestamps) links to OpenRegister's synced-from tab rather than
+  duplicating it.
+- New manifest wiring only where needed; no new top-level menu entry (the
+  bridge is an admin + provenance concern, not a workspace).
+
+## OpenRegister service usage (ADR-001)
+
+| Operation | OR service |
+|---|---|
+| List/read sources + staged docs | `ObjectService::searchObjects()` with `@self.register = bridge` |
+| Status transitions from DocuDesk | `ObjectService::saveObject()` — carrying ALL fields forward (PUT semantics; partial updates would null ZGW metadata) |
+| Lifecycle guard | declarative `x-openregister-lifecycle` on `externalDocument` (canonical `initial:` key) |
+| Provenance | OpenConnector SynchronizationContract + OR synced-from tab (consumed, not reimplemented) |
+| Audit | OR object audit trail (free with register storage) |
+
+ADR-011 check: no new validation/formatting utilities — hashing uses PHP
+`hash('sha256', ...)`; date/UUID handling stays in OR.
+
+## Declarative-vs-imperative decision (ADR-031)
+
+- **Declarative**: `externalDocument` lifecycle (`x-openregister-lifecycle`),
+  schema-level archival annotation deferred (originals are mastered
+  externally; the staging copy carries no independent retention duty —
+  recorded as an open question).
+- **Imperative (justified exceptions)**: (a) `BridgeService` health
+  computation — read-time aggregation across source telemetry (presentation,
+  not persisted); (b) attach-to-dossier — file-system side effect (copy/link
+  into the dossier folder) which no `x-openregister-*` dialect expresses;
+  (c) the external ZGW/StUF I/O itself — external integration, and it lives in
+  OpenConnector, not DocuDesk.
+
+## Seed Data
+
+Shipped in `docudesk_register.json` `objects[]` (nil-UUID/slug style, demo
+municipality flavour):
+
+```json
+{
+  "@self": {"register": "bridge", "schema": "bridgeSource", "slug": "demostad-zaaksysteem"},
+  "name": "Demostad zaaksysteem (ZGW DRC)",
+  "sourceType": "zgw-drc",
+  "vendor": "zaaksysteem.nl",
+  "synchronizationId": "00000000-0000-0000-0000-000000000000",
+  "syncIntervalMinutes": 60,
+  "lastSyncAt": "2026-07-15T06:00:00+00:00",
+  "lastSyncStatus": "success",
+  "active": true
+}
+```
+
+```json
+{
+  "@self": {"register": "bridge", "schema": "externalDocument", "slug": "demostad-zaak-2026-0042-besluit"},
+  "sourceId": "demostad-zaaksysteem",
+  "externalId": "https://zaken.demostad.example/documenten/api/v1/enkelvoudiginformatieobjecten/00000000-0000-0000-0000-000000000000",
+  "zaakIdentificatie": "ZAAK-2026-0042",
+  "title": "Besluit omgevingsvergunning Dorpsstraat 1",
+  "filename": "besluit-omgevingsvergunning.pdf",
+  "format": "application/pdf",
+  "creatiedatum": "2026-06-02",
+  "vertrouwelijkheidaanduiding": "openbaar",
+  "versie": 1,
+  "stagedFileRef": "seed-staged-demostad-zaak-2026-0042",
+  "contentHash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "syncedAt": "2026-07-15T06:00:12+00:00",
+  "processingStatus": "staged"
+}
+```
+
+A second seed `externalDocument` in status `written_back` (with
+`resultExternalId`) demonstrates the full round trip for demos/tests.
+
+## Risks / Trade-offs
+
+- [OpenConnector mapping gap for "new informatieobject + zaak relation"] →
+  contract pins semantics; outbound objects wait visibly in
+  `ready_for_writeback`; OpenConnector issue filed at apply time. Never
+  fail-open into DocuDesk-side HTTP.
+- [Staged copies duplicate storage] → accepted; staging folder is per-source
+  and prunable once `written_back` (retention question logged below).
+- [Vendor variance (Rx.Enterprise vs Djuma vs zaaksysteem.nl)] → variance is
+  absorbed in OpenConnector source/mapping config; DocuDesk schema uses the
+  common ZGW metadata subset only.
+- [Slug/property drift between this contract and OpenConnector mappings] →
+  the contract table in the spec is the review checklist; register version
+  bump + gate 28/30 manifest/register validation on change.
+- [Cross-tenant leakage of staged documents] → `bridge` register objects carry
+  standard OR RBAC/organisation scoping; the staging folder inherits NC
+  folder ACLs; spec requires read scoping in the listing endpoint.
+
+## Migration Plan
+
+Additive only: new register + schemas + seeds (register version bump →
+imported by `ConfigurationService::importFromApp()` on boot), new
+service/controller/routes, new UI panel. No existing schema changes, no data
+migration. Rollback = remove routes/UI; register objects remain inert.
+
+## Open Questions
+
+- Retention of staged copies after `written_back` (delete after N days vs keep
+  for audit) — deferred; default keep, admin-configurable later.
+- Whether `bridgeSource` should be admin-writable in DocuDesk UI or only via
+  OpenConnector setup flow — this change ships read-only health UI; source
+  CRUD stays in OpenConnector.

--- a/openspec/changes/zgw-document-bridge/proposal.md
+++ b/openspec/changes/zgw-document-bridge/proposal.md
@@ -1,0 +1,91 @@
+---
+kind: code
+---
+
+# Proposal: zgw-document-bridge
+
+## Why
+
+Dutch municipalities do not keep their case documents in Nextcloud — they keep
+them in a zaaksysteem, and every recent anonymisation/publication tender makes
+that a hard boundary condition. Dordrecht/Drechtsteden 407973 requires couplings
+with **Rx.Enterprise, Djuma (ZGW), StUF-ZDS and generic ZGW Documenten API**
+sources with a **≤24h sync freshness** requirement; Den Helder 306597/297564
+requires a zaaksysteem.nl (xxllnc) coupling; Arnhem 407824 states explicitly
+that **originals stay in the zaaksysteem** — the anonymisation tool processes
+copies and the zaaksysteem remains the master record. GH #96 counts 109 tenders
+that require document handling against case systems. Today DocuDesk can only
+process files that already live in Nextcloud folders: there is no staging
+model, no provenance, no write-back contract and no per-source health surface,
+which disqualifies DocuDesk from every one of these tenders.
+
+The connector mechanics already exist on the platform side: OpenConnector owns
+the Source → Synchronization → SynchronizationContract triad (bidirectional
+pull/push, file handling, `stuf-adapter`, per-object provenance via
+`synced-from-tab`). What is missing is the **DocuDesk-side contract**: the
+OR-backed staging register OpenConnector syncs into, the processing-status
+model OpenConnector's push leg reacts to, the dossier pick-up hooks, and the UI
+(source badge, admin bridge-status panel).
+
+## What Changes
+
+- New `bridge` register in `lib/Settings/docudesk_register.json` with two
+  schemas:
+  - `bridgeSource` — one object per configured external case-system source
+    (display name, source type `zgw-drc`/`stuf-zds`, vendor label, reference to
+    the OpenConnector synchronization, sync telemetry, computed health).
+  - `externalDocument` — one staging record per synced informatieobject
+    (external identifiers, ZGW metadata, staged-file reference, content hash,
+    processing status, write-back result).
+- A documented, versioned **bridge contract** between OpenConnector and
+  DocuDesk: OpenConnector writes/updates `externalDocument` objects (inbound
+  leg) and picks up objects in status `ready_for_writeback` (outbound leg);
+  DocuDesk never talks ZGW/StUF itself.
+- **Write-back decision (documented)**: the redacted derivative is delivered to
+  the DRC as a **new informatieobject** related to the same zaak; the original
+  informatieobject is never modified or deleted — the zaaksysteem stays master.
+- Dossier pick-up: external documents can be attached to a DocuDesk dossier and
+  flow through the existing anonymize → consent → publish capabilities working
+  on the staged copy.
+- ≤24h freshness SLA: per-source health (`fresh`/`stale`/`failing`) computed
+  from sync telemetry.
+- UI: a source badge ("Zaaksysteem: <vendor>") on externally-sourced documents
+  in MyDocuments/document detail, and a bridge status panel in DocuDesk admin
+  settings showing per-source connection health.
+- Seed data: one demo `bridgeSource` + staged `externalDocument` examples.
+
+## Capabilities
+
+### New Capabilities
+
+- `zgw-document-bridge`: DocuDesk-side contract for processing documents
+  mastered in an external case system — staging register schemas, the
+  OpenConnector sync contract (inbound staging + outbound write-back of the
+  redacted derivative as a new informatieobject), processing-status model,
+  dossier pick-up, ≤24h freshness health, source badge and admin bridge-status
+  panel.
+
+### Modified Capabilities
+
+<!-- none — the dossier, anonymization and consent capabilities are consumed
+     unchanged; the bridge feeds them staged Nextcloud files. -->
+
+## Impact
+
+- `lib/Settings/docudesk_register.json`: new `bridge` register + 2 schemas +
+  seed objects (register version bump).
+- New `lib/Service/BridgeService.php` (staging queries, status transitions,
+  health computation) and `lib/Controller/BridgeController.php` with routes
+  under `api/bridge/*` (sources health, external-document listing, attach to
+  dossier, mark ready-for-writeback).
+- `src/manifest.json` + `src/views/settings/` (bridge status panel),
+  MyDocuments/document detail (source badge).
+- Dependency (soft): OpenConnector installed and a synchronization configured
+  per source; without OpenConnector the bridge register is inert and the admin
+  panel shows "no sources configured". No dependency added to `info.xml`.
+- No change to OpenConnector code — its synchronization engine is consumed
+  as-is; the ZGW/StUF specifics live in OpenConnector source/mapping
+  configuration, not in DocuDesk.
+- Evidence: Dordrecht/Drechtsteden 407973 (couplings + ≤24h), Den Helder
+  306597/297564 (zaaksysteem.nl), Arnhem 407824 ("originals stay in
+  zaaksysteem"), GH #96.

--- a/openspec/changes/zgw-document-bridge/specs/zgw-document-bridge/spec.md
+++ b/openspec/changes/zgw-document-bridge/specs/zgw-document-bridge/spec.md
@@ -1,0 +1,221 @@
+# zgw-document-bridge Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+DocuDesk-side contract for processing documents that are mastered in an
+external case system (zaaksysteem): an OR-backed staging register that
+OpenConnector synchronizes ZGW Documenten API (DRC) and StUF-ZDS documents +
+metadata into (Rx.Enterprise, Djuma, zaaksysteem.nl, generic ZGW — per
+Dordrecht 407973); a processing-status lifecycle through which DocuDesk runs
+its anonymize/consent/publish flows on the staged copy and releases the
+redacted derivative for write-back as a **new** informatieobject; ≤24h
+freshness health per source in admin settings; and source provenance on
+documents. The originals never leave the zaaksysteem as master record (Arnhem
+407824). The connector/sync engine itself is OpenConnector's; DocuDesk defines
+schemas, status semantics, hooks and UI only.
+
+## ADDED Requirements
+
+### Requirement: Bridge staging register schemas (REQ-DDZGW-001)
+
+The app MUST declare a `bridge` register in
+`lib/Settings/docudesk_register.json` with two schemas: `bridgeSource` (per
+configured case-system source: `name`, `sourceType` enum `zgw-drc`|`stuf-zds`,
+`vendor`, `synchronizationId`, `syncIntervalMinutes`, `lastSyncAt`,
+`lastSyncStatus` enum `success`|`error`, `lastSyncError`, `active`) and
+`externalDocument` (per synced informatieobject: `sourceId`, `externalId`,
+`zaakIdentificatie`, `title`, `filename`, `format`, `creatiedatum`,
+`vertrouwelijkheidaanduiding`, `versie`, `stagedFileRef`, `contentHash`,
+`syncedAt`, `processingStatus`, `dossierRef`, `resultFileRef`,
+`resultExternalId`, `writeBackError`). All bridge data MUST be stored as
+OpenRegister objects (ADR-001, no custom tables) and the register version MUST
+be bumped so `ConfigurationService::importFromApp()` imports it on boot.
+
+#### Scenario: Register import creates the bridge schemas
+
+- GIVEN a Nextcloud instance with DocuDesk and OpenRegister installed
+- WHEN the app boots and `ConfigurationService::importFromApp()` runs
+- THEN the `bridge` register exists with schemas `bridgeSource` and `externalDocument`
+- AND the seeded demo source and staged documents are queryable via `ObjectService::searchObjects()` with `@self.register = bridge`
+- @e2e exclude register import is a boot-time backend concern with no UI surface of its own — covered by PHPUnit register-import assertions (tests/unit/Settings/)
+
+### Requirement: Inbound sync contract — OpenConnector stages, DocuDesk never fetches (REQ-DDZGW-002)
+
+External connectivity MUST remain in OpenConnector: one OpenConnector
+Synchronization per source targets register `bridge`, schema
+`externalDocument`, mapping ZGW/StUF document metadata onto the schema
+properties, staging the file content into a per-source Nextcloud staging
+folder and setting `stagedFileRef`, and updating the owning `bridgeSource`'s
+`lastSyncAt`/`lastSyncStatus`/`lastSyncError` after each run. DocuDesk MUST
+NOT contain any ZGW, StUF or case-system HTTP/SOAP client code, and MUST NOT
+declare an `info.xml` dependency on OpenConnector (the bridge register is
+inert without it).
+
+#### Scenario: Synced informatieobject appears as a staged external document
+
+- GIVEN an OpenConnector synchronization configured for source "Demostad zaaksysteem" targeting `bridge`/`externalDocument`
+- WHEN the synchronization runs and delivers a new informatieobject
+- THEN an `externalDocument` object exists with the ZGW metadata, a `stagedFileRef` pointing at the staged copy and `processingStatus` `staged`
+- AND `bridgeSource.lastSyncAt` and `lastSyncStatus` reflect the run
+- @e2e exclude requires a live OpenConnector + mock DRC environment out of scope for DocuDesk's Playwright suite — contract pinned by PHPUnit fixture tests on BridgeService reading pre-seeded objects (tests/unit/Service/BridgeServiceTest.php)
+
+#### Scenario: No case-system client in DocuDesk
+
+- GIVEN the DocuDesk codebase at this change's completion
+- WHEN `lib/` is inspected
+- THEN no class performs HTTP or SOAP calls to a ZGW Documenten API or StUF-ZDS endpoint
+- @e2e exclude static codebase property, enforced by review + a PHPUnit architecture test, not a browser flow
+
+### Requirement: Originals stay mastered in the zaaksysteem (REQ-DDZGW-003)
+
+DocuDesk MUST treat every staged copy as a read-only input: it MUST NOT
+modify, re-version or delete the original informatieobject in the source
+system, MUST NOT edit the staged source file in place (all processing output
+goes to new derivative files), and MUST NOT expose the staged copy as an
+editable document in MyDocuments. Deleting a staged `externalDocument` object
+or file in Nextcloud MUST NOT propagate any deletion to the source system.
+
+#### Scenario: Anonymisation of a bridge document leaves the staged original intact
+
+- GIVEN a staged external document with `contentHash` H
+- WHEN an operator runs anonymisation on it via a dossier flow
+- THEN the redacted output is written to a new file recorded in `resultFileRef`
+- AND the staged file's content hash still equals H
+- @e2e tests/e2e/workflows/zgw-bridge-workflow.spec.ts
+
+### Requirement: Processing-status lifecycle is declarative and guarded (REQ-DDZGW-004)
+
+The `externalDocument` schema MUST declare an `x-openregister-lifecycle`
+annotation with canonical `initial: staged` and exactly the transitions
+`staged → in_processing`, `in_processing → processed`, `in_processing →
+staged`, `processed → ready_for_writeback`, `ready_for_writeback →
+written_back`, `ready_for_writeback → writeback_failed`, `writeback_failed →
+ready_for_writeback`. Invalid transitions MUST be rejected by OpenRegister's
+lifecycle guard. DocuDesk-side transitions (`staged → in_processing →
+processed → ready_for_writeback`) are set by `BridgeService`; the
+`written_back`/`writeback_failed` transitions belong to OpenConnector's push
+leg.
+
+#### Scenario: Invalid transition is rejected
+
+- GIVEN an external document in status `staged`
+- WHEN a save attempts to set `processingStatus` to `written_back` directly
+- THEN OpenRegister rejects the transition and the object remains `staged`
+- @e2e exclude lifecycle guard is enforced server-side by OpenRegister — covered by PHPUnit transition tests (tests/unit/Service/BridgeServiceTest.php) and OR's own lifecycle suite
+
+#### Scenario: Status updates carry all fields forward
+
+- GIVEN an external document with full ZGW metadata
+- WHEN `BridgeService` transitions its status
+- THEN the save carries all schema properties forward (PUT semantics) and no metadata field is nulled
+- @e2e exclude data-integrity property of the save path — covered by a PHPUnit test asserting a non-changed field survives the transition
+
+### Requirement: Write-back delivers the redacted derivative as a new informatieobject (REQ-DDZGW-005)
+
+The bridge write-back contract MUST deliver the redacted derivative to the
+source system as a **new** informatieobject related to the same zaak — never
+as an update, new version or replacement of the original. When an operator (or
+policy) releases a processed document, DocuDesk MUST set `processingStatus =
+ready_for_writeback` with `resultFileRef` populated; OpenConnector's push
+synchronization performs the external write and records the outcome by setting
+`processingStatus = written_back` + `resultExternalId` (success) or
+`writeback_failed` + `writeBackError` (failure). The new informatieobject's
+metadata MUST identify it as a DocuDesk derivative (title suffix
+"(geanonimiseerd)", reference to the original's identificatie, processing
+date and anonymisation profile).
+
+#### Scenario: Release for write-back
+
+- GIVEN a processed external document with a redacted derivative in `resultFileRef`
+- WHEN the operator releases it for write-back
+- THEN `processingStatus` becomes `ready_for_writeback`
+- AND after the OpenConnector push leg succeeds the object shows `written_back` with a `resultExternalId` different from `externalId`
+- @e2e tests/e2e/workflows/zgw-bridge-workflow.spec.ts
+
+#### Scenario: Failed write-back is visible and retryable
+
+- GIVEN a document in `ready_for_writeback` whose push failed
+- WHEN the operator views it
+- THEN it shows status `writeback_failed` with the `writeBackError` message
+- AND a retry action returns it to `ready_for_writeback`
+- @e2e tests/e2e/spec-coverage/zgw-bridge.spec.ts
+
+### Requirement: Dossier pick-up of bridge documents (REQ-DDZGW-006)
+
+An operator MUST be able to attach staged external documents to a DocuDesk
+dossier: the staged file is copied into the dossier's Nextcloud folder (the
+unit the existing folder-batch anonymisation and grondslagen capabilities
+operate on), `externalDocument.dossierRef` is set to the dossier object UUID
+and `processingStatus` transitions to `in_processing`. The existing `dossier`
+schema MUST NOT be modified.
+
+#### Scenario: Attach staged documents to a dossier
+
+- GIVEN a dossier "Woo-verzoek 2026-021" and two staged external documents for zaak ZAAK-2026-0042
+- WHEN the operator attaches both to the dossier
+- THEN copies exist in the dossier folder and both objects carry `dossierRef` and status `in_processing`
+- AND the existing batch-anonymisation flow can process the dossier folder unchanged
+- @e2e tests/e2e/workflows/zgw-bridge-workflow.spec.ts
+
+### Requirement: ≤24h freshness health per source (REQ-DDZGW-007)
+
+`GET api/bridge/sources` MUST return every `bridgeSource` with a computed
+`health` value: `fresh` when the last successful sync is less than 24 hours
+old, `stale` when the source is active but the last successful sync is 24
+hours old or older (Dordrecht 407973 ≤24h freshness requirement), `failing`
+when `lastSyncStatus = error`, and `inactive` when `active = false`. Health
+MUST be computed at read time from stored telemetry, not persisted.
+
+#### Scenario: Source turns stale after 24 hours without sync
+
+- GIVEN an active source whose `lastSyncAt` is 25 hours in the past with `lastSyncStatus` `success`
+- WHEN `api/bridge/sources` is called
+- THEN that source's `health` is `stale`
+- @e2e exclude time-arithmetic unit behaviour — covered by PHPUnit clock-injected tests (tests/unit/Service/BridgeServiceTest.php); the panel rendering is covered under REQ-DDZGW-008
+
+### Requirement: Bridge status panel in admin settings (REQ-DDZGW-008)
+
+DocuDesk admin settings MUST include a bridge status panel listing each
+configured source with name, vendor, source type, last sync time and a health
+chip (`fresh`/`stale`/`failing`/`inactive`), rendered with
+`@conduction/nextcloud-vue` components (ADR-012) and Nextcloud CSS
+variables/NL Design tokens only (ADR-003). When no sources are configured (or
+OpenConnector is not installed) the panel MUST show an explanatory empty state
+instead of an error.
+
+#### Scenario: Admin sees per-source health
+
+- GIVEN an admin on the DocuDesk admin settings page with one fresh and one failing source seeded
+- WHEN the bridge status panel renders
+- THEN both sources are listed with their vendor and last sync time
+- AND the failing source shows a `failing` health chip with its error message
+- @e2e tests/e2e/spec-coverage/zgw-bridge.spec.ts
+
+#### Scenario: Empty state without OpenConnector
+
+- GIVEN an instance where no `bridgeSource` objects exist
+- WHEN the panel renders
+- THEN it shows an empty state explaining that sources are configured via OpenConnector
+- @e2e tests/e2e/spec-coverage/zgw-bridge.spec.ts
+
+### Requirement: Source badge on externally-sourced documents (REQ-DDZGW-009)
+
+Documents whose file id matches an `externalDocument.stagedFileRef` MUST show
+a source badge ("Zaaksysteem: {vendor}") in the MyDocuments listing and on the
+document detail header, so an operator always sees that the master record
+lives in the case system. The badge lookup MUST be batched per listing (one
+bridge query per page, not per row). Provenance detail beyond the badge links
+to OpenRegister's synced-from surface and MUST NOT be reimplemented in
+DocuDesk.
+
+#### Scenario: Badge on a bridge document
+
+- GIVEN a staged external document from vendor "zaaksysteem.nl" visible in MyDocuments
+- WHEN the listing renders
+- THEN the row shows the badge "Zaaksysteem: zaaksysteem.nl"
+- AND a Nextcloud-native file without a bridge record shows no badge
+- @e2e tests/e2e/spec-coverage/zgw-bridge.spec.ts

--- a/openspec/changes/zgw-document-bridge/tasks.md
+++ b/openspec/changes/zgw-document-bridge/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: zgw-document-bridge
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 13.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Register + seed data
+
+- [ ] 1.1 Add the `bridge` register with `bridgeSource` and `externalDocument` schemas to `lib/Settings/docudesk_register.json` (REQ-DDZGW-001)
+  - All properties from design.md D1 with titles, descriptions, enums; `hardValidation: true`; register description documents the bridge contract and bumps the register version.
+  - `x-openregister-lifecycle` on `externalDocument` uses the canonical `initial: staged` key and exactly the REQ-DDZGW-004 transition list.
+
+- [ ] 1.2 Add seed objects: one demo `bridgeSource` plus one `staged` and one `written_back` `externalDocument` (design.md Seed Data)
+  - Nil-UUID/`seed-*` placeholder identifiers only; validates against the schemas on import.
+
+## 2. Backend
+
+- [ ] 2.1 Implement `lib/Service/BridgeService.php` (REQ-DDZGW-002/003/004/007)
+  - Source + staged-document queries via `SettingsService::getObjectService()` with `@self.register = bridge`; clock-injected `getSourceHealth()` (fresh/stale/failing/inactive, 24h SLA); status transitions with full-object PUT-semantic saves.
+  - No ZGW/StUF/HTTP client code anywhere in the service.
+
+- [ ] 2.2 Implement dossier pick-up: attach staged documents to a dossier (REQ-DDZGW-006)
+  - Copies staged file into the dossier folder, sets `dossierRef` + `in_processing`; existing `dossier` schema untouched.
+
+- [ ] 2.3 Implement release/retry for write-back (REQ-DDZGW-005)
+  - `processed → ready_for_writeback` with `resultFileRef` required; `writeback_failed → ready_for_writeback` retry; document the OpenConnector push-leg contract (new informatieobject + zaak relation, derivative metadata) in the service docblock.
+
+- [ ] 2.4 Add `lib/Controller/BridgeController.php` + routes under `api/bridge/*` (sources, external-documents listing, attach, release, retry)
+  - Every method carries an explicit auth attribute and a per-object/admin guard; listing scoped by OR RBAC; routes registered in `appinfo/routes.php` before the catch-all.
+
+- [ ] 2.5 File an OpenConnector issue if the push mapping cannot express "create new informatieobject + relate to zaak" during verification (design.md D2 uncertainty)
+  - Outbound leg degrades to visibly-waiting `ready_for_writeback` objects; never DocuDesk-side HTTP.
+
+## 3. Frontend
+
+- [ ] 3.1 Bridge status panel in admin settings (`src/views/settings/`) (REQ-DDZGW-008)
+  - `CnDataTable` listing with health chips using NC CSS variables; empty state when no sources; data from `api/bridge/sources`.
+
+- [ ] 3.2 Source badge in MyDocuments + document detail (REQ-DDZGW-009)
+  - Batched lookup (one bridge query per listing page); badge text "Zaaksysteem: {vendor}"; provenance detail links to OR synced-from tab.
+
+## 4. Quality
+
+- [ ] 4.1 PHPUnit unit tests for BridgeService, controller and lifecycle transitions — minimum 75% coverage on new code
+  - Run inside the container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`.
+  - Includes: health clock cases, PUT-semantics survival of a non-changed field, invalid-transition rejection, staged-original hash unchanged after processing.
+
+- [ ] 4.2 Playwright e2e specs `tests/e2e/spec-coverage/zgw-bridge.spec.ts` + `tests/e2e/workflows/zgw-bridge-workflow.spec.ts` covering the `@e2e`-referenced scenarios
+  - Verify end-to-end with OpenRegister on the Postgres dev instance (port 8080); test through the UI.
+
+- [ ] 4.3 i18n: EN + NL translations for all new UI strings (badge, panel, statuses, empty state)
+  - Keys in English; `l10n/` updated for both languages.
+
+- [ ] 4.4 Documentation `docs/features/zgw-document-bridge.md` with Playwright MCP screenshots (ADR-010) of the admin panel and source badge; run `openspec validate zgw-document-bridge --strict`
+  - Explains the master-record boundary and the OpenConnector configuration hand-off.

--- a/openspec/specs/anonymization-entity-review/spec.md
+++ b/openspec/specs/anonymization-entity-review/spec.md
@@ -1,6 +1,11 @@
 ---
-status: done
+status: in-progress
 ---
+
+**Status**: in-progress
+**Scope**: docudesk
+**OpenSpec changes**:
+- [anonymization-review-workbench](../../changes/anonymization-review-workbench/) _(active)_ — consolidated-entities response gains `standingConsentMatch` (sibling of `prohibitionMatch`, pre-excluding matched entities) and the batch anonymize commit gains the per-document checked-gate precondition (kind: code)
 
 ## Purpose
 

--- a/openspec/specs/batch-anonymization/spec.md
+++ b/openspec/specs/batch-anonymization/spec.md
@@ -1,9 +1,15 @@
 ---
-status: implementing
+status: in-progress
 or_adoption_change: docudesk-adopt-or-abstractions
 ---
 
 # Batch Anonymization
+
+**Status**: in-progress
+**Scope**: docudesk
+**OpenSpec changes**:
+- [docudesk-adopt-or-abstractions](../../changes/archive/2026-06-14-docudesk-adopt-or-abstractions/) _(implementing)_ — REQ-BANON-00: ICache batch state replaced by `batchAnonymizationJob` OR objects with per-file lifecycle children, scheduled via OR Background Jobs (kind: code)
+- [redaction-at-scale](../../changes/redaction-at-scale/) _(active)_ — batch anonymize becomes a background operation above the synchronous cap (HTTP 202 + work-unit processing, cancel/resume, throughput report, sampling QA) (kind: code)
 
 ## Purpose
 

--- a/openspec/specs/document-validation-checks/spec.md
+++ b/openspec/specs/document-validation-checks/spec.md
@@ -1,8 +1,12 @@
 ---
-status: done
+status: in-progress
 ---
 
 # document-validation-checks Specification
+
+**Status**: in-progress
+**OpenSpec changes**:
+- [pdfua-accessible-output](../../changes/pdfua-accessible-output/) _(active)_ — adds the accessibility check category (`pdf-not-tagged`, `pdf-language-missing`, `pdf-title-missing`, `pdfua-identifier-missing`; REQ-DDPUA-003) riding the existing profile/severity mechanism (kind: code)
 
 ## Purpose
 Runs a catalogue of document quality checks covering format allowlisting, extension/mime consistency, file integrity, PDF encryption, text-layer presence, and metadata completeness, returning structured findings keyed by a stable check ID and severity. It is a pure computation backend that reads document content and records but never writes fields, creates objects, or modifies files. This lets DocuDesk flag documents that are unreadable, scan-only, encrypted, or missing required metadata before further processing.

--- a/openspec/specs/folder-batch-analysis/spec.md
+++ b/openspec/specs/folder-batch-analysis/spec.md
@@ -1,8 +1,13 @@
 ---
-status: done
+status: in-progress
 ---
 
 # folder-batch-analysis Specification
+
+**Status**: in-progress
+**Scope**: docudesk
+**OpenSpec changes**:
+- [redaction-at-scale](../../changes/redaction-at-scale/) _(active)_ — single-run `FolderExtractionJob` replaced by chunked, cancellable coordinator work units; optional `recursive` dossier enumeration with relative paths (kind: code)
 
 ## Purpose
 Creates anonymisation batches from the files already present in a Nextcloud folder, accepting either a folder ID or a folder path and enumerating the folder's direct file children. The batch stores both the rename-proof folder ID and a human-readable path snapshot, resolves multi-mount folder IDs by preferring a writable node, and processes the files through a background extraction job and entity-consolidation service subject to admin-configurable size limits. This lets operators run analysis and anonymisation over an existing document folder in one batch operation.

--- a/openspec/specs/ocr-document-scanning/spec.md
+++ b/openspec/specs/ocr-document-scanning/spec.md
@@ -1,8 +1,13 @@
 ---
-status: done
+status: in-progress
 ---
 
 # OCR Document Scanning
+
+**Status**: in-progress
+**Scope**: docudesk
+**OpenSpec changes**:
+- [ocr-trigger-surface](../../changes/ocr-trigger-surface/) _(active)_ — wires the engine: OCR API route + Run-OCR UI action + anonymisation-pipeline fallback; REQ-OCR-05 corrected from the file-listing MIME heuristic to persisted per-file `ocrResult` objects (kind: code)
 
 ## Purpose
 

--- a/openspec/specs/pdf-generation/spec.md
+++ b/openspec/specs/pdf-generation/spec.md
@@ -1,8 +1,12 @@
 ---
-status: done
+status: in-progress
 ---
 
 # PDF Generation
+
+**Status**: in-progress
+**OpenSpec changes**:
+- [pdfua-accessible-output](../../changes/pdfua-accessible-output/) _(active)_ — adds tagged, accessible PDF output (PDF/UA-1 target): `accessible` option routed through the LibreOffice accessible-export mode with mandatory language/title metadata and honest non-conformance failure on the mPDF path (REQ-DDPUA-001/002) (kind: code)
 
 ## Purpose
 

--- a/openspec/specs/publication-consent/spec.md
+++ b/openspec/specs/publication-consent/spec.md
@@ -1,5 +1,10 @@
 # publication-consent Specification
 
+**Status**: in-progress
+**Scope**: docudesk
+**OpenSpec changes**:
+- [woo-publicatie-pipeline](../../changes/woo-publicatie-pipeline/) _(active)_ — adds the read-only document consent-clearance signal (REQ-DDWPP-020) consumed by the publication-readiness gate; objection-window rules and consent CRUD unchanged (kind: code)
+
 ## Purpose
 TBD - created by archiving change docudesk-consent-to-or-gdpr. Update Purpose after archive.
 ## Requirements

--- a/openspec/specs/template-management/spec.md
+++ b/openspec/specs/template-management/spec.md
@@ -1,5 +1,5 @@
 ---
-status: done
+status: in-progress
 retrofit_extensions:
   - REQ-TMPL-08
   - REQ-TMPL-09
@@ -9,6 +9,10 @@ retrofit_extensions:
 ---
 
 # Template Management
+
+**Status**: in-progress
+**OpenSpec changes**:
+- [office-template-authoring](../../changes/office-template-authoring/) _(active)_ — office-file-native templates: `templateType`/source-file data-model extension (REQ-DDOTA-006) and versioning/lock/preview/duplicate parity for office templates (REQ-DDOTA-007) (kind: code)
 
 ## Purpose
 


### PR DESCRIPTION
## Why

A deep-research pass (competitor scan across 6 categories, TenderNed requirement mining, Codeberg/GitHub issue wishes, Nextcloud ecosystem analysis — all logged in the spectr intelligence DB) identified DocuDesk's highest-demand missing features. This PR adds **apply-ready OpenSpec changes** for the nine selected gaps; it is **markdown-only** (openspec/ docs).

## What

Must-have:
- **anonymization-review-workbench** — human-review UI with per-document checked gate, org always/never-anonymise lists, grondslag proposal surface (evidence: 20-issue wish set GH #45-64, Arnhem tender 407824, algoritmeregister human-review mandate)
- **redaction-at-scale** — cron coordinator, idempotent resume, sampling QA, throughput reporting sized for 25k–55k docs/yr (GH #236, Arnhem + Groningen tenders)
- **ocr-trigger-surface** — wires the orphaned OCR engine into a route, UI action, and the anonymisation extract fallback (GH #85)
- **zgw-document-bridge** — ZGW/StUF staging contract via OpenConnector; originals stay master in the zaaksysteem (Dordrecht/Den Helder tenders)
- **woo-publicatie-pipeline** — publication-readiness gate, DiWoo handoff to OpenCatalogi, de-publication, destruction-date propagation (GH #238, Dordrecht 224 reqs)

Should-have:
- **woo-request-workflow** — passive-disclosure case flow: exemption-ground tagging, sha256 dedupe, inventarislijst, disclosure package (ZyLAB/INDICA competitive category)
- **office-template-authoring** — real DOCX/ODT merge-tag templates + bulk template import (competitive theme #1; Den Helder 486-template migration)
- **document-waarmerk-certification** — organisation-certificate seal, processing certificates, verification page (De Connectie REQ2, Dordrecht VPB-11)
- **pdfua-accessible-output** — PDF/UA rendering via LibreOffice + accessibility validation checks (Besluit digitale toegankelijkheid; zero NC ecosystem coverage)

Eight canonical specs gain an OpenSpec-changes entry + in-progress status. All nine changes pass `openspec validate --strict`; every tasks.md stays under the 20-checkbox cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)