### PR TITLE
docs(openspec): build-phase — portal-signing-actions + pdfua-matterhorn + 23 decision edits

### DIFF
--- a/openspec/changes/archiefwet-retention-engine/design.md
+++ b/openspec/changes/archiefwet-retention-engine/design.md
@@ -317,10 +317,12 @@ runtime artifacts; unit tests build fixtures with nil-UUIDs.
   flagged in the PR for the owning change's reviewer.
 - [Archivist authorization] → relies on OR's 403 guard on `/api/archival/*`;
   DocuDesk adds no weaker parallel path (no pass-through controllers).
-- [Wrong seeded category numbers cause unlawful destruction] → all seeds are
-  explicit TODO placeholders with `nog_niet_bepaald`-safe review posture:
-  seeds default demo schemas only; production categories are a documented
-  admin task before enabling the DestructionCheckJob wiring.
+- [Wrong seeded category numbers cause unlawful destruction] → the seeds ship
+  as explicit `TODO-*` placeholders during authoring, and REQ-DDARE-009 makes
+  replacing them with real selectielijst-manager-approved numbers a hard
+  **apply-blocker**: a PHPUnit seed-lint fails while any `TODO-*` categorie
+  remains, so the change cannot be marked done or applied to production with
+  placeholders. See §Production-enablement below.
 
 ## Migration Plan
 
@@ -332,12 +334,25 @@ remove UI/service; register objects and retention metadata remain inert
 `correspondence` annotation swap only changes which mechanism deletes future
 expired rows.
 
+## Production-enablement (apply-blocker, REQ-DDARE-009)
+
+The seeded `selectielijstEntry.categorie` values ship as `TODO-*`
+placeholders for authoring only. Before this change is applied to production
+or marked done, every placeholder MUST be replaced with a **real VNG
+selectielijst category number confirmed by the responsible
+selectielijst-manager** (records-appraisal sign-off), each with its correct
+`archiefnominatie` and `bewaartermijn`. This is a hard apply-blocker, not a
+follow-up: OpenRegister computes real destruction dates from these numbers
+(REQ-DDARE-003), so a placeholder or wrong code drives a wrong or absent
+retention schedule (unlawful or missed destruction). A PHPUnit seed-lint
+(task 1.4 / 4.1) fails the gate while any `TODO-*` categorie is present. This
+mirrors the flow-operations E3 posture (real selectielijst-approved retention
+on processing-log schemas is likewise an apply-blocker).
+
 ## Open Questions
 
 - Promote selectielijst master data + destruction homes to an OR-owned (or
   hydra-ADR'd shared) register once a second app consumes them?
-- Exact VNG selectielijst 2020 category numbers per schema — selectielijst
-  manager sign-off before production enablement.
 - Should `notificationLeadDays` pre-destruction notifications surface in
   DocuDesk's notification center (OR emits INotification to archivists
   already)? Deferred until OR's notification is verified live.

--- a/openspec/changes/archiefwet-retention-engine/specs/archiefwet-retention-engine/spec.md
+++ b/openspec/changes/archiefwet-retention-engine/specs/archiefwet-retention-engine/spec.md
@@ -35,8 +35,10 @@ OR's `DestructionService` writes (list: `status`, `createdAt`,
 `type`, `destructionDate`, `approvers[]`, per-schema and per-category
 counts, `complianceStatement`, `immutable`). The register version MUST be
 bumped so `ConfigurationService::importFromApp()` imports it on boot.
-Seeded `selectielijstEntry` objects MUST carry explicit placeholder
-category codes (`TODO-*`) pending selectielijst-manager confirmation.
+Seeded `selectielijstEntry` objects MUST, before this change is applied to
+production, carry real VNG selectielijst-manager-approved category codes
+(the apply-blocker in REQ-DDARE-009): placeholder `TODO-*` codes MAY be used
+only during authoring and MUST NOT remain in the seed at apply time.
 
 #### Scenario: Register import creates the archief schemas and seeds
 
@@ -44,7 +46,7 @@ category codes (`TODO-*`) pending selectielijst-manager confirmation.
 - WHEN the app boots and `ConfigurationService::importFromApp()` runs
 - THEN the `archief` register exists with schemas `selectielijstEntry`, `destructionList` and `destructionCertificate`
 - AND the seeded selectielijst entries are queryable via `ObjectService::searchObjects()` with `@self.register = archief`
-- AND every seeded `categorie` value starts with `TODO-` (placeholder pending appraisal sign-off)
+- AND at apply time no seeded `categorie` value is a `TODO-*` placeholder (see the apply-blocker in REQ-DDARE-009)
 - @e2e exclude register import is a boot-time backend concern with no UI surface of its own — covered by PHPUnit register-import assertions (tests/unit/Settings/)
 
 #### Scenario: Selectielijst entry field contract matches the OR reader
@@ -275,3 +277,33 @@ shape.
 - THEN each occurrence parses without validation errors
 - AND no bare-string `retention` value remains
 - @e2e exclude declarative register-content rule — covered by a PHPUnit register-lint test
+
+### Requirement: Real selectielijst category numbers are a production-enablement apply-blocker (REQ-DDARE-009)
+
+This change MUST NOT be applied to a production instance, and MUST NOT be
+marked done, while any seeded `selectielijstEntry.categorie` remains a
+`TODO-*` placeholder. Before apply, every seeded selectielijst category
+number MUST be a real VNG selectielijst category code confirmed by the
+responsible selectielijst-manager (records-appraisal sign-off), each paired
+with its correct `archiefnominatie` (`bewaren`|`vernietigen`) and
+`bewaartermijn`. A placeholder code is a production-enablement blocker, not a
+cosmetic gap: OpenRegister computes real destruction dates from these
+numbers (REQ-DDARE-003), so a placeholder or wrong code yields a wrong or
+absent retention schedule and could drive an unlawful destruction or a
+missed one. The apply/verify gate MUST fail while any `TODO-*` categorie is
+present, and the failure MUST name the offending entries.
+
+#### Scenario: Placeholder category codes block completion
+
+- GIVEN the seed still contains a `selectielijstEntry` whose `categorie` starts with `TODO-`
+- WHEN the change's apply/verify gate (seed-lint) runs
+- THEN it fails with a production-enablement error naming the placeholder entries
+- AND the change cannot be marked done until real selectielijst-manager-approved codes replace them
+- @e2e exclude apply-time enablement gate with no UI surface — covered by a PHPUnit seed-lint test (tests/unit/Settings/) that fails on any `TODO-` categorie
+
+#### Scenario: Real approved codes satisfy the gate
+
+- GIVEN every seeded `selectielijstEntry` carries a real VNG selectielijst category code with its matching `archiefnominatie` and `bewaartermijn`
+- WHEN the seed-lint gate runs
+- THEN no placeholder remains and the gate passes
+- @e2e exclude apply-time enablement gate — covered by the same PHPUnit seed-lint test

--- a/openspec/changes/archiefwet-retention-engine/tasks.md
+++ b/openspec/changes/archiefwet-retention-engine/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: archiefwet-retention-engine
 
-<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 13.
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 14.
      Acceptance criteria are plain bullets, not checkboxes. -->
 
 ## 1. Register + seed data
@@ -10,7 +10,10 @@
   - Unit drift-pin: every field OR's `lookupSelectielijstEntry()` reads exists on `selectielijstEntry`; verify against OR HEAD, not against this spec's snapshot.
 
 - [ ] 1.2 Seed representative VNG selectielijst 2020 entries (design.md Seed Data)
-  - `TODO-*` placeholder category codes only; one `bewaren` and at least one `vernietigen` entry; validates on import.
+  - `TODO-*` placeholder category codes during authoring only; one `bewaren` and at least one `vernietigen` entry; validates on import. Placeholders MUST be replaced with real codes before apply — see task 1.4 (apply-blocker).
+
+- [ ] 1.4 APPLY-BLOCKER — replace every `TODO-*` placeholder with a real VNG selectielijst-manager-approved category number before apply/done (REQ-DDARE-009)
+  - Obtain the real category codes with matching `archiefnominatie` + `bewaartermijn` from the responsible selectielijst-manager (records-appraisal sign-off); this change MUST NOT be marked done while any `TODO-*` categorie remains. Add a PHPUnit seed-lint test that FAILS on any `TODO-` categorie so the gate enforces it (production-enablement gate, same posture as flow-operations E3 retention).
 
 - [ ] 1.3 Add `archive` configuration to the record schemas `correspondence`, `generatedDocument`, `publicationRecord` (REQ-DDARE-020) and remove `x-openregister-archival` from record classes; rewrite the `batchCorrespondenceJob` annotation to `{"retention": {"default": "P1Y"}}` (REQ-DDARE-008, REQ-DREG-01/02)
   - Import-pin unit test proves the `archive` key survives `ConfigurationService::importFromApp()`; file an OpenRegister issue if it is dropped (degradation: OR schema UI configuration, never DocuDesk-side retention code).
@@ -39,7 +42,7 @@
 
 - [ ] 4.1 PHPUnit unit tests — minimum 75% coverage on new code (ADR-009)
   - Run inside the container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`.
-  - Includes: register/seed import pins, selectielijst drift-pin, archive-key import pin, propagation precedence matrix, register-lint for REQ-DDARE-008 (no annotation on record classes, object shape elsewhere), architecture test for "no retention arithmetic".
+  - Includes: register/seed import pins, selectielijst drift-pin, archive-key import pin, propagation precedence matrix, register-lint for REQ-DDARE-008 (no annotation on record classes, object shape elsewhere), architecture test for "no retention arithmetic", and the REQ-DDARE-009 seed-lint that fails on any `TODO-` categorie.
 
 - [ ] 4.2 Playwright e2e `tests/e2e/workflows/archiefwet-retention.spec.ts` covering the `@e2e`-referenced scenarios
   - Wire settings, review/partial-approve/reject a vernietigingslijst, certificates list, overbrenging list; verify on the Postgres dev instance (port 8080); test through the UI.
@@ -51,4 +54,4 @@
   - Covers selectielijst maintenance, the admin wiring step, the archivist workflow and the production checklist (replace `TODO-*` categories before enabling destruction).
 
 - [ ] 4.5 Gates + validation
-  - `composer check:strict` zero new violations; `openspec validate archiefwet-retention-engine --strict` exits 0; fix pre-existing quality issues encountered on touched files.
+  - `composer check:strict` zero new violations; `openspec validate archiefwet-retention-engine --strict` exits 0; the REQ-DDARE-009 seed-lint passes (no `TODO-*` categorie remains); fix pre-existing quality issues encountered on touched files.

--- a/openspec/changes/docudesk-mcp-adoption/design.md
+++ b/openspec/changes/docudesk-mcp-adoption/design.md
@@ -52,6 +52,14 @@ schema gets a write verb.
 
 ## The one curated tool
 
+This adoption baseline adds exactly one curated tool — the document-*generation*
+tool below. It is **not** a closed set: the scannable-services path
+(`DocudeskScannableServices`) is the extension point, and sibling changes MAY add
+further curated tools through it (e.g. `mcp-generation-tools` adds the read-only
+`getDocumentStatus` aggregate and the gate-safe `anonymizeDocument` intake).
+`generateCorrespondence` remains the sole *generation* tool, and every added
+curated tool inherits every refusal in the §Refusals section unchanged.
+
 `CorrespondenceService::generate(string $templateId, array $dataRefs, array $options)` →
 `docudesk.generateCorrespondence`.
 

--- a/openspec/changes/docudesk-mcp-adoption/proposal.md
+++ b/openspec/changes/docudesk-mcp-adoption/proposal.md
@@ -24,7 +24,9 @@ holds **document content, signature material and citizen contact data**, and it 
 would hand an agent the signature blobs, the signer IP addresses, the un-anonymised source
 path behind every redacted document, and the publication-prohibition list of protected
 individuals. This change therefore adopts MCP with a deliberately **narrow, read-biased**
-surface: **8 of 18 schemas ON, all read-only**, plus **exactly one curated write tool**.
+surface: **8 of 18 schemas ON, all read-only**, plus **one curated generation write tool**
+(the sole document-generation tool; sibling changes MAY add further curated tools via the
+same scannable-services path, each bound by the same refusals).
 
 ## What Changes
 
@@ -37,14 +39,17 @@ surface: **8 of 18 schemas ON, all read-only**, plus **exactly one curated write
   letterhead and legal boilerplate); correspondence/generatedDocument/batch rows are
   *audit records* of what was produced; `signingRequest` is the legal spine of a signature
   process. None of them is safe for an agent to mutate.
-- **Add exactly one curated `#[McpTool]`**: `CorrespondenceService::generate()` becomes
+- **Add the curated generation `#[McpTool]`**: `CorrespondenceService::generate()` becomes
   `docudesk.generateCorrespondence` — a genuinely non-CRUD, multi-step action (fetch
   template → resolve OpenRegister data refs → apply huisstijl → render → produce PDF/DOCX/HTML
   → log a `correspondence` register entry). Annotated honestly: `scope: 'create'`,
-  `readOnlyHint: false`, `destructiveHint: false`, `idempotentHint: false`.
+  `readOnlyHint: false`, `destructiveHint: false`, `idempotentHint: false`. This is the sole
+  document-*generation* tool; sibling changes (e.g. `mcp-generation-tools`) MAY add further
+  curated tools via the same scannable-services path, each bound by the refusals below.
 - **Add `lib/Mcp/DocudeskScannableServices.php`** implementing OpenRegister's
-  `IMcpScannableServices` and returning `[CorrespondenceService::class]` — the per-app
-  opt-in that tells OR which classes to scan.
+  `IMcpScannableServices` and returning a list that MUST include `CorrespondenceService::class`
+  (and MAY be extended by sibling changes) — the per-app opt-in that tells OR which classes
+  to scan.
 - **Explicitly REFUSE a signing tool.** No `#[McpTool]` is added to `SigningService`,
   `SigningVerificationService`, `SigningAuditService`, or any
   `Service/Signing/*Provider`. Applying an electronic signature is an act with legal
@@ -61,9 +66,9 @@ surface: **8 of 18 schemas ON, all read-only**, plus **exactly one curated write
 
 ### New Capabilities
 - `docudesk-mcp-surface` — DocuDesk's agent-facing tool surface: the curated schema
-  allowlist and its verb/scope/hint declarations, the single curated generation tool, and
-  the standing refusals (signing, batch mail-merge, signature material, consent/prohibition
-  registers).
+  allowlist and its verb/scope/hint declarations, the curated generation tool (extensible by
+  sibling changes via the scannable-services path), and the standing refusals (signing, batch
+  mail-merge, signature material, consent/prohibition registers).
 
 ### Modified Capabilities
 _None._ No existing DocuDesk requirement changes behaviour: the dialect is additive

--- a/openspec/changes/docudesk-mcp-adoption/specs/docudesk-mcp-surface/spec.md
+++ b/openspec/changes/docudesk-mcp-adoption/specs/docudesk-mcp-surface/spec.md
@@ -1,7 +1,9 @@
 # docudesk-mcp-surface
 
 DocuDesk's agent-facing MCP tool surface under ADR-063: the curated schema allowlist, the
-single curated generation tool, and the standing refusals.
+curated document-generation tool (which sibling changes MAY extend with further curated
+tools via the same scannable-services path, each still bound by the standing refusals here),
+and the standing refusals.
 
 ## ADDED Requirements
 
@@ -69,8 +71,14 @@ tool. The declared filters MUST be: `template` → `category`, `namespace`, `for
 `CorrespondenceService::generate()` MUST carry `#[McpTool(name: 'generateCorrespondence',
 scope: 'create', readOnlyHint: false, destructiveHint: false, idempotentHint: false)]`, and
 `lib/Mcp/DocudeskScannableServices.php` MUST implement OpenRegister's
-`IMcpScannableServices` returning `[CorrespondenceService::class]`. The method is genuine
-non-CRUD behaviour — it fetches a template, resolves OpenRegister data references, applies a
+`IMcpScannableServices` and MUST include `CorrespondenceService::class` in its returned
+list. `generateCorrespondence` MUST remain DocuDesk's sole curated document-*generation*
+tool. The returned list MAY include additional curated services registered by sibling
+changes (for example `mcp-generation-tools`, which adds `getDocumentStatus` and
+`anonymizeDocument`); every such additional curated tool MUST itself honour every standing
+refusal in this spec (no signing act, no batch, none of the excluded schemas, no derived
+write verb) and MUST carry a complete, honest hint set. The method is genuine non-CRUD
+behaviour — it fetches a template, resolves OpenRegister data references, applies a
 huisstijl, renders, produces the output format, and logs a `correspondence` register entry —
 so it is a curated tool and not a derivable CRUD verb. Its hints are load-bearing: a curated
 two-segment tool that declares no hints fails open in Hermiq's write/destructive

--- a/openspec/changes/docudesk-mcp-adoption/tasks.md
+++ b/openspec/changes/docudesk-mcp-adoption/tasks.md
@@ -11,11 +11,11 @@
 
 - [ ] 2.1 Add `#[McpTool(name: 'generateCorrespondence', description: ..., readOnlyHint: false, destructiveHint: false, idempotentHint: false, scope: 'create')]` to `CorrespondenceService::generate()`; logic and signature unchanged.
 - [ ] 2.2 Create `lib/Mcp/DocudeskScannableServices.php` implementing `OCA\OpenRegister\Mcp\IMcpScannableServices`, returning `[CorrespondenceService::class]`, with SPDX + `@spec openspec/specs/docudesk-mcp-surface/spec.md` in the docblock.
-- [ ] 2.3 Confirm `generateBatch()` carries **no** attribute and that no `#[McpTool]` exists anywhere under `lib/Service/Signing/`, `SigningService`, `SigningVerificationService` or `SigningAuditService` (`grep -rn "McpTool" lib/` must show only `CorrespondenceService` + `DocudeskScannableServices`).
+- [ ] 2.3 Confirm `generateBatch()` carries **no** attribute and that no `#[McpTool]` exists anywhere under `lib/Service/Signing/`, `SigningService`, `SigningVerificationService` or `SigningAuditService`. `grep -rn "McpTool" lib/` for this baseline shows `CorrespondenceService` + `DocudeskScannableServices`; sibling changes (e.g. `mcp-generation-tools`) may add their own curated `#[McpTool]` services via the scannable-services path — the invariant to assert is that no `#[McpTool]` ever appears on a signing/batch service.
 
 ## 3. Verify
 
 - [ ] 3.1 Import the register into OpenRegister; `McpAnnotationValidator` returns zero errors.
-- [ ] 3.2 Assert the derived surface is exactly 16 tools (8 schemas x search+get) + `docudesk.generateCorrespondence`, and that no tool name ends in `.create` / `.update` / `.delete`.
+- [ ] 3.2 Assert the derived surface is exactly 16 tools (8 schemas x search+get) — sibling changes add no schema, so this count stays 16 — plus the curated `docudesk.generateCorrespondence` (sibling changes may add further curated tools), and that no tool name ends in `.create` / `.update` / `.delete`.
 - [ ] 3.3 Scoped `phpcs` clean on the two touched/new PHP files; zero new PHPUnit failures vs a self-measured baseline.
 - [ ] 3.4 CHANGELOG entry (ADR-063 adoption: 8 read-only schemas + 1 curated generation tool; signing and batch mail-merge explicitly not exposed).

--- a/openspec/changes/document-sanitization/specs/document-sanitization/spec.md
+++ b/openspec/changes/document-sanitization/specs/document-sanitization/spec.md
@@ -60,14 +60,23 @@ never a success claim.
 
 The PDF sanitization pass MUST remove: /Info identity fields and XMP
 identity namespaces (the field/namespace scope of OR's existing
-`PdfMetadataSanitizer`), comments/annotations, embedded files (with a
-documented exception for declared PDF/A-3 archival attachments carrying an
-`/AFRelationship` of `Source` or `Data`), JavaScript (`/JavaScript` name
-tree, `/JS` actions), `/OpenAction` and `/AA` entries — and MUST emit the
-result as a full re-serialisation so prior-save incremental updates and
-orphaned objects are absent from the output. The pass MUST NOT alter visible
-page content. Removal means removal: no masked, emptied-but-present, or
-overlay constructs.
+`PdfMetadataSanitizer`), comments/annotations, embedded files, JavaScript
+(`/JavaScript` name tree, `/JS` actions), `/OpenAction` and `/AA` entries —
+and MUST emit the result as a full re-serialisation so prior-save incremental
+updates and orphaned objects are absent from the output. The pass MUST NOT
+alter visible page content. Removal means removal: no masked,
+emptied-but-present, or overlay constructs.
+
+The pass MUST make one exception (decision D2): a PDF/A-3 embedded file
+declared with an `/AFRelationship` of `Source` or `Data` is the archival
+payload of the container (the MDTO/machine-readable sidecar that makes the
+PDF/A-3 a valid archival record) and MUST be PRESERVED, together with the
+`/AF` association that binds it to the document. Every other embedded file —
+including PDF/A-3 attachments with any other `/AFRelationship`
+(`Alternative`, `Supplement`, `Unspecified`) and all non-PDF/A-3 embedded
+files — MUST be stripped. Each preserved attachment MUST be listed in the
+sanitization report as preserved (with its relationship), so preservation is
+accountable and never silent.
 
 #### Scenario: Hidden payload is absent from the sanitized PDF
 
@@ -77,13 +86,22 @@ overlay constructs.
 - AND the output is a single full save without incremental-update remnants
 - @e2e exclude byte-level output assertions — covered by PHPUnit against fixture PDFs (tests/unit/Service/DocumentSanitizationServiceTest.php)
 
-#### Scenario: Declared archival attachments survive per the exception
+#### Scenario: Declared PDF/A-3 archival attachment is preserved
 
 - GIVEN a PDF/A-3 file with an MDTO sidecar attachment declared `/AFRelationship /Source`
 - WHEN PDF sanitization runs
-- THEN the sidecar attachment is preserved and listed in the report as preserved
-- AND undeclared embedded files are removed
-- @e2e exclude PDF/A-3 attachment branch — covered by PHPUnit fixtures shared with Pdfa3ConversionServiceTest
+- THEN the sidecar attachment and its `/AF` association are preserved in the output
+- AND the report lists it as a preserved attachment with relationship `Source`
+- @e2e exclude PDF/A-3 attachment-preservation branch — covered by PHPUnit fixtures shared with Pdfa3ConversionServiceTest
+
+#### Scenario: Non-archival embedded files are stripped
+
+- GIVEN a PDF/A-3 file carrying both a `/Source` MDTO sidecar and a separate embedded spreadsheet with `/AFRelationship /Unspecified`, plus a plain (non-PDF/A-3) embedded attachment
+- WHEN PDF sanitization runs
+- THEN the `/Source` sidecar is preserved
+- AND both the `/Unspecified` attachment and the plain embedded attachment are removed from the output
+- AND the report records the removed attachments as an embedded-files count
+- @e2e exclude embedded-file strip branch — covered by PHPUnit fixtures shared with Pdfa3ConversionServiceTest
 
 ### Requirement: Every sanitization run persists a content-free report (REQ-DDSAN-003)
 

--- a/openspec/changes/document-sanitization/tasks.md
+++ b/openspec/changes/document-sanitization/tasks.md
@@ -10,7 +10,7 @@
 
 ## 2. Cross-app (OpenRegister)
 
-- [ ] 2.1 File the OR issue + PR for the standalone PDF sanitizer in the existing `Sanitizer` family: /Info + XMP scope of `PdfMetadataSanitizer`, annotations, embedded files (PDF/A-3 `/AFRelationship` exception), JavaScript/OpenAction/AA, full re-save; public per-file entry point like `OfficeDocumentSanitizer::sanitize()` (REQ-DDSAN-002)
+- [ ] 2.1 File the OR issue + PR for the standalone PDF sanitizer in the existing `Sanitizer` family: /Info + XMP scope of `PdfMetadataSanitizer`, annotations, embedded files (D2 exception: preserve only PDF/A-3 attachments declared `/AFRelationship Source|Data` plus their `/AF` association; strip all others), JavaScript/OpenAction/AA, full re-save; public per-file entry point like `OfficeDocumentSanitizer::sanitize()` (REQ-DDSAN-002)
   - Cross-app dependency; verify against OR HEAD at apply time — do not assume it landed.
 
 ## 3. Backend

--- a/openspec/changes/dossier-management-ui/design.md
+++ b/openspec/changes/dossier-management-ui/design.md
@@ -64,24 +64,43 @@ folder-analysis architecture), repo-inventory notable absence.
 
 ## Decisions
 
-### D1 — Membership = the bound folder (no second membership store)
+### D1 — Membership = home folder ∪ an explicit relation list (`documents[]`)
 
-A dossier's documents ARE the files in its `@self.folder` folder — the
-existing contract that folder-batch anonymisation, the grondslagen summary
-and the Woo collection step already rely on (CB #148's point). Therefore:
+Per decision **E4**, the strict folder=dossier equivalence of the first v1
+draft is relaxed: a document may belong to several dossiers. A dossier keeps
+a bound **home folder** (`@self.folder`) — the physical home of the files it
+owns and the unit that folder-batch anonymisation, the grondslagen summary
+and the Woo collection step still operate on (CB #148's architecture is
+preserved) — but membership is additionally tracked by an explicit
+`documents[]` relation list (NC file node references) on the schema. A
+dossier's **effective membership** (what the index count and detail list
+render) is the deduplicated union of the home-folder files and the
+`documents[]` references. Therefore:
 
-- **Add document** (GH #48) = upload/copy the file into the dossier folder;
-  the documents list refreshes immediately.
-- **Remove document** (GH #50) = delete the file from the dossier folder to
-  the NC trashbin after confirmation (recoverable; never a silent hard
-  delete).
-- No `documents[]` array is added to the schema — a second membership store
-  would drift from the folder truth that the processing capabilities use.
+- **Add document** (GH #48): an uploaded/copied file lands in the home folder
+  AND is recorded in `documents[]`; a file picked from elsewhere is added by
+  reference (node id appended to `documents[]`) WITHOUT being moved or copied
+  (link semantics) — so the same document can be a member of many dossiers.
+  The documents list refreshes immediately.
+- **Remove document** (GH #50), always confirmed: if the file lives in this
+  dossier's home folder and is a member of no other dossier → move it to the
+  NC trashbin (recoverable; never a silent hard delete). If it is a referenced
+  member (lives elsewhere or is also referenced by another dossier) → drop
+  only this dossier's `documents[]` reference; the underlying file is never
+  deleted. The confirmation states which will happen.
+- A `documents[]` entry whose target file is gone or unreadable by the caller
+  renders as a visible "missing/inaccessible" marker (same never-silently-drop
+  rule as unknown grondslag slugs); it never breaks the detail view.
+- All membership writes are full-payload PUTs (saveObject PUT-semantic rule)
+  and must not null the dossier's other fields.
 
-Rejected alternative: object-relation membership (dossier → file refs) —
-would let one file join many dossiers, but breaks the 1-folder-batch
-architecture and duplicates truth; multi-dossier membership is recorded as an
-open question.
+Why not folder-only (the earlier v1 draft): a single bound folder can hold a
+file in exactly one dossier, which contradicts the E4 requirement that one
+document belong to several dossiers. Why not relation-list-only (drop the
+folder): folder-batch anonymisation, the grondslagen PDF and the Woo
+collection step are all keyed on `@self.folder`; keeping the home folder as
+the physical/processing anchor while layering `documents[]` for membership
+preserves that architecture and adds cross-dossier membership on top.
 
 ### D2 — Index + detail aggregation
 
@@ -91,7 +110,7 @@ open question.
 | Facet | Source (existing, unchanged) |
 |---|---|
 | Dossier rows | OR ObjectService search on `dossier`/`dossier` |
-| Document list | folder listing of `@self.folder` (caller ACLs apply) |
+| Document list | effective membership = deduplicated union of the `@self.folder` home-folder listing and the resolved `documents[]` references, all under caller ACLs; unresolvable references shown as a visible marker |
 | Per-document anonymisation state | faceted `anonymizationLink` by `sourceFileId` |
 | Per-document checked state | `documentReview` objects (presence-gated on the review-workbench change) |
 | Grondslagen chips | `BasesResolverService` (unknown slug → visible warning, existing rule) |
@@ -165,6 +184,25 @@ Every presence gate is hidden-not-broken.
 - Modals/dialogs in own files (`src/modals/`, `src/dialogs/`); `NcSelect`
   with `inputLabel`; NL Design tokens via NC CSS variables (ADR-003); store
   per the Options API + createObjectStore pattern.
+- Inline rename (GH #51) triggers the object rename AND the bound-folder
+  rename in one operator action (D7); the "+ Document toevoegen" flow offers
+  both upload-into-home-folder and pick-from-elsewhere (reference) paths, and
+  the remove-confirm dialog names the outcome (trash vs unlink) per D1.
+
+### D7 — Rename keeps the bound home folder in sync (E4)
+
+Renaming a dossier (inline title rename or the create-time name) also renames
+its bound home folder (`@self.folder`) so the object name and its physical
+home folder stay in sync instead of diverging (the earlier v1 draft renamed
+the object only). The folder rename:
+
+- runs under the caller's NC filesystem ACLs (no privilege escalation);
+- is best-effort — if the caller lacks write permission or a sibling node
+  already carries the target name, the object rename still commits and the UI
+  shows a readable warning that the folder was not renamed (a collision never
+  silently overwrites or merges folders);
+- touches only this dossier's own home folder — never folders bound to other
+  dossiers, and never referenced documents that physically live elsewhere.
 
 ## OpenRegister service usage (ADR-001)
 
@@ -207,9 +245,17 @@ for the schema change.
 
 ## Risks / Trade-offs
 
-- [Folder = membership means moving a file out silently changes the dossier]
-  → accepted: it is the architecture every processing capability already
-  assumes (CB #148); the detail view always renders the live folder truth.
+- [Moving a file out of the home folder silently changes home-folder
+  membership] → accepted: it is the architecture every processing capability
+  already assumes (CB #148); the detail view always renders the live union of
+  the folder truth and the `documents[]` references.
+- [Referenced membership can dangle when a target file is deleted elsewhere]
+  → the union resolver renders unresolvable references as a visible
+  "missing/inaccessible" marker (never silently dropped) and a unit test pins
+  that a deleted target does not break the detail view.
+- [A best-effort folder rename can leave object and folder names diverged on
+  ACL/collision] → accepted and surfaced: the object rename always commits and
+  the UI warns when the folder was not renamed (D7); no silent overwrite.
 - [PUT-semantic saves could null fields on rename/status writes] → store
   carries all fields forward; unit test pins that a rename survives `bases`
   and `checkedOn` (the known saveObject trap).
@@ -222,16 +268,23 @@ for the schema change.
 
 ## Migration Plan
 
-Additive: `status` + lifecycle annotation on `dossier` (register version
-bump, boot import — existing objects untouched), new
-service/controller/routes/views. Rollback = remove routes/UI; `status`
-values remain inert data. No data migration.
+Additive: `status` + lifecycle annotation and the optional `documents[]`
+membership relation on `dossier` (register version bump, boot import —
+existing objects untouched), new service/controller/routes/views. A dossier
+without `documents[]` derives membership from its home folder alone, so no
+data migration is needed. Rollback = remove routes/UI; `status` and
+`documents` values remain inert data.
 
 ## Open Questions
 
-- Multi-dossier membership (one file in several dossiers) — needs an
-  object-relation model and a folder-truth decision; deferred.
-- Should renaming the dossier offer to rename the bound folder too (they
-  diverge after a rename)? Deferred UX decision; v1 renames the object only.
+- ~~Multi-dossier membership (one file in several dossiers)~~ — **resolved by
+  E4**: modelled with the `documents[]` relation list over a bound home
+  folder (D1); shipped in v1.
+- ~~Should renaming the dossier rename the bound folder too?~~ — **resolved by
+  E4**: yes, best-effort folder sync on rename (D7); shipped in v1.
 - Dossier deletion/archival UX (with Archiefwet implications) — deferred to
   the retention/archival programme (`archiefwet-retention-engine` sibling).
+- Whether the folder-batch/grondslagen/Woo steps should follow `documents[]`
+  references (not just the home folder) — deferred; v1 keeps those steps
+  keyed on the home folder and uses `documents[]` only for the browse/detail
+  membership view.

--- a/openspec/changes/dossier-management-ui/proposal.md
+++ b/openspec/changes/dossier-management-ui/proposal.md
@@ -53,10 +53,17 @@ depends on that fix and wires the action into the dossier detail.
   to batch progress), publication section (publication record state + publish
   entry, presence-gated).
 - **Create / rename / membership**: create-dossier dialog (name, description,
-  bases, folder); inline title rename (GH #51); "+ Document toevoegen" CTA
-  (GH #48); remove document (to trashbin, confirmed); auto-dossier modal on
-  multi-upload — one document uploads without a modal, several trigger the
-  name + grondslagen-preselect modal (GH #47).
+  bases, folder); inline title rename that also renames the bound home folder
+  to keep them in sync (GH #51, E4); "+ Document toevoegen" CTA — upload into
+  the home folder or add an existing document by reference (GH #48); remove
+  document (confirmed — trashbin when home-folder-owned, unlink-only when
+  referenced elsewhere); auto-dossier modal on multi-upload — one document
+  uploads without a modal, several trigger the name + grondslagen-preselect
+  modal (GH #47).
+- **Multi-dossier membership** (E4): membership is an explicit `documents[]`
+  relation list over a bound home folder, so one document may belong to
+  several dossiers — relaxing the strict folder=dossier equivalence of the
+  first draft while keeping the home folder as the physical/processing anchor.
 - **Dossier lifecycle, declaratively**: the `dossier` schema gains an
   optional `status` governed by an `x-openregister-lifecycle` annotation
   (canonical `initial: open`; `open → in-review → processed →
@@ -76,13 +83,16 @@ depends on that fix and wires the action into the dossier detail.
 
 - `dossier-register`: the `dossier` schema gains the optional `status`
   property with a declarative `x-openregister-lifecycle` (canonical
-  `initial: open`). All other schema properties, the `base` vocabulary, the
-  folder binding and the seed set are unchanged.
+  `initial: open`) and the optional `documents[]` membership relation list
+  (multi-dossier membership, E4). The `base` vocabulary, the `@self.folder`
+  home-folder binding and the seed set are unchanged; status-less,
+  `documents`-less dossiers read as `open` with folder-derived membership.
 
 ## Impact
 
-- `lib/Settings/docudesk_register.json`: `status` + lifecycle annotation on
-  the `dossier` schema; register version bump. No new schemas.
+- `lib/Settings/docudesk_register.json`: `status` + lifecycle annotation and
+  the optional `documents[]` membership relation on the `dossier` schema;
+  register version bump. No new schemas.
 - New `lib/Service/DossierManagementService.php` (membership operations,
   aggregation for detail: documents, batch runs, publication state) + new
   routes/actions on a `DossierManagementController` (the existing

--- a/openspec/changes/dossier-management-ui/specs/dossier-management-ui/spec.md
+++ b/openspec/changes/dossier-management-ui/specs/dossier-management-ui/spec.md
@@ -11,10 +11,13 @@ that aggregates documents, lifecycle status, grondslagen, batch runs and
 publication state; membership operations (create, inline rename, add/remove
 documents, auto-dossier on multi-upload per GH #47/#48/#50/#51); and
 dossier-level actions wired to the existing folder-batch, grondslagen-PDF
-and publication capabilities. A dossier's documents are the files in its
-bound folder (`@self.folder`) — no second membership store. The dossier
-lifecycle itself is declared on the schema (see the `dossier-register`
-delta in this change).
+and publication capabilities. A dossier keeps a bound **home folder**
+(`@self.folder`) as the physical location of the files it owns, but
+membership is an explicit relation list (`documents[]`) so one document may
+belong to several dossiers (the strict folder=dossier equivalence is
+relaxed — see REQ-DDDMU-008); renaming a dossier keeps its bound home folder
+in sync (REQ-DDDMU-009). The dossier lifecycle itself is declared on the
+schema (see the `dossier-register` delta in this change).
 
 ## ADDED Requirements
 
@@ -85,11 +88,18 @@ MUST carry all schema fields forward — a rename MUST NOT null `bases`,
 ### Requirement: Add and remove documents in a dossier (REQ-DDDMU-004)
 
 The dossier detail MUST offer a "+ Document toevoegen" CTA (GH #48) that adds
-an uploaded or picked file into the dossier's bound folder, with the
-documents list updating immediately without a page reload. Removing a
-document (GH #50) MUST require confirmation and MUST move the file to the
-Nextcloud trashbin (recoverable) — never a silent hard delete. Membership is
-the folder content: the app MUST NOT maintain a second membership store.
+an uploaded or picked file to the dossier: an uploaded/copied file lands in
+the dossier's bound home folder and is recorded in `documents[]`; a file
+picked from elsewhere is added by reference (its node id appended to
+`documents[]`) without being moved (see REQ-DDDMU-008). The documents list
+MUST update immediately without a page reload. Removing a document (GH #50)
+MUST require confirmation; the confirmation MUST state whether the file will
+be trashed or merely unlinked. When the document lives in this dossier's home
+folder and is a member of no other dossier, removal MUST move the file to the
+Nextcloud trashbin (recoverable) — never a silent hard delete; when the
+document is a referenced member (lives elsewhere or is also a member of
+another dossier), removal MUST drop only this dossier's membership reference
+and MUST NOT delete the underlying file.
 
 #### Scenario: Added document appears immediately
 
@@ -176,3 +186,64 @@ The UI MUST surface the rejection as a readable error, never silently.
 - WHEN a save attempts `status = published`
 - THEN OpenRegister rejects the transition and the dossier stays `open`
 - @e2e exclude server-side lifecycle guard — covered by PHPUnit transition tests (tests/unit/Service/DossierManagementServiceTest.php)
+
+### Requirement: Multi-dossier membership via an explicit relation list (REQ-DDDMU-008)
+
+A document MAY belong to several dossiers. Membership MUST be tracked by an
+explicit `documents[]` relation list on the `dossier` schema (NC file node
+references — see the `dossier-register` delta) rather than by the bound home
+folder alone; the strict folder=dossier equivalence is relaxed. A dossier's
+membership set that the index count and detail list render MUST be the union
+of the files physically present in its bound home folder and the files
+referenced in `documents[]` (deduplicated). Files uploaded or created through
+the dossier MUST land in the home folder AND be recorded in `documents[]`;
+adding an existing document to a second dossier MUST append its node
+reference to that dossier's `documents[]` and MUST NOT move or copy the file
+(link semantics), so the same document appears in every dossier that
+references it. A `documents[]` entry whose target file no longer exists (or
+the caller cannot read) MUST be rendered as a visible "missing/inaccessible"
+marker, never silently dropped, and MUST NOT break the detail view. All
+membership writes are full-payload PUTs (the saveObject PUT-semantic rule)
+and MUST NOT null the dossier's other fields.
+
+#### Scenario: One document is a member of two dossiers
+
+- GIVEN dossier A whose home folder holds a document, and dossier B
+- WHEN the operator adds that document to dossier B via "+ Document toevoegen" (pick from elsewhere)
+- THEN B's `documents[]` gains the file's node reference, the file is not moved out of A's home folder, and both A and B list the document in their detail
+- @e2e tests/e2e/workflows/dossier-management.spec.ts
+
+#### Scenario: Unlinking a referenced member keeps the file
+
+- GIVEN a document that is a member of dossier A (its home folder) and dossier B (by reference)
+- WHEN the operator removes the document from dossier B and confirms
+- THEN only B's membership reference is dropped, the underlying file is untouched, and the document still lists in dossier A
+- @e2e tests/e2e/spec-coverage/dossier-management.spec.ts
+
+### Requirement: Renaming a dossier keeps the bound home folder in sync (REQ-DDDMU-009)
+
+Renaming a dossier MUST attempt to rename the dossier's bound home folder
+(`@self.folder`) to match — whether the rename comes from the inline title
+rename (REQ-DDDMU-003) or the create-time name — keeping the object name and
+its physical home folder in sync rather than diverging. The rename MUST run under the caller's
+NC filesystem ACLs. If the folder cannot be renamed — the caller lacks write
+permission, or a sibling node with the target name already exists — the
+dossier object rename MUST still succeed and the UI MUST surface a readable
+warning that the bound folder was not renamed (a name collision MUST NOT
+silently overwrite or merge folders). Only the dossier's own bound home
+folder is renamed; folders bound to other dossiers and referenced documents
+that live elsewhere are never touched.
+
+#### Scenario: Inline rename renames the bound folder
+
+- GIVEN a dossier named "Handhaving 2024" bound to a writable home folder of the same name
+- WHEN the operator renames the dossier inline to "Handhaving 2025"
+- THEN the dossier object and its bound home folder are both named "Handhaving 2025"
+- @e2e tests/e2e/workflows/dossier-management.spec.ts
+
+#### Scenario: Folder rename collision keeps the object rename and warns
+
+- GIVEN a dossier whose parent already contains a sibling folder with the target name
+- WHEN the operator renames the dossier to that name
+- THEN the dossier object is renamed, the bound folder is left unchanged, and the UI shows a readable warning that the folder could not be renamed
+- @e2e exclude filesystem collision path — covered by PHPUnit tests (tests/unit/Service/DossierManagementServiceTest.php)

--- a/openspec/changes/dossier-management-ui/specs/dossier-register/spec.md
+++ b/openspec/changes/dossier-management-ui/specs/dossier-register/spec.md
@@ -6,18 +6,23 @@ status: proposed
 
 ## Purpose
 
-Adds an optional, declaratively-guarded `status` lifecycle to the existing
-`dossier` schema so the dossier-management UI can render and transition
-dossier state (`open → in-review → processed → published/closed`). All other
-dossier properties, the `base` grondslagen vocabulary, the `@self.folder`
-binding, the `checkedOn` audit behaviour and the seed set are unchanged;
-existing status-less dossiers read as `open`.
+Adds an optional, declaratively-guarded `status` lifecycle and an optional
+`documents[]` membership relation list to the existing `dossier` schema so the
+dossier-management UI can render and transition dossier state
+(`open → in-review → processed → published/closed`) and track multi-dossier
+membership (one document in several dossiers, relaxing the strict
+folder=dossier equivalence). The `base` grondslagen vocabulary, the
+`@self.folder` home-folder binding, the `checkedOn` audit behaviour and the
+seed set are unchanged; existing status-less, `documents`-less dossiers read
+as `open` with their membership derived from the home folder alone.
 
 ## MODIFIED Requirements
 
 ### Requirement: Dossier schema captures folder-level anonymisation metadata
 
-The system SHALL define a `dossier` schema with the following properties: `name` (string, required, mirrors folder name at creation), `description` (string, optional), `bases` (array of strings, optional, no `minItems` — each string is the slug of a `base` object), `checkedOn` (date-time, optional), and `status` (string, optional — the dossier lifecycle state). The schema SHALL be stored under `components.schemas.dossier` in `docudesk_register.json`, follow OpenRegister's OpenAPI 3.0.0 schema conventions (ADR-006), and MUST include `slug: "dossier"`, `title`, `description`, and `configuration.objectNameField: "name"` so list UIs render the stored name.
+The system SHALL define a `dossier` schema with the following properties: `name` (string, required, mirrors the bound home-folder name at creation and kept in sync on rename), `description` (string, optional), `bases` (array of strings, optional, no `minItems` — each string is the slug of a `base` object), `checkedOn` (date-time, optional), `status` (string, optional — the dossier lifecycle state), and `documents` (array of strings, optional, no `minItems` — each string is a Nextcloud file node reference recording an explicit membership so one document may belong to several dossiers). The schema SHALL be stored under `components.schemas.dossier` in `docudesk_register.json`, follow OpenRegister's OpenAPI 3.0.0 schema conventions (ADR-006), and MUST include `slug: "dossier"`, `title`, `description`, and `configuration.objectNameField: "name"` so list UIs render the stored name.
+
+The `documents` property SHALL be optional for backwards compatibility: a dossier without it SHALL have its membership derived from the files in its bound `@self.folder` home folder alone, and existing objects SHALL NOT be migrated. When present, a dossier's effective membership SHALL be the deduplicated union of its home-folder files and its `documents` references; a reference whose target no longer exists SHALL be surfaced as a visible marker, never silently dropped.
 
 The `status` property SHALL be governed by an `x-openregister-lifecycle` annotation on the schema using the canonical `initial` key (`initial: open`) with exactly the transitions `open → in-review`, `in-review → processed`, `in-review → open` (reopen), `processed → published`, `processed → closed`, and `published → closed`. OpenRegister's lifecycle guard SHALL reject any out-of-order status write. `status` SHALL be optional for backwards compatibility: a dossier without it SHALL be treated by consumers as `open`, and existing objects SHALL NOT be migrated.
 
@@ -36,6 +41,12 @@ The `status` property SHALL be governed by an `x-openregister-lifecycle` annotat
 - **WHEN** a client posts `POST /api/objects/dossier` without a `name`
 - **THEN** the response is a validation error citing the missing required property
 - @e2e exclude pre-existing validation contract carried over unchanged — covered by Newman register contract tests
+
+#### Scenario: A membership reference is stored verbatim and shared across dossiers
+- **GIVEN** two dossiers A and B and a file node reference `f`
+- **WHEN** `f` is appended to both dossiers' `documents` arrays via full-payload saves
+- **THEN** `GET` on each dossier returns `documents` containing `f` (stored verbatim), and neither save nulls the other dossier's fields
+- @e2e exclude register/API contract for the new relation property — covered by register-import PHPUnit assertions and the membership scenarios in tests/e2e/workflows/dossier-management.spec.ts
 
 #### Scenario: Lifecycle transitions are declaratively guarded
 - **GIVEN** a dossier without a `status` value (treated as `open`)

--- a/openspec/changes/dossier-management-ui/tasks.md
+++ b/openspec/changes/dossier-management-ui/tasks.md
@@ -5,16 +5,16 @@
 
 ## 1. Register
 
-- [ ] 1.1 Add the optional `status` property + `x-openregister-lifecycle` annotation to the `dossier` schema in `lib/Settings/docudesk_register.json` (dossier-register delta)
-  - Canonical `initial: open` (the lifecycle dialect trap: only the canonical `initial` key is honoured); exactly the six declared transitions; register-i18n tags on the new user-facing enum values; register version bump with changelog entry; existing seed dossiers untouched (absent status = open).
+- [ ] 1.1 Add the optional `status` property + `x-openregister-lifecycle` annotation AND the optional `documents[]` membership relation to the `dossier` schema in `lib/Settings/docudesk_register.json` (dossier-register delta)
+  - Canonical `initial: open` (the lifecycle dialect trap: only the canonical `initial` key is honoured); exactly the six declared transitions; `documents[]` = array of NC file node references (no `minItems`, optional — absent = membership from home folder alone); register-i18n tags on the new user-facing enum values; register version bump with changelog entry; existing seed dossiers untouched (absent status = open, absent documents = folder-only membership).
 
 ## 2. Backend
 
-- [ ] 2.1 Implement `lib/Service/DossierManagementService.php` detail/index aggregation (REQ-DDDMU-001, REQ-DDDMU-002)
-  - Folder listing under caller ACLs; faceted `anonymizationLink` state; `documentReview` checked state, redaction-at-scale batch data and `publicationRecord` state each presence-gated (hidden-not-broken); `BasesResolverService` for grondslagen with visible unknown-slug warnings.
+- [ ] 2.1 Implement `lib/Service/DossierManagementService.php` detail/index aggregation with the union membership resolver (REQ-DDDMU-001, REQ-DDDMU-002, REQ-DDDMU-008)
+  - Effective membership = deduplicated union of the `@self.folder` home-folder listing and resolved `documents[]` references, all under caller ACLs; unresolvable references rendered as a visible missing/inaccessible marker (never silently dropped); faceted `anonymizationLink` state; `documentReview` checked state, redaction-at-scale batch data and `publicationRecord` state each presence-gated (hidden-not-broken); `BasesResolverService` for grondslagen with visible unknown-slug warnings.
 
-- [ ] 2.2 Implement membership operations (REQ-DDDMU-004, REQ-DDDMU-005)
-  - Add = upload/copy into the bound folder; remove = confirmed move to trashbin; auto-dossier creation binding a new folder for multi-uploads; no second membership store.
+- [ ] 2.2 Implement membership operations incl. multi-dossier references and rename-folder sync (REQ-DDDMU-004, REQ-DDDMU-005, REQ-DDDMU-008, REQ-DDDMU-009)
+  - Add = upload/copy into the home folder AND record in `documents[]`, or pick-from-elsewhere = append node reference without moving (one document may be a member of several dossiers); remove = confirmed trashbin move only when home-folder-owned and not referenced elsewhere, otherwise drop only this dossier's reference (never delete the file); auto-dossier creation binding a new home folder for multi-uploads; rename = best-effort rename of the bound home folder under caller ACLs with a readable warning on ACL/collision (object rename always commits, no silent overwrite); all writes full-payload PUT.
 
 - [ ] 2.3 Add `lib/Controller/DossierManagementController.php` + `api/dossiers/*` routes (REQ-DDDMU-002)
   - Explicit auth attributes on every method; per-object dossier readability guard before aggregation (no IDOR); ADR-022 justification (five-source aggregation) in the docblock; routes registered before any catch-all; the grondslagen-PDF route itself stays owned by `fix-dossier-grondslagen-route-mismatch` (declared dependency — verify it is merged or include it in the test environment).
@@ -27,20 +27,20 @@
 - [ ] 3.2 Dossier detail: documents section with inline viewer switch + mini-menu, grondslagen, batch runs, publication sections (REQ-DDDMU-002, REQ-DDDMU-006)
   - No page reload on document switch (GH #50); mark-as-checked presence-gated on the review workbench; header actions batch-anonymize / grondslagen-PDF / publish (presence-gated); deep-link to redaction-at-scale progress when installed.
 
-- [ ] 3.3 Create dialog, inline title rename, "+ Document toevoegen" CTA, remove-confirm dialog (REQ-DDDMU-003, REQ-DDDMU-004)
-  - Full-payload PUT on every dossier update (PUT-semantic rule — rename must not null `bases`/`checkedOn`); modals/dialogs in own files under `src/modals/`/`src/dialogs/`; `NcSelect` with `inputLabel`; NL Design tokens.
+- [ ] 3.3 Create dialog, inline title rename (with bound-folder sync), "+ Document toevoegen" CTA (upload + pick-from-elsewhere reference), remove-confirm dialog naming trash-vs-unlink (REQ-DDDMU-003, REQ-DDDMU-004, REQ-DDDMU-008, REQ-DDDMU-009)
+  - Full-payload PUT on every dossier update (PUT-semantic rule — rename must not null `bases`/`checkedOn`/`documents`); rename shows the folder-not-renamed warning on ACL/collision; remove-confirm states whether the file is trashed or the reference is unlinked; modals/dialogs in own files under `src/modals/`/`src/dialogs/`; `NcSelect` with `inputLabel`; NL Design tokens.
 
 - [ ] 3.4 Auto-dossier modal on multi-upload (REQ-DDDMU-005)
   - Shown only for >1 document in one action (GH #47); name prefill + "grondslagen allemaal geselecteerd" toggle preselecting the six canonical bases; cancel uploads without a dossier.
 
 ## 4. Quality
 
-- [ ] 4.1 PHPUnit unit tests for DossierManagementService/Controller (aggregation presence gates, IDOR guard, lifecycle transitions incl. out-of-order rejection, rename field-survival) — minimum 75% coverage on new code
+- [ ] 4.1 PHPUnit unit tests for DossierManagementService/Controller (union membership resolver incl. dangling-reference marker, multi-dossier link/unlink semantics, rename-folder sync incl. ACL/collision warning path, aggregation presence gates, IDOR guard, lifecycle transitions incl. out-of-order rejection, rename field-survival) — minimum 75% coverage on new code
   - Run inside the container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`.
-  - Explicit pin: a rename PUT preserves `bases`, `checkedOn`, `description`, `status` (saveObject PUT-semantic trap).
+  - Explicit pins: a rename PUT preserves `bases`, `checkedOn`, `description`, `status`, `documents` (saveObject PUT-semantic trap); unlinking a referenced member does not delete the file; a deleted reference target does not break the detail view.
 
 - [ ] 4.2 Playwright e2e specs `tests/e2e/workflows/dossier-management.spec.ts` + `tests/e2e/spec-coverage/dossier-management.spec.ts` covering the `@e2e`-referenced scenarios end-to-end with OpenRegister on the Postgres dev instance
-  - Multi-upload modal, add/remove with trashbin restore, no-reload document switch, transition offers; test through the UI; nldesign-theme accessibility pass.
+  - Multi-upload modal, add/remove with trashbin restore, one-document-in-two-dossiers link + unlink-keeps-file, inline rename renames the bound folder, no-reload document switch, transition offers; test through the UI; nldesign-theme accessibility pass.
 
 - [ ] 4.3 Verify the dossier → folder-batch → grondslagen-PDF chain end-to-end on a seeded dossier with the route fix applied
   - Batch runs appear in the detail; the grondslagen PDF downloads (no 500); publication section renders per pipeline presence.
@@ -49,4 +49,4 @@
   - Keys in English.
 
 - [ ] 4.5 Documentation `docs/features/dossier-management.md` with Playwright MCP screenshots (ADR-010); run `openspec validate dossier-management-ui --strict`
-  - Documents the folder-as-membership model, the lifecycle semantics and the GH #47/#48/#50/#51 behaviours.
+  - Documents the home-folder + `documents[]` union membership model (multi-dossier membership), the rename-folder-sync behaviour, the lifecycle semantics and the GH #47/#48/#50/#51 behaviours.

--- a/openspec/changes/e-discovery-legal-hold/design.md
+++ b/openspec/changes/e-discovery-legal-hold/design.md
@@ -47,15 +47,16 @@ vernietigingslijsten shrink while holds are active), record owners
 
 - A case-level hold object with matter type, reason, explicit scope,
   custodian and a declarative lifecycle.
-- Platform-enforced destruction freeze (OR legal holds), overlap-safe
-  release, owner notifications, full audit trail, searchable register.
+- Platform-enforced destruction freeze (OR legal holds, primary) plus a
+  Nextcloud file-lock (`files_lock`) backstop against raw file deletion,
+  overlap-safe release, owner notifications, full audit trail, searchable
+  register.
 
 **Non-Goals (the ZyLAB boundary):**
 
 - No document review UI, tagging, TAR/analytics, production/export sets,
   custodian questionnaires or matter workflow beyond active→released.
 - No query-based or self-updating scopes this wave.
-- No storage-layer file locking (open question below).
 
 ## Decisions
 
@@ -137,6 +138,34 @@ their records; silent freezes get violated innocently.
   read access via OR RBAC; hold placement authority restricted to a
   designated group (records-manager/juridisch), verified server-side.
 
+### D6 — File-level freeze backstop via `files_lock` (REQ-DDEDL-007)
+
+The OR record hold (D3) freezes *record destruction* — it does not stop a
+user with Files/WebDAV/sync access from deleting the underlying Nextcloud
+file. That gap is a real evidence-spoliation risk under a running matter.
+**Decision:** alongside every OR hold, place an app-scoped lock on the
+document's file node via OCP `\OCP\Files\Lock\ILockManager`
+(`ILock::TYPE_APP`, owner = the DocuDesk app id — an app lock, not a user
+lock, so it is not tied to the placing user's session and blocks all raw file
+mutation). The lock provider is the `files_lock` app; DocuDesk consumes the
+OCP interface, never `files_lock` internals.
+
+- **Primary vs backstop:** the OR record freeze stays authoritative for
+  Archiefwet destruction; the file lock is strictly a storage-layer backstop.
+  Neither replaces the other.
+- **Overlap-safe:** the file lock follows the SAME overlap ledger as the OR
+  hold (D3) — a file is unlocked only when no other active case covers it.
+- **Honest degradation:** probe `ILockManager::isLockProviderAvailable()`;
+  when false (`files_lock` not installed) the case fan-out status records the
+  backstop as unavailable and the UI never claims file-level protection — the
+  OR record freeze still applies.
+- **Imperative:** lock/unlock fan-out joins the existing per-object fan-out
+  status (visible, retried, audited), an ADR-031-justified imperative side
+  effect exactly like the OR-hold fan-out.
+
+Rejected: a user-scoped lock (`TYPE_USER`) — tied to the placing custodian
+and liftable by them, defeating the freeze; a WebDAV-token lock — transient.
+
 ## OpenRegister service usage (ADR-001 / config.yaml)
 
 | Operation | OR surface |
@@ -157,8 +186,9 @@ in OR.
 - **Imperative (justified exceptions)**: fan-out/release orchestration with
   overlap accounting (cross-object, cross-register side effects with a
   platform single-slot limitation — no `x-openregister-*` dialect expresses
-  it); owner notifications (external side effect). Both append to the case
-  audit so the imperative path stays declaratively readable.
+  it); the `files_lock` file-lock backstop fan-out (D6, OCP `ILockManager`
+  side effect); owner notifications (external side effect). All append to the
+  case audit so the imperative path stays declaratively readable.
 
 ## Seed Data
 
@@ -191,10 +221,12 @@ demo-municipality flavour):
 - [Fan-out partial failure] → per-object fan-out status on the case;
   retries; case not treated as fully protective until every object holds —
   visible, never silent.
-- [NC file deletion bypasses record-level holds] → OR holds freeze record
-  destruction, not raw file deletion by a user with filesystem access;
-  mitigations (files_lock integration, trashbin retention) are an open
-  question; the risk is documented in the feature docs.
+- [NC file deletion bypasses record-level holds] → addressed (REQ-DDEDL-007,
+  decision D6): an app-scoped `files_lock` file lock is placed alongside the
+  OR record hold and lifted overlap-safe on release, blocking raw file
+  deletion/rename/overwrite at the storage layer. When `files_lock` is not
+  installed the backstop is recorded as unavailable and the OR record freeze
+  still applies — the case never claims file-level protection it lacks.
 - [Hold placement authority] → server-side group check on the controller
   (semantic-auth gate); UI hiding is never the control.
 - [Scope mistakes (missing document)] → explicit-reference scope is
@@ -212,9 +244,6 @@ migration.
 
 ## Open Questions
 
-- Storage-layer freeze: integrate `files_lock` (or trashbin policy) so the
-  underlying NC file of a held record cannot be deleted either? Deferred —
-  needs a fleet decision on file-level immutability.
 - Native multi-hold support in OR (issue to file) — adopt and delete the
   overlap ledger when available.
 - Should Woo-request cases (woo-request-workflow, wave 1) auto-propose a

--- a/openspec/changes/e-discovery-legal-hold/proposal.md
+++ b/openspec/changes/e-discovery-legal-hold/proposal.md
@@ -42,18 +42,26 @@ review platform:
    with matter type (litigation | audit | woo-appeal | other), reason,
    explicit scope (document and dossier references — no query-based
    scopes), custodian, and a declarative `active → released` lifecycle.
-2. **Freeze enforcement via OR**: activating a case places an OR legal
-   hold (reason = case reference) on every in-scope OR object; held
+2. **Freeze enforcement via OR (primary)**: activating a case places an OR
+   legal hold (reason = case reference) on every in-scope OR object; held
    records are excluded from vernietigingslijsten by OR itself and the
    Archiefbeheer UI shows the exclusion. Releasing a case lifts only the
    holds this case placed, and only on objects no *other* active case
    still covers (overlap-safe by design).
-3. **Notifications**: affected document/dossier owners are notified on
+3. **File-level freeze via files_lock (backstop)**: activating a case also
+   places an app-scoped Nextcloud file lock (OCP `ILockManager`,
+   `ILock::TYPE_APP`) on each in-scope document's file node, so raw file
+   deletion/rename/overwrite through the Files UI, WebDAV or sync is blocked
+   at the storage layer — closing the gap the record freeze does not cover.
+   The OR record freeze stays primary; the file lock is a backstop, lifted
+   overlap-safe on release, and degrades honestly when `files_lock` is not
+   installed.
+4. **Notifications**: affected document/dossier owners are notified on
    place and on release.
-4. **Audit trail**: OR's `legalHold.history` plus the case object's own
+5. **Audit trail**: OR's `legalHold.history` plus the case object's own
    audit trail; released cases are retained (bewaren) — a hold register is
    itself a record.
-5. **Searchable register**: a hold-register surface (filter by status,
+6. **Searchable register**: a hold-register surface (filter by status,
    type, custodian) plus an active-hold indicator on document/dossier
    detail that also disables destruction-adjacent actions.
 
@@ -64,7 +72,8 @@ review platform:
 - `e-discovery-legal-hold`: case-level legal holds for
   litigation/audit/Woo-appeal matters — scope + custodian + reason on a
   hold case, destruction freeze enforced through OpenRegister's per-object
-  legal holds (overriding the retention engine's disposal), owner
+  legal holds (overriding the retention engine's disposal) with a Nextcloud
+  file-lock (`files_lock`) backstop against raw file deletion, owner
   notifications, overlap-safe release with a full audit trail, and a
   searchable hold register. Hold + freeze + audit only; no review
   platform.
@@ -80,7 +89,9 @@ review platform:
   accounting), hold register UI + detail indicators, notifications, this
   OpenSpec change.
 - Consumed: `openregister` — `retention.legalHold`, `LegalHoldService`,
-  `/api/archival/legal-holds*`, DestructionCheckJob hold exclusion.
+  `/api/archival/legal-holds*`, DestructionCheckJob hold exclusion; Nextcloud
+  `files_lock` via OCP `\OCP\Files\Lock\ILockManager` (app-scoped file-lock
+  backstop, probed with `isLockProviderAvailable()`).
 - Depends on: `archiefwet-retention-engine` (the disposal workflow the
   freeze overrides; Archiefbeheer surfaces that display exclusions).
 
@@ -91,9 +102,6 @@ review platform:
   (design.md Non-Goals); DocuDesk ships hold + freeze + audit only.
 - Query/saved-search-based hold scopes (explicit references only in this
   wave; re-evaluated scopes are a follow-up).
-- Freezing Nextcloud file deletion at the storage layer — OR holds freeze
-  record destruction; storage-layer locking is an open question
-  (design.md).
 - The dossier-register canonical spec file (sibling ownership) — dossier
   scope entries are expressed as capability behaviour.
 

--- a/openspec/changes/e-discovery-legal-hold/specs/e-discovery-legal-hold/spec.md
+++ b/openspec/changes/e-discovery-legal-hold/specs/e-discovery-legal-hold/spec.md
@@ -78,6 +78,54 @@ the existing hold.
 - AND the case is not presented as fully protective
 - @e2e tests/e2e/workflows/e-discovery-legal-hold.spec.ts
 
+### Requirement: File-level freeze via Nextcloud file locking (REQ-DDEDL-007)
+
+The app MUST place a file-layer lock on the underlying Nextcloud file node of
+every in-scope document when a hold case is activated, using OCP
+`\OCP\Files\Lock\ILockManager` with an app-scoped lock (`ILock::TYPE_APP`,
+owner the DocuDesk app id), so that raw Nextcloud file operations — deletion,
+rename and overwrite via the Files UI, WebDAV or a sync client — are blocked
+at the storage layer while the hold is active. This file lock is IN ADDITION
+to the OpenRegister per-object record-destruction freeze (REQ-DDEDL-002),
+which remains the PRIMARY and authoritative freeze governing Archiefwet
+destruction. The
+file lock is a BACKSTOP that closes the gap the record freeze does not cover
+(a user deleting the actual file through Nextcloud rather than destroying the
+OR record); it MUST NOT replace or weaken the OR record freeze. On release
+the app MUST unlock a file only when no other active case covers it, using
+the same overlap accounting as REQ-DDEDL-003 (the file stays locked while any
+active case still covers it). When the lock provider is unavailable
+(`ILockManager::isLockProviderAvailable()` is false — the `files_lock` app is
+not installed), the app MUST record the file-layer backstop as unavailable on
+the case fan-out status and MUST NOT claim file-level protection it does not
+have; the OR record freeze still applies. Per-object lock and unlock failures
+MUST be visible and retried like the record fan-out, never silent.
+
+#### Scenario: Placing a hold blocks raw file deletion
+
+- GIVEN an in-scope document and an installed `files_lock` lock provider
+- WHEN the hold case is activated
+- THEN an app-scoped lock is placed on the document's Nextcloud file node
+- AND an attempt to delete that file through the Files app or WebDAV is refused while the hold is active
+- @e2e exclude storage-layer lock enforcement is Nextcloud/files_lock behaviour — covered by PHPUnit on the lock fan-out (tests/unit/Service/LegalHoldCaseServiceTest.php) plus the record-freeze e2e in tests/e2e/workflows/e-discovery-legal-hold.spec.ts
+
+#### Scenario: File lock lifts only after the last covering case releases
+
+- GIVEN a file covered by two active hold cases, both holding the file lock
+- WHEN the first case is released
+- THEN the file remains locked (a case still covers it)
+- AND only after the second case is released is the file lock lifted
+- @e2e exclude overlap-safe unlock is backend orchestration — covered by PHPUnit overlap-matrix tests (tests/unit/Service/LegalHoldCaseServiceTest.php)
+
+#### Scenario: Missing lock provider degrades honestly
+
+- GIVEN an instance without the `files_lock` app installed
+- WHEN a hold case is activated
+- THEN the OpenRegister record freeze is placed as usual
+- AND the case fan-out status records the file-layer backstop as unavailable
+- AND the case does not claim file-level deletion protection
+- @e2e exclude provider-availability degradation branch — covered by PHPUnit (tests/unit/Service/LegalHoldCaseServiceTest.php)
+
 ### Requirement: Release is overlap-safe and audited (REQ-DDEDL-003)
 
 The app MUST release a case only with a mandatory `releaseReason`, and MUST

--- a/openspec/changes/e-discovery-legal-hold/tasks.md
+++ b/openspec/changes/e-discovery-legal-hold/tasks.md
@@ -1,11 +1,11 @@
 # Tasks: e-discovery-legal-hold
 
-<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 14.
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 15.
      Acceptance criteria are plain bullets, not checkboxes. -->
 
 ## 1. Register + seed data
 
-- [ ] 1.1 Add the `legalHoldCase` schema to the document register in `lib/Settings/docudesk_register.json` (REQ-DDEDL-001, REQ-DDEDL-020)
+- [ ] 1.1 Add the `legalHoldCase` schema to the document register in `lib/Settings/docudesk_register.json` (REQ-DDEDL-001)
   - Properties/enums per design.md D1; `hardValidation: true`; `x-openregister-lifecycle` with canonical `initial: active` and only `active → released`; `archive.defaultNominatie: bewaren`; no `x-openregister-archival`; register version bump.
 
 - [ ] 1.2 Seed one demo `woo-appeal` case (design.md Seed Data)
@@ -28,6 +28,9 @@
 - [ ] 2.5 File the OpenRegister issue for native multi-hold support (design.md D3 limitation)
   - Single hold slot per object forces the case-layer overlap ledger; link on tracking issue #234 with the adopt-and-delete plan.
 
+- [ ] 2.6 Implement the `files_lock` file-level freeze backstop (REQ-DDEDL-007)
+  - On activation place an app-scoped lock (`\OCP\Files\Lock\ILockManager`, `ILock::TYPE_APP`, owner = app id) on each in-scope document's file node; on release unlock overlap-safe (only when no other active case covers the file); probe `isLockProviderAvailable()` and record the backstop as unavailable when `files_lock` is absent (never claim file-level protection); per-object lock/unlock failures visible + retried like the record fan-out. OR record freeze stays primary.
+
 ## 3. Frontend
 
 - [ ] 3.1 Hold register page + case detail (REQ-DDEDL-005)
@@ -40,7 +43,7 @@
 
 - [ ] 4.1 PHPUnit unit tests — minimum 75% coverage on new code (ADR-009)
   - Run inside the container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`.
-  - Includes: overlap matrix (two cases/one record, release order permutations), partial fan-out failure visibility, incremental additions, release-reason guard, notification recipients, controller 403 for non-authority users, register-lint (lifecycle shape, bewaren config, no archival annotation), PUT-semantics survival of a non-changed case field.
+  - Includes: overlap matrix (two cases/one record, release order permutations) for BOTH the OR record hold and the files_lock file lock, partial fan-out failure visibility, file-lock backstop-unavailable degradation, incremental additions, release-reason guard, notification recipients, controller 403 for non-authority users, register-lint (lifecycle shape, bewaren config, no archival annotation), PUT-semantics survival of a non-changed case field.
 
 - [ ] 4.2 Playwright e2e `tests/e2e/workflows/e-discovery-legal-hold.spec.ts` covering the `@e2e`-referenced scenarios
   - Create case → fan-out status → held record excluded from vernietigingslijst (case name shown) → owner notification → blocked reason-less release → release; verify on the Postgres dev instance (port 8080); test through the UI.
@@ -49,7 +52,7 @@
   - Keys in English; NL legal vocabulary (bezwaar, bewaring, vrijgave) correct in the NL locale.
 
 - [ ] 4.4 Documentation `docs/features/e-discovery-legal-hold.md` with Playwright MCP screenshots (ADR-010)
-  - Covers the hold lifecycle, overlap behaviour, the ZyLAB non-goal boundary and the documented storage-layer limitation (NC file deletion vs record destruction).
+  - Covers the hold lifecycle, overlap behaviour, the ZyLAB non-goal boundary, and the two-layer freeze (OR record-destruction freeze as primary + `files_lock` file-deletion backstop, and its honest degradation when `files_lock` is absent).
 
 - [ ] 4.5 Gates + validation
   - `composer check:strict` zero new violations; `openspec validate e-discovery-legal-hold --strict` exits 0; fix pre-existing quality issues encountered on touched files.

--- a/openspec/changes/flow-operations/design.md
+++ b/openspec/changes/flow-operations/design.md
@@ -163,9 +163,14 @@ New register schema `flowOperationRun` (additive, union-merge):
 confidence / findings / producedFileId), `producedFileId`,
 `errorMessage`. Declared with `x-openregister-lifecycle` (canonical
 `initial: queued`; transitions queued→running→succeeded|failed, and
-queued→skipped) and `x-openregister-archival` retention `P1Y`
-(operational processing log, same Archiefwet cat. 1.2 rationale as
-`anonymizationResult` in the anonymization spec). Failure notification is
+queued→skipped) and `x-openregister-archival` TTL log-rotation retention in
+the OR-validated object shape (`{"retention": {"default": "<ISO-8601>"}}`).
+`flowOperationRun` is an operational processing-log schema — the only class
+for which `x-openregister-archival` is permitted (`archiefwet-retention-engine`
+REQ-DDARE-008); its retention duration ships as a `P1Y` **placeholder** and
+is a production-enablement apply-blocker (REQ-DDFLO-010): a real
+selectielijst-manager-approved value MUST replace it before apply, enforced
+by a register-lint. Failure notification is
 declared in the verified `x-openregister-notifications` dialect on this
 schema, recipient `{"kind": "field", "field": "ownerUserId"}` — a
 confirmed NC uid, satisfying the `docudesk-notifications` staff-safe
@@ -278,13 +283,23 @@ a clean install (nil-consequence fixture fileIds, self-evidently fake).
 5. Rollback: deleting a Flow rule stops triggering; the operations are
    inert without rules; no data migration to unwind.
 
+## Production-enablement (apply-blocker, REQ-DDFLO-010)
+
+The `flowOperationRun` `x-openregister-archival` retention ships as a `P1Y`
+placeholder for authoring only. Before this change is applied to production
+or marked done, it MUST be replaced with a **real selectielijst-manager-
+approved retention value** for this processing log — the runs carry
+`ownerUserId`, file names and per-type entity counts, so their lifespan is a
+records-appraisal decision, expressed in the OR-validated object shape. A
+PHPUnit register-lint fails the gate while the placeholder remains. This
+mirrors the `archiefwet-retention-engine` B4 posture (REQ-DDARE-009). The
+sibling processing-log schemas `entitySearchLog` (`entity-search`) and
+`classificationResult` (`inbound-auto-classification`) carry the same
+obligation in their own changes and are out of scope here.
+
 ## Open Questions
 
 - Should the anonymise operation optionally tag the file (e.g.
   `awaiting-review`) so a second Flow rule can chain on it? Deferred —
   chaining via tags is engine-idiomatic but needs a loop-safety review
   first.
-- Per-operation run-retention: is `P1Y` right for validation runs that
-  carry findings referenced by audits? Provisional `P1Y` pending
-  selectielijst-manager sign-off (same placeholder pattern as
-  `financialExtraction`).

--- a/openspec/changes/flow-operations/specs/flow-operations/spec.md
+++ b/openspec/changes/flow-operations/specs/flow-operations/spec.md
@@ -216,8 +216,14 @@ object (`operation`, `fileId`, `fileName`, `ownerUserId`, `status`
 `queued|running|succeeded|failed|skipped`, `statusReason`,
 `triggerEvent`, `startedAt`, `finishedAt`, `resultSummary`,
 `producedFileId`, `errorMessage`) with lifecycle declared via
-`x-openregister-lifecycle` (initial `queued`) and retention via
-`x-openregister-archival` (`P1Y`, operational processing log). A run
+`x-openregister-lifecycle` (initial `queued`) and TTL log-rotation retention
+via `x-openregister-archival` in the OR-validated object shape
+(`{"retention": {"default": "<ISO-8601>"}}`, never a bare string).
+`flowOperationRun` is an operational processing-log schema (the only class of
+schema for which `x-openregister-archival` is permitted — see
+`archiefwet-retention-engine` REQ-DDARE-008), but its retention duration is a
+placeholder pending a real selectielijst-approved value and MUST be resolved
+before apply (REQ-DDFLO-010). A run
 entering `failed` MUST notify the file owner via a Nextcloud notification
 declared in the verified `x-openregister-notifications` dialect with
 recipient `{"kind": "field", "field": "ownerUserId"}` (a confirmed NC
@@ -254,3 +260,35 @@ apps (workflow_ocr, workflow_pdf_converter) are found.
 - WHEN its category elements are read
 - THEN both `organization` and `workflow` are present
 - @e2e exclude static app-metadata declaration; covered by PHPUnit (tests/unit/AppInfo/InfoXmlTest.php)
+
+### Requirement: Real selectielijst-approved retention on flowOperationRun is a production-enablement apply-blocker (REQ-DDFLO-010)
+
+The `flowOperationRun` schema MUST NOT ship its `x-openregister-archival`
+retention as the `P1Y` placeholder to production. Before this change is
+applied or marked done, the retention MUST be set to a real
+selectielijst-manager-approved value for this processing log (the runs carry
+`ownerUserId`, file names and per-type entity counts, so their lifespan is a
+records-appraisal decision, not a developer guess), expressed in the
+OR-validated object shape (`{"retention": {"default": "<ISO-8601>"}}`). This
+is a hard apply-blocker with the same posture as
+`archiefwet-retention-engine` REQ-DDARE-009: a PHPUnit register-lint MUST
+fail while the retention is still the `P1Y` placeholder, so the change cannot
+be marked done with it. (The sibling processing-log schemas `entitySearchLog`
+and `classificationResult` carry the same obligation in their own changes —
+`entity-search` and `inbound-auto-classification` — and are out of scope for
+this delta.)
+
+#### Scenario: Placeholder retention blocks completion
+
+- GIVEN `flowOperationRun` still declares the `P1Y` placeholder retention
+- WHEN the change's apply/verify register-lint runs
+- THEN it fails with a production-enablement error requiring a real selectielijst-approved retention value
+- AND the change cannot be marked done until the approved value replaces the placeholder
+- @e2e exclude apply-time enablement gate with no UI surface — covered by a PHPUnit register-lint test (tests/unit/Settings/)
+
+#### Scenario: Approved retention satisfies the gate
+
+- GIVEN `flowOperationRun` declares a real selectielijst-approved retention in the validated object shape
+- WHEN the register-lint runs
+- THEN no placeholder remains and the gate passes
+- @e2e exclude apply-time enablement gate — covered by the same PHPUnit register-lint test

--- a/openspec/changes/flow-operations/tasks.md
+++ b/openspec/changes/flow-operations/tasks.md
@@ -1,12 +1,14 @@
 # Tasks: flow-operations
 
-<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 14.
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 16.
      Acceptance criteria are plain bullets, not checkboxes. -->
 
 ## 1. Register & seed data
 
-- [ ] 1.1 Add the `flowOperationRun` schema (operation, fileId, fileName, ownerUserId, status, statusReason, triggerEvent, startedAt, finishedAt, resultSummary, producedFileId, errorMessage) to `lib/Settings/docudesk_register.json` with `x-openregister-lifecycle` (initial `queued`), `x-openregister-archival` (`P1Y` placeholder pending selectielijst sign-off) and the failure-notification rule in the verified `x-openregister-notifications` dialect (recipient `kind:field ownerUserId`) — additive, union-merge only; re-validate JSON after merge (REQ-DDFLO-008)
+- [ ] 1.1 Add the `flowOperationRun` schema (operation, fileId, fileName, ownerUserId, status, statusReason, triggerEvent, startedAt, finishedAt, resultSummary, producedFileId, errorMessage) to `lib/Settings/docudesk_register.json` with `x-openregister-lifecycle` (initial `queued`), `x-openregister-archival` TTL retention in the OR-validated object shape (`{"retention": {"default": "<ISO-8601>"}}` — `P1Y` placeholder for authoring, see the apply-blocker task 1.3) and the failure-notification rule in the verified `x-openregister-notifications` dialect (recipient `kind:field ownerUserId`) — additive, union-merge only; re-validate JSON after merge (REQ-DDFLO-008)
 - [ ] 1.2 Seed the two `flowOperationRun` fixtures from design.md so the runs listing renders on a clean install
+- [ ] 1.3 APPLY-BLOCKER — replace the `P1Y` retention placeholder on `flowOperationRun` with a real selectielijst-manager-approved retention value before apply/done (REQ-DDFLO-010)
+  - Obtain the approved processing-log retention from the responsible selectielijst-manager (records-appraisal decision — the runs carry `ownerUserId`, file names and per-type entity counts); express it in the validated object shape; add a PHPUnit register-lint that FAILS while `P1Y` remains so the gate enforces it (same production-enablement posture as archiefwet B4 / REQ-DDARE-009). Note only: `entitySearchLog` and `classificationResult` carry the same obligation in `entity-search` and `inbound-auto-classification` — out of scope here.
 
 ## 2. Backend
 
@@ -32,4 +34,4 @@
 - [ ] 4.2 Playwright spec `tests/e2e/spec-coverage/flow-operations.spec.ts` for the `@e2e`-referenced scenarios
 - [ ] 4.3 i18n EN + NL for all new UI strings (keys in English); nldesign theme check (ADR-005, ADR-003)
 - [ ] 4.4 Docs: `docs/features/flow-operations.md` with Playwright screenshots (rule builder with a DocuDesk operation, runs listing, failure notification) (ADR-010)
-- [ ] 4.5 Validate: `openspec validate flow-operations --strict` passes; hydra gates green
+- [ ] 4.5 Validate: `openspec validate flow-operations --strict` passes; the REQ-DDFLO-010 register-lint passes (no `P1Y` placeholder remains); hydra gates green

--- a/openspec/changes/guided-document-wizard/design.md
+++ b/openspec/changes/guided-document-wizard/design.md
@@ -76,10 +76,14 @@ extended by Wave-1 in the same release train) is not touched twice; lookup is
 `GET /api/templates/{id}/wizard` (a filtered OR query on
 `templateId + active`). **Relationship note (canonical-spec touch
 discipline):** this adds a schema to the templates register but does not
-modify the `template`/`templateVersion` data model, so no `template-management`
-delta is needed; the new schema is specified in this change's own capability
-spec, and the templates-register version bump is additive on top of Wave-1's
-`2.1.0`.
+modify the `template`/`templateVersion` data model, so no requirement-level
+`template-management` delta is needed. Per decision C3 (single source of
+truth) the new `wizardDefinition` schema **is** registered in the canonical
+`openspec/specs/template-management/spec.md` header — its "Templates Register
+Schemas" listing and `**OpenSpec changes**` list — while the full
+requirements (question model, validation, translation, prefill, runner) remain
+in this change's own capability spec (REQ-DDGDW-*). The templates-register
+version bump is additive on top of Wave-1's `2.1.0`.
 
 ### D2 — Question model: four types, dotted `mapsTo`, one-level conditions
 
@@ -214,7 +218,12 @@ behaviour extensions are used or needed.
 No custom database tables. Register import stays
 `ConfigurationService::importFromApp()` on boot; templates register bump is
 additive on top of Wave-1 (`2.1.0` → `2.2.0`), document register `2.2.0` →
-`2.3.0`.
+`2.3.0` (`2.2.0` verified current at HEAD). **Apply order (pinned):** this
+change applies first (document register → `2.3.0`); the co-scheduled
+`multi-format-output` change applies after it (document register `2.3.0` →
+`2.4.0`, adding `docx` + `outputs`). The two bumps touch disjoint additive
+properties of `generatedDocument`; register import is idempotent. No
+rebase-on-whichever-lands-second.
 
 ## Seed Data
 

--- a/openspec/changes/guided-document-wizard/proposal.md
+++ b/openspec/changes/guided-document-wizard/proposal.md
@@ -96,7 +96,11 @@ extension), local-only, and documented in design.md Security.
 - **Register**: `lib/Settings/docudesk_register.json` — new `wizardDefinition`
   schema in the `templates` register (version bump, additive on top of
   Wave-1's `2.1.0`); `generatedDocument` schema gains optional
-  `wizardContext` (document register bump `2.2.0` → `2.3.0`, additive).
+  `wizardContext` (document register bump `2.2.0` → `2.3.0`, additive; `2.2.0`
+  is the verified current version at HEAD). Apply order is pinned: this change
+  applies **first** and takes the document register to `2.3.0`; the
+  co-scheduled `multi-format-output` change applies **after** it and bumps
+  `2.3.0` → `2.4.0` — no rebase-on-whichever-lands-second.
 - **Frontend**: wizard authoring panel on `TemplateDetail.vue`, new wizard
   runner view + register-object picker using `@conduction/nextcloud-vue`
   components (ADR-012); "Generate with wizard" entry points on the template

--- a/openspec/changes/guided-document-wizard/tasks.md
+++ b/openspec/changes/guided-document-wizard/tasks.md
@@ -5,7 +5,7 @@
 
 ## 1. Register & data model
 
-- [ ] 1.1 Extend `lib/Settings/docudesk_register.json`: new `wizardDefinition` schema in the `templates` register (name, description, namespace, templateId, active, questions[] per design.md D2); `generatedDocument` gains optional `wizardContext` object; bump templates register (additive on top of Wave-1 `2.1.0` → `2.2.0`) and document register (`2.2.0` → `2.3.0`)
+- [ ] 1.1 Extend `lib/Settings/docudesk_register.json`: new `wizardDefinition` schema in the `templates` register (name, description, namespace, templateId, active, questions[] per design.md D2); `generatedDocument` gains optional `wizardContext` object; bump templates register (additive on top of Wave-1 `2.1.0` → `2.2.0`) and document register (`2.2.0` → `2.3.0`). Apply order pinned: this change FIRST (document → `2.3.0`), `multi-format-output` SECOND (document `2.3.0` → `2.4.0`)
   - All new properties optional except `wizardDefinition` required `name`/`templateId`/`questions`; schema refs by slug
   - `tests/validate-manifest.js` and register import on boot both pass
 

--- a/openspec/changes/image-redaction/design.md
+++ b/openspec/changes/image-redaction/design.md
@@ -2,8 +2,11 @@
 
 ## Context
 
-Verified at HEAD (worktree `spec/market-gap-wave2-2026-07`, includes the nine
-wave-1 changes):
+Verified at merged HEAD (`development`, includes the nine wave-1 changes and
+Robert's PR #314: KENTEKEN entity type, ODT anonymisation, PDF entity-review
+viewer, grondslag/prohibition guards, eml assembly). Robert's baseline covers
+entity-type and office-format anonymisation; the pixel/signature/embedded-image
+gap below remains:
 
 - OR `DocumentProcessingHandler` (lib/Service/File/) dispatches
   `replaceWords()` by extension/MIME: `pdf` → `PdfTextReplacer` (+
@@ -240,11 +243,14 @@ a clean install.
 
 ## Open Questions
 
-- Should embedded-image extraction for born-digital PDFs ship in v1, or only
-  image files + scanned pages (the tender-relevant 90%)? Provisional: v1
-  ships image files + scanned pages; embedded-XObject extraction is task-
-  gated and may slip to a fast-follow with its own flag reason
-  (`embedded_images_unsupported`).
+- Embedded-image extraction for born-digital PDFs: **RESOLVED — in v1**
+  (decision D1). All three submission sources ship in the first release:
+  image-MIME files, scanned-PDF page rasters, and images extracted from image
+  XObjects of born-digital PDFs (`Pdfa3ConversionService` already handles the
+  XObject-wrapping direction; the extraction direction reuses the same fpdi
+  parsing Robert added). Only if a specific PDF's XObject cannot be decoded
+  does the file flag `imageDetectionSkipped` reason `embedded_images_unsupported`
+  — a per-file honest-degradation reason, not a whole-feature deferral.
 - Minimum confidence for auto-including SIGNATURE regions (signatures have
   no text to eyeball) — provisional: same threshold mechanism as other
   entities; the workbench preview overlay IS the review affordance.

--- a/openspec/changes/image-redaction/proposal.md
+++ b/openspec/changes/image-redaction/proposal.md
@@ -6,9 +6,17 @@ kind: code
 
 ## Why
 
-DocuDesk can now *detect* PII on scans (wave-1 `ocr-trigger-surface` feeds
-OCR-recovered text into OpenRegister entity detection) but it cannot *remove*
-PII from pixels. Verified at HEAD:
+Robert's project branch (merged into `development`, PR #314) is the new
+baseline: it landed the `KENTEKEN` entity type (`src/services/entityTypes.js`,
+`GrondslagProposalService`), ODT anonymisation (`AnonymizationService`,
+`LibreOfficeHeadlessBackend`/`PhpWordBackend`), the PDF entity-review viewer,
+grondslag/prohibition guards and eml assembly. This change therefore does NOT
+re-spec entity-type coverage or ODT/office anonymisation — those ship. It
+scopes to the gap Robert's branch did **not** close: DocuDesk can now *detect*
+PII on scans (wave-1 `ocr-trigger-surface` feeds OCR-recovered text into
+OpenRegister entity detection) but it still cannot *remove* PII from pixels,
+detect **handwritten signatures**, or reach images **embedded** in born-digital
+PDFs. Verified at HEAD:
 
 - OpenRegister's `DocumentProcessingHandler::replaceWords()` dispatches PDF →
   `PdfTextReplacer` (text-operator replacement), DOCX/ODT → sanitize +

--- a/openspec/changes/image-redaction/specs/image-redaction/spec.md
+++ b/openspec/changes/image-redaction/specs/image-redaction/spec.md
@@ -23,9 +23,13 @@ image-detection seam on the anonymisation backend chain (Presidio image mode
 as the first supported backend), returning detected entities typed by the
 shared taxonomy (PERSON, ORGANIZATION, EMAIL, IBAN, …, SIGNATURE) with
 per-page bounding boxes normalised to [0..1]. DocuDesk MUST submit: (a) files
-with an image MIME type, and (b) page rasters of scanned PDFs (rasterised via
+with an image MIME type, (b) page rasters of scanned PDFs (rasterised via
 the existing Imagick path at the configured OCR DPI, one shared raster per
-page for detection and burn). DocuDesk MUST NOT implement or embed its own
+page for detection and burn), and (c) images extracted from the image
+XObjects of born-digital PDFs (in v1 — decision D1). When a specific embedded
+XObject cannot be decoded, that file MUST flag `imageDetectionSkipped` reason
+`embedded_images_unsupported` (per-file honest degradation), never a silent
+skip of the whole document. DocuDesk MUST NOT implement or embed its own
 image-detection engine (ADR-017/ADR-022) and MUST NOT send image content to
 any endpoint other than the OpenRegister seam (processing stays local,
 AVG/EDPB posture).
@@ -44,6 +48,22 @@ AVG/EDPB posture).
 - THEN the file bytes are submitted to the OpenRegister image seam without rasterisation
 - AND detected entities carry boxes without a page number
 - @e2e exclude backend submission plumbing — covered by PHPUnit (tests/unit/Service/ImageRedactionServiceTest.php)
+
+#### Scenario: Born-digital PDF with an embedded image is reached
+
+- GIVEN a born-digital PDF whose page carries a photo as an image XObject (no scanned page raster) and a printed BSN inside that photo
+- WHEN extraction runs with an image-capable backend
+- THEN the embedded image is extracted and submitted to the OpenRegister seam
+- AND the BSN entity is returned with `origin: "image"` and a bounding box referencing that page
+- @e2e exclude embedded-XObject extraction path — covered by PHPUnit (tests/unit/Service/ImageRedactionServiceTest.php)
+
+#### Scenario: Undecodable embedded image flags the file honestly
+
+- GIVEN a born-digital PDF whose embedded image XObject cannot be decoded
+- WHEN extraction runs
+- THEN that file carries `imageDetectionSkipped` with reason `embedded_images_unsupported`
+- AND the review workbench shows the image-not-scanned warning for the document
+- @e2e exclude degradation-reason branch — covered by PHPUnit (tests/unit/Service/ImageRedactionServiceTest.php)
 
 ### Requirement: Missing image capability degrades fail-flagged, never fail-silent (REQ-DDIMR-002)
 

--- a/openspec/changes/image-redaction/tasks.md
+++ b/openspec/changes/image-redaction/tasks.md
@@ -15,8 +15,9 @@
 
 ## 3. Backend
 
-- [ ] 3.1 New `ImageRedactionService`: image submission (image MIME as-is; scanned-PDF pages via the existing Imagick raster path at OCR DPI, one shared raster per page), box normalisation, container reassembly after burn, irreversibility verification (REQ-DDIMR-001, REQ-DDIMR-004)
+- [ ] 3.1 New `ImageRedactionService`: image submission (image MIME as-is; scanned-PDF pages via the existing Imagick raster path at OCR DPI, one shared raster per page; born-digital embedded image XObjects extracted via fpdi/tcpdf — D1, v1), box normalisation, container reassembly after burn, irreversibility verification (REQ-DDIMR-001, REQ-DDIMR-004)
   - Verification rejects overlay-style output and any output still containing the original image stream.
+  - Undecodable embedded XObject flags `imageDetectionSkipped` reason `embedded_images_unsupported` (per-file, not a whole-document skip).
 - [ ] 3.2 Extend `AnonymizationService::extractAndDetectEntities()` with the image-detection leg after the wave-1 OCR fallback; attach `origin`/`boxes` additively; route image entities through proposals/policy-match/risk unchanged (REQ-DDIMR-007)
 - [ ] 3.3 Fail-flagged degradation: `imageDetectionSkipped` reasons on extract, `imageRedactionPending` on anonymise, derived from the OR backend state (`supportsImages`) and seam availability (REQ-DDIMR-002)
 - [ ] 3.4 Burn orchestration in the anonymise commit before the `outputFormat` conversion gate, composing with OR text replacement; burned-region text-layer/chunk redaction; honest `burnedRegionCount` from performed burns only (REQ-DDIMR-004, REQ-DDIMR-006, REQ-DDIMR-008)

--- a/openspec/changes/mcp-generation-tools/design.md
+++ b/openspec/changes/mcp-generation-tools/design.md
@@ -132,19 +132,22 @@ detection run and carry an `mcp` attribution the same way
 `triggeredBy`). No DocuDesk-side grant enforcement code — duplicating the
 authz path is the ADR-022 violation the fleet keeps re-learning.
 
-### D6 — ScannableServices reconciliation (coordination note)
+### D6 — ScannableServices reconciliation (already reconciled per F4)
 
 `DocudeskScannableServices::getScannableServices()` becomes
 `[CorrespondenceService::class, FileListingService::class,
-AnonymizationService::class]`. The in-flight `docudesk-mcp-adoption`
-delta words the list as exactly `[CorrespondenceService::class]` and its
-narrative says "exactly one curated tool"; with both changes in-flight,
-whichever archives second amends that wording (flagged in both changes'
-task lists via this note; also recorded as a deferred question). None of
+AnonymizationService::class]`. This wording collision with
+`docudesk-mcp-adoption` has been **reconciled in the build phase (decision
+F4)**: the adoption delta no longer pins the list as exactly
+`[CorrespondenceService::class]` — it now requires the list to *include*
+`CorrespondenceService::class` and explicitly permits sibling changes (this
+one) to add further curated services via the same scannable-services path,
+with `generateCorrespondence` remaining the sole *generation* tool. None of
 the adoption change's testable guarantees (16 derived read tools, the
 generate tool's registration and hints, every refusal) is weakened — the
-"exactly one write" statement generalises to "every write is a curated,
-fully-hinted, gate-safe tool; derived write verbs remain zero".
+former "exactly one write" narrative is now "every write is a curated,
+fully-hinted, gate-safe tool; derived write verbs remain zero". No
+archive-time amendment of the adoption delta is required.
 
 ### D7 — Declarative vs imperative (ADR-031) and ADR-001/ADR-011
 
@@ -194,8 +197,10 @@ seeded sample documents that already ship
   this change is applied first by mistake, the ScannableServices class
   does not exist yet — the task list makes creating/extending it
   explicitly conditional on the adoption change's artifact.
-- [Two in-flight changes touching one wording] → D6 coordination note +
-  deferred question; mechanical, not semantic, conflict.
+- [Two in-flight changes touching one wording] → reconciled in the build
+  phase (decision F4): the adoption delta's wording now permits this
+  extension (D6); mechanical, not semantic, conflict — resolved, no
+  archive-time amendment.
 
 ## Migration Plan
 

--- a/openspec/changes/mcp-generation-tools/proposal.md
+++ b/openspec/changes/mcp-generation-tools/proposal.md
@@ -24,11 +24,13 @@ The in-flight sibling change **`docudesk-mcp-adoption`** (read at HEAD
 `9cc14407`, proposal/design/specs/tasks complete) establishes DocuDesk's
 baseline: 8 read-only schemas via `x-openregister-mcp`
 (`docudesk.template.search|get`, `docudesk.generatedDocument.search|get`,
-`docudesk.signingRequest.search|get`, ...), exactly one curated write
-tool `docudesk.generateCorrespondence`, and standing refusals (no
-signing, no batch mail-merge, no `publicationConsent`/
-`publicationProhibition`/`anonymizationLink`/signature-material
-exposure). This change EXTENDS that surface and contradicts none of it.
+`docudesk.signingRequest.search|get`, ...), the curated generation write
+tool `docudesk.generateCorrespondence` (its sole *generation* tool, which
+the adoption delta explicitly permits sibling changes to extend, per
+decision F4), and standing refusals (no signing, no batch mail-merge, no
+`publicationConsent`/`publicationProhibition`/`anonymizationLink`/
+signature-material exposure). This change EXTENDS that surface with two
+further curated tools and contradicts none of it.
 
 Measured against the market's four assistant-facing document operations
 (the Carbone MCP feature set: generate document, get status, list
@@ -90,13 +92,13 @@ templates — plus DocuDesk's differentiator, anonymisation):
 
 ### Modified Capabilities
 
-- None in this repo's canonical specs. The in-flight
-  `docudesk-mcp-adoption` delta describes `DocudeskScannableServices` as
-  returning `[CorrespondenceService::class]`; this change extends that
-  list (adding the services carrying the two new curated tools). Both
-  changes are in-flight, so the reconciliation is a coordination note in
-  design.md (and a flagged wording amendment for whichever archives
-  second) — no landed requirement moves.
+- None in this repo's canonical specs. The `docudesk-mcp-adoption` delta
+  now requires `DocudeskScannableServices` to *include*
+  `CorrespondenceService::class` and explicitly permits sibling changes to
+  extend the list; this change adds the services carrying the two new
+  curated tools. The wording collision was reconciled in the build phase
+  (decision F4) directly in the adoption delta — no archive-time amendment
+  and no landed requirement move.
 
 ## Impact
 

--- a/openspec/changes/mcp-generation-tools/tasks.md
+++ b/openspec/changes/mcp-generation-tools/tasks.md
@@ -10,7 +10,7 @@
 - [ ] 1.3 Add `AnonymizationService::anonymizeViaAgent(int $fileId): array` — fileId-only signature; intake pipeline via `extractAndDetectEntities()`; identical checked-gate + prohibition-gate rules as every surface; `ProhibitionGateException` mapped to a refused result; `mcp` attribution on the run — with `#[McpTool(name: 'anonymizeDocument', scope: 'create', readOnlyHint: false, destructiveHint: false, idempotentHint: false)]` (REQ-DDMGT-003, REQ-DDMGT-005)
   - Counts-only response shape: `{status, entityCounts, reviewRequired, refusedReason?}` — never entity values/placeholder maps/text (REQ-DDMGT-004).
 - [ ] 1.4 Extend `lib/Mcp/DocudeskScannableServices.php` to `[CorrespondenceService::class, FileListingService::class, AnonymizationService::class]` (REQ-DDMGT-002..003)
-  - Coordination (design.md D6): whichever of this change / `docudesk-mcp-adoption` archives second amends the adoption delta's `[CorrespondenceService::class]` wording and its "exactly one curated tool" narrative.
+  - Coordination (design.md D6): the wording collision is already reconciled (decision F4) — the `docudesk-mcp-adoption` delta now requires the list to *include* `CorrespondenceService::class` and permits this change to extend it, so no archive-time amendment is needed; just verify the extended list still passes OR's scanner and every adoption refusal holds.
 
 ## 2. Quality
 

--- a/openspec/changes/multi-format-output/design.md
+++ b/openspec/changes/multi-format-output/design.md
@@ -65,7 +65,7 @@ intermediate:
 
 | Target | From HTML (twig) | From filled DOCX (office) |
 |---|---|---|
-| `html` | passthrough | not offered (no faithful DOCX→HTML path in the cascade) |
+| `html` | passthrough | shared `DocxToHtmlConverter` (LO headless DOCX→HTML, D3) — full format parity (C1) |
 | `pdf` | `PdfService::renderPdf()` (mPDF) | `PdfConversionService::convertToPdf()` (cascade) |
 | `odf` | LO headless HTML→ODT (existing `convertToOdf()`) | LO headless DOCX→ODT |
 | `docx` | shared `HtmlToDocxConverter` (LO headless, D3) | the filled DOCX itself (true editable passthrough) |
@@ -88,16 +88,34 @@ sharing — the DOCX must be shareable to the buurgemeente directly from
 Nextcloud, which is the point) and multipart responses (poor client
 support). A caller wanting one file uses `options.format`.
 
-### D3 — Promote `CorrespondenceService`'s DOCX conversion to a shared converter (ADR-011)
+### D3 — Shared local office converters (ADR-011)
 
-Extract the existing private HTML→DOCX LibreOffice invocation
-(`CorrespondenceService::produceOutput()` `docx` case, verified: `soffice
---headless --convert-to docx`) into `lib/Service/Conversion/
-HtmlToDocxConverter` (same serialization lock discipline as the cascade's LO
-backend — pdf-conversion's "LibreOffice headless invocations MUST be
-serialised" applies to every soffice caller). `CorrespondenceService` and
-`DocumentService` both consume it; correspondence behaviour is unchanged
-(pinned by its existing tests). No second DOCX implementation is written.
+**HTML→DOCX (docx output).** Extract the existing private HTML→DOCX
+LibreOffice invocation (`CorrespondenceService::produceOutput()` `docx` case,
+verified: `soffice --headless --convert-to docx`) into
+`lib/Service/Conversion/HtmlToDocxConverter` (same serialization lock
+discipline as the cascade's LO backend — pdf-conversion's "LibreOffice
+headless invocations MUST be serialised" applies to every soffice caller).
+`CorrespondenceService` and `DocumentService` both consume it; correspondence
+behaviour is unchanged (pinned by its existing tests). No second DOCX
+implementation is written.
+
+**DOCX→HTML (office html output — C1).** Verified at HEAD: the cascade's
+`LibreOfficeHeadlessBackend::convert()` hard-codes a PDF target
+(`--convert-to pdf:writer_pdf_Export:UseTaggedPDF=true,SelectPdfVersion=2`,
+emits `.pdf`) and there is **no** DOCX→HTML path anywhere in
+`lib/Service/Conversion/` — so office (DOCX/ODT) templates previously had no
+HTML output (the D1 table's old "not offered" cell). The earlier decision that
+office HTML was "not offered" is now reversed: a new
+`lib/Service/Conversion/DocxToHtmlConverter` runs `soffice --headless
+--convert-to html` (LibreOffice's `HTML (StarWriter)` export filter) on the
+filled DOCX, giving office templates full format parity. It reuses the same
+soffice serialization lock, temp-dir hygiene (0700 dirs, `basename()` on the
+source name, unlink after use, array-form `proc_open` — no shell-interpolated
+user input) and timeout discipline the cascade's LO backend already enforces.
+Because it depends on LibreOffice, office `html` is a
+LibreOffice-availability-gated format in the matrix (D4), exactly like `odf`
+and `docx`. `twig` `html` stays a zero-cost passthrough.
 
 ### D4 — Capability introspection on the cascade + a `FormatMatrixService`
 
@@ -108,12 +126,16 @@ consumers and tests share fixtures). On top of it, `FormatMatrixService`
 computes:
 
 - **instance matrix** (`GET /api/documents/formats`): for each output format,
-  `{available: bool, reason?: string}` — `pdf`/`html` always true (mPDF is a
-  composer dep), `odf`/`docx` true iff an LO-capable backend reports
-  available.
+  `{available: bool, reason?: string}` — `pdf` always true (mPDF is a composer
+  dep), `html` from a `twig` render always true (passthrough), and the
+  LibreOffice-gated formats `odf`/`docx`/**office `html`** true iff an
+  LO-capable backend reports available.
 - **template matrix** (`GET /api/templates/{id}/formats`): instance matrix
-  intersected with the template's `templateType` row of the D1 table (e.g.
-  `html` absent for office templates).
+  intersected with the template's `templateType` row of the D1 table. For a
+  `twig` template `html` is always available (passthrough); for an `office`
+  template `html` is available iff a LibreOffice backend is available
+  (DOCX→HTML, D3/C1) — every format is now reachable for both template types
+  subject to backend availability.
 
 The matrix is computed live per request (availability can change when
 LibreOffice is installed/removed); responses carry `Cache-Control: no-store`.
@@ -127,10 +149,14 @@ status, error?}`) and its `format` enum gains `docx`. For multi-format jobs
 one `generatedDocument` object is written per render (not per format) with
 `format` set to the first requested format (back-compat for consumers that
 read the scalar) and `outputs` carrying the full truth. Single-format
-generations stay exactly as today (no `outputs`). Register bump is additive;
-this wave also bumps the document register in `guided-document-wizard` —
-whichever change lands second rebases its version number (both additive, no
-conflict; noted in tasks).
+generations stay exactly as today (no `outputs`). The register bump is
+additive and the apply order is **pinned**, not "whichever lands second":
+`guided-document-wizard` applies first and bumps the document register
+`2.2.0` → `2.3.0` (its own additive `wizardContext` on `generatedDocument`);
+this change applies second and bumps `2.3.0` → `2.4.0` (`docx` enum value +
+`outputs` array). `2.2.0` is the verified current version in
+`lib/Settings/docudesk_register.json` at HEAD. Register import is idempotent;
+the two bumps touch disjoint properties of the same schema.
 
 ### D6 — Flows read the matrix
 
@@ -199,12 +225,18 @@ dossier data and asserts both files land in the output folder.
   *editing*, the PDF remains the presentation artifact; office templates get
   native-fidelity DOCX (the filled source). The docs state which path gives
   which fidelity.
+- [Office HTML via DOCX→HTML (C1) is a web-oriented, layout-approximate export
+  — LO's HTML writer flattens print layout] → accepted: office `html` is for
+  web display / archival plain-content use, not print fidelity; the PDF/DOCX
+  paths remain the presentation/editable artifacts. The docs state which path
+  gives which fidelity, mirroring the twig-DOCX note above.
 - [Multi-format jobs multiply soffice work under the serialization lock] →
   formats convert sequentially per job; `odf`+`docx` from one HTML means two
   LO calls — bounded by the formats list length (≤4 valid formats), and bulk
   jobs already queue.
-- [Two changes bump the document register this wave] → additive properties,
-  explicit rebase note in tasks; register import is idempotent.
+- [Two changes bump the document register this wave] → apply order is pinned
+  (wizard first `2.2.0`→`2.3.0`, this change second `2.3.0`→`2.4.0`); disjoint
+  additive properties; register import is idempotent. No rebase-on-land-order.
 - [Manifest response is a new shape for `api/documents/generate`] → gated
   entirely behind `options.formats`; existing clients cannot receive it
   accidentally.

--- a/openspec/changes/multi-format-output/proposal.md
+++ b/openspec/changes/multi-format-output/proposal.md
@@ -46,6 +46,16 @@ Priority **could-have**.
   out of it) and as the filled source DOCX (true editable passthrough) for
   office templates (Wave-1 REQ-DDOTA-003). This is the editable-DOCX delivery
   for inter-municipal exchange.
+- **Office-template HTML output (full format parity)**: office (DOCX/ODT)
+  templates can now also produce `html`, via LibreOffice headless DOCX→HTML
+  (new `DocxToHtmlConverter`, `soffice --convert-to html`, sharing the
+  cascade's soffice serialization lock and temp-dir hygiene). Verified at
+  HEAD: the conversion cascade (`lib/Service/Conversion/`) hard-codes a PDF
+  target (`LibreOfficeHeadlessBackend` → `--convert-to pdf:writer_pdf_Export…`)
+  and offers **no** DOCX→HTML path today — office templates previously had no
+  HTML output at all. With this converter every output format
+  (`pdf`/`odf`/`docx`/`html`) is reachable for both `twig` and `office`
+  templates, subject to live backend availability.
 - **Format-capability matrix**: `GET /api/documents/formats` (instance-level)
   and `GET /api/templates/{id}/formats` (per template) report which output
   formats are currently producible and why not (e.g. `odf`/`docx` unavailable
@@ -79,8 +89,10 @@ local (LibreOffice headless, mPDF — no external API calls).
 
 - `document-creatie-sjablonen`: output-format support (REQ-DCS-03 family) is
   extended — `docx` becomes a valid generation format (editable delivery),
-  `options.formats` produces multiple outputs from one render, and the
-  `generatedDocument` audit object records every produced output.
+  `html` becomes a valid output format for `office` templates too (LibreOffice
+  DOCX→HTML — full format parity), `options.formats` produces multiple outputs
+  from one render, and the `generatedDocument` audit object records every
+  produced output.
 - `pdf-conversion`: the conversion cascade gains a non-throwing capability
   introspection surface (per-backend availability + supported conversions)
   that powers the format matrix — today that report only exists inside
@@ -91,13 +103,17 @@ local (LibreOffice headless, mPDF — no external API calls).
 - **Backend**: `DocumentService` — `formats` handling, render-once/convert-N
   pipeline, DOCX production (shared `HtmlToDocxConverter` extracted from
   `CorrespondenceService`'s private implementation — ADR-011 reuse instead of
-  a second copy); `PdfConversionService` — public `getCapabilities()`;
-  new `FormatMatrixService`; `DocumentController` manifest response;
-  `CorrespondenceService` delegates its DOCX conversion to the shared
+  a second copy) and office HTML production (new `DocxToHtmlConverter`,
+  LibreOffice headless DOCX→HTML); `PdfConversionService` — public
+  `getCapabilities()`; new `FormatMatrixService`; `DocumentController` manifest
+  response; `CorrespondenceService` delegates its DOCX conversion to the shared
   converter (behaviour unchanged).
 - **Register**: `generatedDocument` schema — `format` enum gains `docx`,
-  new optional `outputs` array (document register bump, additive; coordinates
-  with `guided-document-wizard`'s bump of the same register in this wave).
+  new optional `outputs` array (document register bump `2.3.0` → `2.4.0`,
+  additive). Apply order is fixed: `guided-document-wizard` applies **first**
+  and bumps the document register `2.2.0` → `2.3.0`; this change applies
+  **after** it and bumps `2.3.0` → `2.4.0` (both additive; no
+  rebase-on-whichever-lands-second — the order is pinned in tasks/design).
 - **Routes**: `GET api/documents/formats`, `GET api/templates/{id}/formats`
   (`appinfo/routes.php`).
 - **Frontend**: format checkboxes/disabled states driven by the matrix in
@@ -128,6 +144,9 @@ local (LibreOffice headless, mPDF — no external API calls).
 - One `POST /api/documents/generate` with `options.formats: ["pdf", "docx"]`
   returns a manifest referencing a PDF and an editable DOCX produced from one
   render pass; the DOCX opens editable in Word/LibreOffice.
+- An `office` template generates `html` output via LibreOffice DOCX→HTML, and
+  its per-template matrix offers `html` when a LibreOffice backend is
+  available (full format parity with `twig` templates).
 - Requests with the existing single `options.format` are byte-identical to
   today's behaviour.
 - With LibreOffice unavailable, the matrix reports `docx`/`odf` unavailable

--- a/openspec/changes/multi-format-output/specs/document-creatie-sjablonen/spec.md
+++ b/openspec/changes/multi-format-output/specs/document-creatie-sjablonen/spec.md
@@ -8,9 +8,11 @@ status: proposed
 
 Extend output-format support (REQ-DCS-03) and the generation API/audit
 (REQ-DCS-07, DCS-072): `docx` becomes a first-class, genuinely editable
-generation format; `options.formats` produces multiple outputs from a single
-render pass; and the `generatedDocument` audit object records every produced
-output. Existing single-format behaviour is unchanged; this delta only ADDs.
+generation format; `html` becomes an output format for `office` templates too
+(LibreOffice DOCX→HTML — full format parity, REQ-DDMFO-007); `options.formats`
+produces multiple outputs from a single render pass; and the
+`generatedDocument` audit object records every produced output. Existing
+single-format behaviour is unchanged; this delta only ADDs.
 
 ## ADDED Requirements
 
@@ -74,6 +76,35 @@ extraction.
 - WHEN `CorrespondenceService` produces `docx` output through the shared converter
 - THEN the produced content and error behaviour match the pre-extraction implementation
 - @e2e exclude refactor-equivalence pin; covered by the existing PHPUnit correspondence suite (tests/unit/Service/CorrespondenceServiceTest.php)
+
+### Requirement: Office templates produce HTML output via LibreOffice DOCX→HTML (REQ-DDMFO-007)
+
+The document generation path MUST accept `html` as an output format for
+`office` templates (full format parity with `twig` templates, which already
+produce `html` as a render passthrough). Office HTML MUST be produced from the
+filled DOCX intermediate via a shared local LibreOffice DOCX→HTML converter
+(`soffice --headless --convert-to html`), which MUST reuse the cascade's
+soffice serialization lock, temp-dir hygiene, and timeout discipline (exactly
+one soffice invocation pattern in the app). Because it depends on LibreOffice,
+office `html` MUST be gated on LibreOffice-backend availability in the matrix
+(REQ-DDMFO-002) and, when no capable backend is available, a forced office
+`html` generation MUST fail with HTTP 503 carrying the matrix reason (no
+silent substitution). `twig` `html` output MUST remain the existing render
+passthrough, unchanged.
+
+#### Scenario: Office template delivers HTML via DOCX→HTML
+
+- GIVEN a seeded office template on an instance with a working LibreOffice backend
+- WHEN `POST /api/documents/generate` is called for that template with format `html`
+- THEN the output is HTML derived from the filled DOCX and contains the resolved data
+- @e2e tests/e2e/spec-coverage/multi-format-output.spec.ts
+
+#### Scenario: Office html fails 503 when LibreOffice is unavailable
+
+- GIVEN a seeded office template on an instance without a working LibreOffice backend
+- WHEN an `html` generation is forced for that template
+- THEN the request fails HTTP 503 with the same reason the matrix reports and no other-format file is produced
+- @e2e exclude requires an instance-level LibreOffice teardown — covered by PHPUnit (tests/unit/Service/DocumentServiceTest.php::testOfficeHtmlRequiresLibreOffice)
 
 ### Requirement: Every produced output is recorded on the generation audit object (REQ-DDMFO-006)
 

--- a/openspec/changes/multi-format-output/specs/multi-format-output/spec.md
+++ b/openspec/changes/multi-format-output/specs/multi-format-output/spec.md
@@ -10,7 +10,7 @@ Format-capability honesty around document generation: a per-instance and
 per-template output-format matrix computed from live conversion-backend
 availability, surfaced to the generation and correspondence flows so clerks
 choose from what is actually producible. The multi-format render contract
-itself extends `document-creatie-sjablonen` (REQ-DDMFO-001/003/006, this
+itself extends `document-creatie-sjablonen` (REQ-DDMFO-001/003/006/007, this
 change) and the backend introspection extends `pdf-conversion`
 (REQ-DDMFO-005, this change). Evidence: Docmosis/Carbone/Fluent simultaneous
 renders (competitor theme #5); municipalities exchange editable DOCX
@@ -24,14 +24,18 @@ The app MUST expose a format-capability matrix at `GET
 /api/documents/formats` (instance level) and `GET /api/templates/{id}/formats`
 (template level), reporting for each output format `{available: bool,
 reason?: string}`. The matrix MUST be computed from live conversion-backend
-availability (LibreOffice-dependent formats `odf`/`docx` are available iff a
-capable backend reports available) intersected, at template level, with the
-formats the template's `templateType` supports (`html` MUST NOT be offered
-for `office` templates). Matrix responses MUST be authenticated, read-only,
-and non-cacheable (`Cache-Control: no-store`). Generating a format the matrix
-reports unavailable MUST fail with HTTP 503 carrying the **same** reason
-string the matrix reports — the app MUST NOT silently substitute another
-format.
+availability: the LibreOffice-dependent formats `odf`, `docx`, and — for
+`office` templates — `html` (produced via DOCX→HTML, REQ-DDMFO-007) are
+available iff a capable LibreOffice backend reports available. At template
+level the instance matrix MUST be intersected with the formats the template's
+`templateType` supports; every output format (`pdf`/`odf`/`docx`/`html`) MUST
+be reachable for both `twig` and `office` templates subject to backend
+availability (`html` for a `twig` template is an always-available passthrough,
+`html` for an `office` template is LibreOffice-gated). Matrix responses MUST
+be authenticated, read-only, and non-cacheable (`Cache-Control: no-store`).
+Generating a format the matrix reports unavailable MUST fail with HTTP 503
+carrying the **same** reason string the matrix reports — the app MUST NOT
+silently substitute another format.
 
 #### Scenario: LibreOffice absence disables docx and odf with a reason
 
@@ -43,10 +47,17 @@ format.
 
 #### Scenario: Template matrix reflects the template type
 
-- GIVEN an office template
+- GIVEN an office template on an instance with a working LibreOffice backend
 - WHEN `GET /api/templates/{id}/formats` is fetched
-- THEN `html` is not offered and `docx` is offered as the editable passthrough format (subject to backend availability for `pdf`/`odf`)
+- THEN `docx` is offered as the editable passthrough format, `html` is offered (produced via DOCX→HTML), and `pdf`/`odf` are offered
 - @e2e tests/e2e/spec-coverage/multi-format-output.spec.ts
+
+#### Scenario: Office html is LibreOffice-gated in the matrix
+
+- GIVEN an office template on an instance without a working LibreOffice backend
+- WHEN `GET /api/templates/{id}/formats` is fetched
+- THEN `html`, `docx`, and `odf` are reported unavailable with a reason and only `pdf` is available
+- @e2e exclude requires an instance-level LibreOffice teardown — covered by PHPUnit (tests/unit/Service/FormatMatrixServiceTest.php::testOfficeHtmlGatedOnLibreOffice)
 
 ### Requirement: Generation and correspondence flows drive format choice from the matrix (REQ-DDMFO-004)
 

--- a/openspec/changes/multi-format-output/tasks.md
+++ b/openspec/changes/multi-format-output/tasks.md
@@ -1,11 +1,11 @@
 # Tasks: multi-format-output
 
-<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 13.
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 15.
      Acceptance criteria are plain bullets, not checkboxes. -->
 
 ## 1. Register & data model
 
-- [ ] 1.1 Extend `lib/Settings/docudesk_register.json`: `generatedDocument.format` enum gains `docx`; new optional `outputs` array (`{format, fileId, status, error?}`); document register bump (additive — rebase the version number on whichever of this change / `guided-document-wizard` lands second)
+- [ ] 1.1 Extend `lib/Settings/docudesk_register.json`: `generatedDocument.format` enum gains `docx`; new optional `outputs` array (`{format, fileId, status, error?}`); bump the document register `2.3.0` → `2.4.0` (additive). Apply order is pinned: `guided-document-wizard` applies FIRST (`2.2.0` → `2.3.0`), this change SECOND (`2.3.0` → `2.4.0`) — no rebase-on-whichever-lands-second
   - `tests/validate-manifest.js` and register import on boot both pass
 
 ## 2. Backend
@@ -20,6 +20,8 @@
 
 - [ ] 2.5 `docx` on the document path: shared converter for twig templates, filled-DOCX passthrough for office templates; forced-unavailable → 503 with matrix reason; single-`format` requests byte-identical to today (REQ-DDMFO-003)
 
+- [ ] 2.7 `docx` → `html` for office templates: new `lib/Service/Conversion/DocxToHtmlConverter` (`soffice --headless --convert-to html` on the filled DOCX, reusing the cascade soffice serialization lock + temp-dir hygiene + timeout); office `html` gated on LibreOffice availability in the matrix, forced-unavailable → 503 with matrix reason; twig `html` passthrough unchanged (REQ-DDMFO-007, C1 — full format parity)
+
 - [ ] 2.6 Audit logging: one `generatedDocument` per render with `outputs` array for multi-format jobs; scalar `format` = first requested format; single-format generations unchanged (REQ-DDMFO-006)
 
 ## 3. Routes & controller
@@ -33,9 +35,9 @@
 
 ## 5. Quality, i18n, docs
 
-- [ ] 5.1 Unit tests (≥75% coverage on new code): formats validation, render-once/convert-N with partial failure, docx passthrough vs converted, capability report shape, matrix/503 reason equality, register-drift pin for `outputs`; run in container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`
+- [ ] 5.1 Unit tests (≥75% coverage on new code): formats validation, render-once/convert-N with partial failure, docx passthrough vs converted, office DOCX→HTML converter + office-html-gated-on-LibreOffice (REQ-DDMFO-007), capability report shape, matrix/503 reason equality, register-drift pin for `outputs`; run in container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`
 
-- [ ] 5.2 Playwright e2e `tests/e2e/spec-coverage/multi-format-output.spec.ts`: generate `["pdf","docx"]` from the seeded template → both files in the output folder, DOCX opens editable (content assertion via download); matrix-driven disabled state in correspondence view; verify on Postgres (8080), test with nldesign theme enabled
+- [ ] 5.2 Playwright e2e `tests/e2e/spec-coverage/multi-format-output.spec.ts`: generate `["pdf","docx"]` from the seeded template → both files in the output folder, DOCX opens editable (content assertion via download); office template `html` output via DOCX→HTML with resolved data; matrix-driven disabled state in correspondence view; verify on Postgres (8080), test with nldesign theme enabled
 
 - [ ] 5.3 i18n: all new UI strings (disabled-format reasons, manifest labels) with English source keys + NL translations (ADR-005)
 

--- a/openspec/changes/pdfua-verapdf-matterhorn/.openspec.yaml
+++ b/openspec/changes/pdfua-verapdf-matterhorn/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/pdfua-verapdf-matterhorn/design.md
+++ b/openspec/changes/pdfua-verapdf-matterhorn/design.md
@@ -1,0 +1,244 @@
+# Design: pdfua-verapdf-matterhorn
+
+## Context
+
+Verified at merged HEAD (`development`, includes the nine wave-1 changes and
+Robert's PR #314):
+
+- `DocumentValidationService` owns a stable check-id catalogue, per-profile
+  severities (`off|warning|blocking`), parser-free byte heuristics, verdict
+  aggregation, and an on-demand endpoint. At HEAD it has six checks; the
+  `accessibility` category (`pdf-not-tagged`, `pdf-language-missing`,
+  `pdf-title-missing`, `pdfua-identifier-missing`) is spec'd by wave-1
+  `pdfua-accessible-output` (REQ-DDPUA-003) but not yet applied, and the
+  `category` finding key it introduces (default `document`) is the extension
+  point this change reuses.
+- `verapdf-validation` (spec'd, not yet applied) introduces `VeraPdfService`
+  — veraPDF as an optional, probed, local CLI binary (`docudesk.verapdf.*`
+  config; admin-settings status row next to soffice/Tesseract), a validate
+  contract that returns rule-level results, a `conformanceReport` OR object,
+  and the `archival` check category with the validator-presence-gated,
+  per-profile-opt-in (`off` default) pattern. That change also MODIFIES the
+  profiles-defaults requirement to make validator-backed checks default off.
+- veraPDF validates PDF/UA-1 natively via its `ua1` flavour (the Matterhorn
+  Protocol test suite); the same binary and JSON output format `VeraPdfService`
+  already parses for PDF/A carries PDF/UA results.
+- Wave-1 heuristics answer "looks tagged"; the Matterhorn Protocol answers
+  "conforms" — the two are complementary, not redundant (a heuristic pass can
+  precede a Matterhorn fail).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Real PDF/UA-1 conformance verdicts, locally computed via the shared veraPDF
+  binary, stored per document and reachable through the existing validation
+  surface.
+- Upgrade the wave-1 accessibility heuristics from presence-guessing to
+  validator truth when the binary is present, without regressing the
+  always-available heuristic floor when it is absent.
+- Honest, actionable remediation guidance; never a certification claim.
+
+**Non-Goals:**
+
+- No second validator binary or probe — this change consumes
+  `verapdf-validation`'s `VeraPdfService`; it does not re-specify the backend
+  integration, config, or admin status row.
+- No PDF/UA *remediation engine* — this change verifies and guides;
+  retagging/re-authoring stays with the generation paths and the source
+  document. No auto-retag of imported pages (the PDF/A font-embedding
+  limitation has an accessibility analogue).
+- No re-modelling of the wave-1 heuristic checks — they stay exactly as
+  `pdfua-accessible-output` specs them; this change ADDS validator-backed
+  siblings alongside them.
+- No PDF/UA-2 target in v1 — PDF/UA-1 (ISO 14289-1) is what EN 301 549 and
+  Dutch procurement demand.
+
+## Decisions
+
+### D1 — Extend the shared veraPDF backend, do not fork it
+
+**Decision:** the PDF/UA path is a method on the same `VeraPdfService`
+`verapdf-validation` introduces — e.g. `validateUa(File $file): array` that
+invokes the same probed binary with `--flavour ua1` and parses the same JSON
+result shape (flavour, `compliant`, failed checks with
+specification/clause/test references, validator version). It reuses the same
+`docudesk.verapdf.binary_path`, `docudesk.verapdf.max_seconds`,
+`docudesk.verapdf.enabled` config, the same availability probe, and the same
+admin-settings status row. No new binary, no new config namespace, no second
+probe.
+
+Rejected: a separate PDF/UA validator service — duplicates the probe, the
+config, the degradation logic and the admin surface for the same tool;
+divergence risk on every veraPDF version bump.
+
+**Sequencing note:** the shipped `depends_on` is `pdfua-accessible-output`
+(this change upgrades its heuristics and reuses its `category` key). There is
+ALSO a hard build dependency on `verapdf-validation` for `VeraPdfService` and
+the probe/admin plumbing; the two changes are co-owned siblings on the
+veraPDF backend and are expected to apply together. Kept out of `depends_on`
+per the build-phase decision (D4), documented here so the apply order is not
+lost. See Open Questions.
+
+### D2 — Validator-backed checks in the existing `accessibility` category
+
+PDF/UA is accessibility, so validator-backed PDF/UA checks belong in wave-1's
+`accessibility` category (unlike PDF/A, which `verapdf-validation` put in a
+new `archival` category because PDF/A is not accessibility). **Decision:** add
+check ids to `DocumentValidationService` under `category: "accessibility"`:
+
+| checkId | Backed by |
+|---|---|
+| `pdfua-conformance-failed` | veraPDF `ua1` verdict is non-compliant; finding params carry the flavour, the failed-checkpoint count and the top Matterhorn clause references |
+| `accessibility-validator-unavailable` | a validator-backed accessibility check is enabled in the resolved profile but veraPDF is absent/disabled — an explicit "not validated" finding (severity `warning`, non-escalatable), never a silent skip |
+
+These run ONLY on PDFs, ONLY when the resolved profile enables them
+(per-profile opt-in; a JVM start per document is the cost), and default `off`
+in shipped profiles. The wave-1 heuristic checks keep their own ids and stay
+default `warning` — the heuristic floor is always on; the validator is the
+opt-in truth. This is additive to the check catalogue and does NOT re-MODIFY
+the profiles-defaults requirement (already amended by `verapdf-validation` to
+cover validator-backed checks) — avoiding a double-MODIFY of the same base
+requirement across two in-flight changes.
+
+### D3 — A separate `accessibilityConformanceReport`, not a shared report
+
+`verapdf-validation` persists a `conformanceReport` keyed by `fileId` for
+PDF/A. **Decision:** PDF/UA verdicts persist to a SEPARATE
+`accessibilityConformanceReport` OR object, also keyed by `fileId`
+(re-running updates it): `flavour` (`ua1`), `compliant`, `failedCheckCount`,
+`failedChecks` (bounded list of `{clause, testNumber, checkpoint,
+description-ref}` — references only, never document content),
+`validatorVersion`, `validatedAt`, `trigger` (`manual` | `validation` |
+`generation`). Two reports because a document can be simultaneously PDF/A
+conformant and PDF/UA non-conformant (or vice versa); one shared object would
+have each run clobber the other's verdict. Content-free by construction
+(clause references and checkpoint numbers only — AVG Art. 5(1)(c)); it is
+accessibility-audit evidence. Endpoint:
+`POST /api/validation/accessibility/{fileId}` (IDOR-safe user-folder
+resolution, mirrors the existing on-demand validation endpoint but persists).
+
+Rejected: extending `verapdf-validation`'s `conformanceReport` with a
+`standard` discriminator — cross-change schema coupling to an unarchived
+sibling, and it re-introduces the clobber problem for re-runs.
+
+### D4 — Remediation guidance from the failure shape
+
+Guidance strings (i18n EN/NL) keyed by failure class, attached to the report
+and the accessibility findings panel:
+
+- Structure/tagging failures on a document produced by DocuDesk's own
+  accessible/tagged output path (`pdfua-accessible-output` REQ-DDPUA-001/002
+  LibreOffice `PDFUACompliance` route) → "regenerate through DocuDesk with the
+  accessible output option" (its path emits tagged structure).
+- Failures on a document produced by the untagged mPDF path or on an
+  imported/uploaded PDF → "DocuDesk does not retag imported pages; re-author
+  from an accessible source (tagged DOCX/template) and regenerate" — honest
+  limitation, the accessibility analogue of the PDF/A font-embedding trap.
+- Per-checkpoint failures → the Matterhorn clause/checkpoint reference plus
+  the generic regenerate-accessible advice.
+
+No auto-remediation in v1 (Non-Goals). The report and UI state a conformance
+verdict; they never assert "PDF/UA certified".
+
+### D5 — Heuristic-vs-validator hierarchy: floor and truth, labelled
+
+When the validator is unavailable, the wave-1 heuristics are the only
+accessibility signal and the UI presents them as heuristic ("looks tagged").
+When the validator is available and its checks are enabled, the Matterhorn
+verdict is the authoritative accessibility conformance for the document; the
+UI labels validator findings as validator-backed (distinct from heuristic
+findings, exactly as `verapdf-validation` distinguishes `archival` from
+`document`/`accessibility`). A heuristic pass with a validator fail is
+reported as a validator fail — the stronger, correct verdict wins in the
+surfaced conformance state, while both findings remain visible with their
+source. The heuristic floor never regresses; it is never removed.
+
+### D6 — Declarative vs imperative (ADR-031), OR usage (ADR-001), frontend (ADR-012)
+
+`accessibilityConformanceReport` is a **declarative** register addition
+(single-state evidence record, no lifecycle annotations). Validator
+invocation, the check leg and the endpoint are **imperative** —
+external-binary document processing, the established ADR-031 exception (same
+category as soffice/Tesseract/veraPDF-for-PDF/A). Persistence via
+ObjectService/AppHost (no custom tables); OR services otherwise untouched.
+ADR-011: no new parsing utilities beyond reusing the veraPDF JSON reader that
+`verapdf-validation` adds. Frontend: validator findings in the existing
+`accessibility` category-grouped panel; a PDF/UA conformance card on document
+detail; NC CSS variables (ADR-003); strings EN-keyed with NL translations
+(ADR-005). All new UI itself satisfies WCAG 2.1 AA.
+
+## Seed Data
+
+```json
+// accessibilityConformanceReport — a conformant generated besluit
+{ "fileId": 816001,
+  "flavour": "ua1",
+  "compliant": true,
+  "failedCheckCount": 0,
+  "failedChecks": [],
+  "validatorVersion": "veraPDF 1.26.2",
+  "validatedAt": "2026-07-18T09:20:00Z",
+  "trigger": "generation" }
+
+// accessibilityConformanceReport — an imported PDF failing Matterhorn checkpoints
+{ "fileId": 816002,
+  "flavour": "ua1",
+  "compliant": false,
+  "failedCheckCount": 3,
+  "failedChecks": [
+    { "clause": "7.1", "testNumber": "01-006", "checkpoint": "Real content not tagged" },
+    { "clause": "7.3", "testNumber": "09-004", "checkpoint": "Figure without alternative description" } ],
+  "validatorVersion": "veraPDF 1.26.2",
+  "validatedAt": "2026-07-18T09:22:10Z",
+  "trigger": "manual" }
+```
+
+Test fixtures (committed under `tests/sample-documents/`, generated content,
+no personal data): a genuinely PDF/UA-1-conformant tagged PDF, and a PDF that
+passes the wave-1 heuristics (has `/StructTreeRoot`, `/Lang`, title,
+`pdfuaid:part`) but fails Matterhorn checkpoints (untagged content, a figure
+without alt) — the fixture that proves heuristics ≠ conformance.
+
+## Risks / Trade-offs
+
+- [Depends on an unapplied sibling (`verapdf-validation`) for the backend] →
+  the changes are co-owned and apply together; the check leg and report are
+  independently testable against a `VeraPdfService` fake pinned to the
+  documented `ua1` result shape; verified against merged HEAD at apply time.
+- [JVM cost per validation] → per-profile opt-in checks (D2), on-demand
+  endpoint, the existing `docudesk.verapdf.max_seconds` budget, no default-on
+  upload validation.
+- [Two conformance reports per file (PDF/A + PDF/UA)] → deliberate (D3);
+  each is small, content-free, keyed independently; the document-detail view
+  shows both cards.
+- [Heuristic vs validator disagreement confuses operators] → D5 labels the
+  source and surfaces the stronger verdict; docs explain the hierarchy.
+- [Matterhorn verdicts are strict — many existing PDFs will fail] →
+  validator-backed checks default `off` (opt-in); guidance (D4) is honest
+  about imported-page limits so a fail is actionable, not a mystery.
+
+## Migration Plan
+
+1. Register JSON: add `accessibilityConformanceReport` (additive, union-merge).
+2. Extend `VeraPdfService` with `validateUa()` (inert without the binary /
+   without `verapdf-validation` applied).
+3. `accessibility` validator checks + accessibility conformance endpoint +
+   document-detail card.
+4. Wire the validator verdict into the surfaced accessibility conformance
+   state (D5), heuristics remaining the floor.
+5. Rollback: disable via `docudesk.verapdf.enabled` or leave the archival/
+   accessibility validator checks `off` — everything degrades to the wave-1
+   heuristic behaviour; reports remain as inert evidence; no data migration.
+
+## Open Questions
+
+- Should `depends_on` also list `verapdf-validation`? The build-phase
+  decision (D4) fixed `depends_on: [pdfua-accessible-output]`; the hard
+  backend dependency on `verapdf-validation` is documented here and the two
+  are expected to apply together. Flagged for the apply orchestrator to
+  confirm the apply order (VeraPdfService must exist first).
+- Should generation of an `accessible`-option document auto-validate PDF/UA
+  when veraPDF is present (trigger `generation`)? Provisional: yes via the
+  same hook once the tagged-output path is live; scenario-gated so it never
+  errors the base generation flow when the validator is absent.

--- a/openspec/changes/pdfua-verapdf-matterhorn/proposal.md
+++ b/openspec/changes/pdfua-verapdf-matterhorn/proposal.md
@@ -1,0 +1,125 @@
+---
+kind: code
+depends_on: [pdfua-accessible-output, verapdf-validation]
+---
+
+# Proposal: pdfua-verapdf-matterhorn
+
+## Why
+
+Wave-1 `pdfua-accessible-output` made accessibility *visible* but only
+*heuristically*: `DocumentValidationService` gained parser-free presence
+checks (`pdf-not-tagged`, `pdf-language-missing`, `pdf-title-missing`,
+`pdfua-identifier-missing`) that answer "does this PDF look tagged?" — not
+"does this PDF actually conform to PDF/UA-1?". Its own spec is explicit that
+these are "accessibility presence heuristics, not certified PDF/UA
+(Matterhorn/veraPDF-grade) validation" (REQ-DDPUA-003), and its Impact
+section defers veraPDF-grade validation to a separate change. This is that
+change.
+
+The heuristic floor cannot detect the failures that actually fail an audit: a
+PDF can carry `/StructTreeRoot`, `/Marked true`, `/Lang`, a title and
+`pdfuaid:part` and still violate PDF/UA-1 (ISO 14289-1) — untagged content
+inside the structure tree, figures without alternative descriptions, headings
+that don't map to real structure elements, tables without proper header
+associations, an incomplete role map. The **Matterhorn Protocol** (the PDF
+Association's PDF/UA test suite: 31 checkpoints, 136 failure conditions) is
+the accepted way to test conformance, and **veraPDF** — which DocuDesk is
+already adopting for PDF/A in `verapdf-validation` — implements it as its
+`ua1` validation flavour.
+
+Statutory frame unchanged: the Besluit digitale toegankelijkheid overheid
+(EU Directive 2016/2102 → EN 301 549 → WCAG 2.1 AA) makes accessible PDFs a
+hard procurement gate for every document a Dutch government body publishes
+under Woo or sends to a citizen. A heuristic "looks tagged" verdict is not
+evidence; a Matterhorn verdict is.
+
+Verified at merged HEAD (`development`): `DocumentValidationService` ships six
+content checks (`format-not-allowed`, `extension-mime-mismatch`,
+`file-unreadable`, `pdf-encrypted`, `text-layer-missing`,
+`metadata-incomplete`) — the wave-1 `accessibility` category and the
+`verapdf-validation` `archival` category are both spec'd but not yet applied,
+and no `VeraPdfService` exists yet. This change is a follow-up that lands on
+top of both: it reuses (does not duplicate) the optional veraPDF binary
+integration that `verapdf-validation` introduces, and it upgrades the wave-1
+accessibility heuristics with validator truth when that binary is present.
+
+## What Changes
+
+- **PDF/UA-1 (Matterhorn) validation through the shared veraPDF backend**: the
+  `VeraPdfService` integration introduced by `verapdf-validation` (probed,
+  admin-installed local CLI binary, `docudesk.verapdf.*` config, honest
+  degradation) is EXTENDED with a PDF/UA validation path (veraPDF `ua1`
+  flavour). No second binary, no second probe, no second admin status row —
+  one validator integration serves both PDF/A (archival) and PDF/UA
+  (accessibility). This change does not re-specify that backend; it consumes
+  and extends it.
+- **Validator-backed accessibility checks** in `DocumentValidationService`:
+  new check ids (`pdfua-conformance-failed`, `accessibility-validator-unavailable`)
+  in the existing `accessibility` category (wave-1 REQ-DDPUA-003), riding the
+  same profile/severity/verdict mechanism, validator-presence-gated and
+  per-profile opt-in (default `off`) — exactly the pattern
+  `verapdf-validation` established for its `archival` checks, so heuristic and
+  validator findings coexist and the UI labels the source.
+- **A persisted, re-runnable accessibility conformance report** per document
+  (`accessibilityConformanceReport`, keyed by `fileId`): the PDF/UA flavour,
+  the verdict, the failed Matterhorn checkpoints/clauses (references only,
+  never document content), the validator version. Sibling of
+  `verapdf-validation`'s `conformanceReport` (PDF/A); the two are kept
+  separate so a PDF/A report is not overwritten by a PDF/UA run and vice
+  versa.
+- **Honest remediation guidance** derived from the failure shape: documents
+  produced by DocuDesk's own tagged-output path advise regeneration through
+  DocuDesk with the accessible option; imported/uploaded PDFs advise
+  re-authoring from an accessible source and state honestly that DocuDesk
+  does not retag imported pages. The report and UI MUST NOT claim PDF/UA
+  certification — they report a conformance verdict with references.
+- **Local processing only**: veraPDF runs on the instance; document bytes
+  never leave it — same posture as the PDF/A integration and the wave-1
+  heuristics.
+
+## Capabilities
+
+### New Capabilities
+
+- `pdfua-verapdf-matterhorn`: validator-backed PDF/UA-1 (Matterhorn)
+  conformance validation via the shared veraPDF backend, a persisted
+  accessibility conformance report, and honest remediation guidance —
+  upgrading the wave-1 heuristic accessibility surface from "looks tagged" to
+  "verified conformant".
+
+### Modified Capabilities
+
+- `document-validation-checks`: gains the validator-backed accessibility
+  check ids in the existing `accessibility` category (additive; no change to
+  the profiles-defaults requirement, which `verapdf-validation` already
+  amends for validator-backed checks).
+
+## Impact
+
+- **Backend**: extend `VeraPdfService` (from `verapdf-validation`) with a
+  `validateUa()` path (veraPDF `--flavour ua1`); new
+  `accessibility`-category validator checks in
+  `lib/Service/DocumentValidationService.php`; a new accessibility
+  conformance endpoint + report persistence.
+- **Register JSON** (`lib/Settings/docudesk_register.json`): new
+  `accessibilityConformanceReport` schema (additive, union-merge).
+- **Frontend**: the `accessibility` findings group (wave-1) gains
+  validator-backed findings labelled as such; a PDF/UA conformance card on
+  document detail (flavour, verdict, failed checkpoints, guidance); no new
+  admin status row (reuses the veraPDF row from `verapdf-validation`).
+- **Config**: PDF/UA checks ride the existing
+  `docudesk.validation.profiles` per-check severity mechanism and the
+  existing `docudesk.verapdf.*` binary config; validator-backed checks
+  default `off` (admin opt-in), consistent with `archival` checks.
+- **Relationship to `verapdf-validation`**: hard build dependency on its
+  `VeraPdfService` and admin/probe plumbing (shared integration). Modelled as
+  a sibling because the veraPDF backend is co-owned; `depends_on` is declared
+  on `pdfua-accessible-output` (whose heuristics this upgrades) — see design
+  for the sequencing note.
+- **Sibling boundaries**: publication endpoints remain OpenCatalogi/OpenWoo's;
+  DocuDesk only reports conformance and gates its own hand-off readiness via
+  the wave-1 publication-readiness signal (REQ-DDPUA-005, referenced not
+  modified).
+- **No new dependencies**: no second binary; veraPDF is the same Java CLI
+  `verapdf-validation` already integrates.

--- a/openspec/changes/pdfua-verapdf-matterhorn/specs/document-validation-checks/spec.md
+++ b/openspec/changes/pdfua-verapdf-matterhorn/specs/document-validation-checks/spec.md
@@ -1,0 +1,77 @@
+# document-validation-checks Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Extend the document validation check catalogue with validator-backed PDF/UA
+accessibility checks (veraPDF `ua1` / Matterhorn Protocol), riding the
+existing `accessibility` category (wave-1 REQ-DDPUA-003) and the existing
+profile/severity/verdict mechanism, with an honest unavailable-validator
+finding instead of a silent skip. This delta only ADDs requirements; the
+profiles-defaults requirement is NOT modified here (`verapdf-validation`
+already amends it to default validator-backed checks to `off`, and that rule
+governs these checks too).
+
+## ADDED Requirements
+
+### Requirement: The check catalogue MUST include validator-backed PDF/UA accessibility checks (REQ-DDPUM-005)
+
+`DocumentValidationService` MUST implement validator-backed accessibility
+checks grouped under the existing finding `category: "accessibility"`
+(alongside the wave-1 heuristic checks, which keep their ids), riding the
+existing catalogue/profile/severity mechanism:
+
+- `pdfua-conformance-failed` — veraPDF reports the PDF non-compliant with
+  PDF/UA-1 (`ua1` flavour); finding params carry the flavour, the
+  failed-checkpoint count and the top Matterhorn clause/test references
+  (`pdfua-verapdf-matterhorn` REQ-DDPUM-001).
+- `accessibility-validator-unavailable` — a validator-backed accessibility
+  check is enabled in the resolved profile but the veraPDF binary is absent or
+  disabled; an explicit "not validated" finding (severity `warning`,
+  non-escalatable) so absence is visible, never a silent skip.
+
+These checks MUST run only for PDF files and only when the resolved profile
+enables them (per-profile opt-in — validator invocations cost a JVM start per
+document), MUST default to `off` in every shipped profile (validator-backed
+checks are an explicit admin opt-in, per the profiles rule
+`verapdf-validation` already establishes), and MUST carry checkpoint and
+clause references only — never document content. Aggregation
+(`validationStatus`) and the 422 blocking gate apply to these findings exactly
+as to existing checks. The wave-1 heuristic accessibility checks
+(`pdf-not-tagged`, `pdf-language-missing`, `pdf-title-missing`,
+`pdfua-identifier-missing`) MUST be left unchanged — they remain the
+always-available floor.
+
+#### Scenario: Non-conformant PDF fires the validator-backed accessibility finding
+
+- GIVEN a profile with `pdfua-conformance-failed` at severity `warning`, an available validator, and a PDF that passes the heuristics but fails Matterhorn checkpoints
+- WHEN validation runs
+- THEN the findings contain `{checkId: "pdfua-conformance-failed", category: "accessibility"}` with the flavour and failed-checkpoint references in params
+- AND the heuristic accessibility findings for the same document are also present, unchanged
+- @e2e tests/e2e/spec-coverage/pdfua-verapdf-matterhorn.spec.ts
+
+#### Scenario: Missing validator is an explicit finding, not a silent skip
+
+- GIVEN a profile enabling `pdfua-conformance-failed` and no veraPDF binary on the instance
+- WHEN validation runs on a PDF
+- THEN the findings contain `{checkId: "accessibility-validator-unavailable", category: "accessibility", severity: "warning"}`
+- AND no `pdfua-conformance-failed` finding is fabricated
+- @e2e exclude degradation branch — covered by PHPUnit (tests/unit/Service/DocumentValidationServiceTest.php)
+
+#### Scenario: Shipped defaults leave validator-backed accessibility checks off
+
+- GIVEN an instance where the admin has never edited validation settings
+- WHEN any PDF is validated
+- THEN no `pdfua-conformance-failed` or `accessibility-validator-unavailable` finding is produced
+- AND only the wave-1 heuristic accessibility findings (if any) appear
+- @e2e exclude default-profile resolution — covered by PHPUnit (tests/unit/Service/DocumentValidationServiceTest.php)
+
+#### Scenario: Escalated conformance check gates intake
+
+- GIVEN a profile with `pdfua-conformance-failed` set to `blocking`, an available validator, and a non-conformant PDF upload
+- WHEN intake runs
+- THEN the existing 422 gate rejects it listing the accessibility finding
+- @e2e exclude gate reuse without modification — covered by PHPUnit (tests/unit/Service/DocumentValidationServiceTest.php)

--- a/openspec/changes/pdfua-verapdf-matterhorn/specs/pdfua-verapdf-matterhorn/spec.md
+++ b/openspec/changes/pdfua-verapdf-matterhorn/specs/pdfua-verapdf-matterhorn/spec.md
@@ -1,0 +1,148 @@
+# pdfua-verapdf-matterhorn Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Upgrade the wave-1 heuristic accessibility surface to real PDF/UA-1
+(Matterhorn Protocol) conformance validation, computed locally through the
+veraPDF backend that `verapdf-validation` introduces (shared, not
+duplicated). Produce a persisted, re-runnable accessibility conformance
+report per document and honest remediation guidance, without regressing the
+always-available heuristic floor. Statutory frame: Besluit digitale
+toegankelijkheid overheid / EU Directive 2016/2102 / EN 301 549 → WCAG 2.1
+AA; validated profile PDF/UA-1 (ISO 14289-1).
+
+## ADDED Requirements
+
+### Requirement: PDF/UA-1 conformance is validated through the shared veraPDF backend (REQ-DDPUM-001)
+
+The app MUST validate PDF/UA-1 conformance using the veraPDF integration
+introduced by `verapdf-validation` (`VeraPdfService`) — the SAME probed,
+admin-installed local CLI binary, the SAME `docudesk.verapdf.*` app config,
+the SAME availability probe and admin-settings status row — invoked with
+veraPDF's PDF/UA (`ua1`) validation flavour. This change MUST NOT introduce a
+second validator binary, a second probe, a second config namespace, or a
+second admin status row. Document bytes MUST NOT leave the instance. When the
+veraPDF binary is absent or disabled, PDF/UA validation MUST degrade honestly
+(the heuristic floor from `pdfua-accessible-output` remains, with an explicit
+"not validated" state) and MUST NEVER fabricate a conformance verdict. The
+validation result MUST be machine-readable — `flavour` (`ua1`), `compliant`,
+`failedChecks` (Matterhorn clause/test/checkpoint references only, never
+document content), `validatorVersion` — and a validator timeout, crash, or
+unparseable output MUST raise a typed error that is NEVER recorded or reported
+as compliant.
+
+#### Scenario: Heuristically-tagged PDF fails real Matterhorn validation
+
+- GIVEN an available veraPDF binary and a PDF that carries `/StructTreeRoot`, `/Lang`, a title and `pdfuaid:part` but contains untagged real content and a figure without an alternative description
+- WHEN PDF/UA validation runs
+- THEN the result is `compliant: false` for flavour `ua1` with the failed Matterhorn checkpoints listed by clause reference
+- @e2e tests/e2e/spec-coverage/pdfua-verapdf-matterhorn.spec.ts
+
+#### Scenario: Absent validator degrades to the heuristic floor honestly
+
+- GIVEN no veraPDF binary on the instance
+- WHEN PDF/UA conformance validation is requested
+- THEN the response states the validator is unavailable and PDF/UA conformance was not validated
+- AND no `compliant` value or conformance verdict is fabricated
+- AND the wave-1 heuristic accessibility findings remain available
+- @e2e exclude probe/degradation branch — covered by PHPUnit (tests/unit/Service/VeraPdfServiceTest.php)
+
+### Requirement: A persisted accessibility conformance report is stored per document and re-runnable (REQ-DDPUM-002)
+
+`POST /api/validation/accessibility/{fileId}` MUST run PDF/UA validation for a
+file resolved through the requesting user's folder (404 when not resolvable,
+without existence disclosure) and persist the result as an
+`accessibilityConformanceReport` object via OpenRegister, keyed by `fileId`
+(re-running updates the same object, no duplicates): `flavour` (`ua1`),
+`compliant`, `failedCheckCount`, `failedChecks` (bounded list of
+`{clause, testNumber, checkpoint}` references), `validatorVersion`,
+`validatedAt`, `trigger` (`manual` | `validation` | `generation`). This report
+MUST be SEPARATE from `verapdf-validation`'s PDF/A `conformanceReport` (a
+document may be PDF/A conformant yet PDF/UA non-conformant; one shared object
+would let each run clobber the other). The report MUST contain checkpoint and
+clause references only — no document content or personal data (AVG Art.
+5(1)(c)); it is accessibility-audit evidence. The document detail view MUST
+surface the report (flavour, verdict, failed checkpoints, guidance).
+
+#### Scenario: Accessibility conformance report is stored and shown
+
+- GIVEN a readable PDF and an available validator
+- WHEN the user runs the accessibility conformance check from the document detail view
+- THEN an `accessibilityConformanceReport` exists for the file with verdict, flavour `ua1` and validator version
+- AND the detail view shows the verdict with any failed checkpoints
+- @e2e tests/e2e/spec-coverage/pdfua-verapdf-matterhorn.spec.ts
+
+#### Scenario: PDF/A and PDF/UA reports coexist without clobbering
+
+- GIVEN a file with an existing `conformanceReport` (PDF/A, verapdf-validation)
+- WHEN PDF/UA validation runs and persists its report
+- THEN the `accessibilityConformanceReport` is written as a distinct object
+- AND the existing PDF/A `conformanceReport` is unchanged
+- @e2e exclude dual-report persistence — covered by PHPUnit (tests/unit/Service/VeraPdfServiceTest.php)
+
+#### Scenario: Inaccessible file yields 404
+
+- GIVEN a fileId that does not resolve within the requesting user's folder
+- WHEN the accessibility conformance endpoint is called
+- THEN the response is HTTP 404 with a generic body
+- @e2e exclude IDOR-safe resolution — covered by PHPUnit controller tests mirroring the ValidationController pattern
+
+### Requirement: Remediation guidance is honest and never claims certification (REQ-DDPUM-003)
+
+The accessibility conformance report and findings MUST attach remediation
+guidance (i18n EN/NL) derived from the failure shape: a document produced by
+DocuDesk's own tagged/accessible output path MUST advise regenerating through
+DocuDesk with the accessible output option; an imported/uploaded PDF or an
+untagged-mPDF-path output MUST advise re-authoring from an accessible source
+and MUST state honestly that DocuDesk does not retag imported pages; per-check
+failures MUST reference the Matterhorn clause/checkpoint. The report and UI
+MUST describe a conformance verdict and MUST NOT claim PDF/UA certification.
+The app MUST NOT auto-retag or otherwise auto-remediate imported pages in v1.
+
+#### Scenario: Imported PDF failing Matterhorn gets honest guidance
+
+- GIVEN a failed PDF/UA verdict on an uploaded PDF that DocuDesk did not generate
+- WHEN the report renders
+- THEN the guidance states DocuDesk does not retag imported pages and advises re-authoring from an accessible source
+- AND the report does not claim the document is PDF/UA certified
+- @e2e tests/e2e/spec-coverage/pdfua-verapdf-matterhorn.spec.ts
+
+#### Scenario: DocuDesk-generated artifact advises regeneration
+
+- GIVEN a PDF/UA failure on a document generated by DocuDesk's accessible output path
+- WHEN the report renders
+- THEN the guidance advises regenerating the document through DocuDesk with the accessible option
+- @e2e exclude guidance-classification branch — covered by PHPUnit (tests/unit/Service/VeraPdfServiceTest.php)
+
+### Requirement: Validator verdict is the authoritative conformance, heuristics remain the floor (REQ-DDPUM-004)
+
+The app MUST surface the PDF/UA (Matterhorn) validator verdict as the
+authoritative accessibility conformance state for a document whenever the
+veraPDF validator is available and its accessibility checks are enabled in the
+resolved profile. When the validator is unavailable, the wave-1 heuristic
+accessibility findings (`pdfua-accessible-output` REQ-DDPUA-003) MUST remain
+the accessibility signal and MUST be presented as heuristic ("looks tagged"),
+never as a conformance verdict. Both heuristic and validator findings MUST remain visible with their
+source labelled (heuristic vs validator-backed), consistent with how
+`verapdf-validation` distinguishes `archival` from heuristic findings. A
+heuristic pass together with a validator fail MUST surface as a fail. The
+heuristic floor MUST NOT be removed or regressed by this change.
+
+#### Scenario: Validator fail overrides a heuristic pass in the surfaced state
+
+- GIVEN a PDF whose heuristic accessibility checks all pass but whose veraPDF `ua1` verdict is non-compliant, with validator checks enabled
+- WHEN the operator views the document's accessibility conformance
+- THEN the surfaced conformance state is non-conformant (the validator verdict)
+- AND both the passing heuristic findings and the failing validator findings are visible with their source labelled
+- @e2e tests/e2e/spec-coverage/pdfua-verapdf-matterhorn.spec.ts
+
+#### Scenario: Without the validator, heuristics are labelled as heuristic
+
+- GIVEN no veraPDF binary and a PDF that passes the wave-1 heuristics
+- WHEN the operator views its accessibility state
+- THEN the state is presented as a heuristic "looks tagged" result, not a PDF/UA conformance verdict
+- @e2e exclude presentation-labelling branch — covered by Vitest on the accessibility panel state

--- a/openspec/changes/pdfua-verapdf-matterhorn/tasks.md
+++ b/openspec/changes/pdfua-verapdf-matterhorn/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: pdfua-verapdf-matterhorn
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 13.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Register & seed data
+
+- [ ] 1.1 Add the `accessibilityConformanceReport` schema (`fileId`, `flavour`, `compliant`, `failedCheckCount`, `failedChecks` clause/test/checkpoint references, `validatorVersion`, `validatedAt`, `trigger`) to `lib/Settings/docudesk_register.json` — additive, union-merge only; references only, never document content (REQ-DDPUM-002)
+- [ ] 1.2 Seed two `tests/sample-documents/` fixtures (generated, no personal data): one genuinely PDF/UA-1-conformant tagged PDF; one that passes the wave-1 heuristics but fails Matterhorn checkpoints (untagged content + figure without alt) — the "heuristics ≠ conformance" fixture
+
+## 2. Shared backend (verapdf-validation)
+
+- [ ] 2.1 Extend `verapdf-validation`'s `VeraPdfService` with `validateUa(File): array` invoking the same probed binary with `--flavour ua1`, parsing the same JSON shape (flavour/compliant/failedChecks/validatorVersion), typed error on timeout/crash/unparseable — NO second binary, probe, config or admin row (REQ-DDPUM-001)
+  - Hard build dependency on `verapdf-validation`; verify `VeraPdfService` exists at apply time — apply the two together (see design D1 / Open Questions).
+
+## 3. Backend
+
+- [ ] 3.1 Add `accessibility`-category validator checks to `DocumentValidationService`: `pdfua-conformance-failed`, `accessibility-validator-unavailable` — PDF-only, per-profile opt-in, default `off`, validator-presence-gated, references only; wave-1 heuristic checks untouched (REQ-DDPUM-005)
+- [ ] 3.2 New accessibility conformance endpoint `POST /api/validation/accessibility/{fileId}` — auth attribute, IDOR-safe user-folder resolution (404, no existence disclosure), persists/updates the `accessibilityConformanceReport` distinct from the PDF/A `conformanceReport` (REQ-DDPUM-002)
+- [ ] 3.3 Remediation guidance from failure shape (DocuDesk-generated → regenerate accessible; imported/mPDF → re-author from accessible source, no retag of imported pages), i18n-keyed; verdict never claims certification (REQ-DDPUM-003)
+- [ ] 3.4 Surface the validator verdict as the authoritative accessibility conformance when available; heuristics remain the labelled floor when absent; heuristic-pass + validator-fail surfaces as fail (REQ-DDPUM-004)
+
+## 4. Frontend
+
+- [ ] 4.1 PDF/UA conformance card on document detail (flavour, verdict, failed checkpoints, guidance); validator findings rendered in the existing `accessibility` findings group, source-labelled (REQ-DDPUM-002, REQ-DDPUM-004)
+- [ ] 4.2 Heuristic-vs-validator labelling in the accessibility panel; "not validated" state when the binary is absent (REQ-DDPUM-001, REQ-DDPUM-004)
+
+## 5. Quality
+
+- [ ] 5.1 PHPUnit for `validateUa()` parsing/degradation, the two checks, endpoint resolution + dual-report persistence, guidance classification, verdict-hierarchy — 75% coverage on new code (ADR-009)
+  - Run in container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`.
+  - Live-verify on Postgres (8080) with veraPDF installed: validate the heuristic-pass/Matterhorn-fail fixture → non-conformant verdict, findings + card; remove the binary → honest heuristic-floor degradation.
+- [ ] 5.2 Playwright spec `tests/e2e/spec-coverage/pdfua-verapdf-matterhorn.spec.ts` for the `@e2e`-referenced scenarios
+- [ ] 5.3 i18n EN + NL for all new UI + guidance strings (keys in English); nldesign theme check; new UI itself WCAG 2.1 AA (ADR-005, ADR-003)
+- [ ] 5.4 Docs: `docs/features/pdfua-verapdf-matterhorn.md` with Playwright screenshots (conformance card, source-labelled findings, degradation) and the heuristic→validator hierarchy explainer (ADR-010)
+- [ ] 5.5 Validate: `openspec validate pdfua-verapdf-matterhorn --type change --strict` passes; hydra gates green
+
+## Quality checklist
+
+- GDPR: reports and findings carry checkpoint/clause references only — no document content or personal data (AVG Art. 5(1)(c)); processing stays 100% local.
+- Shared integration: reuses `verapdf-validation`'s `VeraPdfService`, probe, `docudesk.verapdf.*` config and admin status row — no second validator surface.
+- `pdfua-accessible-output` (heuristics) and `verapdf-validation` (PDF/A backend + `archival` category) specs are referenced/consumed, not modified; the profiles-defaults requirement is not re-modified here.

--- a/openspec/changes/portal-signing-actions/.openspec.yaml
+++ b/openspec/changes/portal-signing-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/portal-signing-actions/design.md
+++ b/openspec/changes/portal-signing-actions/design.md
@@ -1,0 +1,225 @@
+# Design: portal-signing-actions
+
+## Context
+
+hydra ADR-046 makes **portaliq** the ONE external portal for people without a
+Nextcloud account. Contribution contract v2 (portaliq
+`openspec/specs/portal-contribution-contract/spec.md`, verified at HEAD) defines
+**A6 endpoint bearer-forward actions**: an app declares actions
+`{id, label, endpoint, method, minTrust?}` on a manifest; portaliq exposes
+`POST /portal/api/actions/{appId}/{actionId}` which authorises against the
+SUBJECT's own aggregated manifest, then forwards the call server-to-server
+(`OCP\Http\Client\IClientService`) to the declared instance-local endpoint,
+attaching a short-lived (~60 s) HS256 `X-Portal-Subject` assertion and NEVER the
+client's `Authorization` header, and relays the domain app's JSON status+body.
+
+`portal-contribution` already ships DocuDesk's plain `PortalContributionProvider`
+with a `signer` audience, but with `actions: []` (`REQ-DDPORT-006`) — its
+design.md explicitly defers sign/decline as "A6 endpoint actions … so the
+receiver + `PortalAssertionVerifier` land as a reviewed unit". This change is
+that reviewed unit.
+
+### Verified facts (HEAD, docudesk + portaliq)
+
+- **portaliq mints the assertion** in `PortalJwtService::createAssertion()`
+  (`lib/Service/PortalJwtService.php:160`): header `{"alg":"HS256","typ":"JWT"}`,
+  claims exactly `sub, audience, organisation, trust, jti, use="assertion",
+  iat, exp, iss="portaliq"`, `exp-iat = 60`. This is FROZEN
+  ("Frozen assertion wire format" requirement) — a receiver may rely on the
+  shape byte-for-byte. It is signed with portaliq's `jwt_signing_secret`
+  instance secret (`PortalSessionService::issueAssertion` → `createAssertion`).
+- **The A6 forward** (`ContributionController::action()`,
+  `lib/Controller/ContributionController.php:744`) is `#[PublicPage]` +
+  `#[NoCSRFRequired]`, rejects full http(s) URLs (SSRF guard), forwards the
+  client body as-is, relays the decoded JSON body + status, and returns `502` on
+  transport failure. The receiver must mirror that JSON-only relay shape.
+- **`signerRecord`** (`lib/Settings/docudesk_register.json`, register `signing`)
+  properties: `signingRequestId, userId, displayName, email, order, status,
+  signedAt, declineReason, ipAddress, signatureData`. There is NO external
+  contact UUID — the invited `email` is the only stable external identity (same
+  reason `portal-contribution` scopes the signer by `signerEmail`).
+- **`signingRequest`** properties: `documentFileId, documentName,
+  initiatorUserId, signatureLevel, signingMode, status, provider, deadline,
+  signerIds`. The document to view lives at `documentFileId`.
+- **`SigningService::sign()` / `decline()`** (`lib/Service/SigningService.php`,
+  `sign` :352, `decline` :441) derive the actor from
+  `$this->userSession->getUser()` and reject the act unless
+  `signer['userId'] === $user->getUID()` (the #282 fix) AND
+  `signer['signingRequestId'] === $requestId` (the C4 belongs-to-request check).
+  An external portal signer has NO Nextcloud user, so these methods CANNOT be
+  called unchanged from a `#[PublicPage]` receiver — the central design problem
+  below.
+
+## The identity chain (server-derived, never client)
+
+```
+portaliq SPA (accountless signer, magic-link/eIDAS session, trust=substantial)
+  → POST /portal/api/actions/docudesk/sign     body: {signingRequestId, ...}
+  → portaliq authorises against the signer's OWN manifest, re-checks minTrust
+  → forwards to /apps/docudesk/api/portal/signing/sign
+        header  X-Portal-Subject: <HS256 assertion>   (client bearer dropped)
+        body    {signingRequestId, ...}                (client-supplied)
+  → DocuDesk receiver:
+        1. PortalAssertionVerifier: verify HS256 vs shared secret; alg=HS256 only;
+           iss=portaliq; use=assertion; unexpired; frozen claim set  → else 401
+        2. audience==signer && trust>=substantial (re-check)          → else 403
+        3. signerEmail := verified assertion scope claim (NEVER body) → else 403
+        4. target := body.signingRequestId  (opaque id; reject URL/path → SSRF)
+        5. signerRecord := OR find email==signerEmail && signingRequestId==target
+                                                                       → else 403/404 uniform
+        6. SigningService::sign(target, signerRecord, actor=verified-external)
+        7. audit: portal email + assertion jti; relay JSON; 502 on downstream fail
+```
+
+Steps 1–5 make identity and authorisation entirely server-derived. Step 5 is the
+anti-IDOR boundary: the acting signer must be an invited `signerRecord` on the
+EXACT target request, so knowing another request's id buys nothing.
+
+## Composition with the two dependencies
+
+- **Extends `portal-contribution`.** This change adds to the SAME
+  `PortalContributionProvider` file: the `signer` manifest's `actions` goes from
+  `[]` to the three A6 actions. It supersedes `REQ-DDPORT-006` for the `signer`
+  audience ONLY (the `data-subject` manifest stays read-only). Because
+  `portal-contribution`'s canonical spec is not assigned to this change (wave
+  canonical-touch discipline), the relaxation is modelled as this change's own
+  `portal-signing-actions` capability and noted here; apply order is
+  `portal-contribution` first, then this change layers the actions on.
+- **Consumes `signing-trust-rebuild`.** That change makes `decline()` pass the
+  terminal-state status machine and binds the assertion MAC to signer identity,
+  timestamp, level and method. This change does NOT re-implement signing; it
+  calls the honest primitive so an external signature is exactly as trustworthy
+  as an in-app one, and a `decline` on a COMPLETED request is rejected the same
+  way. The only new seam is the verified-actor entrypoint (below).
+
+### The verified-actor entrypoint (the one signing-service seam)
+
+`sign()`/`decline()` read the actor from `userSession`. An external signer has
+none. Rather than duplicate the signing logic in the receiver (which would fork
+the honest primitive and re-open #282), this change adds an actor-source seam to
+`SigningService`: an overload/optional parameter that accepts an already-resolved
+verified `signerRecord` as the actor. When the receiver supplies it, identity is
+asserted against `signer['email']` (matching the verified assertion) instead of
+`signer['userId']` against a Nextcloud uid; the belongs-to-request C4 check, the
+status machine, the audit write and the MAC binding are all UNCHANGED. When no
+actor is supplied the method behaves exactly as today (Nextcloud userSession).
+This keeps ONE honest signing path for both audiences and is the intended
+reading of the brief's "calls the existing `SigningService::sign()/decline()`".
+
+## Declarative vs imperative
+
+- **Declarative (pure data):** the three A6 action declarations on the `signer`
+  manifest. Like the rest of `PortalContributionProvider`, they are constants —
+  no I/O, no branching on subject data beyond the audience. This keeps the
+  provider a plain, dependency-free, duck-typed class (ADR-046 A1) and keeps the
+  authorisation contract audit-readable.
+- **Imperative (justified external-integration exception):** the
+  `PortalSigningReceiverController` and `PortalAssertionVerifier` are genuinely
+  imperative — they verify a cryptographic assertion, read the shared secret,
+  query OpenRegister for the invited `signerRecord`, and call `SigningService`.
+  This is NOT an ADR-022 violation (apps-consume-OR-abstractions) or an
+  ADR-008 layering break: it is the **A6 consumer half of a cross-app security
+  protocol**. portaliq's own contract states "Receiving-app assertion
+  verification (A6 consumer side) is out of scope here by design — tracked per
+  app in the ADR-046 rollout waves"; this IS that per-app consumer, and a signed
+  server-to-server assertion cannot be validated declaratively. The imperative
+  surface is deliberately minimal (verify → resolve → delegate) and every
+  business rule (status machine, MAC, audit) stays inside the honest
+  `SigningService` primitive, not the receiver.
+
+## Document-view transport
+
+portaliq's A6 forward relays a DECODED JSON body only, so the `viewDocument`
+action cannot stream binary. v1 returns `{documentName, mimeType, contentBase64}`
+resolved from `signingRequest.documentFileId`, carried inside the single JSON
+hop. This is correct and fail-closed but heavy for large PDFs; a streaming /
+short-lived signed-URL variant is an Open Question follow-up (below), not a v1
+blocker — an external signer must be able to read the modest documents typical of
+a signing request before signing.
+
+## Security Considerations
+
+- **Fail closed on every path** (ADR-005): `401` (missing/invalid/expired/
+  wrong-`alg`/wrong-`iss`/wrong-`use` assertion, or no shared secret configured),
+  `403` (wrong audience, trust below substantial, not an invited signer,
+  malformed target), `404`/`403` uniform where an oracle would leak, `502`
+  (downstream/OR failure). No path falls open to acting without a verified
+  assertion.
+- **alg-confusion / `none` defeated:** the verifier accepts ONLY
+  `alg == "HS256"`; a token declaring `none` or an asymmetric alg is rejected
+  before signature checking.
+- **Shared-secret sourcing:** the verifier reads the portaliq-managed instance
+  signing secret server-side (the same `jwt_signing_secret` portaliq signs with)
+  and fails closed when it is unset — it never accepts an empty-secret or
+  unsigned assertion.
+- **No cross-signer IDOR:** identity is the assertion's `signerEmail`; the act
+  is allowed only when a `signerRecord` exists with that email AND the target
+  `signingRequestId`. A body-supplied identity is ignored.
+- **SSRF:** the receiver never makes an outbound request; the client
+  `signingRequestId` is used only as an OR object id and is rejected if it looks
+  like a URL/path. (portaliq additionally rejects full-URL endpoints on the
+  forward side.)
+- **Token confusion:** the `X-Portal-Subject` assertion carries `use:
+  assertion`; portaliq's `resolveFromBearer` already rejects it as a session
+  bearer, and the DocuDesk receiver treats it only as an action assertion, never
+  a session.
+- **Audit:** every act writes a signing-audit entry (via the honest
+  `SigningService`/`SigningAuditService` path) recording the portal signer email
+  and the assertion `jti`, so the external act is traceable to its portaliq
+  session.
+- **No client secrets, tokens or endpoints** are introduced by the manifest —
+  only relative endpoint paths.
+
+## Seed Data
+
+This change adds NO OpenRegister schemas, registers or objects — it reuses the
+`signing` register's `signerRecord` / `signingRequest` schemas verified at HEAD,
+and the existing `signingAuditEntry` audit path. There is therefore no register
+version bump and no migration.
+
+Unit tests construct the provider directly (no container) and build synthetic
+assertions/subjects on the **nil-UUID pattern** so fixtures are self-evidently
+fake and can never collide with live data (mirroring `portal-contribution`):
+
+```php
+$signerAssertionClaims = [
+    'sub'          => '00000000-0000-0000-0000-000000000003',
+    'audience'     => 'signer',
+    'organisation' => '00000000-0000-0000-0000-000000000002',
+    'trust'        => 'substantial',
+    'jti'          => '00000000-0000-0000-0000-0000000000aa',
+    'use'          => 'assertion',
+    'iss'          => 'portaliq',
+    // signerEmail scope claim carried per the portaliq A6 amendment (Open Qs)
+    'signerEmail'  => 'signer@example.invalid',
+];
+```
+
+Live seeding (a portalAccount carrying `claims.docudesk.signerEmail`, an invited
+`signerRecord` on a PENDING `signingRequest`) belongs to portaliq's + DocuDesk's
+shared e2e environment, not to this change.
+
+## Open questions (apply-blocker dependencies)
+
+1. **The A6 assertion does not carry the resolved scope claim.** The FROZEN
+   wire format is `sub, audience, organisation, trust, jti, use, iat, exp,
+   iss` — there is NO `signerEmail`, and `sub` is portaliq's subjectRef UUID,
+   which DocuDesk cannot map to an invited email (DocuDesk owns no portalAccount).
+   The receiver's identity step REQUIRES the invited email server-side. Resolution
+   options, both keeping identity server-derived:
+   - **(a, preferred)** a small portaliq A6 amendment: for a claim-scoped
+     action, `createAssertion` also forwards the resolved scope claim (e.g.
+     `signerEmail`) it already resolved server-side for the collection read; the
+     DocuDesk verifier consumes it. This spec is written to consume that claim.
+   - **(b)** the DocuDesk receiver resolves `sub` → invited email via a
+     portaliq server-to-server callback.
+   This is a **named apply-blocker**: portal-signing-actions cannot go live until
+   (a) or (b) lands on the portaliq side. The DocuDesk receiver is authored to
+   fail closed (`403`) when no signer-identifying claim is present, so shipping
+   it early is safe (it simply refuses every act until the claim arrives).
+2. **Large-document `viewDocument`.** base64-in-JSON is fine for typical signing
+   documents; a streaming / short-lived signed-URL transport for large PDFs is a
+   follow-up.
+3. **Shared-secret provisioning.** Confirm DocuDesk reads portaliq's
+   `jwt_signing_secret` app value directly (same instance) vs a dedicated
+   shared-secret config surface — an install/ops decision to confirm at apply.

--- a/openspec/changes/portal-signing-actions/proposal.md
+++ b/openspec/changes/portal-signing-actions/proposal.md
@@ -1,0 +1,120 @@
+---
+kind: code
+depends_on: [portal-contribution, signing-trust-rebuild]
+tracking_issue: https://codeberg.org/Conduction/docudesk/issues/160
+---
+
+# Proposal: portal-signing-actions
+
+## Why
+
+`portal-contribution` gave an external **signer** (a person WITHOUT a Nextcloud
+account) a READ-ONLY window into DocuDesk through **portaliq**, the shared
+external portal (hydra ADR-046, contribution contract v2). That change
+deliberately shipped `actions: []` on the signer manifest (`REQ-DDPORT-006`) and
+recorded sign/decline as deferred A6 endpoint actions "so the receiver +
+`PortalAssertionVerifier` land as a reviewed unit" (its design.md "Deferred
+actions"), tracked on Conduction/docudesk#160.
+
+This is the headline follow-up: it gives that signer a real outside signing
+FRONTEND. An invited external signer can, from portaliq's SPA, read the document
+awaiting them and then **sign** or **decline** it — with no Nextcloud account —
+because portaliq forwards the act server-to-server to a guarded DocuDesk
+receiver under a short-lived signed subject assertion. Without this change the
+only way to sign remains an in-app Nextcloud session, which the whole premise of
+portaliq (accountless externals, ADR-046) excludes; DocuDesk's signing product
+cannot serve external counterparties at all.
+
+The write path is only honest to sell once two preconditions land, hence the
+`depends_on`:
+
+- `portal-contribution` ships the plain `PortalContributionProvider` and the
+  `signer` audience whose manifest this change extends.
+- `signing-trust-rebuild` makes `SigningService::sign()` / `decline()` HONEST
+  (terminal-state status machine on `decline()`, identity-bound assertion MAC,
+  provider/level honesty). This change consumes that honest primitive rather
+  than re-implementing signing.
+
+Tracking issue: Conduction/docudesk#160.
+
+## What Changes
+
+- **Signer manifest gains three A6 endpoint actions.** Extend
+  `lib/Portal/PortalContributionProvider.php` (still plain, dependency-free) so
+  the `signer` manifest declares contract-v2 `{id, label, endpoint, method,
+  minTrust}` actions `sign` (POST), `decline` (POST, reason in body) and
+  `viewDocument` (GET), all `minTrust: substantial`, all pointing at
+  instance-local relative paths under `/apps/docudesk/api/portal/signing/`. The
+  `data-subject` manifest stays read-only.
+- **A bearer-guarded DocuDesk receiver.** A new controller exposes the three
+  `#[PublicPage]` + `#[NoCSRFRequired]` receiver routes portaliq forwards to.
+- **`PortalAssertionVerifier`.** Validates portaliq's frozen `X-Portal-Subject`
+  HS256 assertion (signature against the portaliq-managed shared secret;
+  `alg = HS256` only; `iss = portaliq`; `use = assertion`; unexpired; the frozen
+  claim set) and derives `subjectRef` / `audience` / `organisation` / `trust` /
+  `jti` and the resolved `signerEmail` scope claim SERVER-SIDE — never from the
+  request body or `Authorization` header.
+- **Server-side signer resolution + IDOR guard.** The receiver resolves the
+  invited `signerRecord` (`email == assertion signerEmail` AND
+  `signingRequestId == target`) before any act, so no signer can act on a
+  request they were not invited to; the client's `signingRequestId` is treated
+  as an opaque id only (full URLs / paths rejected — SSRF).
+- **Honest sign/decline via a verified-actor entrypoint.** The receiver drives
+  `SigningService::sign()` / `decline()` as the resolved external signer (email
+  identity, no Nextcloud uid), preserving every existing guard, and records each
+  act in the signing audit (portal email + assertion `jti`).
+- Close Conduction/docudesk#160 with live-verified evidence once applied.
+
+## Capabilities
+
+### Added Capabilities
+
+- `portal-signing-actions`: an external, accountless signer signs or declines a
+  document — and reads it first — through portaliq's A6 endpoint actions,
+  validated by a fail-closed DocuDesk receiver that derives identity from a
+  signed subject assertion and drives the honest `SigningService` primitive.
+
+## Affected Projects
+
+- [x] Project: `docudesk` — extend `lib/Portal/PortalContributionProvider.php`; new `lib/Controller/PortalSigningReceiverController.php` + `lib/Portal/PortalAssertionVerifier.php`; a verified-actor entrypoint on `lib/Service/SigningService.php`; routes in `appinfo/routes.php`; unit tests under `tests/unit/Portal/`; Newman receiver contract; this OpenSpec change.
+- Contract: `apps-extra/portaliq` — the A6 "Endpoint bearer-forward actions" and "Frozen assertion wire format" requirements (`openspec/specs/portal-contribution-contract/spec.md`) this receiver is templated against; runtime consumer that forwards the actions.
+- Reference: `hydra` ADR-046 (portaliq external portal, contribution contract v2, A6).
+- Depends on: `portal-contribution` (signer manifest), `signing-trust-rebuild` (honest sign/decline).
+
+## Out of Scope
+
+- Any portal UI, session, auth edge or rendering — portaliq owns the entire
+  external surface (ADR-046); DocuDesk ships zero portal frontend, only the
+  receiver.
+- Any change to portaliq itself. This change is templated against portaliq's
+  FROZEN assertion wire format and its A6 forward; the portaliq-side amendment
+  that forwards the resolved `signerEmail` scope claim in the A6 assertion is a
+  named apply-blocker dependency, not authored here (design.md "Open questions").
+- The `data-subject` objection-intake write path — still deferred
+  (`portal-contribution` design.md); this change touches the `signer` audience
+  only.
+- Full PAdES/CMS chain validation, deed-of-signing artifacts, NL identity rails
+  and bulk send — owned by `signing-trust-rebuild` / `signer-identity-rails` /
+  `bulk-signing-field-builder`.
+
+## Success Criteria
+
+- `openspec validate portal-signing-actions --strict` exits 0.
+- The `signer` manifest declares exactly `sign`, `decline`, `viewDocument` as
+  substantial-gated A6 endpoint actions with instance-local relative endpoints;
+  the `data-subject` manifest's `actions` stays empty.
+- The receiver rejects a missing/invalid/expired/wrongly-signed assertion, an
+  `alg` other than `HS256`, a wrong `iss`/`use`, and an unconfigured shared
+  secret — all `401` — before any OpenRegister or `SigningService` call.
+- Signer identity is derived only from the verified assertion; a body-supplied
+  `email`/`userId`/`subjectRef`/`claims` never changes it.
+- A signer who is not an invited `signerRecord` on the target request gets the
+  identical not-authorised result as a non-existent request (no existence
+  oracle) and `SigningService` is never called; a full-URL `signingRequestId` is
+  rejected.
+- A verified invited signer's `sign`/`decline` flows through the honest
+  `SigningService` primitive, preserves the terminal-state and
+  belongs-to-request guards, and writes a signing-audit entry carrying the
+  portal email and assertion `jti`.
+- `composer phpcs`, `phpstan`, `psalm` and the unit suite pass on the new files
+  with zero new violations.

--- a/openspec/changes/portal-signing-actions/specs/portal-signing-actions/spec.md
+++ b/openspec/changes/portal-signing-actions/specs/portal-signing-actions/spec.md
@@ -1,0 +1,199 @@
+# portal-signing-actions Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+DocuDesk gives an external **signer** (a person WITHOUT a Nextcloud account) a
+real outside signing frontend through **portaliq**, the shared external portal
+(hydra ADR-046, contribution contract v2). Today `portal-contribution` exposes a
+READ-ONLY signer surface (its `REQ-DDPORT-006` mandates the signer manifest's
+`actions` be empty). This change closes the write path: it declares the
+contract-v2 A6 `endpoint`-type actions `sign`, `decline` and `viewDocument` on
+the signer manifest, and adds a bearer-guarded DocuDesk **receiver** plus a
+`PortalAssertionVerifier` that validates portaliq's frozen `X-Portal-Subject`
+HS256 assertion, derives the signer identity SERVER-SIDE from that assertion
+(never from client input), verifies the signer is genuinely invited on the
+target request, and calls the honest `SigningService::sign()` / `decline()`
+primitive delivered by `signing-trust-rebuild`. Every path fails closed
+(401/403/502) and every act is written to the signing audit.
+
+## ADDED Requirements
+
+### Requirement: Signer manifest declares three substantial-gated endpoint actions (REQ-DDPSA-001)
+
+`OCA\DocuDesk\Portal\PortalContributionProvider`'s `signer` manifest MUST
+declare an `actions` array containing exactly three contract-v2 A6 endpoint
+actions, each shaped `{id, label, endpoint, method, minTrust}`:
+
+- `sign` — `method: POST`, `minTrust: substantial`.
+- `decline` — `method: POST`, `minTrust: substantial` (the client supplies a
+  decline `reason` in the request body).
+- `viewDocument` — `method: GET`, `minTrust: substantial`.
+
+Every `endpoint` MUST be an instance-local RELATIVE path under
+`/apps/docudesk/api/portal/signing/…` (leading slash, no scheme, no host, no
+`..`), so portaliq's SSRF guard and its `urlGenerator->getAbsoluteURL()` forward
+accept it. This requirement RELAXES `portal-contribution`'s read-only signer
+constraint for the `signer` audience only; the `data-subject` manifest's
+`actions` MUST remain empty. The provider stays a plain, dependency-free class
+(no portaliq import, no `implements`, no constructor) — it only adds pure-data
+action declarations.
+
+#### Scenario: The signer manifest carries exactly the three endpoint actions
+
+- GIVEN a constructed `PortalContributionProvider` and a subject with `audience: 'signer'`
+- WHEN `getContribution($subject)` is called
+- THEN the returned manifest's `actions` contains exactly `sign`, `decline` and `viewDocument`
+- AND each action declares an instance-local relative `endpoint` under `/apps/docudesk/api/portal/signing/`, a `method` of `POST`/`POST`/`GET` respectively, and `minTrust: substantial`
+- AND the `data-subject` manifest's `actions` is still empty
+- @e2e exclude backend contract-data declaration consumed by portaliq, no DocuDesk UI surface — covered by PHPUnit (tests/unit/Portal/PortalContributionProviderTest.php::testSignerManifestDeclaresEndpointActions)
+
+### Requirement: Bearer-guarded receiver validates the frozen portaliq assertion (REQ-DDPSA-002)
+
+DocuDesk MUST ship a receiver controller for the three action endpoints, each
+route declaring `#[PublicPage]` + `#[NoCSRFRequired]` (portaliq forwards
+server-to-server without a Nextcloud session or CSRF token). A
+`PortalAssertionVerifier` MUST validate the inbound `X-Portal-Subject` header as
+portaliq's frozen A6 assertion BEFORE any other work: it MUST verify the HS256
+signature against the portaliq-managed shared signing secret; reject any token
+whose header `alg` is not exactly `HS256` (defeating `none` / alg-confusion);
+require `iss` = `portaliq`, `use` = `assertion`, and a present, unexpired `exp`;
+and require the claim set `sub`, `audience`, `organisation`, `trust`, `jti`,
+`use`, `iat`, `exp`, `iss`. A missing, malformed, wrongly-signed, expired or
+wrong-`use` assertion MUST fail closed with `401`. The verifier MUST source the
+shared secret server-side (the portaliq-managed instance secret) and MUST fail
+closed with `401` when no shared secret is configured — it MUST NEVER accept an
+unsigned or empty-secret assertion.
+
+#### Scenario: An invalid or missing assertion is rejected 401
+
+- GIVEN a POST to a portal signing receiver endpoint
+- WHEN the `X-Portal-Subject` header is absent, has `alg` other than `HS256`, has `iss` other than `portaliq`, has `use` other than `assertion`, is expired, or its signature does not match the shared secret
+- THEN the receiver responds `401` and performs no OpenRegister read or write and no `SigningService` call
+- AND when no shared signing secret is configured the receiver also responds `401`
+- @e2e exclude server-to-server verifier contract with no DocuDesk UI surface — covered by PHPUnit (tests/unit/Portal/PortalAssertionVerifierTest.php) and a Newman 401 contract
+
+### Requirement: Signer identity is derived server-side, never from the client (REQ-DDPSA-003)
+
+After signature validation the receiver MUST derive the acting signer's
+identity ONLY from the verified assertion, NEVER from the request body, query,
+or `Authorization` header. It MUST require `audience` = `signer` and re-check
+`trust` server-side to be at least `substantial` (defence in depth — portaliq
+already gates the action, but the receiver MUST NOT rely on that); any other
+audience or a lower trust MUST fail closed with `403`. The signer's scoping
+identity is the invited email carried as the assertion's resolved `signerEmail`
+scope claim (the same `claims.docudesk.signerEmail` value `portal-contribution`
+scopes the signer collections by); the receiver MUST take that email from the
+verified assertion only and MUST fail closed with `403` when no
+signer-identifying claim is present. A client-supplied email, `userId`,
+`subjectRef` or `claims` value MUST NEVER influence the resolved identity.
+
+#### Scenario: Identity comes from the assertion and client-supplied identity is ignored
+
+- GIVEN a valid assertion whose `audience` is `signer`, `trust` is `substantial`, and which carries the resolved `signerEmail` scope claim
+- AND a request body that also contains an `email` and a `userId` naming a DIFFERENT signer
+- WHEN the receiver resolves the acting signer
+- THEN the identity used is the assertion's `signerEmail`, and the body's `email`/`userId` are ignored entirely
+- AND an assertion with `audience` other than `signer`, with `trust` below `substantial`, or with no signer-identifying claim is rejected `403`
+- @e2e exclude server-derived-identity contract with no DocuDesk UI surface — covered by PHPUnit (tests/unit/Portal/SigningReceiverControllerTest.php::testIdentityIsServerDerived)
+
+### Requirement: No cross-signer IDOR — the actor must be an invited signer on the target request (REQ-DDPSA-004)
+
+The receiver MUST treat the client-supplied `signingRequestId` (carried in the
+request body) ONLY as an opaque object reference (an id), and MUST reject any
+value that is a full URL or
+contains a path/scheme/host (SSRF hardening), and MUST NEVER use it to build an
+outbound request. Before any signing act the receiver MUST resolve, via
+OpenRegister, the `signerRecord` whose `email` equals the assertion-derived
+`signerEmail` AND whose `signingRequestId` equals the target — i.e. the acting
+signer MUST be a genuinely invited signer on that exact request. When no such
+`signerRecord` exists (wrong email, request the signer was not invited to, or a
+non-existent request id) the receiver MUST fail closed with a single uniform
+not-authorised result and MUST NOT reveal whether the request exists (no
+existence oracle) and MUST NOT touch `SigningService`.
+
+#### Scenario: A signer cannot act on a request they were not invited to
+
+- GIVEN a valid `signer` assertion resolving to email `A`
+- AND a `signingRequestId` in the body whose `signerRecord` set does NOT include a row with `email == A` and that `signingRequestId`
+- WHEN the receiver processes a `sign`, `decline` or `viewDocument` call
+- THEN the receiver fails closed with the identical not-authorised response for a foreign request, a not-invited signer, and a non-existent request id (no existence oracle)
+- AND `SigningService::sign()` / `decline()` is never called
+- AND a `signingRequestId` value that is a full URL or contains a path is rejected before any lookup
+- @e2e exclude IDOR/SSRF security invariant on a backend-only receiver — covered by PHPUnit (tests/unit/Portal/SigningReceiverControllerTest.php::testCrossSignerIdorFailsClosed) and a Newman 403/404 contract
+
+### Requirement: Sign and decline call the honest SigningService primitive with the verified external actor (REQ-DDPSA-005)
+
+On a verified, authorised request the receiver MUST perform the signing act
+through the existing `OCA\DocuDesk\Service\SigningService::sign()` /
+`decline()` primitive (the honest, status-machine-gated, identity-bound version
+delivered by `signing-trust-rebuild`), acting as the resolved verified external
+signer rather than a Nextcloud user session. Because those methods derive the
+actor from the Nextcloud `userSession` (an external signer has no Nextcloud
+account), this change MUST provide a verified-actor entrypoint so the SAME
+honest primitive serves both an in-app Nextcloud signer and an external portal
+signer: the receiver passes the OpenRegister-resolved `signerRecord`
+(identified above) as the verified actor, the `signerRecord.email` (not a
+Nextcloud uid) is the identity the act is bound to, and every existing
+invariant — the signer-belongs-to-request C4 check, the terminal-state status
+machine, and identity-bound assertion MAC — MUST still hold. `decline` MUST
+carry the client-supplied `reason`. Each act MUST be written to the signing
+audit with the acting portal signer (email) and the assertion `jti` recorded so
+the portal act is traceable to its originating portaliq session. The receiver
+MUST relay the primitive's outcome as JSON and MUST return `502` on a downstream
+or OpenRegister failure (never leaking transport or exception internals).
+
+#### Scenario: A verified portal signer signs through the honest primitive and is audited
+
+- GIVEN a valid `signer` assertion resolving to email `A` and a `signingRequestId` on which `A` is an invited, still-PENDING signer
+- WHEN the receiver processes the `sign` action
+- THEN it calls `SigningService::sign()` acting as the resolved `signerRecord` for `A` (no Nextcloud user session required)
+- AND the signer-belongs-to-request and terminal-state guards still apply, so a `decline` on a COMPLETED request is rejected unchanged
+- AND a signing-audit entry is written recording the portal signer email and the assertion `jti`
+- AND a downstream/OpenRegister failure is relayed as `502` with no internal detail
+- @e2e exclude backend receiver → service contract with no DocuDesk UI surface (the signing UI is portaliq's SPA) — covered by PHPUnit (tests/unit/Portal/SigningReceiverControllerTest.php) and a Newman happy-path contract
+
+### Requirement: Document view returns the target document to the verified signer only (REQ-DDPSA-006)
+
+The `viewDocument` action MUST let the verified invited signer READ the target
+document before signing, scoped by the IDENTICAL invited-signer guard as
+`sign`/`decline` (REQ-DDPSA-004). The receiver MUST resolve the document from
+the target `signingRequest.documentFileId` server-side and return it to the
+signer within the A6 JSON relay as document metadata (`documentName`, MIME type)
+plus the document content (base64), so the single JSON hop portaliq forwards can
+carry it. A signer who is not invited on the target request MUST receive the
+same uniform not-authorised result as for `sign`/`decline` (no existence
+oracle), and a missing or unreadable document MUST fail closed (`404`/`502`),
+never returning another request's document.
+
+#### Scenario: An invited signer reads the document; a non-invited one cannot
+
+- GIVEN a valid `signer` assertion resolving to email `A`
+- WHEN the receiver processes `viewDocument` for a `signingRequestId` on which `A` is invited
+- THEN it returns the document metadata and base64 content resolved from that request's `documentFileId`
+- AND when `A` is NOT invited on the target the receiver returns the identical not-authorised result as `sign`/`decline`, and a missing/unreadable document fails closed
+- @e2e exclude backend document-read receiver with no DocuDesk UI surface — covered by PHPUnit (tests/unit/Portal/SigningReceiverControllerTest.php::testViewDocumentScopedToInvitedSigner)
+
+### Requirement: Assertion is never a portal session and every path fails closed (REQ-DDPSA-007)
+
+The receiver MUST NOT accept the `X-Portal-Subject` assertion (or any token
+carrying `use: assertion`) as a Nextcloud/portal session bearer — a relayed or
+leaked assertion can never be replayed to authenticate anything other than the
+one action forward it was minted for. All receiver failure modes MUST be
+fail-closed and MUST NOT leak internals: `401` for a missing/invalid assertion
+or unconfigured secret, `403` for wrong audience / insufficient trust /
+not-an-invited-signer / malformed target reference, `404`/`403` uniformly where
+an existence oracle would otherwise leak, and `502` for a downstream or
+OpenRegister failure. No receiver path may fall open to acting without a
+verified assertion, and no receiver response may echo raw exception text.
+
+#### Scenario: The receiver never falls open and never leaks internals
+
+- GIVEN any receiver call whose assertion is absent/invalid, whose audience/trust is insufficient, whose signer is not invited, or whose downstream fails
+- WHEN the receiver handles it
+- THEN it returns `401`/`403`/`404`/`502` per the mode above, performs no signing act on any non-authorised path, and returns no raw exception text
+- AND an `X-Portal-Subject` assertion presented as an `Authorization: Bearer` to any DocuDesk endpoint is never treated as a valid session
+- @e2e exclude fail-closed security invariant on a backend-only receiver — covered by PHPUnit fail-closed matrix (tests/unit/Portal/SigningReceiverControllerTest.php, PortalAssertionVerifierTest.php) and a Newman error-contract collection

--- a/openspec/changes/portal-signing-actions/tasks.md
+++ b/openspec/changes/portal-signing-actions/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: portal-signing-actions
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 12.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## Prerequisites (apply-blockers)
+
+- [ ] Confirm the portaliq A6 amendment that forwards the resolved `signerEmail` scope claim in the `X-Portal-Subject` assertion (design.md Open Question 1, option a) is landed — OR the subjectRef→email callback (option b). The DocuDesk receiver fails closed `403` without a signer-identifying claim, so this gates go-live, not authoring.
+- [ ] Confirm the shared-secret sourcing (design.md Open Question 3): the verifier reads portaliq's `jwt_signing_secret` instance secret server-side; fail closed `401` when unset.
+
+## Implementation
+
+- [ ] Extend `lib/Portal/PortalContributionProvider.php` — signer manifest actions (REQ-DDPSA-001)
+  - Add exactly `sign` (POST), `decline` (POST), `viewDocument` (GET) as `{id,label,endpoint,method,minTrust:'substantial'}`; endpoints are instance-local relative paths under `/apps/docudesk/api/portal/signing/`. Keep the class plain/dependency-free; `data-subject` `actions` stays `[]`. EUPL-1.2/SPDX docblock + `@spec` tags.
+
+- [ ] Ship `lib/Portal/PortalAssertionVerifier.php` (REQ-DDPSA-002)
+  - Verify HS256 vs the portaliq-managed shared secret; accept `alg == HS256` ONLY (defeat `none`/alg-confusion); require `iss=portaliq`, `use=assertion`, unexpired `exp`, and the frozen claim set; return the derived claims or fail closed. No client input, no `Authorization` header.
+
+- [ ] Ship `lib/Controller/PortalSigningReceiverController.php` (REQ-DDPSA-003/004/006/007)
+  - Three `#[PublicPage]` + `#[NoCSRFRequired]` routes; derive identity server-side (audience==signer, trust>=substantial, `signerEmail` from the verified assertion — never body); reject a `signingRequestId` that is a URL/path (SSRF); resolve the invited `signerRecord` (email+signingRequestId) via OpenRegister; uniform not-authorised (no existence oracle); fail closed 401/403/404/502; never echo raw exception text.
+
+- [ ] Add the verified-actor entrypoint to `lib/Service/SigningService.php` (REQ-DDPSA-005)
+  - Accept an already-resolved verified external `signerRecord` as actor; assert against `signer['email']` instead of the Nextcloud uid; keep the belongs-to-request C4 check, terminal-state status machine, MAC binding and audit write UNCHANGED; default (no actor) behaves exactly as today.
+
+- [ ] Wire `sign`/`decline`/`viewDocument` through the honest primitive + audit (REQ-DDPSA-005/006)
+  - `sign`/`decline` call `SigningService` with the resolved actor; `decline` carries the client `reason`; `viewDocument` returns `{documentName,mimeType,contentBase64}` from `signingRequest.documentFileId`, IDOR-scoped identically; each act writes a signing-audit entry recording the portal email + assertion `jti`.
+
+- [ ] Register the three routes in `appinfo/routes.php`
+  - Paths exactly matching the manifest endpoints; each controller method carries the correct auth attributes (route-auth + route-reachability gates).
+
+## Testing & quality
+
+- [ ] Unit tests `tests/unit/Portal/PortalContributionProviderTest.php` (extend)
+  - Pin the three signer actions (ids, methods, `minTrust`, relative endpoints); assert `data-subject` `actions` stays empty; register-drift pin covers `documentFileId`.
+
+- [ ] Unit tests `tests/unit/Portal/PortalAssertionVerifierTest.php` + `SigningReceiverControllerTest.php`
+  - Fail-closed matrix: missing/expired/wrong-`alg`/wrong-`iss`/wrong-`use`/bad-sig assertion → 401; no secret → 401; wrong audience / low trust / no signer claim → 403; cross-signer + non-existent request → identical result, `SigningService` never called; URL `signingRequestId` rejected; happy-path sign/decline/viewDocument; assertion-as-bearer never a session; downstream failure → 502; audit entry asserted.
+
+- [ ] Newman receiver contract `tests/newman/portal-signing-actions.postman_collection.json`
+  - 401 (no/invalid assertion), 403 (not-invited / low trust), happy-path 200 sign+decline+viewDocument, 502 on downstream fault (stubbed).
+
+- [ ] Pass the quality gates
+  - `php -l`, `composer phpcs`, `phpstan`, `psalm`, the unit suite (php:8.3-cli / NC container per config.yaml) and the relevant Hydra gates (route-auth, route-reachability, no-admin-idor, security-change-has-tests, spec-coverage) pass with zero new violations.
+
+- [ ] Validate + close the issue
+  - `openspec validate portal-signing-actions --strict` exits 0; after apply + live-verify, close Conduction/docudesk#160 with fixing-commit evidence.
+
+## Quality checklist
+
+- Every MUST in the spec has a unit or Newman test; the fail-closed matrix and the no-cross-signer-IDOR guard are explicitly asserted (`SigningService` never called on a non-authorised path).
+- Manifest labels ship in English source (i18n policy); portaliq owns portal-side translation.
+- No register JSON change — every referenced property (`signerRecord.email/signingRequestId`, `signingRequest.documentFileId`) verified against HEAD.
+- No DocuDesk UI ships (the signing frontend is portaliq's SPA) — no Playwright; receiver covered by PHPUnit + Newman.
+- `openspec validate portal-signing-actions --strict` passes.

--- a/openspec/changes/signer-identity-rails/specs/signer-identity-rails/spec.md
+++ b/openspec/changes/signer-identity-rails/specs/signer-identity-rails/spec.md
@@ -180,3 +180,26 @@ shipped wallet integration.
 - WHEN it is run through the abstract provider contract suite
 - THEN the suite exercises initiate/complete/fail-closed cases without any DocuDesk core change
 - @e2e exclude plugin-seam conformance — covered by PHPUnit (tests/unit/Service/SignerAuth/SignerAuthProviderContractTest.php)
+
+### Requirement: Resolved assurance is surfaced to downstream consumers (REQ-DDSIR-007)
+
+A completed signing act's resolved eIDAS assurance level MUST be surfaced to
+downstream consumers (`low | substantial | high`) without ever exposing a
+BSN, other national identifier, or the raw ID token. Specifically: (a) the
+completion payload of the `docudesk-signing` delegation seam
+(`signing-trust-rebuild` REQ-DDSTR-010) MUST carry the resolved assurance so
+decidesk's `QesGuard` can gate resolution adoption on it; and (b) the same
+assurance MUST be readable by the `portal-signing-actions` `minTrust` gate so an
+external portal signer's act is admitted only when its assurance meets the
+request's `requiredAssurance`. The surfaced value MUST be exactly the assurance
+recorded in `identityEvidence` (REQ-DDSIR-004) — never re-derived from a
+client-supplied value — and only the pairwise `subjectPseudonym`, never a BSN,
+may accompany it.
+
+#### Scenario: QesGuard and portal gate read the same recorded assurance
+
+- GIVEN a signing act completed after DigiD-substantial step-up (recorded `identityEvidence.assurance` = `substantial`)
+- WHEN the delegation-seam completion payload and the `portal-signing-actions` `minTrust` gate read the assurance
+- THEN both observe `substantial` — the exact value from `identityEvidence`, not a re-derived or client-supplied one
+- AND neither receives a BSN nor the raw ID token
+- @e2e exclude cross-app assurance propagation — covered by PHPUnit (tests/unit/Service/SigningServiceTest.php) + the docudesk-signing seam Newman contract

--- a/openspec/changes/signer-identity-rails/tasks.md
+++ b/openspec/changes/signer-identity-rails/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: signer-identity-rails
 
-<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 12.
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 14.
      Acceptance criteria are plain bullets, not checkboxes. -->
 
 ## 1. Register & data model
@@ -27,6 +27,8 @@
 - [ ] 3.2 Evidence recording: persist `identityEvidence` on the signer record, extend the OR audit `changed` context, include the tuple in the v2 artifact assertion (MAC-covered per REQ-DDSTR-001); raw token never stored, evidenceHash only (REQ-DDSIR-004)
 
 - [ ] 3.3 Step-up UI: sign dialog (in `src/modals/`) triggers `initiateAuthentication` on 403 step-up, handles the broker redirect/callback, re-attempts the signature; request form exposes `requiredAssurance` with floor hints (NcSelect with `inputLabel`)
+
+- [ ] 3.4 Surface resolved assurance to consumers (REQ-DDSIR-007): expose the recorded `identityEvidence.assurance` on the `docudesk-signing` completion payload (feeds decidesk `QesGuard`; coordinates with `signing-trust-rebuild` REQ-DDSTR-010) and make it readable by the `portal-signing-actions` `minTrust` gate; surface pseudonym + assurance only, never BSN/raw token
 
 ## 4. Quality, i18n, docs
 

--- a/openspec/changes/signing-trust-rebuild/specs/document-signing/spec.md
+++ b/openspec/changes/signing-trust-rebuild/specs/document-signing/spec.md
@@ -11,7 +11,9 @@ verified open at HEAD, with the already-shipped fixes explicitly out of
 scope): bind signer identity into the signed artifact's MAC, report
 verification honestly in three states, enforce provider/level honesty on the
 completion path, route every terminal transition through the status machine,
-and make the session download fail closed. All requirements are ADDED; no
+make the session download fail closed, and preserve the decidesk delegation
+seam (`docudesk-signing`) backward-compatibly while exposing the resolved
+eIDAS assurance level on completion. All requirements are ADDED; no
 existing `document-signing` requirement is weakened.
 
 ## ADDED Requirements
@@ -161,3 +163,38 @@ may ever escalate to `verified` without a passing MAC.
 - THEN the signature reports status `invalid`
 - AND the document `verdict` is `tampered`
 - @e2e exclude artifact byte-flip mutation — covered by PHPUnit (tests/unit/Service/SigningVerificationServiceTest.php)
+
+### Requirement: The decidesk delegation seam is preserved and exposes assurance (REQ-DDSTR-010)
+
+The rebuild MUST preserve — or version without breaking — the
+`docudesk-signing` OpenConnector Source contract that decidesk drives from
+`EIDASSignatureService` (verified at HEAD: source slug `docudesk-signing`,
+`EIDASSignatureService::composeDocudeskSigningRequest()`). The request contract
+`POST /signing-requests` accepting `{documentId, signatories, signingLevel,
+returnTarget}` and returning `{id | signingRequestId, signingUrl}` MUST remain
+backward-compatible: no existing field may be removed, renamed, or have its type
+changed, and any new field MUST be additive. On completion, the callback the
+consumer maps to `resolveSignatureStage()` MUST include the resolved eIDAS
+**assurance level** (`low | substantial | high`) of the completed request so
+decidesk's `QesGuard` can gate on it. For a native SES completion the exposed
+assurance MUST be `low` (the SES level floor); a broker-authenticated value is
+populated into this same field by `signer-identity-rails` (REQ-DDSIR-007). The
+assurance level MUST be the only identity-strength signal exposed on the seam —
+no BSN, other national identifier, or raw token may appear in the seam payload
+(data minimisation carried from `signer-identity-rails`).
+
+#### Scenario: Decidesk seam request/response shape is unchanged
+
+- GIVEN decidesk posts `{documentId, signatories, signingLevel, returnTarget}` to the `docudesk-signing` source `/signing-requests` endpoint
+- WHEN the signing request is created
+- THEN the response carries `id` (or `signingRequestId`) and `signingUrl` with unchanged field names and types
+- AND no previously present request or response field is removed or renamed
+- @e2e exclude cross-app OpenConnector Source contract — decidesk drives it with no docudesk UI surface; covered by Newman (docudesk-signing collection) + PHPUnit (tests/unit/Controller/SigningControllerTest.php)
+
+#### Scenario: Completion payload exposes the resolved assurance level
+
+- GIVEN a signing request delegated from decidesk that completes via the native provider
+- WHEN the completion callback the consumer maps to `resolveSignatureStage()` is emitted
+- THEN it includes the resolved eIDAS assurance level, which is `low` for a native SES completion
+- AND `QesGuard` can read the assurance without receiving any BSN or raw token
+- @e2e exclude backend completion-payload contract — covered by PHPUnit (tests/unit/Service/SigningServiceTest.php) + Newman

--- a/openspec/changes/signing-trust-rebuild/tasks.md
+++ b/openspec/changes/signing-trust-rebuild/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: signing-trust-rebuild
 
-<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 13.
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 16.
      Acceptance criteria are plain bullets, not checkboxes. -->
 
 ## 1. Identity-bound assertion + honest verification
@@ -25,6 +25,9 @@
 
 - [ ] 2.4 Unit tests for 2.1–2.3 incl. the QES+native 400, unknown-provider completion failure, decline-on-COMPLETED rejection, marker-less download refusal
 
+- [ ] 2.5 Preserve the decidesk delegation seam (REQ-DDSTR-010): keep the `docudesk-signing` `/signing-requests` request (`documentId, signatories, signingLevel, returnTarget`) and response (`id`/`signingRequestId`, `signingUrl`) fields backward-compatible (additive only), and add the resolved eIDAS `assuranceLevel` (`low` for native SES) to the completion payload the consumer maps to `resolveSignatureStage()`; Newman contract test against the docudesk-signing collection
+  - Verify decidesk's `EIDASSignatureService::composeDocudeskSigningRequest()` expectations still pass; broker-resolved assurance is populated by `signer-identity-rails` (REQ-DDSIR-007) into the same field
+
 ## 3. Audit binding + proven immutability
 
 - [ ] 3.1 `SigningAuditService::logEvent()` resolves the real signing-request entity (register `signing`/schema `signingRequest`) with uuid fallback + warning (REQ-DDSTR-006); `getAuditTrail()` switches to an objectUuid-scoped mapper query — verify the REAL AuditTrailMapper filter key at OR HEAD, add the filter OR-side if missing (REQ-DDSTR-007)
@@ -39,7 +42,7 @@
 
 - [ ] 4.3 i18n: EN source + NL translations for new verdict/reason strings and error messages (keys in English)
 
-- [ ] 4.4 Docs: `docs/features/` signing verification page updated (tri-state semantics, legacy-artifact guidance, screenshots via Playwright MCP); F-13/`features.json` narrative updated per the honest-readiness requirement; close GH #282/#284/#287/#289/#304 with evidence links, #283 jointly with `multi-tenant-hardening`
+- [ ] 4.4 Docs: `docs/features/` signing verification page updated (tri-state semantics, legacy-artifact guidance, screenshots via Playwright MCP); F-13/`features.json` narrative updated per the honest-readiness requirement; close GH #282/#283/#284/#287/#289/#304 with fixing-commit evidence links ONLY AFTER apply + tests pass (#283 jointly with `multi-tenant-hardening`)
 
 - [ ] 4.5 Quality gates: `composer check:strict` green; hydra gates pass; `openspec validate signing-trust-rebuild --strict` exits 0
 

--- a/openspec/changes/verapdf-validation/proposal.md
+++ b/openspec/changes/verapdf-validation/proposal.md
@@ -1,16 +1,16 @@
 ---
 kind: code
-tracking_issue: https://codeberg.org/Conduction/docudesk/issues/182
+tracking_issue: https://github.com/ConductionNL/docudesk/issues/315
 ---
 
 # Proposal: verapdf-validation
 
 ## Why
 
-DocuDesk claims archival conformance it never verifies. CB #182 (this
-change's tracking issue — the GitHub number 182 is an unrelated merged PR,
-so the Codeberg issue stays canonical) documents both limitations verified
-at HEAD:
+DocuDesk claims archival conformance it never verifies. GitHub #315 (this
+change's tracking issue; GitHub is primary — it mirrors the original Codeberg
+#182, referenced below for the analysis history) documents both limitations
+verified at HEAD:
 
 - **Validation is shallow.** `Pdfa3ConversionService::validateOutput()`
   asserts the `%PDF-` header and the `pdfaid:part`/`pdfaid:conformance` XMP

--- a/openspec/changes/verapdf-validation/tasks.md
+++ b/openspec/changes/verapdf-validation/tasks.md
@@ -37,4 +37,4 @@
 - No composer/npm dependency added — veraPDF is an admin-installed local binary (design D1 justifies the choice over PDFBox/JHOVE).
 - OR services used: ObjectService/AppHost persistence for `conformanceReport`; no other OR surface touched.
 - `pdfua-accessible-output` heuristics untouched; category naming aligned (`archival` beside `accessibility`); PDF/UA validation is a named follow-up, not smuggled in.
-- Tracking issue: CB #182 (GitHub #182 is an unrelated merged PR — Codeberg issue stays canonical until mirrored).
+- Tracking issue: GitHub #315 (primary; mirrors the original Codeberg #182, kept for analysis history).

--- a/openspec/specs/template-management/spec.md
+++ b/openspec/specs/template-management/spec.md
@@ -13,6 +13,7 @@ retrofit_extensions:
 **Status**: in-progress
 **OpenSpec changes**:
 - [office-template-authoring](../../changes/office-template-authoring/) _(active)_ — office-file-native templates: `templateType`/source-file data-model extension (REQ-DDOTA-006) and versioning/lock/preview/duplicate parity for office templates (REQ-DDOTA-007) (kind: code)
+- [guided-document-wizard](../../changes/guided-document-wizard/) _(active)_ — adds the `wizardDefinition` schema to the templates register (guided-interview definitions fronting a template by `templateId`; the `template`/`templateVersion` data model is unchanged) — full requirements live in the `guided-document-wizard` capability (REQ-DDGDW-*) (kind: code)
 
 ## Purpose
 
@@ -266,6 +267,19 @@ Template objects from OpenRegister are consistently serialized for API responses
 | namespace | string | Yes | -- | App identifier (max 64 chars, lowercase alphanumeric) |
 | format | string (enum) | No | A4 | Page format: A4, A3, Letter, Legal |
 | orientation | string (enum) | No | P | Page orientation: P (portrait), L (landscape) |
+
+### Templates Register Schemas
+
+The `templates` register (`lib/Settings/docudesk_register.json`) is the single
+source of truth for template-related schemas. It contains:
+
+| Schema | Owning capability | Purpose |
+|--------|-------------------|---------|
+| `template` | template-management | The template data model (this spec, REQ-TMPL-01) |
+| `templateVersion` | template-management | Versioned template snapshots (REQ-TMPL-08) |
+| `textFragment` | office-template-authoring | Reusable text fragments for office templates |
+| `templateImportJob` | office-template-authoring | Office-template import job records |
+| `wizardDefinition` | guided-document-wizard | Guided-interview definition (ordered questions, skip logic, register-object pickers) attached to exactly one template by `templateId`; does not modify the `template`/`templateVersion` data model — full requirements in the `guided-document-wizard` capability (REQ-DDGDW-*) |
 
 ## API Endpoints
 


### PR DESCRIPTION
Applies the reviewed deferred-question decisions (23) on top of the merged base, plus two new changes. **Markdown-only** (openspec/).

## New changes
- **portal-signing-actions** — the external-signer write path: sign/decline A6 endpoint actions on the portaliq signer manifest + a bearer-guarded receiver → `SigningService`. Verified finding: portaliq's A6 assertion carries **no signer-identity claim**, so the receiver fails closed until portaliq forwards one — filed **portaliq#3** as the cross-app apply-blocker. Depends on portal-contribution + signing-trust-rebuild. Tracking CB docudesk#160.
- **pdfua-verapdf-matterhorn** — veraPDF PDF/UA-1 (Matterhorn) validation upgrading wave-1's accessibility heuristics; shares verapdf-validation's backend. Depends on pdfua-accessible-output + verapdf-validation.

## Decision edits (all 23)
Signing: decidesk delegation-seam preserved + assurance-level exposed for QesGuard (verified against decidesk code); legacy signatures = unverifiable; close #282-304 post-apply; assurance surfaced to portal minTrust. Generation: office DOCX→HTML parity; concrete register version pin (wizard first); wizardDefinition registered canonically. Redaction/records: embedded-XObject into image-redaction v1 (re-baselined vs Robert's KENTEKEN/ODT); PDF/A-3 attachment preservation; veraPDF→GH #315; files_lock legal-hold freeze. Discovery/platform/enterprise: multi-dossier membership + rename sync; MCP wording reconciled; selectielijst numbers + processing-log retention as explicit apply-blockers.

## Quality
All 15 new/edited changes pass `openspec validate --strict`; correct `### Requirement:` headers; every tasks.md within the 20-checkbox cap. Verified against merged HEAD (Robert's PR #314). Two pre-existing spec-validation failures (document-preview, signing-via-or-approval-with-provider-plugins) are unrelated and untouched.

## Follow-ups filed
OpenRegister: or#2029 (shared archief register), or#2030 (per-object classificatie endpoint), or#2031 (MDTO fields), or#2032 (multi-hold), or#2033 (OCR text seam). Portaliq: portaliq#3 (external-signer identity claim).

## Apply-blockers to note
Real VNG selectielijst category numbers (archiefwet-retention-engine) and selectielijst-approved processing-log retention (flow-operations, + entity-search/inbound-auto-classification) must be obtained from the selectielijst-manager before those changes apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)