### PR TITLE
docs(openspec): wave-3 market-gap specs (9 changes, 2026-07-23 deep research)

### DIFF
--- a/openspec/changes/accessible-redaction-output/.openspec.yaml
+++ b/openspec/changes/accessible-redaction-output/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/accessible-redaction-output/design.md
+++ b/openspec/changes/accessible-redaction-output/design.md
@@ -1,0 +1,231 @@
+# Design: accessible-redaction-output
+
+## Context
+
+Verified at HEAD (DocuDesk `development`, branch
+`spec/market-gap-wave3-2026-07`):
+
+- **Redaction is OR's engine, DocuDesk is the leaf.** `AnonymizationService`
+  (2237 LOC) drives OR's `TextExtractionService` + `DocumentProcessingHandler`
+  (`replaceWords()` → `PdfTextReplacer` for PDF). ADR-022 and R4 D are explicit:
+  the anonymisation/redaction engine is OpenRegister's; DocuDesk owns detection
+  heuristics + orchestration + UI, not the PDF-rewriting engine.
+- **Every run is recorded as `anonymizationLink`.** Verified in
+  `lib/Settings/docudesk_register.json` (schema `anonymizationLink`, register
+  v7.3.0): it pairs `sourceFileId ↔ anonymizedFileId` with run metadata and
+  real replacement counts (closed GH #286). It is the natural home for a
+  per-run accessibility outcome.
+- **The engine half is a parallel OR change.** OpenRegister's
+  `tag-preserving-redaction` change (openregister repo, drafted in parallel)
+  makes the redaction engine preserve the PDF tag tree and emit a
+  `structurePreservation` block on the processing result. **This DocuDesk
+  change assumes that contract** and does not implement tag rewriting.
+- **`verapdf-validation` is an active DocuDesk change** that wires veraPDF as an
+  optional local validator (verified: `openspec/changes/verapdf-validation/`).
+  It is the right home for "is this output genuinely tagged/valid?"; this change
+  consumes it when present, never re-integrates veraPDF.
+- **`pdfua-accessible-output` is a separate active change** for *generated*
+  documents (template → tagged PDF-UA output). Different pipeline; see Boundary.
+
+## Assumed contract (from OR `tag-preserving-redaction`)
+
+DocuDesk consumes this block on OR's processing result — the interface DocuDesk
+codes against:
+
+```jsonc
+"structurePreservation": {
+  "requested": true,            // DocuDesk asked for tag preservation
+  "preserved": true,            // engine kept the tag structure
+  "tagCountBefore": 128,        // structural tags in the source
+  "tagCountAfter": 128,         // structural tags in the redacted output
+  "lossReasons": []             // e.g. ["source-untagged","raster-fallback","engine-unsupported-format"]
+}
+```
+
+**Fail-safe consumption**: if the block or a field is absent (older OR, engine
+without the change), DocuDesk treats preservation as **unknown** and applies the
+degraded path (warn + flag), never a crash and never a false "preserved".
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ask OR's redaction engine to preserve tags on every PDF redaction (default
+  on), and honestly consume the outcome.
+- Make the accessibility outcome **visible** (report + review UI) and
+  **auditable** (on `anonymizationLink`).
+- **Gate clearance** so a tag-destroyed redaction cannot be silently published
+  under Woo — default warn (never a hard block by surprise), admin-escalatable
+  to block.
+- Upgrade a self-reported "preserved" to a validator-backed fact when
+  `verapdf-validation` is present.
+
+**Non-Goals:**
+
+- No DocuDesk-local PDF tag-rewriting engine — that is OR's
+  `tag-preserving-redaction` (ADR-022; the second-engine anti-pattern R4 D
+  flags).
+- No veraPDF integration of DocuDesk's own — that is `verapdf-validation`
+  (consumed, presence-gated).
+- No tagging of *generated* documents — that is `pdfua-accessible-output`
+  (Boundary below).
+- No image/raster redaction accessibility (raster output is inherently
+  untagged; DocuDesk reports it as a `lossReason`, does not try to fix it).
+
+## Decisions
+
+### D1 — Request preservation (default ON for PDF)
+
+`AnonymizationService` and the batch/folder services pass `preserveTags: true`
+to OR's processing call for PDF inputs (default on; admin can default it off via
+`docudesk.redaction.preserve_tags_default`, but on is the shipped default
+because the legal gate is on by default). Non-PDF formats that cannot carry PDF
+tags pass `preserveTags` through unchanged and rely on the engine to report an
+appropriate `lossReason` (e.g. format-unsupported). The option is additive to
+the existing anonymise call; no signature break.
+
+### D2 — Consume + map the outcome (`RedactionAccessibilityService`)
+
+A thin `RedactionAccessibilityService` reads `structurePreservation` from the
+processing result and maps it to a leaf-level state:
+
+| State | Condition |
+|---|---|
+| `preserved` | `preserved === true` (and, if `verapdf-validation` present, veraPDF confirms tagged/valid — D4) |
+| `degraded` | `requested === true` but `preserved === false` |
+| `not-applicable` | source was untagged / raster / unsupported (`lossReasons` explains) |
+| `unknown` | block/field absent (fail-safe → treated as `degraded` for the gate) |
+
+The service owns no PDF parsing — it interprets the engine's block and calls the
+veraPDF hook. This is a clean unit seam (phpunit can prove the mapping without a
+live NC instance).
+
+### D3 — Record on `anonymizationLink` + surface it
+
+- **Record**: the mapped outcome (`structurePreservation` sub-object:
+  requested, preserved, tagCountBefore/After, lossReasons, veraPdfVerified?) is
+  written onto the run's `anonymizationLink` object, alongside the existing
+  replacement counts — no entity values (Art. 5(1)(c)).
+- **Surface**: the document report and the anonymisation review surface show an
+  accessibility state chip (preserved/degraded/not-applicable) with tag counts
+  and human-readable loss reasons; a **prominent flag** when degraded.
+
+### D4 — veraPDF verification hook (presence-gated)
+
+When `verapdf-validation` is present, `RedactionAccessibilityService` asks it to
+validate the redacted output (tagged / PDF-UA-relevant checks). Result:
+
+- veraPDF confirms → `veraPdfVerified: true`; a self-reported `preserved` is now
+  validator-backed.
+- veraPDF contradicts (`preserved` claimed but output not actually valid) →
+  downgrade to `degraded` and flag — the validator wins.
+- `verapdf-validation` absent → `veraPdfVerified` omitted; the engine's
+  self-reported outcome stands (no duplication, no crash).
+
+This is a dependency, not duplication: DocuDesk never invokes veraPDF directly;
+it calls the `verapdf-validation` capability if that change has shipped.
+
+### D5 — Clearance gate (default warn)
+
+Accessibility joins the existing publication/clearance checks (next to the
+prohibition/consent gates). Config
+`docudesk.redaction.accessibility_gate`:
+
+- `warn` (**default**) — clearance proceeds but the degraded state is surfaced
+  as a prominent flag on the clearance decision and recorded.
+- `block` — a `degraded`/`unknown` outcome blocks clearance until an operator
+  overrides with a reason (recorded).
+- `off` — no gate (the outcome is still recorded + surfaced).
+
+Default `warn` (not `block`) so the change never silently breaks an existing
+publication flow; municipalities that treat WCAG as hard can escalate to
+`block`.
+
+## Boundary vs `pdfua-accessible-output` (explicit)
+
+| | `pdfua-accessible-output` (active) | `accessible-redaction-output` (this change) |
+|---|---|---|
+| Pipeline | document **generation** (template → PDF) | document **anonymisation/redaction** |
+| Engine | DocuDesk template renderer (mPDF / LibreOffice headless) | OpenRegister redaction engine (`tag-preserving-redaction`) |
+| Failure fixed | output was **never tagged** | tags **destroyed by redaction** |
+| Artifact | a newly generated citizen/Woo document | a redacted copy of an existing document |
+
+The two are complementary halves of DocuDesk's accessible-output story and MUST
+NOT both claim the redaction path. This change owns redaction output only;
+`pdfua-accessible-output` owns generated output only.
+
+## OpenRegister service usage (ADR-001)
+
+| Operation | Service |
+|---|---|
+| Redaction + tag preservation | OR `DocumentProcessingHandler` (via `AnonymizationService`), consuming the `tag-preserving-redaction` engine change |
+| Outcome record | OR ObjectService `saveObject()` on `anonymizationLink` |
+| veraPDF verification | `verapdf-validation` capability (presence-gated), never invoked directly |
+
+## Declarative vs imperative
+
+- **Declarative**: the `structurePreservation` sub-object on the
+  `anonymizationLink` schema + register-i18n tags; the config keys; the report
+  chip.
+- **Imperative (justified)**: passing `preserveTags`, mapping the engine block,
+  the veraPDF hook call, the clearance gate decision.
+
+## Seed Data
+
+Extend one existing `anonymizationLink` seed with a preserved outcome so the
+report renders non-empty:
+
+```json
+"structurePreservation": {
+  "requested": true,
+  "preserved": true,
+  "tagCountBefore": 96,
+  "tagCountAfter": 96,
+  "lossReasons": []
+}
+```
+
+## Security / Compliance Considerations
+
+- No entity values recorded — only tag counts + loss reasons (AVG Art.
+  5(1)(c)).
+- Fail-safe: absent/partial block → `unknown` → warn+flag, never a false
+  "preserved" and never a crash.
+- The gate defaults to `warn` so it cannot silently harden an existing flow;
+  `block` overrides are reason-recorded.
+- The accessibility outcome is metadata about the redaction, not document
+  content; nothing new is exposed publicly.
+
+## Risks / Trade-offs
+
+- [Depends on the OR engine change to actually preserve tags] → this leaf is
+  honest regardless: without the engine change the outcome reports `unknown`/
+  `degraded` (warn), correctly telling operators accessibility is unverified —
+  it never claims a preservation that did not happen.
+- [Default-on preservation may change redaction output/perf] → the engine owns
+  the cost; DocuDesk only requests it; admin can default it off.
+- [Warn-by-default lets a degraded doc through] → accepted: a hard block by
+  surprise is worse; the flag is prominent and recorded, and `block` is one
+  setting away.
+- [veraPDF absent → self-reported only] → acceptable; the outcome is labelled
+  "engine-reported, not validator-verified" until `verapdf-validation` lands.
+
+## Migration Plan
+
+Additive: `structurePreservation` sub-object on `anonymizationLink` (version
+bump, seed), `preserveTags` passthrough, a mapping service, a config-driven
+clearance check, report/review UI. No existing schema field changes; no data
+migration. Rollback = stop passing `preserveTags` + remove the gate; recorded
+outcomes remain readable.
+
+## Open Questions
+
+- Exact field names in OR's `structurePreservation` block — DocuDesk codes to
+  the assumed contract and tolerates absence (fail-safe); reconcile with the OR
+  `tag-preserving-redaction` change before apply.
+- Whether `not-applicable` (source untagged) should count as a WCAG failure for
+  the gate — provisional: no (you cannot preserve tags a source never had), but
+  surface it so operators know the source itself is inaccessible.
+- Whether the veraPDF check should run inline or as a background job for large
+  batches — provisional: background for folder/batch runs, inline for single
+  documents.

--- a/openspec/changes/accessible-redaction-output/proposal.md
+++ b/openspec/changes/accessible-redaction-output/proposal.md
@@ -1,0 +1,129 @@
+---
+kind: code
+---
+
+# Proposal: accessible-redaction-output
+
+## Why
+
+When Dutch anonymisation software redacts a PDF it frequently **strips or
+mangles the document's tag structure**, silently breaking screen-reader
+accessibility — and since the European Accessibility Act deadline
+(**2025-06-28**, R2 C4) that is a live legal defect, not a nice-to-have. This
+is the single highest-demand unspecced DocuDesk gap in the user-wishes
+research (**demand_score 5**, the top-ranked item, R3 A/E):
+
+- **Gebruiker Centraal** — *"zwart lakken? Vergeet de toegankelijkheid niet."*
+- **DigiToegankelijk kennisbank** — "een toegankelijke pdf met zwartgelakte
+  delen."
+- **RVIHH** (direct quote, R3 C): *"Sommige anonimiseringssoftware lakt niet
+  alleen informatie weg, maar verandert of verwijdert ook de tags in de PDF,
+  waardoor deze niet meer toegankelijk is voor screenreaders."*
+- Plus the DigiToegankelijk event "Zwartgelakte documenten en digitale
+  toegankelijkheid" and documenten-en-toegankelijkheid.nl.
+
+Every Woo-published or citizen-facing redacted PDF is in scope of the Besluit
+digitale toegankelijkheid (EN 301 549 / WCAG 2.1 AA) — a **hard procurement
+gate**. A redaction that removes PII but leaves an untagged, screen-reader-
+hostile PDF fails that gate.
+
+**Redaction is OpenRegister's engine, not DocuDesk's** (ADR-022). Verified at
+HEAD: DocuDesk's `AnonymizationService` (2237 LOC) drives OR's
+`TextExtractionService` + `DocumentProcessingHandler::replaceWords()` (PDF →
+`PdfTextReplacer`); DocuDesk records each run as an `anonymizationLink` object
+(verified in `lib/Settings/docudesk_register.json`, schema `anonymizationLink`,
+register v7.3.0). Tag preservation must therefore be **fixed in the redaction
+engine (OR), consumed by DocuDesk** — not re-implemented as a second
+DocuDesk-local PDF pipeline (the exact ADR-022 failure mode R4 D flags for
+`image-redaction`). A parallel agent is speccing the **OR engine half** as the
+`tag-preserving-redaction` change in the openregister repo; that change makes
+OR's processing result carry a `structurePreservation` block. **This change is
+the DocuDesk LEAF half**: request preservation, surface the outcome, and gate
+clearance on it.
+
+This is **distinct from the active `pdfua-accessible-output` change**, which
+makes DocuDesk's *generated* documents (templates → mPDF/LibreOffice output)
+tagged/PDF-UA. That change tags documents DocuDesk *creates*; this change
+preserves tags in documents DocuDesk *redacts*. Different pipeline (generation
+vs anonymisation), different engine ownership (DocuDesk template renderer vs OR
+redaction engine), different failure mode (never-tagged vs tags-destroyed). The
+boundary is stated explicitly in design.md.
+
+## What Changes
+
+- **Request tag preservation** on anonymisation/redaction jobs: DocuDesk passes
+  a `preserveTags` option (default **ON for PDF**) to OR's document-processing
+  engine on every redaction run and folder/batch run.
+- **Consume the outcome**: DocuDesk reads OR's `structurePreservation` block
+  (`{requested, preserved, tagCountBefore, tagCountAfter, lossReasons[]}`, the
+  contract the OR `tag-preserving-redaction` change delivers) from the
+  processing result.
+- **Surface it** in the document report and the review UI: a clear
+  "accessibility preserved / degraded" state with tag counts and loss reasons.
+- **Gate clearance/publication**: when structure was lost, block or warn
+  (admin-configurable, **default warn + prominent flag**) before a redacted
+  document is cleared for publication — accessibility joins the existing
+  prohibition/consent clearance gates.
+- **Record the outcome** in the `anonymizationLink` object so the accessibility
+  result is auditable per redaction run alongside the replacement counts.
+- **veraPDF verification hook** (dependency, presence-gated): when the active
+  `verapdf-validation` change is present, DocuDesk asks it to confirm the
+  redacted output is genuinely tagged/valid, turning a self-reported
+  `preserved: true` into a validator-backed fact — **if** that change has
+  landed; otherwise the self-reported outcome stands (no duplication of the
+  veraPDF integration).
+
+## Capabilities
+
+### New Capabilities
+
+- `accessible-redaction-output`: tag-preserving redaction as a DocuDesk leaf —
+  request structure preservation from OR's redaction engine (default on for
+  PDF), surface the `structurePreservation` outcome in the report + review UI,
+  record it on `anonymizationLink`, and gate publication clearance on preserved
+  accessibility (default warn), with an optional veraPDF-backed verification
+  when `verapdf-validation` is present.
+
+### Modified Capabilities
+
+<!-- none — the redaction engine and its structurePreservation result are owned
+     by OpenRegister's tag-preserving-redaction change (dependency, consumed
+     unchanged). The veraPDF integration is owned by the active
+     verapdf-validation change (presence-gated dependency). This change adds no
+     DocuDesk-local redaction or validation engine. -->
+
+## Impact
+
+- **Backend**: `AnonymizationService` (and the batch services
+  `BatchAnonymizeService`/`FolderBatchService`) pass `preserveTags` to OR's
+  processing call and read back `structurePreservation`; a small
+  `RedactionAccessibilityService` maps the outcome to a report/clearance state
+  and (when present) invokes the `verapdf-validation` verification.
+- **Register**: `anonymizationLink` schema in `lib/Settings/docudesk_register.json`
+  gains a `structurePreservation` sub-object (requested, preserved,
+  tagCountBefore, tagCountAfter, lossReasons[], veraPdfVerified?) with a
+  register **version bump** + register-i18n tags; one seed run showing a
+  preserved outcome.
+- **Clearance gate**: the accessibility check is added to the existing
+  publication/clearance path (alongside the prohibition gate), config
+  `docudesk.redaction.accessibility_gate` = `warn` (default) | `block` | `off`.
+- **Frontend**: an accessibility state chip + tag-count/loss-reason detail on
+  the document report and in the anonymisation review surface (manifest V2
+  shell); a prominent flag when degraded. ADR-012 Cn components, NL Design
+  tokens.
+- **Depends on**:
+  - OpenRegister `tag-preserving-redaction` (parallel, openregister repo) — the
+    engine that actually preserves tags and emits `structurePreservation`.
+    DocuDesk assumes the block shape as the contract; if a field is absent
+    DocuDesk degrades to "unknown" (fail-safe warn), never crashes.
+  - `verapdf-validation` (active) — presence-gated verification hook; consumed,
+    not duplicated.
+- **Boundary**: distinct from `pdfua-accessible-output` (generated templates) —
+  stated in design.md; the two must not both claim redaction output.
+- **GDPR/WCAG**: no entity values recorded — only tag counts and loss reasons
+  (AVG Art. 5(1)(c) data minimisation); the accessibility outcome is metadata
+  about the redaction, not document content.
+- **Evidence**: R3 section C (5 gov sources; RVIHH direct quote that software
+  strips PDF tags) + R3 E #1 (top-ranked, demand_score 5); EAA live 2025-06-28
+  (R2 C4); ADR-022 consume-not-rebuild (R4 D, redaction engine = OR); HEAD
+  verification of `AnonymizationService` + `anonymizationLink`.

--- a/openspec/changes/accessible-redaction-output/specs/accessible-redaction-output/spec.md
+++ b/openspec/changes/accessible-redaction-output/specs/accessible-redaction-output/spec.md
@@ -1,0 +1,157 @@
+# accessible-redaction-output Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Tag-preserving accessible redaction as a DocuDesk leaf over OpenRegister's
+redaction engine. Dutch anonymisation software routinely strips a PDF's tag
+structure, breaking screen-reader accessibility — a hard WCAG procurement gate
+and, since the European Accessibility Act deadline (2025-06-28), a live legal
+defect (R3 section C, 5 gov sources incl. the RVIHH quote; top-ranked unspecced
+demand, R3 E #1). Because redaction is OpenRegister's engine (ADR-022; verified
+at HEAD via `AnonymizationService` → `DocumentProcessingHandler`), the
+tag-preservation fix lives in OR's parallel `tag-preserving-redaction` change,
+which makes the processing result carry a `structurePreservation` block. This
+change is the DocuDesk half: request preservation (default on for PDF), consume
+and surface the outcome, record it on `anonymizationLink`, gate publication
+clearance on it (default warn), and — when the active `verapdf-validation`
+change is present — upgrade a self-reported outcome to a validator-backed fact.
+It is distinct from `pdfua-accessible-output` (generated templates); this change
+owns redaction output only.
+
+## ADDED Requirements
+
+### Requirement: Request tag-structure preservation on redaction jobs (REQ-DDARO-001)
+
+DocuDesk MUST request tag-structure preservation from OpenRegister's
+document-processing engine on every PDF anonymisation/redaction run, including
+folder and batch runs, by passing a `preserveTags` option that defaults to ON
+for PDF inputs. The request MUST be additive to the existing anonymise call and
+MUST NOT introduce a DocuDesk-local PDF tag-rewriting engine — tag preservation
+is owned by OpenRegister's `tag-preserving-redaction` change. Formats that
+cannot carry PDF tags MUST pass the option through and rely on the engine's
+reported loss reason rather than failing.
+
+#### Scenario: PDF redaction requests preservation by default
+
+- GIVEN a tagged source PDF submitted for anonymisation
+- WHEN DocuDesk invokes OpenRegister's redaction engine
+- THEN the call carries `preserveTags: true` by default
+- @e2e tests/e2e/spec-coverage/accessible-redaction-output.spec.ts
+
+#### Scenario: The default can be disabled by an administrator
+
+- GIVEN `docudesk.redaction.preserve_tags_default` is set to false
+- WHEN a PDF is redacted
+- THEN `preserveTags` is passed as false and the outcome is recorded accordingly
+- @e2e exclude admin-config default is backend logic — covered by PHPUnit (tests/unit/Service/AnonymizationServiceTest.php)
+
+### Requirement: Surface the structure-preservation outcome (REQ-DDARO-002)
+
+DocuDesk MUST read the `structurePreservation` block
+(`{requested, preserved, tagCountBefore, tagCountAfter, lossReasons[]}`) from
+OpenRegister's processing result and surface it in the document report and the
+anonymisation review UI as an accessibility state — `preserved`, `degraded`,
+or `not-applicable` — with the tag counts and human-readable loss reasons, and
+a prominent flag when degraded. When the block or a field is absent (an
+OpenRegister without the engine change), DocuDesk MUST treat the outcome as
+`unknown` and surface it as unverified — it MUST NOT report a false `preserved`
+and MUST NOT crash.
+
+#### Scenario: Preserved redaction shows an accessibility-preserved state
+
+- GIVEN a redaction whose processing result reports `preserved: true` with equal before/after tag counts
+- WHEN the operator opens the document report
+- THEN an "accessibility preserved" state is shown with the tag counts
+- @e2e tests/e2e/spec-coverage/accessible-redaction-output.spec.ts
+
+#### Scenario: Degraded redaction shows a prominent flag with loss reasons
+
+- GIVEN a redaction whose result reports `requested: true, preserved: false` with a `lossReasons` entry
+- WHEN the report renders
+- THEN a prominent "accessibility degraded" flag is shown with the loss reasons
+- @e2e tests/e2e/spec-coverage/accessible-redaction-output.spec.ts
+
+#### Scenario: Absent block is reported as unknown, never false-preserved
+
+- GIVEN a processing result with no `structurePreservation` block
+- WHEN DocuDesk maps the outcome
+- THEN the state is `unknown` (unverified), never `preserved`, and no error is raised
+- @e2e exclude fail-safe mapping is backend logic — covered by PHPUnit (tests/unit/Service/RedactionAccessibilityServiceTest.php::testAbsentBlockIsUnknown)
+
+### Requirement: Gate publication clearance on preserved accessibility (REQ-DDARO-003)
+
+When a redacted document's structure was lost, DocuDesk MUST gate publication/
+clearance according to `docudesk.redaction.accessibility_gate`: `warn` (default)
+proceeds but attaches a prominent, recorded flag to the clearance decision;
+`block` prevents clearance until an operator overrides with a recorded reason;
+`off` records the outcome without gating. The gate MUST default to `warn` so it
+never hardens an existing publication flow by surprise, and MUST sit alongside
+the existing prohibition/consent clearance checks, not replace them. An
+`unknown` outcome MUST be treated as degraded for the gate.
+
+#### Scenario: Degraded redaction warns and flags at clearance by default
+
+- GIVEN the gate is `warn` (default) and a degraded redaction is cleared for publication
+- WHEN clearance is evaluated
+- THEN clearance proceeds AND a prominent accessibility-degraded flag is attached to and recorded on the clearance decision
+- @e2e tests/e2e/spec-coverage/accessible-redaction-output.spec.ts
+
+#### Scenario: Block mode stops clearance until a reasoned override
+
+- GIVEN the gate is `block` and a degraded redaction is submitted for clearance
+- WHEN clearance is evaluated
+- THEN clearance is blocked until an operator overrides with a recorded reason
+- @e2e exclude gate-mode branching is backend logic — covered by PHPUnit (tests/unit/Service/RedactionAccessibilityServiceTest.php)
+
+### Requirement: Record the outcome on the anonymizationLink object (REQ-DDARO-004)
+
+DocuDesk MUST record the structure-preservation outcome on the run's
+`anonymizationLink` object as a `structurePreservation` sub-object (requested,
+preserved, tagCountBefore, tagCountAfter, lossReasons, and veraPdfVerified when
+applicable), alongside the existing replacement counts. The recorded outcome
+MUST contain no entity values and no document content (AVG Art. 5(1)(c) data
+minimisation) — only tag counts and loss reasons. The `anonymizationLink`
+schema MUST gain this sub-object with a register version bump.
+
+#### Scenario: The redaction run records its accessibility outcome
+
+- GIVEN a completed PDF redaction with a preserved outcome
+- WHEN the `anonymizationLink` object for that run is inspected
+- THEN it carries a `structurePreservation` sub-object with the tag counts and no entity values
+- @e2e exclude object-shape assertion is backend logic — covered by PHPUnit (tests/unit/Service/RedactionAccessibilityServiceTest.php)
+
+### Requirement: Optional veraPDF-backed verification when verapdf-validation is present (REQ-DDARO-005)
+
+When the `verapdf-validation` capability is present, DocuDesk MUST ask it to
+verify that the redacted output is genuinely tagged/valid and record the result
+as `veraPdfVerified`; a validator contradiction (output not actually valid
+despite a self-reported `preserved`) MUST downgrade the state to `degraded`.
+DocuDesk MUST NOT integrate veraPDF directly — the integration is owned by
+`verapdf-validation` — and when that capability is absent DocuDesk MUST fall
+back to the engine's self-reported outcome, labelled as engine-reported and not
+validator-verified, without error.
+
+#### Scenario: veraPDF confirms a preserved redaction
+
+- GIVEN `verapdf-validation` is present and a redaction self-reports `preserved: true`
+- WHEN DocuDesk runs the verification hook
+- THEN veraPDF confirmation is recorded as `veraPdfVerified: true`
+- @e2e exclude requires the verapdf binary/capability — covered by PHPUnit with a fake verapdf-validation capability (tests/unit/Service/RedactionAccessibilityServiceTest.php)
+
+#### Scenario: veraPDF contradiction downgrades a self-reported outcome
+
+- GIVEN `verapdf-validation` is present and a redaction self-reports `preserved: true` but the output is not actually valid
+- WHEN the verification hook runs
+- THEN the state is downgraded to `degraded` and flagged
+- @e2e exclude validator-contradiction path is backend logic — covered by PHPUnit (tests/unit/Service/RedactionAccessibilityServiceTest.php::testVeraPdfContradictionDowngrades)
+
+#### Scenario: Absent verapdf-validation leaves the engine outcome standing
+
+- GIVEN `verapdf-validation` is not present
+- WHEN DocuDesk maps a redaction outcome
+- THEN the engine's self-reported outcome stands, labelled engine-reported-only, with no error
+- @e2e exclude presence-gate fallback is backend logic — covered by PHPUnit (tests/unit/Service/RedactionAccessibilityServiceTest.php)

--- a/openspec/changes/accessible-redaction-output/tasks.md
+++ b/openspec/changes/accessible-redaction-output/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: accessible-redaction-output
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 9.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Register + seed data
+
+- [ ] 1.1 Add a `structurePreservation` sub-object to the `anonymizationLink` schema in `lib/Settings/docudesk_register.json` (REQ-DDARO-004)
+  - Fields `requested`, `preserved`, `tagCountBefore`, `tagCountAfter`, `lossReasons[]`, `veraPdfVerified?` (design.md D3); no entity values (Art. 5(1)(c)); register-i18n tags on user-facing strings; register version bump with changelog entry; extend one existing anonymizationLink seed with a preserved outcome; schema refs use slugs.
+
+## 2. Backend
+
+- [ ] 2.1 Pass `preserveTags` to OR's redaction engine on single + batch/folder runs (REQ-DDARO-001)
+  - `AnonymizationService` and `BatchAnonymizeService`/`FolderBatchService` pass `preserveTags` (default ON for PDF via `docudesk.redaction.preserve_tags_default`) to the OR processing call; additive, no signature break; non-PDF passes through and relies on engine `lossReasons`.
+
+- [ ] 2.2 Implement `RedactionAccessibilityService` mapping the engine outcome (REQ-DDARO-002, REQ-DDARO-004)
+  - Read `structurePreservation` from the processing result; map to `preserved`/`degraded`/`not-applicable`/`unknown` (fail-safe: absent block → `unknown` → treated as degraded, never crash, never false-preserved); write the outcome onto the run's `anonymizationLink`.
+
+- [ ] 2.3 Add the accessibility clearance gate (REQ-DDARO-003)
+  - Config `docudesk.redaction.accessibility_gate` = `warn` (default) | `block` | `off`; on `degraded`/`unknown` warn+prominent-flag (default) or block-until-reason-override (recorded); wired next to the existing prohibition/consent clearance checks; never a hard block by surprise.
+
+- [ ] 2.4 Add the presence-gated veraPDF verification hook (REQ-DDARO-005)
+  - When `verapdf-validation` is present, validate the redacted output and set `veraPdfVerified`; validator contradiction downgrades `preserved`→`degraded`; absent → outcome labelled engine-reported-only; never invoke veraPDF directly (no duplication).
+
+## 3. Frontend
+
+- [ ] 3.1 Surface the accessibility outcome in the document report + review UI (REQ-DDARO-002)
+  - Accessibility state chip (preserved/degraded/not-applicable) with tag counts and human-readable loss reasons; prominent flag when degraded; on the clearance decision surface too; manifest V2 shell; ADR-012 Cn components, NL Design tokens.
+
+## 4. Quality
+
+- [ ] 4.1 PHPUnit unit tests for `RedactionAccessibilityService` + the gate (REQ-DDARO-002, REQ-DDARO-003, REQ-DDARO-004)
+  - Mapping matrix incl. fail-safe absent-block→unknown; degraded blocks under `block` and warns under `warn`; outcome recorded on `anonymizationLink` with no entity values; veraPDF-present downgrade-on-contradiction; min 75% on new code; run in the container (`docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`).
+
+- [ ] 4.2 Playwright e2e `tests/e2e/spec-coverage/accessible-redaction-output.spec.ts` (REQ-DDARO-001, REQ-DDARO-002, REQ-DDARO-003)
+  - Redact a tagged fixture PDF through the UI with OpenRegister on the Postgres dev instance; assert the preserved chip + tag counts on the report; assert the degraded warn-flag path; test through the UI; nldesign-theme accessibility pass.
+
+- [ ] 4.3 i18n (EN + NL) for the chip/loss-reason/flag/gate strings; docs `docs/features/accessible-redaction-output.md` with MCP screenshots; run `openspec validate accessible-redaction-output --strict`
+  - Keys in English; document the OR `tag-preserving-redaction` dependency, the `verapdf-validation` presence gate, the RVIHH/EAA evidence, and the explicit boundary vs `pdfua-accessible-output`.

--- a/openspec/changes/custom-dictionary-recognition/.openspec.yaml
+++ b/openspec/changes/custom-dictionary-recognition/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/custom-dictionary-recognition/design.md
+++ b/openspec/changes/custom-dictionary-recognition/design.md
@@ -1,0 +1,224 @@
+# Design: custom-dictionary-recognition
+
+## Context
+
+Verified at HEAD (DocuDesk `spec/market-gap-wave3-2026-07`, OpenRegister HEAD):
+
+- **Detection is OR-owned.** `EntityRecognitionHandler`
+  (`lib/Service/TextExtraction/`) dispatches over `regex` / `presidio` /
+  `openanonymiser` / `llm` / `hybrid`. Its entity types are compile-time
+  constants (`ENTITY_TYPE_PERSON … ENTITY_TYPE_IP_ADDRESS`) and its regex
+  set (`getRegexPatterns()`) is a hard-coded, instance-global list. There is
+  no organisation-scoped, user-managed term list anywhere in OR.
+- **The catalogue is shared and type-agnostic.** OR persists detections in
+  `oc_openregister_entities` (`type`, `value`, `category`, `organisation`)
+  with one `oc_openregister_entity_relations` row per occurrence
+  (`fileId`, `positionStart/End`, `confidence`, `detectionMethod`,
+  `anonymized`, `bases[]`, `skipAnonymization`). `EntityRelationMapper`
+  writes it; the review UI, grondslagen pass and redaction read it.
+- **Redaction is type-agnostic.** `DocumentProcessingHandler::anonymizeDocument()`
+  builds `[<localized-type>: <number>]` for any entity type and
+  `localizeEntityType()` returns the raw label for a type it does not know —
+  so a `CUSTOM_DICTIONARY` occurrence redacts with zero engine change.
+- **DocuDesk already reads document text** (`AnonymizationService::readNodeTextSafely()`)
+  and owns the enabled-type whitelist
+  (`GrondslagProposalService::getEntityTypeWhitelist()`), and its
+  `extractAndDetectEntities()` is the single detection entry point every
+  DocuDesk flow drives.
+- OR's `detectionMethod` for these rows is a DocuDesk-contributed value
+  (`custom_dictionary`) parallel to the existing `manual` method.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Organisation-managed term lists that add `CUSTOM_DICTIONARY` occurrences
+  to OR's shared catalogue so they flow through review and redaction like any
+  other entity.
+- CRUD + CSV/newline import + an admin page, all org-scoped fail-closed.
+- A pure, unit-testable matcher (exact / case-insensitive / word-boundary)
+  that needs no live NC instance to prove.
+
+**Non-Goals:**
+
+- No new detection engine and no fork of the pipeline — matches are written
+  into OR's catalogue, not a DocuDesk-local entity store.
+- No change to OR's `EntityRecognitionHandler`, its type constants, its regex
+  set or its redaction placeholder format.
+- No fuzzy/approximate matching in v1 (flag declared, deferred — Open
+  Questions).
+- No review-workbench UI work — that is `anonymization-review-workbench`
+  (active); `CUSTOM_DICTIONARY` rows surface there for free via the catalogue.
+
+## Decisions
+
+### D1 — Dictionaries + terms as register objects, org-scoped (justified controller)
+
+Two schemas in the `document` register:
+
+- `customDictionary`: `label`, `description`, `colour`, `matchMode`
+  (`exact`|`caseInsensitive`|`wordBoundary`, default `caseInsensitive`),
+  `fuzzy` (bool, accepted-and-ignored in v1), `active` (bool), `termCount`
+  (calculated). Owning organisation via `@self.organisation`.
+- `customDictionaryTerm`: `value` (the term), `label` (optional per-term
+  display, defaults to the dictionary label), `dictionary` (uuid reference).
+
+CRUD is OR's `ObjectService`. DocuDesk wraps it in
+`CustomDictionaryController` (`api/custom-dictionaries`,
+`api/custom-dictionaries/{uuid}`, `.../{uuid}/terms`,
+`.../{uuid}/import`). Per ADR-022 a bare proxy is forbidden; this controller
+is justified because it adds (1) the **organisation gate** (a caller may only
+read/write dictionaries of their accessible organisations — fail-closed,
+mirroring OR's tenant rule), (2) **CSV/newline import parsing** (server-side,
+not client-side), and (3) **term-count enrichment**. OR services are resolved
+lazily by FQCN string via the DI container (the `EmlBackend`/`EntitySearch`
+cross-app pattern) so DocuDesk stays loadable without OR; without OR the
+endpoints return an explanatory unavailable state.
+
+### D2 — The matcher (pure, unit-pinned)
+
+`CustomDictionaryMatchService::match(string $text, array $terms, string $mode): array`
+returns occurrences `{value, label, positionStart, positionEnd}`:
+
+| Mode | Rule |
+|---|---|
+| `exact` | `mb_strpos` byte-for-byte, case-sensitive |
+| `caseInsensitive` (default) | `mb_stripos`, case-folded both sides |
+| `wordBoundary` | case-insensitive **and** the match is delimited by a non-word boundary (`\b` semantics over Unicode letters/digits) so "Berg" does not match inside "Bergen" |
+
+All modes return **every** occurrence (all positions), not just the first,
+so multi-occurrence redaction and counts are correct. Blank/whitespace-only
+terms are skipped. Longest-term-first ordering is applied so an overlapping
+shorter term cannot pre-empt a longer one (mirrors OR's redaction
+longest-needle rule). This method is a pure function of its inputs — the
+primary phpunit seam; no NC container required.
+
+### D3 — Writing occurrences into OR's catalogue
+
+For each active dictionary of the file's organisation, the matcher runs over
+the document text; occurrences are written as `CUSTOM_DICTIONARY`
+entities/relations through OR's `EntityRelationMapper`:
+
+- entity `type` = `CUSTOM_DICTIONARY`, `value` = the matched term,
+  `category` = `contextual_data` (OR's `CATEGORY_CONTEXTUAL_DATA`).
+- relation `detectionMethod` = `custom_dictionary`, `confidence` = `1.0`
+  (a dictionary hit is a certainty, not a probability), positions from D2,
+  and the per-list label carried so the review/summary can show which
+  dictionary matched.
+- Idempotency: a re-run first clears prior `custom_dictionary` relations for
+  the file (matching OR's re-extract semantics) so re-matching does not
+  append duplicates.
+
+The pass is **best-effort** and hooked into
+`AnonymizationService::extractAndDetectEntities()` after OR extraction and
+before the normalize/policy pass, so `CUSTOM_DICTIONARY` rows are in the
+returned entity set and the review UI. A matcher failure is logged and never
+blocks OR-side detection (honest degradation: the operator sees OR's hits
+plus a warning that dictionary matching did not run).
+
+### D4 — Respecting the enabled-type whitelist
+
+`CUSTOM_DICTIONARY` participates in
+`GrondslagProposalService::getEntityTypeWhitelist()`: when the operator has
+disabled it, the matcher is skipped (dictionaries stay manageable but do not
+auto-detect). This keeps one consistent enable/disable surface for all types.
+
+### D5 — CSV / newline import
+
+`POST api/custom-dictionaries/{uuid}/import` accepts either a `text/csv`
+upload (first column = value, optional second column = per-term label) or a
+`text/plain` newline list. The server trims, drops blanks, de-duplicates
+against existing terms (case-insensitive), creates `customDictionaryTerm`
+objects, and returns `{added, skipped, total}`. No client-side parsing (a
+malformed file must fail on the server, not silently in the browser).
+
+### D6 — UI (Manifest-V2 shell)
+
+A "Custom dictionaries" page registered in `src/manifest.json` +
+`registry.js` (NOT `src/router/index.js`): `CnIndexPage`/`CnDataTable` of
+dictionaries (label, term count, match mode, active); a detail/edit view
+(term table, add/remove, import upload, match-mode `NcSelect` with
+`inputLabel`, active toggle, colour picker). Dialogs live in their own files
+under `src/dialogs/`. NL Design tokens; the page is admin/manager gated
+consistently with the controller.
+
+## OpenRegister service usage (ADR-001)
+
+| Operation | Service |
+|---|---|
+| Dictionary/term CRUD | OR `ObjectService` (via `CustomDictionaryController`, org-gated) |
+| Document text | DocuDesk `AnonymizationService::readNodeTextSafely()` (already reads the node) |
+| Catalogue writes | OR `EntityRelationMapper` (lazy FQCN, `CUSTOM_DICTIONARY` rows) |
+| Redaction of matches | OR `DocumentProcessingHandler` (unchanged, type-agnostic) |
+
+ADR-011 check: no crypto here; matching is verbatim string comparison over
+already-extracted text.
+
+## Declarative vs imperative
+
+- **Declarative**: the two schemas + register-i18n tags on user-facing string
+  fields; the manifest page; per-dictionary `matchMode` as data.
+- **Imperative (justified)**: the org gate, CSV import parsing, the matcher
+  (position-accurate string scanning), and the catalogue write (must be
+  atomic with the detection run it feeds).
+
+## Seed Data
+
+One demo dictionary so the admin page renders non-empty:
+
+```json
+{
+  "@self": {"register": "document", "schema": "customDictionary", "slug": "seed-custom-dictionary-projectnamen"},
+  "label": "Projectnamen",
+  "description": "Interne projectcodenamen die niet door Presidio worden herkend",
+  "colour": "#8E44AD",
+  "matchMode": "caseInsensitive",
+  "fuzzy": false,
+  "active": true
+}
+```
+
+Plus two demo `customDictionaryTerm` rows ("Operatie Zilverreiger",
+"Dossier Karekiet") referencing it. No real personal data by construction.
+
+## Security Considerations
+
+- Every dictionary/term route is org-gated fail-closed; a caller never sees or
+  edits another organisation's lists.
+- Terms are organisation content, not secrets, and are stored as ordinary
+  register objects (they are the *search needles*, not detected PII); the
+  detected *occurrences* live in OR's catalogue under OR's existing scoping.
+- The matcher never logs matched values (count-only logs, PII-free).
+- Import size is bounded (max rows / bytes config) to avoid a
+  denial-of-service via a huge upload.
+
+## Risks / Trade-offs
+
+- [A very large dictionary × large document is O(terms × text)] → bounded by a
+  configurable max active-terms-per-organisation; matcher is a single linear
+  pass per term; acceptable for the low-hundreds term lists municipalities
+  actually maintain.
+- [`CUSTOM_DICTIONARY` redacts as `[CUSTOM_DICTIONARY: n]` unless localized] →
+  accepted for v1; the per-list label is carried on the relation for the
+  review UI, and a localized placeholder label is an OR-side follow-up.
+- [False positives from a broad term (e.g. a common word added as a term)] →
+  the operator owns the list; word-boundary mode mitigates; every hit is still
+  reviewable/skippable in the workbench before redaction.
+
+## Migration Plan
+
+Additive: two schemas + seed + register version bump (boot import), new
+services/controller/routes/views, one detection hook. No existing schema
+changes; no data migration. Rollback = remove routes/UI + the detection hook;
+dictionary objects remain readable.
+
+## Open Questions
+
+- **Fuzzy matching** (Levenshtein / phonetic for near-misses and OCR noise) —
+  flag declared now, matching deferred; would need a bounded-distance matcher
+  and a per-term threshold. Recorded, not built in v1.
+- **Localized `CUSTOM_DICTIONARY` placeholder label** in OR's
+  `localizeEntityType()` — OR-side follow-up so redaction shows a localized
+  label instead of the raw type.
+- **Sharing a dictionary across organisations** (central + local lists) —
+  deferred; v1 is strictly single-organisation ownership.

--- a/openspec/changes/custom-dictionary-recognition/proposal.md
+++ b/openspec/changes/custom-dictionary-recognition/proposal.md
@@ -1,0 +1,134 @@
+---
+kind: code
+---
+
+# Proposal: custom-dictionary-recognition
+
+## Why
+
+Presidio and regex catch the *generic* identifiers (PERSON, BSN, IBAN,
+EMAIL). They do not — and cannot — catch the identifiers that only a
+specific municipality knows are sensitive: an internal project codename
+("Operatie Zilverreiger"), a local street or buurt name that models miss,
+a case-file code format unique to that organisation, the name of a
+whistle-blower, a supplier under a running procurement. Municipal
+anonymisation tooling treats an organisation-managed **term list** as core,
+not a nice-to-have:
+
+- **Octobox Anonimiseren** (Gemeente Zaanstad, algoritmeregister
+  gm0479/24449830) is described as "algoritmes, **waardelijsten voor
+  automatische termherkenning** en NLP" — value-lists sit *next to* the NLP
+  model, not inside it (R3 section C).
+- **Anonimiseringssoftware Gemeente Noordwijk** (algoritmeregister
+  gm0575/91386595) is registered as municipal PII detection tuned by
+  value-lists rather than a fixed entity model (R3 section C).
+- R3's ranked demand table lists "**Custom dictionary / value-list /
+  context-aware term recognition**" as an unspecced concept (demand_score 2,
+  municipal table-stakes) — no active DocuDesk change covers it.
+
+This is a recall gap with a hard privacy consequence: a project codename or
+a named individual that the operator *knows* is sensitive silently ships to
+the Woo-publicatie because no recognizer was watching for it. A managed
+dictionary closes it, and it is buildable as a leaf recognizer over the
+engines OpenRegister already owns.
+
+Verified at HEAD (why this is a leaf, not a rebuild):
+
+- OpenRegister's `EntityRecognitionHandler` owns detection with a fixed set
+  of entity-type constants (`ENTITY_TYPE_PERSON … ENTITY_TYPE_IP_ADDRESS`)
+  and a method dispatch (`regex`, `presidio`, `openanonymiser`, `llm`,
+  `hybrid`); it has **no** organisation-scoped term-list recognizer and its
+  `getRegexPatterns()` is a hard-coded, instance-global list
+  (`lib/Service/TextExtraction/EntityRecognitionHandler.php`).
+- OR persists every detection in the shared catalogue
+  (`oc_openregister_entities` + one `oc_openregister_entity_relations` row
+  per occurrence) via `EntityRelationMapper` — the same store the review UI,
+  the grondslagen pass and OR's redaction engine already read.
+- OR's redaction engine is entity-type-agnostic: `DocumentProcessingHandler`
+  builds a placeholder `[<localized-type>: <number>]` for *any* entity type
+  and falls back to the raw label for a type it does not localize
+  (`localizeEntityType()`), so a new `CUSTOM_DICTIONARY` type flows through
+  redaction with no engine change.
+- DocuDesk already reads a document's text projection itself
+  (`AnonymizationService::readNodeTextSafely()`) and already owns the
+  enabled-entity-type selection (`GrondslagProposalService::getEntityTypeWhitelist()`).
+
+So DocuDesk adds a recognizer that contributes `CUSTOM_DICTIONARY`
+occurrences into OR's shared catalogue — exactly parallel to the existing
+manual-entity path — while OR keeps ownership of extraction, the catalogue,
+review and redaction.
+
+## What Changes
+
+- **Managed dictionaries (register-backed, org-scoped)**: two new schemas in
+  the `document` register — `customDictionary` (a named list: label, colour,
+  match options, owning organisation, active flag) and `customDictionaryTerm`
+  (one term per row: value, optional per-term label, dictionary reference).
+  Full CRUD is OR's ObjectService via a thin DocuDesk controller that adds
+  the organisation gate; lists are organisation-scoped fail-closed.
+- **Matching engine option**: per-dictionary match mode — exact,
+  case-insensitive (default), and word-boundary — applied by a
+  `CustomDictionaryMatchService` over the document's extracted text. A
+  `fuzzy` flag is declared in the schema but explicitly deferred (matching
+  it is out of scope for v1; the flag is accepted and ignored with a note).
+- **A distinct entity type through the normal pipeline**: matches become
+  `CUSTOM_DICTIONARY` entities/relations written through OR's
+  `EntityRelationMapper` (per-list label carried on the relation), so they
+  appear in detection results, the review workbench, the grondslagen summary
+  and OR's redaction identically to a Presidio hit — no pipeline fork.
+- **CSV / newline import**: bulk-load terms into a dictionary from an
+  uploaded CSV or a pasted newline-separated list (dedupe, trim, skip
+  blanks), reporting added/skipped counts.
+- **Admin UI page (Manifest-V2 shell)**: a "Custom dictionaries" management
+  page registered in `src/manifest.json` + `registry.js` (never the dead
+  `src/router/index.js`) — list/create/edit dictionaries, manage terms,
+  import, toggle active, pick match mode.
+
+## Capabilities
+
+### New Capabilities
+
+- `custom-dictionary-recognition`: organisation-managed term lists as an
+  additional PII recognizer — register-backed dictionary + term CRUD,
+  exact/case-insensitive/word-boundary matching, a `CUSTOM_DICTIONARY` entity
+  type flowing through the existing detection→review→anonymisation pipeline,
+  CSV/newline import, and a Manifest-V2 admin page.
+
+### Modified Capabilities
+
+<!-- none — OR's TextExtractionService, EntityRelationMapper, entity
+     catalogue, review workbench and DocumentProcessingHandler redaction are
+     consumed unchanged. The `anonymization` capability's detection→review→
+     anonymise pipeline is extended by a new recognizer, not modified. -->
+
+## Impact
+
+- `lib/Settings/docudesk_register.json`: new `customDictionary` and
+  `customDictionaryTerm` schemas in the `document` register (org-scoped,
+  register-i18n on user-facing string fields), seed data (one demo
+  dictionary + terms), register version bump with changelog entry.
+- New `lib/Service/CustomDictionaryMatchService.php`: text-vs-terms matcher
+  (exact / case-insensitive / word-boundary), producing `CUSTOM_DICTIONARY`
+  occurrences and writing them via OR's `EntityRelationMapper` (lazy FQCN
+  container resolution — loadable without OR).
+- New `lib/Service/CustomDictionaryService.php` + a thin
+  `lib/Controller/CustomDictionaryController.php` (`api/custom-dictionaries/*`
+  CRUD + `/import`): justified non-pass-through per ADR-022 (org gate + CSV
+  import parsing + term-count enrichment; not a bare OR proxy).
+- Hook the matcher into DocuDesk's detection entry point
+  (`AnonymizationService::extractAndDetectEntities`) as a best-effort
+  post-pass after OR extraction, respecting the enabled-entity-type
+  whitelist.
+- `src/manifest.json` + `registry.js` + new views: Custom dictionaries admin
+  page (schema refs use slug form).
+- Consumes (unchanged, presence-gated so DocuDesk loads without OR): OR
+  `TextExtractionService` (text/chunks), `EntityRelationMapper` (catalogue
+  writes), `DocumentProcessingHandler` redaction (type-agnostic).
+- Dependencies / non-overlap: `anonymization-review-workbench` (active) renders
+  the review — `CUSTOM_DICTIONARY` rows appear there via the shared catalogue,
+  no change to that surface; `enable-kenteken-entity-type` (active) adds one
+  fixed KENTEKEN type — orthogonal to this change's *dynamic, per-list* type;
+  `redaction-at-scale` / `image-redaction` (active) are not touched. These are
+  declared dependencies, not re-specced.
+- Evidence: Octobox Zaanstad + Noordwijk algoritmeregister (R3 C); R3
+  ranked-demand table row "Custom dictionary / value-list … term recognition".

--- a/openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+++ b/openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
@@ -1,0 +1,182 @@
+# custom-dictionary-recognition Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Let an organisation manage its own term lists — project codenames, local
+street/buurt names, case-file codes, internal codenames, named individuals —
+as an additional PII recognizer alongside Presidio/regex. Terms are stored as
+organisation-scoped register objects with a chosen match mode
+(exact / case-insensitive / word-boundary); matches become a distinct
+`CUSTOM_DICTIONARY` entity type written into OpenRegister's shared entity
+catalogue, so they flow through the existing detection → review →
+anonymisation pipeline exactly like any other entity. Terms load via CSV or a
+newline list and are managed from a Manifest-V2 admin page. Detection,
+catalogue, review and redaction remain OpenRegister-owned (verified at HEAD);
+DocuDesk adds a recognizer, not an engine.
+
+## ADDED Requirements
+
+### Requirement: Organisation-managed dictionaries and terms (REQ-DDCDR-001)
+
+The app MUST provide organisation-scoped `customDictionary` and
+`customDictionaryTerm` register objects (in the `document` register) storing,
+per dictionary, a label, description, colour, match mode
+(`exact`|`caseInsensitive`|`wordBoundary`, default `caseInsensitive`), a
+deferred `fuzzy` flag, an `active` flag and a calculated term count; and per
+term a value, an optional per-term label and a reference to its dictionary. A
+dictionary and its terms MUST belong to exactly one organisation and MUST be
+readable and editable only by callers whose accessible organisations include
+it (fail-closed).
+
+#### Scenario: A dictionary and its terms are organisation-scoped
+
+- GIVEN organisation A owns a dictionary "Projectnamen" with two terms
+- WHEN a user whose only accessible organisation is B lists custom dictionaries
+- THEN "Projectnamen" and its terms are not returned
+- @e2e exclude tenant-scoping is backend authorization logic — covered by PHPUnit (tests/unit/Service/CustomDictionaryServiceTest.php)
+
+#### Scenario: Match mode defaults to case-insensitive
+
+- GIVEN a new dictionary created without an explicit match mode
+- WHEN it is persisted and read back
+- THEN its match mode is `caseInsensitive`
+- @e2e tests/e2e/spec-coverage/custom-dictionary-recognition.spec.ts
+
+### Requirement: Deterministic term matching engine (REQ-DDCDR-002)
+
+The matcher MUST return every occurrence of a dictionary's terms in a text
+according to the dictionary's match mode: `exact` MUST match byte-for-byte
+case-sensitively; `caseInsensitive` MUST match ignoring case; `wordBoundary`
+MUST match ignoring case only when the occurrence is delimited by a non-word
+boundary so a term does not match inside a longer word. Each returned
+occurrence MUST carry its start and end positions. Blank or whitespace-only
+terms MUST be skipped, and overlapping terms MUST be resolved longest-term
+first so a shorter term cannot pre-empt a longer one. The `fuzzy` flag MUST be
+accepted and ignored in this version (no approximate matching).
+
+#### Scenario: Word-boundary mode does not match inside a longer word
+
+- GIVEN a dictionary in `wordBoundary` mode with the term "Berg"
+- WHEN the text "De inwoners van Bergen protesteerden" is matched
+- THEN no occurrence is returned for "Berg"
+- @e2e exclude pure matcher logic — covered by PHPUnit (tests/unit/Service/CustomDictionaryMatchServiceTest.php::testWordBoundaryDoesNotMatchInsideWord)
+
+#### Scenario: Case-insensitive mode returns all occurrences
+
+- GIVEN a dictionary in `caseInsensitive` mode with the term "Zilverreiger"
+- WHEN a text contains "Zilverreiger" and "zilverreiger"
+- THEN both occurrences are returned with their positions
+- @e2e exclude pure matcher logic — covered by PHPUnit (tests/unit/Service/CustomDictionaryMatchServiceTest.php)
+
+### Requirement: Matches flow through the pipeline as CUSTOM_DICTIONARY entities (REQ-DDCDR-003)
+
+Dictionary matches MUST be written into OpenRegister's shared entity catalogue
+via `EntityRelationMapper` as entities of type `CUSTOM_DICTIONARY`
+(category `contextual_data`) with one relation per occurrence carrying
+`detectionMethod = custom_dictionary`, confidence `1.0`, the occurrence
+positions and the owning dictionary's label — so the occurrences appear in
+detection results, the review workbench, the grondslagen summary and
+OpenRegister's redaction identically to any other entity. The matching pass
+MUST run inside DocuDesk's existing detection entry point after OpenRegister
+extraction, MUST be skipped when the `CUSTOM_DICTIONARY` type is disabled in
+the operator's enabled-type selection, MUST clear its prior
+`custom_dictionary` relations for a file before re-matching (no duplicates),
+and MUST be best-effort: a matcher failure MUST be logged and surfaced as a
+warning without blocking OpenRegister-side detection. DocuDesk MUST NOT add a
+DocuDesk-local entity store and MUST NOT modify OpenRegister's detection
+engine or redaction placeholder format.
+
+#### Scenario: A dictionary hit is detected, reviewable and redacted
+
+- GIVEN an active dictionary with the term "Operatie Zilverreiger" and a document containing it
+- WHEN the document is extracted and detected
+- THEN a CUSTOM_DICTIONARY occurrence for "Operatie Zilverreiger" appears in the review workbench and is replaced in the anonymised output
+- @e2e tests/e2e/spec-coverage/custom-dictionary-recognition.spec.ts
+
+#### Scenario: Re-running detection does not duplicate dictionary relations
+
+- GIVEN a document already matched once by a dictionary
+- WHEN detection is run again on the same document
+- THEN the CUSTOM_DICTIONARY occurrence count is unchanged (prior custom_dictionary relations were cleared first)
+- @e2e exclude idempotency of the catalogue write — covered by PHPUnit (tests/unit/Service/CustomDictionaryMatchServiceTest.php::testReRunDoesNotDuplicate)
+
+#### Scenario: Matcher failure does not block OpenRegister detection
+
+- GIVEN the dictionary catalogue write path fails
+- WHEN a document is detected
+- THEN OpenRegister's own detected entities are still returned together with a warning that dictionary matching did not run
+- @e2e exclude fault-injection on the write path — covered by PHPUnit (tests/unit/Service/AnonymizationServiceTest.php)
+
+### Requirement: Organisation-gated dictionary and term management API (REQ-DDCDR-004)
+
+The app MUST provide `api/custom-dictionaries` CRUD routes (list, create,
+read, update, delete a dictionary and manage its terms) backed by
+OpenRegister's ObjectService. Every route MUST enforce the organisation gate
+server-side and fail closed: a caller may only operate on dictionaries of
+their accessible organisations, and a non-permitted call MUST receive HTTP 403
+with a neutral body. Each route MUST declare an explicit Nextcloud auth
+attribute and MUST perform the organisation check in the method body (not rely
+on the hidden navigation entry). When OpenRegister is unavailable the routes
+MUST return an explanatory unavailable state, never a crash.
+
+#### Scenario: Editing another organisation's dictionary is refused
+
+- GIVEN a dictionary owned by organisation A
+- WHEN a user with access only to organisation B calls update on it
+- THEN the response is HTTP 403 and the dictionary is unchanged
+- @e2e exclude authorization matrix — covered by PHPUnit (tests/unit/Controller/CustomDictionaryControllerTest.php)
+
+#### Scenario: A permitted manager creates a dictionary
+
+- GIVEN a manager of organisation A
+- WHEN they create a dictionary "Straatnamen" with match mode word-boundary
+- THEN it is persisted under organisation A and listed for them
+- @e2e tests/e2e/spec-coverage/custom-dictionary-recognition.spec.ts
+
+### Requirement: CSV and newline term import (REQ-DDCDR-005)
+
+The app MUST provide `POST api/custom-dictionaries/{uuid}/import` accepting
+either a CSV upload (first column the term value, optional second column a
+per-term label) or a newline-separated plain-text list, parsed server-side.
+Import MUST trim values, skip blank lines, de-duplicate case-insensitively
+against the dictionary's existing terms, create `customDictionaryTerm`
+objects for the remainder, and return the counts of added, skipped and total
+terms. Import size MUST be bounded to prevent a denial-of-service via an
+oversized upload. Parsing MUST NOT be delegated to the browser.
+
+#### Scenario: Import adds new terms and skips duplicates
+
+- GIVEN a dictionary already containing the term "Ridderkerk"
+- WHEN a newline list of "Ridderkerk", "Barendrecht", "  " (blank) is imported
+- THEN the response reports 1 added, 2 skipped, and only "Barendrecht" is created
+- @e2e exclude import parsing/dedupe logic — covered by PHPUnit (tests/unit/Service/CustomDictionaryServiceTest.php::testImportDedupesAndSkipsBlanks)
+
+#### Scenario: Import through the admin page
+
+- GIVEN a manager on a dictionary detail page
+- WHEN they upload a CSV of terms
+- THEN the new terms appear in the term table with the reported added count
+- @e2e tests/e2e/spec-coverage/custom-dictionary-recognition.spec.ts
+
+### Requirement: Custom-dictionary admin UI (REQ-DDCDR-006)
+
+The app MUST provide a gated "Custom dictionaries" management page registered
+in the Manifest-V2 shell (`src/manifest.json` + `registry.js`, never
+`src/router/index.js`): an index (`CnIndexPage` + `CnDataTable`: label, term
+count, match mode, active) and a detail/edit view (term table with add/remove,
+CSV/newline import, match-mode selector, active toggle, colour). Every
+`NcSelect` MUST carry an `inputLabel`; modals and dialogs MUST live in their
+own files under `src/modals/`/`src/dialogs/`; colours and spacing MUST use
+Nextcloud CSS variables / NL Design tokens with no hardcoded colours. The
+navigation entry MUST be hidden for users the organisation gate refuses.
+
+#### Scenario: The dictionaries page lists dictionaries with their term counts
+
+- GIVEN two dictionaries owned by the operator's organisation
+- WHEN the operator opens the Custom dictionaries page
+- THEN both are listed with their label, term count, match mode and active state
+- @e2e tests/e2e/spec-coverage/custom-dictionary-recognition.spec.ts

--- a/openspec/changes/custom-dictionary-recognition/tasks.md
+++ b/openspec/changes/custom-dictionary-recognition/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: custom-dictionary-recognition
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 12.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Register + seed data
+
+- [ ] 1.1 Add `customDictionary` and `customDictionaryTerm` schemas to the `document` register in `lib/Settings/docudesk_register.json` (REQ-DDCDR-001)
+  - `customDictionary` (label, description, colour, `matchMode` enum default `caseInsensitive`, `fuzzy` bool, `active` bool, `termCount` calculated); `customDictionaryTerm` (value, optional label, dictionary uuid ref); register-i18n on user-facing string fields; register version bump with changelog; seed one demo dictionary + two demo terms (design.md Seed Data). Schema refs in slug form.
+
+## 2. Backend — matcher + catalogue
+
+- [ ] 2.1 Implement `lib/Service/CustomDictionaryMatchService.php` pure matcher (REQ-DDCDR-002)
+  - `exact` / `caseInsensitive` / `wordBoundary` modes; returns every occurrence with positions; blank terms skipped; longest-term-first ordering; `fuzzy` accepted-and-ignored. Pure function — no NC container.
+
+- [ ] 2.2 Write matches into OR's catalogue as `CUSTOM_DICTIONARY` occurrences (REQ-DDCDR-003)
+  - Lazy FQCN resolution of OR `EntityRelationMapper`; entity type `CUSTOM_DICTIONARY`, category `contextual_data`, `detectionMethod=custom_dictionary`, `confidence=1.0`, per-list label carried; re-run clears prior `custom_dictionary` relations for the file (no duplicates); best-effort, never blocks OR detection.
+
+- [ ] 2.3 Hook the pass into `AnonymizationService::extractAndDetectEntities` respecting the type whitelist (REQ-DDCDR-003)
+  - Runs after OR extraction, before normalize/policy; skipped when `CUSTOM_DICTIONARY` is disabled in `getEntityTypeWhitelist()`; a matcher failure is logged and surfaces a warning, not a crash.
+
+## 3. Backend — CRUD + import
+
+- [ ] 3.1 Implement `lib/Service/CustomDictionaryService.php` + `lib/Controller/CustomDictionaryController.php` org-gated CRUD (REQ-DDCDR-004)
+  - `api/custom-dictionaries` (+ `/{uuid}`, `/{uuid}/terms`) via OR ObjectService; org gate fail-closed on every route (explicit auth attributes + in-method guard, semantic-auth); term-count enrichment; ADR-022 justification in the controller docblock.
+
+- [ ] 3.2 Implement CSV / newline import `POST .../{uuid}/import` (REQ-DDCDR-005)
+  - Accept `text/csv` (value + optional label column) or `text/plain` newline list; server-side trim/dedupe/skip-blank; bounded size; returns `{added, skipped, total}`; no client-side parsing.
+
+## 4. Frontend (Manifest-V2 shell)
+
+- [ ] 4.1 Custom dictionaries admin page + gated nav entry in `src/manifest.json` + `registry.js` (REQ-DDCDR-006)
+  - `CnIndexPage`/`CnDataTable` (label, term count, match mode, active); NOT `src/router/index.js`; schema refs use slugs.
+
+- [ ] 4.2 Dictionary detail/edit view with term management + import (REQ-DDCDR-006)
+  - Term table (add/remove), import upload dialog in its own file under `src/dialogs/`, match-mode `NcSelect` with `inputLabel`, active toggle, colour picker; NL Design tokens.
+
+## 5. Quality
+
+- [ ] 5.1 PHPUnit unit tests for `CustomDictionaryMatchService` (all three modes, multi-occurrence, overlap/longest-first, blank skip) and `CustomDictionaryService` org-gate matrix + import dedupe — minimum 75% coverage on new code
+  - Run in the container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`.
+
+- [ ] 5.2 Playwright e2e `tests/e2e/spec-coverage/custom-dictionary-recognition.spec.ts` covering the `@e2e` scenarios
+  - Create a dictionary, import terms, extract a fixture document, assert a `CUSTOM_DICTIONARY` hit appears in review and is redacted; nldesign accessibility pass; test through the UI.
+
+- [ ] 5.3 i18n EN + NL for all new UI strings (page, match-mode labels, import dialog, empty state)
+  - Keys in English.
+
+- [ ] 5.4 Documentation `docs/features/custom-dictionary-recognition.md` with Playwright MCP screenshots (ADR-010); run `openspec validate custom-dictionary-recognition --strict`
+  - Documents the Octobox/Noordwijk positioning, org-scoping, the `CUSTOM_DICTIONARY` pipeline path and the deferred fuzzy flag.

--- a/openspec/changes/files-confidential-labels/.openspec.yaml
+++ b/openspec/changes/files-confidential-labels/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/files-confidential-labels/design.md
+++ b/openspec/changes/files-confidential-labels/design.md
@@ -1,0 +1,181 @@
+# Design: files-confidential-labels
+
+## Context
+
+Verified at HEAD:
+
+- **DocuDesk's optional-dependency idiom.** `MetadataService::getObjectService()`
+  (`lib/Service/MetadataService.php` L76–84) guards OpenRegister consumption:
+  `if (in_array('openregister', $this->appManager->getInstalledApps(), true))
+  then $this->container->get('OCA\OpenRegister\Service\ObjectService') else
+  throw`. Callers treat "unavailable" as "skip", not "fail". This change reuses
+  the guard shape for `files_confidential`.
+- **The attach point.** `AnonymizationService::extractAndDetectEntities(int
+  $fileId)` returns `['entities' => $normalized, 'riskLevel' => $riskLevel, …]`
+  (`lib/Service/AnonymizationService.php` L269). This result feeds the
+  entity-review surface and is the natural place to add the confidentiality
+  signal for one file.
+- **No priority ordering today.** `grep -n priority` in `FolderBatchService` /
+  `BatchAnonymizeService` is empty — batch/folder analysis has no priority
+  concept, so the optional priority hint is additive and cannot regress existing
+  ordering.
+- **`files_confidential` is not installed in this workspace** (verified) — so the
+  design binds to Nextcloud's **public** system-tag API (`ISystemTagManager`,
+  `ISystemTagObjectMapper`), which is how `files_confidential` surfaces its labels
+  (it assigns classification labels as system tags on file nodes). DocuDesk must
+  not couple to `files_confidential` internals.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Read an existing confidentiality label for a file as a read-only signal, safely
+  when `files_confidential` is present and inertly when it is not.
+- Surface the label in the document report / entity-review context.
+- Optionally let the label suggest (not enforce) batch/folder analysis priority.
+
+**Non-Goals:**
+
+- No classification/detection engine (files_confidential owns labelling; DocuDesk
+  owns PII detection — these stay separate).
+- No policy/enforcement/gating on the label (no block, no forced redaction, no
+  publication veto — those are `entity-publication-policies` / prohibition-gate
+  territory, explicitly out of scope).
+- No write to `files_confidential` or its tags — read-only.
+- No coupling to `files_confidential` PHP internals — read via NC's public tag
+  API only.
+
+## Decisions
+
+### D1 — `ConfidentialityLabelService` (availability-guarded read, the unit seam)
+
+New `lib/Service/ConfidentialityLabelService.php`:
+
+```
+getLabelForFile(int $fileId): ?ConfidentialityLabel
+```
+
+- **Guard**: return `null` immediately if `files_confidential` is not in
+  `IAppManager::getInstalledApps()`. DocuDesk never depends on it at boot.
+- **Read**: resolve the file's assigned system tags via
+  `ISystemTagObjectMapper::getTagIdsForObjects([$fileId], 'files')` →
+  `ISystemTagManager::getTagsByIds()`, take visible tag names.
+- **Match + normalise**: match tag names against the admin-configured
+  `docudesk.confidentiality.label_vocabulary` (a map of label/tag name →
+  normalised level on an ordered scale, e.g. `public=0 < internal=1 <
+  confidential=2 < secret=3`; default vocabulary seeds the common TSCP/BAILS
+  names). Return the highest-level matching label as
+  `{ label: string, level: int }`; `null` if no tag matches the vocabulary.
+- **Fail-safe**: any exception from the tag API is caught and treated as "no
+  label" (`null`) — a signal read must never break anonymisation. (Fail-*open* is
+  correct here precisely because the label only *adds* prominence; it never
+  relaxes a control, so absence degrades to "no extra signal", not "less
+  protection".)
+
+Resolution of the tag services: constructor-injected NC interfaces
+(`ISystemTagManager`, `ISystemTagObjectMapper`, `IAppManager`, `IAppConfig`) —
+these are core NC, always present, so no lazy container trickery is needed (the
+guard is on `files_confidential` presence, not on the tag API).
+
+Unit-testable in isolation: mock the tag mappers + app manager + config; assert
+label/level for a tagged file, `null` for an untagged file, `null` when
+`files_confidential` absent, `null` on tag-API exception, and highest-wins when
+multiple labels match.
+
+### D2 — Surface in the document report + entity-review context
+
+In `AnonymizationService::extractAndDetectEntities()` result assembly (L269),
+call `ConfidentialityLabelService::getLabelForFile($fileId)` and, when non-null,
+add `confidentialityLabel` (display string) and `confidentialityLevel`
+(normalised int) to the returned array. When null, omit both (or set null) — the
+review UI simply shows no confidentiality chip.
+
+**Persistence decision**: the entity-review result is served transiently by the
+controller (it is recomputed per review load), so **no OR schema change is
+required** for the review context. IF a persisted per-file document report OR
+object is later shown to store risk/entity summaries, add nullable
+`confidentialityLabel`/`confidentialityLevel` properties there with a register
+version bump; provisional decision is transient-only (no schema change) to keep
+scope minimal. Recorded as an Open Question.
+
+The review UI adds a read-only confidentiality chip next to the existing risk
+chip (NL Design tokens, no hardcoded colour). It is informational — it carries no
+action.
+
+### D3 — Optional analysis-priority suggestion (off by default)
+
+Admin flag `docudesk.confidentiality.prioritise_analysis` (bool, default
+`false`). When on, batch/folder analysis scheduling uses the normalised level as
+a **tie-breaking priority hint** so higher-confidentiality files are analysed
+sooner. Mechanics:
+
+- The batch enumerator computes each file's level via
+  `ConfidentialityLabelService` (guarded; unlabelled → level 0), and orders the
+  work queue by level descending as a secondary sort key (primary order
+  unchanged).
+- It is a *suggestion*: it changes ordering only. It never skips, blocks or
+  redacts, and with the flag off (default) ordering is byte-for-byte identical to
+  today.
+
+Rationale for opt-in: reordering analysis has operational implications
+(throughput expectations); defaulting off keeps the change a pure additive signal
+until an admin opts in.
+
+## Data shapes
+
+`ConfidentialityLabel` (value object): `{ label: string, level: int }`.
+
+Result addition (entity-review context):
+
+```json
+{ "entities": [...], "riskLevel": "high",
+  "confidentialityLabel": "Confidential", "confidentialityLevel": 2 }
+```
+
+`docudesk.confidentiality.label_vocabulary` (IAppConfig JSON):
+
+```json
+{ "Public": 0, "Internal": 1, "Confidential": 2, "Secret": 3 }
+```
+
+## Security Considerations
+
+- Read-only; no writes to files, tags or `files_confidential`.
+- The label read honours the caller's context (tags are read for a file the
+  caller is already anonymising / reviewing — same file the review flow resolved);
+  it exposes only a classification name the organisation itself assigned.
+- Fail-open is safe *only because the signal never relaxes a control* — it adds a
+  chip and (optionally) reorders a queue. No security decision keys off its
+  presence.
+- No new route is added by the service itself; it is consumed inside existing
+  anonymisation/review paths that already enforce their auth.
+
+## Risks / Trade-offs
+
+- [`files_confidential` may surface labels via a mechanism other than plain
+  system tags in some versions] → the service is written against the public tag
+  API and vocabulary-matches by name; if a deployment uses a different surface,
+  the vocabulary/config is the single adjustment point and absence degrades to
+  "no signal" (no crash).
+- [Priority reordering could surprise operators] → default off; documented; pure
+  secondary sort.
+- [Vocabulary drift between the org's labels and DocuDesk's defaults] →
+  admin-configurable vocabulary; unmatched tags are simply ignored.
+
+## Migration Plan
+
+Additive. New service + two admin config keys + two optional result fields; no
+schema change under the provisional transient-report decision. DocuDesk with
+`files_confidential` absent behaves exactly as today. Rollback = remove the
+service call in the result assembly and the config keys.
+
+## Open Questions
+
+- Persist the confidentiality signal on a document-report OR object, or keep it
+  transient? Provisional: transient (no schema change). If a persisted report
+  object gains risk/entity fields, add nullable confidentiality fields there with
+  a version bump.
+- Default label vocabulary: seed with the common TSCP/BAILS English names
+  (Public/Internal/Confidential/Secret) — confirm the exact BAILS label set with
+  a deployment that runs `files_confidential`; the config makes this adjustable
+  without code change.

--- a/openspec/changes/files-confidential-labels/proposal.md
+++ b/openspec/changes/files-confidential-labels/proposal.md
@@ -1,0 +1,101 @@
+---
+kind: code
+---
+
+# Proposal: files-confidential-labels
+
+## Why
+
+When a file already carries an organisation's confidentiality classification,
+DocuDesk should treat that as a sensitivity signal rather than pretend it does
+not exist. Nextcloud's `files_confidential` app assigns TSCP/BAILS
+confidentiality labels to files (as system tags derived from document content /
+metadata markers) and is flagged in the ecosystem map as **INTEGRATE + partial
+OVERLAP**: *"Overlaps DocuDesk's PII/sensitivity classification; consume its
+labels as an input signal rather than re-detect"* (R4-ecosystem-leaves.md §A,
+Confidential files row) — and it is called out as an explicit unspecced leaf
+opportunity: *"files_confidential label consumption — ingest existing TSCP/BAILS
+confidentiality tags as a PII/sensitivity signal into anonymisation appraisal
+(avoid re-classifying already-labelled files)"* (R4 §E.3).
+
+The strategic frame is DocuDesk-as-integrated-compliance-suite over fragmented
+NC pieces (R4 §A category-fit: "the pieces are fragmented across LibreSign,
+workflow_ocr, files_retention, **files_confidential**"). Consuming an existing
+classification is a cheap trust signal for the anonymisation reviewer: a file the
+organisation already marked "Confidential/BAILS" deserves visible prominence in
+the entity-review context and can be prioritised in batch/folder analysis, with
+**no new classification engine** and no policy machinery.
+
+This is deliberately a "could": a small signal-ingestion-and-surfacing change,
+availability-guarded because `files_confidential` may be absent.
+
+## What Changes
+
+- **Read the label (availability-guarded)**: a new
+  `lib/Service/ConfidentialityLabelService.php` returns a file's confidentiality
+  label + normalised level when `files_confidential` is installed and the file
+  carries a label; returns `null` (never throws) when the app is absent, the file
+  has no label, or the tag manager is unavailable. It mirrors DocuDesk's existing
+  optional-dependency pattern — `MetadataService::getObjectService()` guards OR
+  consumption with `IAppManager::getInstalledApps()` + lazy container resolution
+  (verified `lib/Service/MetadataService.php` L76–84); the label service applies
+  the same guard and reads the file's Nextcloud system tags via
+  `ISystemTagManager` / `ISystemTagObjectMapper`, matching them against an
+  admin-configured confidentiality-label vocabulary.
+- **Surface in the document report + entity review context**: the extract/detect
+  result already returned by `AnonymizationService::extractAndDetectEntities()`
+  (verified: returns `['entities' => …, 'riskLevel' => …]`,
+  `lib/Service/AnonymizationService.php` L269) gains
+  `confidentialityLabel` / `confidentialityLevel` fields so the reviewer sees the
+  pre-existing classification alongside detected entities and risk.
+- **Optional analysis-priority suggestion**: an admin config flag
+  (`docudesk.confidentiality.prioritise_analysis`, default off) lets a higher
+  confidentiality level raise a file's suggested analysis priority in
+  batch/folder analysis ordering. This is a *suggestion signal only* — it
+  reorders, it does not gate, block, redact or enforce anything.
+
+## Capabilities
+
+### New Capabilities
+
+- `files-confidential-labels`: consume `files_confidential` TSCP/BAILS
+  confidentiality labels as a sensitivity signal — surfaced in the document
+  report + entity-review context and optionally used to suggest batch/folder
+  analysis priority — availability-guarded, with no classification or policy
+  engine of DocuDesk's own.
+
+### Modified Capabilities
+
+<!-- none re-owned. AnonymizationService's result shape is DocuDesk's; adding two
+     optional fields is additive. No OR spec, no files_confidential internals are
+     modified — labels are read through NC's public system-tag API. -->
+
+## Impact
+
+- New `lib/Service/ConfidentialityLabelService.php` — availability-guarded label
+  read (`IAppManager` + `ISystemTagManager`/`ISystemTagObjectMapper`), vocabulary
+  matching, level normalisation. **The testable unit seam.**
+- `lib/Service/AnonymizationService.php` (L269 result assembly): merge
+  `confidentialityLabel`/`confidentialityLevel` when the label service returns a
+  value (both omitted/`null` otherwise).
+- Batch/folder analysis ordering (`FolderBatchService` / `BatchAnonymizeService`
+  scheduling): when `docudesk.confidentiality.prioritise_analysis` is on, use the
+  normalised level as a tie-breaking priority hint. (No priority ordering exists
+  today — verified: `grep priority` in those services is empty — so this is
+  additive and off by default.)
+- Admin settings: `docudesk.confidentiality.label_vocabulary` (map of
+  tag/label name → normalised level) and `docudesk.confidentiality.prioritise_analysis`.
+- `lib/Settings/docudesk_register.json`: OPTIONAL — if the document report is
+  persisted as an OR object, add nullable `confidentialityLabel`/`Level`
+  properties (register version bump); if the report is transient (returned by the
+  controller only), no schema change. Design.md D2 records which.
+- Consumes (unchanged): NC `ISystemTagManager`/`ISystemTagObjectMapper` (public
+  API), `files_confidential` labels (read-only, via tags — no coupling to its
+  internals). DocuDesk loads and functions unchanged when `files_confidential` is
+  absent.
+- **Non-overlap note**: this is a *signal*, distinct from DocuDesk's own PII
+  detection (`EntityDetectionService`) and from `entity-publication-policies` /
+  prohibition gates — it neither detects nor enforces; it surfaces an existing
+  external label. No active change covers it (dd-coverage-baseline.md).
+- Evidence: R4 §A (Confidential files INTEGRATE+overlap), §B, §E.3; MetadataService
+  optional-dependency pattern (L76–84); AnonymizationService result shape (L269).

--- a/openspec/changes/files-confidential-labels/specs/files-confidential-labels/spec.md
+++ b/openspec/changes/files-confidential-labels/specs/files-confidential-labels/spec.md
@@ -1,0 +1,104 @@
+# files-confidential-labels Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Consume the confidentiality classification a file already carries — the TSCP/BAILS
+labels assigned by Nextcloud's `files_confidential` app (surfaced as system tags)
+— as a read-only sensitivity signal in DocuDesk's anonymisation appraisal:
+surface it in the document report / entity-review context and, optionally,
+suggest batch/folder analysis priority. The read is availability-guarded
+(`files_confidential` may be absent) using DocuDesk's existing optional-dependency
+idiom, binds only to Nextcloud's public system-tag API (no coupling to
+`files_confidential` internals), and adds no classification or policy engine of
+DocuDesk's own. It is a signal — it never blocks, redacts, gates or enforces.
+
+## ADDED Requirements
+
+### Requirement: Read a file's confidentiality label, availability-guarded (REQ-DDFCL-001)
+
+The app MUST provide `ConfidentialityLabelService::getLabelForFile(int
+$fileId): ?ConfidentialityLabel` returning the file's confidentiality label and a
+normalised level when `files_confidential` is installed and the file carries a
+label matching the configured vocabulary, and returning `null` otherwise. The
+service MUST guard on `files_confidential` presence via
+`IAppManager::getInstalledApps()` before reading, MUST read labels through
+Nextcloud's public system-tag API (`ISystemTagObjectMapper` /
+`ISystemTagManager`) rather than any `files_confidential` internal, MUST match tag
+names against the admin-configured `docudesk.confidentiality.label_vocabulary`
+returning the highest-level match, and MUST NOT throw — any tag-API failure MUST
+be treated as "no label" (`null`). DocuDesk MUST load and function normally when
+`files_confidential` is absent.
+
+#### Scenario: Labelled file returns its label and level
+
+- GIVEN `files_confidential` is installed and a file is tagged "Confidential" which the vocabulary maps to level 2
+- WHEN `getLabelForFile(fileId)` is called
+- THEN it returns a label "Confidential" with level 2
+- @e2e exclude service-level read — covered by PHPUnit (tests/unit/Service/ConfidentialityLabelServiceTest.php::testLabelledFileReturnsLabel)
+
+#### Scenario: Absent app yields no signal, no crash
+
+- GIVEN `files_confidential` is not installed
+- WHEN `getLabelForFile(fileId)` is called
+- THEN it returns null and DocuDesk's anonymisation flow proceeds unchanged
+- @e2e exclude availability guard — covered by PHPUnit (tests/unit/Service/ConfidentialityLabelServiceTest.php::testAbsentAppReturnsNull)
+
+#### Scenario: Tag-API failure degrades to no label
+
+- GIVEN the system-tag API throws while resolving a file's tags
+- WHEN `getLabelForFile(fileId)` is called
+- THEN it returns null (the exception is caught) and never propagates into the anonymisation path
+- @e2e exclude fault-injection on the tag API — covered by PHPUnit (tests/unit/Service/ConfidentialityLabelServiceTest.php::testTagApiFailureReturnsNull)
+
+### Requirement: Surface the label in the document report and entity-review context (REQ-DDFCL-002)
+
+The appraisal result MUST carry the confidentiality signal when a label resolves: the result returned by `AnonymizationService::extractAndDetectEntities()` MUST include
+`confidentialityLabel` (display string) and `confidentialityLevel` (normalised
+integer) alongside the existing `entities` and `riskLevel`, and the entity-review
+surface MUST show it as a read-only confidentiality chip next to the risk
+indicator (NL Design tokens, no hardcoded colour). When no label resolves, the
+result MUST omit or null those fields and the review surface MUST show no
+confidentiality chip. The signal MUST be informational only — it MUST NOT trigger
+any block, redaction, gate or enforcement.
+
+#### Scenario: Review context shows the confidentiality chip
+
+- GIVEN a file tagged "Confidential" is opened for entity review
+- WHEN the entity-review context loads
+- THEN the appraisal result carries `confidentialityLabel: "Confidential"` and `confidentialityLevel: 2`, and the review surface shows a read-only confidentiality chip beside the risk chip
+- @e2e tests/e2e/spec-coverage/files-confidential-labels.spec.ts
+
+#### Scenario: Unlabelled file shows no chip and no fields
+
+- GIVEN a file with no confidentiality label (or `files_confidential` absent)
+- WHEN the entity-review context loads
+- THEN the appraisal result omits the confidentiality fields and no confidentiality chip is shown, with entities and risk rendered as before
+- @e2e exclude negative rendering permutation — covered by component tests and PHPUnit result-merge assertions
+
+### Requirement: Optionally suggest batch/folder analysis priority (REQ-DDFCL-003)
+
+The app MUST expose an admin flag
+`docudesk.confidentiality.prioritise_analysis` defaulting to off. When off,
+batch/folder analysis ordering MUST be identical to current behaviour. When on,
+the analysis enumerator MUST use the normalised confidentiality level (unlabelled
+= 0) as a secondary, tie-breaking sort key so higher-confidentiality files are
+analysed sooner. The flag MUST only reorder work — it MUST NOT skip, block,
+redact or otherwise change what analysis does to any file.
+
+#### Scenario: Flag off leaves ordering unchanged
+
+- GIVEN `prioritise_analysis` is off (default)
+- WHEN a folder of mixed-confidentiality files is analysed
+- THEN the analysis order is identical to the pre-change behaviour
+- @e2e exclude ordering equivalence — covered by PHPUnit (tests/unit/Service/…::testPriorityOffOrderingUnchanged)
+
+#### Scenario: Flag on prioritises higher confidentiality
+
+- GIVEN `prioritise_analysis` is on and a folder contains a "Secret" (level 3) and an unlabelled (level 0) file
+- WHEN the folder is analysed
+- THEN the "Secret" file is ordered ahead of the unlabelled file as a secondary sort key, and neither file's analysis outcome is otherwise changed
+- @e2e exclude secondary-sort ordering — covered by PHPUnit (tests/unit/Service/…::testPriorityOnOrdersByLevel)

--- a/openspec/changes/files-confidential-labels/tasks.md
+++ b/openspec/changes/files-confidential-labels/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: files-confidential-labels
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 8.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Label read service (the unit seam)
+
+- [ ] 1.1 Implement `lib/Service/ConfidentialityLabelService.php` (REQ-DDFCL-001)
+  - `getLabelForFile(int $fileId): ?ConfidentialityLabel`; availability-guard on `files_confidential` via `IAppManager::getInstalledApps()` (MetadataService L76–84 pattern); read file system tags via `ISystemTagObjectMapper`/`ISystemTagManager`; match names against `docudesk.confidentiality.label_vocabulary`; return highest-level match or null; catch tag-API exceptions → null (never throw).
+
+## 2. Surface the signal
+
+- [ ] 2.1 Add `confidentialityLabel`/`confidentialityLevel` to the entity-review result (REQ-DDFCL-002)
+  - Merge into `AnonymizationService::extractAndDetectEntities()` result (L269) when the label service returns non-null; omit/null otherwise; transient report — no OR schema change (design.md D2).
+- [ ] 2.2 Render a read-only confidentiality chip in the entity-review context (REQ-DDFCL-002)
+  - Chip beside the existing risk chip; NL Design tokens (no hardcoded colour); informational only, no action; hidden when no label.
+
+## 3. Optional priority suggestion
+
+- [ ] 3.1 Add `docudesk.confidentiality.prioritise_analysis` (default off) as a batch/folder ordering hint (REQ-DDFCL-003)
+  - When on, use normalised level as a secondary (tie-breaking) sort key in batch/folder analysis enumeration; unlabelled → level 0; with flag off, ordering is identical to today; never skips/blocks/redacts.
+
+## 4. Config
+
+- [ ] 4.1 Admin settings: `label_vocabulary` (name→level map, seeded Public/Internal/Confidential/Secret) + `prioritise_analysis` toggle (REQ-DDFCL-001, REQ-DDFCL-003)
+  - `IAppConfig`-backed; explicit auth on any settings route; documented default vocabulary; unmatched tags ignored.
+
+## 5. Quality
+
+- [ ] 5.1 PHPUnit unit tests for `ConfidentialityLabelService` (REQ-DDFCL-001) — min 75% on new code
+  - Mock tag mappers + app manager + config: label+level for a tagged file; null for untagged; null when `files_confidential` absent; null on tag-API exception; highest-wins on multiple matches; run in the nextcloud:34 container (host PHP too old).
+- [ ] 5.2 PHPUnit test that the result merge and priority hint are additive (REQ-DDFCL-002, REQ-DDFCL-003)
+  - Assert result fields present only when a label resolves; assert batch ordering unchanged when `prioritise_analysis` is off and level-descending as secondary key when on.
+- [ ] 5.3 i18n EN + NL for the chip label and settings strings (keys English) + docs `docs/features/files-confidential-labels.md`; run `openspec validate files-confidential-labels --strict` (REQ-DDFCL-002)
+  - Documents the availability guard, read-only signal (no policy engine), the vocabulary config and the off-by-default priority hint; MCP screenshot of the confidentiality chip when `files_confidential` is present (ADR-010).

--- a/openspec/changes/libresign-signing-provider/.openspec.yaml
+++ b/openspec/changes/libresign-signing-provider/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/libresign-signing-provider/design.md
+++ b/openspec/changes/libresign-signing-provider/design.md
@@ -1,0 +1,215 @@
+# Design: libresign-signing-provider
+
+## Context
+
+Verified at HEAD (DocuDesk `development`, branch
+`spec/market-gap-wave3-2026-07`):
+
+- **The provider registry is a real extension seam.**
+  `SigningProviderInterface` defines `getIdentifier()`, `initiateSigning()`,
+  `checkStatus()`, `downloadSignedDocument()`, `cancelSigning()`,
+  `supportsLevel()`, and `produceSignedArtifact()`.
+  `SigningProviderFactory::__construct` wires
+  `['native' => NativeSigningProvider, 'validsign' => ValidSignProvider]` and
+  `getActiveProvider()` reads `docudesk.signing_provider` (default `native`),
+  **falling back to `native` on an unknown name**. `getAvailableProviders()`
+  returns `array_keys($this->providers)`.
+- **`supportsLevel` honesty already varies by provider.**
+  `NativeSigningProvider::supportsLevel()` returns `$level === 'SES'` and its
+  `produceSignedArtifact()` **does not** re-check the level;
+  `ValidSignProvider::supportsLevel()` returns true for SES/AdES/QES but its
+  `produceSignedArtifact()` throws (honest-completion gate, unimplemented).
+- **The completion path can launder levels.** Per `signing-trust-rebuild`
+  (GH #304, verified open): `produceAndStoreSignedArtifact` falls back to
+  `getActiveProvider()` on an unknown provider and native never checks
+  `supportsLevel()`, so a QES request can complete with an SES artifact
+  claiming QES. That fix is owned by `signing-trust-rebuild`; this change
+  depends on it and additionally refuses unsupported levels inside
+  `LibreSignProvider`.
+- **procest already integrates LibreSign** for besluit signing
+  (`apps-extra/procest/openspec/specs/libresign-besluit-signing/spec.md`), so
+  the fleet's certificate-signing engine is settled.
+- **LibreSign is not installed on this instance** — no `libresign` app dir
+  under `apps/` or `apps-extra/`. Exact API endpoints are therefore specced
+  against LibreSign's documented OCS API and marked as Open Questions (D3).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Offer LibreSign's X.509/OpenSSL certificate signing as a first-class provider
+  in the existing registry.
+- Be **honest about assurance level** — advertise only what the configured
+  LibreSign certificate delivers, and refuse to produce a level not supported,
+  so no fallback can launder SES into a QES claim.
+- Only present the provider when LibreSign is actually available; fail closed
+  otherwise.
+- Round-trip the signed artifact and audit into OpenRegister via existing
+  DocuDesk paths (ADR-022: consume OR's store + audit, no local stores).
+
+**Non-Goals:**
+
+- No new signing crypto in DocuDesk — LibreSign owns the certificate/key.
+- No change to `SigningProviderInterface`/`SigningProviderFactory` contracts
+  beyond adding a provider and the availability gate.
+- No fix to the shared completion-path fallback — that is
+  `signing-trust-rebuild` (dependency).
+- No signer-chain create UI / field placement / bulk send (owned by
+  `orphaned-surface-restoration`, `bulk-signing-field-builder`).
+- No EUDI-wallet / DigiD identity rails (owned by `signer-identity-rails`).
+
+## Decisions
+
+### D1 — Availability-guarded registration
+
+`SigningProviderFactory` registers `libresign` **only when the LibreSign app is
+enabled**, checked via `OCP\App\IAppManager` (`isEnabledForUser()` /
+`isInstalled('libresign')`) resolved in the factory. Behaviour:
+
+- LibreSign absent → `libresign` is **not** in `getAvailableProviders()`; the
+  admin picker does not offer it; `getProvider('libresign')` throws the existing
+  `RuntimeException` ("Signing provider not available").
+- LibreSign present but the caller selected another provider → unaffected.
+- `docudesk.signing_provider = libresign` but LibreSign later removed →
+  `getActiveProvider()` MUST fail closed with an explanatory error, **not**
+  silently return native. (This tightens the current unknown-name→native
+  fallback for the specific configured-but-absent case; the general
+  no-silent-fallback rule is `signing-trust-rebuild`'s.)
+
+### D2 — Honest capability mapping (`supportsLevel`)
+
+LibreSign signs with an X.509 certificate via OpenSSL, producing PAdES-class
+signatures. The mapping to DocuDesk's `SES|AdES|QES` levels is
+**certificate-dependent**, so it is config-driven, not hardcoded true:
+
+| DocuDesk level | LibreSign support | Default |
+|---|---|---|
+| `SES` | always (any certificate) | on |
+| `AdES` | when signing with a real X.509 certificate (LibreSign's normal mode) | on |
+| `QES` | only when the configured certificate is qualified / backed by a QTSP | **off** (admin opt-in) |
+
+`supportsLevel($level)` reads the admin config
+(`docudesk.libresign_qualified` boolean, default false) and returns true for
+`SES`/`AdES` and for `QES` only when qualified. `produceSignedArtifact()` /
+delegation MUST re-check `supportsLevel()` and **throw** on an unsupported
+level — never emit a lower-assurance artifact under a higher-level request.
+This is the anti-laundering core of the change.
+
+### D3 — Delegation to LibreSign's API (endpoints = Open Question)
+
+LibreSign exposes an OCS/REST API under
+`/ocs/v2.php/apps/libresign/api/v1/...`. The delegation flow DocuDesk needs:
+
+1. **Create a signature request** — register the file + signer(s) with
+   LibreSign, receiving a request/file uuid. *Documented endpoint (verify):*
+   `POST /api/v1/request-signature` (file + users).
+2. **Drive the signer flow** — LibreSign presents its own signing UI/link;
+   DocuDesk stores the returned uuid on the `signingSession`.
+3. **Retrieve the signed file** — after signers complete, fetch the signed
+   PDF. *Documented endpoint (verify):* the file-download / signed-file
+   retrieval by uuid.
+4. **Validate** — LibreSign's own validation. *Documented endpoint (verify):*
+   `GET /api/v1/file/validate/uuid/{uuid}` (or `.../file_id/{fileId}`).
+5. **Completion signal** — whether LibreSign pushes a webhook/notification or
+   DocuDesk polls `checkStatus()` is unresolved without a live instance.
+
+**Open Question (must resolve before apply):** confirm the exact request/sign/
+retrieve/validate endpoint paths and payloads against the LibreSign version
+targeted (its OCS API docs / an installed instance), and whether completion is
+push or poll. Until confirmed, `LibreSignProvider` is coded against an
+`interface`-level `LibreSignClient` seam so the concrete endpoints are swapped
+in one place. The client is resolved lazily (either an openconnector source or
+a thin `IClientService` HTTP client) so DocuDesk stays loadable without
+LibreSign.
+
+### D4 — Artifact + audit round-trip into OR (ADR-022)
+
+- **Artifact**: the signed PDF LibreSign returns is stored as a new document
+  version through DocuDesk's existing OR-backed completion path
+  (`produceAndStoreSignedArtifact` → new file version) — the same path native
+  uses. `LibreSignProvider::produceSignedArtifact()` returns the LibreSign
+  signed bytes (or throws per the honest-completion gate); it does not write
+  files itself.
+- **Audit**: every provider action (request created, signer completed, signed
+  file retrieved, validation result) is recorded via the existing
+  `SigningAuditService`, which routes to OR's hash-chained `AuditTrailMapper`
+  (`signing-audit-via-or`, status done). No DocuDesk-local audit store.
+- **Session**: reuse the `signingSession` schema; store `provider: libresign`
+  and the LibreSign `externalId` (request uuid). No new schema for MVP.
+
+### D5 — Honest-completion gate
+
+`produceSignedArtifact()` and `downloadSignedDocument()` MUST throw a
+descriptive exception when LibreSign has not produced a verifiable signed file
+(request incomplete, LibreSign unreachable, validation failed) — never return
+the unsigned original. This mirrors `ValidSignProvider`'s gate at HEAD and the
+interface docblock's honest-completion contract.
+
+## OpenRegister service usage (ADR-001)
+
+| Operation | Service |
+|---|---|
+| Signed-file storage | existing OR-backed completion path (new document version) |
+| Audit | `SigningAuditService` → OR `AuditTrailMapper` (hash-chained) |
+| Session persistence | OR ObjectService on `signingSession` (provider + externalId) |
+| LibreSign availability | `OCP\App\IAppManager` |
+| LibreSign API | lazy `LibreSignClient` seam (openconnector source or `IClientService`) |
+
+## Declarative vs imperative
+
+- **Declarative**: admin config keys (`signing_provider`,
+  `libresign_qualified`, LibreSign endpoint/source config); the provider picker
+  entry.
+- **Imperative (justified)**: availability gate, capability enforcement, API
+  delegation, honest-completion throw, audit writes.
+
+## Seed Data
+
+None — no new schema; signing sessions are created by real signing runs. Unit
+tests use a fake `LibreSignClient` and a fake `IAppManager`.
+
+## Security Considerations
+
+- **No assurance-level laundering**: `supportsLevel` config-driven; unsupported
+  level → throw, never a silent lower-assurance artifact. This is the change's
+  central security property and directly addresses the HEAD level-honesty
+  defect.
+- **Fail closed when configured-but-absent** (D1) — never fall through to
+  native for `signing_provider = libresign`.
+- **No keys in DocuDesk** — LibreSign holds the certificate/private key;
+  DocuDesk never stores signing keys.
+- **Immutable audit** via OR's hash chain.
+- API calls to LibreSign stay in-cluster (local NC app); no third-party cloud.
+
+## Risks / Trade-offs
+
+- [Endpoints unverified without a live LibreSign] → mitigated by the
+  `LibreSignClient` seam + an explicit Open Question gating apply; concrete
+  paths land in one file.
+- [Depends on `signing-trust-rebuild` for the shared no-fallback rule] →
+  accepted; `LibreSignProvider` refuses unsupported levels in its own methods
+  regardless, so it is honest even before that change lands.
+- [QES claim requires a qualified certificate] → default-off opt-in; the
+  provider never advertises QES on a non-qualified certificate.
+- [Completion push-vs-poll unknown] → seam supports both; poll via
+  `checkStatus()` is the safe default until a webhook is confirmed.
+
+## Migration Plan
+
+Additive: one provider class + factory registration behind an availability
+gate + admin config. No schema change, no route change for MVP. Rollback =
+remove the provider from the factory; existing native/validsign paths
+unaffected.
+
+## Open Questions
+
+- **Exact LibreSign OCS endpoints + payloads** for create-request / sign /
+  retrieve-signed / validate, and **completion push vs poll** — resolve against
+  LibreSign's documented API or an installed instance before apply (D3).
+- Whether a LibreSign **completion callback route** is needed (push model) or
+  polling suffices — provisional: poll via `checkStatus()`.
+- Whether provider-specific session metadata warrants extending
+  `signingSession` — provisional: no; reuse `provider` + `externalId`.
+- **QES qualification**: which qualified-certificate/QTSP configuration
+  LibreSign exposes to mark a signature QES — provisional: admin boolean
+  `libresign_qualified`, refined when the QTSP path is confirmed.

--- a/openspec/changes/libresign-signing-provider/proposal.md
+++ b/openspec/changes/libresign-signing-provider/proposal.md
@@ -1,0 +1,128 @@
+---
+kind: code
+---
+
+# Proposal: libresign-signing-provider
+
+## Why
+
+DocuDesk's only working signature today is its **native SES** — an HMAC marker
+over a document hash. Everything above SES (AdES/QES) needs certificate-based
+X.509/OpenSSL crypto DocuDesk does not own and should not build. **LibreSign**
+already ships exactly that, in-cluster, open-source:
+
+- LibreSign is *"the single most credible OSS rival to DocuDesk's signing rail
+  … owns the OpenSSL/X.509 crypto DocuDesk's native SES lacks"* (R4 A, R4 C
+  "Signing crypto / verification"). The strategic move is **R4 opportunity #1**:
+  absorb it as a provider plugin rather than out-build its certificate stack —
+  *"neutralises the strongest OSS rival by absorbing it, and gives real
+  cert-based signing without building crypto."*
+- **procest already trusts LibreSign for besluit signing** — verified at HEAD:
+  `apps-extra/procest/openspec/specs/libresign-besluit-signing/spec.md` (the
+  change archived 2026-07-13). The fleet has already committed to LibreSign as
+  the certificate-signing engine; DocuDesk consuming the same engine is
+  consistency, not a new bet.
+- DocuDesk's provider registry is **built for this**. Verified at HEAD:
+  `SigningProviderFactory` holds `['native' => NativeSigningProvider,
+  'validsign' => ValidSignProvider]` and resolves the active provider from the
+  `docudesk.signing_provider` app-config; `SigningProviderInterface` already
+  defines `getIdentifier()`, `supportsLevel()`, `produceSignedArtifact()` and
+  the async-flow seam. Adding a `LibreSignProvider` is a first-class extension,
+  not a refactor.
+
+But the registry has an **honesty defect this change must not inherit**.
+Verified at HEAD: `SigningProviderFactory::getActiveProvider()` falls back to
+`native` for any unknown provider name, and (per the active
+`signing-trust-rebuild` change, GH #304) the completion path
+`produceAndStoreSignedArtifact` silently falls back to `getActiveProvider()`
+while `NativeSigningProvider::produceSignedArtifact()` never checks
+`supportsLevel()` — so **a QES request can complete with a native SES artifact
+whose assertion claims QES**. A LibreSign provider that advertised AES/QES while
+the framework could silently substitute native would launder a lower assurance
+level into a higher claim. This change therefore ships an **honest capability
+contract**: `LibreSignProvider::supportsLevel()` returns only what LibreSign's
+configured certificate actually delivers, and `produceSignedArtifact()` refuses
+a level it does not support rather than let a fallback fill in — and it declares
+`signing-trust-rebuild` (the no-silent-fallback fix) as a dependency.
+
+## What Changes
+
+- **`LibreSignProvider`** implementing `SigningProviderInterface`, registered in
+  `SigningProviderFactory` under identifier `libresign`.
+- **Availability-guarded registration**: the provider is offered (appears in
+  `getAvailableProviders()` / the admin provider picker) **only when the
+  LibreSign app is installed and enabled** (`IAppManager::isEnabledForUser` /
+  `isInstalled`). When LibreSign is absent the provider is not selectable and,
+  if configured-but-absent, fails closed with an explanatory error — never a
+  silent downgrade to native.
+- **Honest capability mapping**: `supportsLevel()` maps LibreSign's X.509/
+  OpenSSL certificate-based capability to the AES-class levels it genuinely
+  provides (SES + AdES; QES only when backed by a qualified certificate/QTSP —
+  configurable, default off). It never claims a level the configured
+  certificate cannot back.
+- **Request delegation to LibreSign**: signing requests are delegated to
+  LibreSign's API (create signature request, drive signer flow, retrieve the
+  signed file, validate). The exact OCS endpoints are pinned as an Open
+  Question against LibreSign's documented API (this instance has no LibreSign
+  installed — see design.md D3).
+- **Artifact + audit round-trip into OR**: the signed file LibreSign produces
+  is stored as a new document version via DocuDesk's existing OR-backed path,
+  and every provider action is recorded through `SigningAuditService` (OR
+  hash-chained `AuditTrailMapper`) — no DocuDesk-local audit store.
+- **Honest-completion enforcement**: `produceSignedArtifact()` / download throw
+  (never return the unsigned original) when LibreSign has not produced a signed
+  artifact, matching the `ValidSignProvider` honest-completion gate already at
+  HEAD.
+
+## Capabilities
+
+### New Capabilities
+
+- `libresign-signing-provider`: a LibreSign-backed plugin in DocuDesk's signing
+  provider registry — availability-guarded registration, honest X.509/AES-class
+  `supportsLevel` with no silent lower-level substitution, delegation to
+  LibreSign's signing API, and signed-artifact + hash-chained-audit round-trip
+  into OpenRegister.
+
+### Modified Capabilities
+
+<!-- none — SigningProviderInterface and SigningProviderFactory are extended by
+     adding a provider, not by changing their contracts. The no-silent-fallback
+     enforcement on the shared completion path is delivered by the active
+     signing-trust-rebuild change (dependency), referenced not re-specced. -->
+
+## Impact
+
+- **Backend**: new `lib/Service/Signing/LibreSignProvider.php`
+  (implements `SigningProviderInterface`); `SigningProviderFactory` constructor
+  gains the provider and registers it **only when LibreSign is enabled**;
+  admin settings gain a LibreSign section (certificate/QTSP config, default-QES
+  off). LibreSign's API is called via its OCS endpoints (openconnector source
+  or a thin HTTP client resolved lazily — design.md D3).
+- **Register**: no new schema required for MVP — signing sessions reuse the
+  existing `signingSession` schema; a `provider: libresign` and
+  `externalId` (LibreSign request uuid) are stored on the existing session
+  object. If provider-specific metadata proves necessary it is added additively
+  with a version bump (design.md Open Questions).
+- **Routes**: none new for MVP — the provider plugs into the existing
+  `signing#*` routes; a LibreSign completion callback endpoint is an Open
+  Question (design.md D3) depending on whether LibreSign pushes or DocuDesk
+  polls.
+- **Frontend**: the existing signing provider picker gains `libresign` when
+  available; no new page. (The orphaned signer-chain create UI is owned by
+  `orphaned-surface-restoration` / `bulk-signing-field-builder`, not this
+  change.)
+- **Depends on**:
+  - `signing-trust-rebuild` (active) — removes the silent provider/level
+    fallback on the completion path (GH #304). This change relies on it so a
+    QES request can never be quietly served by native; until it lands,
+    `LibreSignProvider` still refuses unsupported levels in its own methods.
+  - LibreSign app installed + enabled (runtime availability gate).
+- **Security**: honest `supportsLevel` (no assurance-level laundering);
+  fail-closed when configured-but-absent; audit through OR's immutable chain;
+  no signing keys stored by DocuDesk (LibreSign holds the certificate/key).
+- **Evidence**: R4 A/C + opportunity #1 (absorb LibreSign, don't out-build);
+  procest `libresign-besluit-signing` spec (fleet already trusts LibreSign);
+  MAC/level-honesty defect verified at HEAD (`signing-trust-rebuild` GH #304);
+  registry structure verified at HEAD (`SigningProviderFactory`,
+  `SigningProviderInterface`).

--- a/openspec/changes/libresign-signing-provider/specs/libresign-signing-provider/spec.md
+++ b/openspec/changes/libresign-signing-provider/specs/libresign-signing-provider/spec.md
@@ -1,0 +1,127 @@
+# libresign-signing-provider Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+A LibreSign-backed provider plugin in DocuDesk's existing signing provider
+registry (`SigningProviderInterface` / `SigningProviderFactory`, verified at
+HEAD), giving DocuDesk real X.509/OpenSSL certificate-based (AES-class)
+signatures without building crypto — absorbing the strongest OSS signing rival
+(R4 opportunity #1) that procest already trusts for besluit signing. The
+provider is offered only when the LibreSign app is enabled, maps its capability
+to signature levels honestly (never advertising a level the configured
+certificate cannot back), refuses to produce an unsupported level rather than
+let the framework substitute a lower one (the assurance-level-laundering defect
+tracked by `signing-trust-rebuild`, GH #304), and round-trips the signed
+artifact and audit into OpenRegister. The shared no-silent-fallback fix on the
+completion path is owned by `signing-trust-rebuild` (dependency), not
+re-specced here.
+
+## ADDED Requirements
+
+### Requirement: Availability-guarded registration in the provider registry (REQ-DDLSP-001)
+
+The `SigningProviderFactory` MUST register a `libresign` provider only when the
+LibreSign app is installed and enabled (checked via `OCP\App\IAppManager`).
+When LibreSign is absent the provider MUST NOT appear in
+`getAvailableProviders()` and MUST NOT be selectable in admin settings, and
+`getProvider('libresign')` MUST throw. When `docudesk.signing_provider` is set
+to `libresign` but LibreSign is not available, provider resolution MUST fail
+closed with an explanatory error and MUST NOT silently fall back to the native
+provider.
+
+#### Scenario: Provider offered only when LibreSign is enabled
+
+- GIVEN the LibreSign app is enabled
+- WHEN the admin opens the signing provider picker
+- THEN `libresign` is offered
+- AND WHEN LibreSign is disabled, `libresign` is not offered and `getProvider('libresign')` throws
+- @e2e tests/e2e/spec-coverage/libresign-signing-provider.spec.ts
+
+#### Scenario: Configured-but-absent fails closed, never native
+
+- GIVEN `docudesk.signing_provider` is `libresign` and the LibreSign app is not installed
+- WHEN a signing request resolves the active provider
+- THEN resolution fails with an explanatory error
+- AND the request is NOT silently served by the native provider
+- @e2e exclude provider-resolution fail-closed is factory logic — covered by PHPUnit (tests/unit/Service/Signing/SigningProviderFactoryTest.php)
+
+### Requirement: Honest capability mapping and no assurance-level laundering (REQ-DDLSP-002)
+
+`LibreSignProvider::supportsLevel()` MUST return only the signature levels the
+configured LibreSign certificate genuinely provides: SES and AdES for a real
+X.509 certificate, and QES only when the certificate is qualified / QTSP-backed
+(admin-configured via `docudesk.libresign_qualified`, default off).
+`produceSignedArtifact()` and any delegation MUST re-check `supportsLevel()` and
+MUST throw on a level the provider does not support — it MUST NOT emit a
+lower-assurance artifact under a higher-level request. The provider MUST NOT
+advertise QES on a non-qualified certificate.
+
+#### Scenario: QES is not advertised without a qualified certificate
+
+- GIVEN `libresign_qualified` is false (default)
+- WHEN `supportsLevel('QES')` is checked
+- THEN it returns false, and `supportsLevel('SES')` and `supportsLevel('AdES')` return true
+- @e2e exclude capability matrix is unit logic — covered by PHPUnit (tests/unit/Service/Signing/LibreSignProviderTest.php)
+
+#### Scenario: An unsupported level is refused, not laundered
+
+- GIVEN `libresign_qualified` is false and a request asks for QES
+- WHEN `produceSignedArtifact()` is invoked on the LibreSign provider
+- THEN it throws rather than producing an AES/SES artifact that claims QES
+- @e2e exclude anti-laundering enforcement is provider crypto logic — covered by PHPUnit (tests/unit/Service/Signing/LibreSignProviderTest.php::testUnsupportedLevelThrows)
+
+### Requirement: Signing delegated to LibreSign's API (REQ-DDLSP-003)
+
+The provider MUST delegate the signing flow to LibreSign's signing API —
+create a signature request, drive the signer flow, retrieve the signed file,
+and validate — through a `LibreSignClient` seam resolved lazily so DocuDesk
+stays loadable without LibreSign. The provider MUST persist the LibreSign
+request identifier as the session `externalId` with `provider: libresign` on
+the existing `signingSession` object. The concrete LibreSign OCS endpoints MUST
+be confirmed against LibreSign's documented API before implementation is
+considered complete (recorded as a design Open Question, this instance having
+no LibreSign installed).
+
+#### Scenario: A signing request is delegated to LibreSign
+
+- GIVEN LibreSign is enabled and selected as the provider
+- WHEN a signing request is initiated for a document
+- THEN a LibreSign signature request is created and its identifier is stored as the session `externalId` with `provider: libresign`
+- @e2e exclude requires a live LibreSign instance absent from this environment — covered by PHPUnit with a fake LibreSignClient (tests/unit/Service/Signing/LibreSignProviderTest.php)
+
+#### Scenario: Signer flow status is read from LibreSign
+
+- GIVEN an in-progress LibreSign signature request
+- WHEN the provider checks status
+- THEN it reports LibreSign's current signer state without mutating step state itself
+- @e2e exclude live-instance dependency — covered by PHPUnit with a fake LibreSignClient (tests/unit/Service/Signing/LibreSignProviderTest.php)
+
+### Requirement: Signed-artifact and audit round-trip into OpenRegister with an honest-completion gate (REQ-DDLSP-004)
+
+The signed PDF LibreSign produces MUST be stored as a new document version
+through DocuDesk's existing OpenRegister-backed completion path, and every
+provider action MUST be recorded through `SigningAuditService` (OpenRegister
+hash-chained `AuditTrailMapper`) — DocuDesk MUST NOT keep a local audit store.
+`produceSignedArtifact()` and `downloadSignedDocument()` MUST throw when
+LibreSign has not produced a verifiable signed file (request incomplete,
+LibreSign unreachable, or validation failed) and MUST NOT return the unsigned
+original.
+
+#### Scenario: Completed LibreSign signature is stored and audited
+
+- GIVEN a LibreSign signature request whose signers have all completed
+- WHEN the provider retrieves the signed file
+- THEN the signed PDF is stored as a new document version via the OR-backed path
+- AND an immutable audit entry is recorded through OR's hash-chained audit trail
+- @e2e exclude live-instance dependency — covered by PHPUnit with a fake LibreSignClient and a fake audit service (tests/unit/Service/Signing/LibreSignProviderTest.php)
+
+#### Scenario: Incomplete LibreSign result never yields the unsigned original
+
+- GIVEN a LibreSign request that has not produced a signed file
+- WHEN `produceSignedArtifact()` or `downloadSignedDocument()` is called
+- THEN it throws, and the unsigned original is never returned as the signed document
+- @e2e exclude honest-completion gate is provider logic — covered by PHPUnit (tests/unit/Service/Signing/LibreSignProviderTest.php::testHonestCompletionGate)

--- a/openspec/changes/libresign-signing-provider/tasks.md
+++ b/openspec/changes/libresign-signing-provider/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: libresign-signing-provider
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 9.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Provider implementation
+
+- [ ] 1.1 Implement `lib/Service/Signing/LibreSignProvider.php` implementing `SigningProviderInterface` (REQ-DDLSP-003, REQ-DDLSP-004)
+  - `getIdentifier() = 'libresign'`; delegate initiate/status/download/cancel to a lazy `LibreSignClient` seam (design.md D3); `produceSignedArtifact()`/`downloadSignedDocument()` throw when LibreSign has not produced a verifiable signed file (honest-completion gate, D5) — never return the unsigned original.
+
+- [ ] 1.2 Implement honest capability mapping `supportsLevel()` (REQ-DDLSP-002)
+  - Config-driven (`docudesk.libresign_qualified`, default false): true for SES/AdES always, QES only when qualified; `produceSignedArtifact()`/delegation re-checks `supportsLevel()` and throws on an unsupported level so no fallback can launder SES into a higher claim.
+
+- [ ] 1.3 Implement the `LibreSignClient` seam + concrete OCS calls (REQ-DDLSP-003)
+  - `interface LibreSignClient` (createRequest/getStatus/downloadSigned/validate) with one concrete impl (openconnector source or `IClientService`), resolved lazily so DocuDesk loads without LibreSign; endpoint paths confirmed against LibreSign's documented OCS API (RESOLVE the design.md Open Question before apply).
+
+## 2. Registration + config
+
+- [ ] 2.1 Register `libresign` in `SigningProviderFactory` behind an availability gate (REQ-DDLSP-001)
+  - Register only when `IAppManager` reports LibreSign installed+enabled; absent → not in `getAvailableProviders()`, `getProvider('libresign')` throws; `signing_provider=libresign` while LibreSign is absent MUST fail closed with an explanatory error, never silently return native.
+
+- [ ] 2.2 Admin settings: LibreSign section (REQ-DDLSP-001, REQ-DDLSP-002)
+  - Provider selectable only when available; `libresign_qualified` toggle (default off) gating QES advertisement; LibreSign endpoint/source config; no signing keys stored by DocuDesk.
+
+## 3. Round-trip
+
+- [ ] 3.1 Artifact + audit round-trip into OpenRegister (REQ-DDLSP-004)
+  - Signed PDF stored as a new document version via the existing OR-backed completion path; every provider action recorded through `SigningAuditService` → OR hash-chained `AuditTrailMapper`; `signingSession` carries `provider: libresign` + LibreSign `externalId`; no DocuDesk-local audit store.
+
+## 4. Quality
+
+- [ ] 4.1 PHPUnit unit tests for `LibreSignProvider` and the factory gate (REQ-DDLSP-001, REQ-DDLSP-002, REQ-DDLSP-004)
+  - Availability gate (present/absent/configured-but-absent fail-closed); `supportsLevel` matrix incl. QES off-by-default; unsupported-level throws (no laundering); honest-completion throw on incomplete LibreSign result; audit written on each action — via fake `LibreSignClient`+`IAppManager`; min 75% on new code; run in the container (`docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`).
+
+- [ ] 4.2 Playwright e2e `tests/e2e/spec-coverage/libresign-signing-provider.spec.ts` (REQ-DDLSP-001)
+  - Provider appears in the signing picker only when LibreSign is enabled (gated by instance state); test through the UI; `@e2e exclude` the certificate-signing round-trip where no LibreSign instance is available, covered by PHPUnit.
+
+- [ ] 4.3 i18n (EN + NL) for the admin section + picker label; docs `docs/features/libresign-signing-provider.md`; run `openspec validate libresign-signing-provider --strict`
+  - Keys in English; document the availability gate, the honest supportsLevel/no-laundering rule, the signing-trust-rebuild dependency, the procest reuse, and the resolved LibreSign endpoints.

--- a/openspec/changes/llm-entity-detection-provider/.openspec.yaml
+++ b/openspec/changes/llm-entity-detection-provider/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/llm-entity-detection-provider/design.md
+++ b/openspec/changes/llm-entity-detection-provider/design.md
@@ -1,0 +1,228 @@
+# Design: llm-entity-detection-provider
+
+## Context
+
+Verified at HEAD (DocuDesk `spec/market-gap-wave3-2026-07`, OpenRegister and
+hermiq HEAD):
+
+- **OR models `llm` but has not built it.** `EntityRecognitionHandler`
+  (`lib/Service/TextExtraction/`) has `METHOD_LLM = 'llm'`,
+  `detectEntities()` dispatches to `detectWithLLM()`, and that method's whole
+  body is a TODO that returns `detectWithRegex(...)` — i.e. requesting `llm`
+  today **silently produces regex results**. The active method is a **global**
+  `IAppConfig` setting resolved by `AnonymisationBackendService::getState()`
+  (`effectiveMethod`); there is no per-organisation selection.
+- **hermiq runs graphs, admin-only, over objects.** `GraphController::run()`
+  (`POST /api/graph/run`) requires an authenticated **admin**
+  (`groupManager->isAdmin()` → 403 otherwise), takes `graph` (object) +
+  `subjectUuid`/`subjectRegister`/`subjectSchema`, resolves that OR object,
+  runs `GraphExecutor::run(graph, object)` and returns
+  `{subjectUuid, state, trace}`. It is not a text→entities API; there is no
+  raw-text detection endpoint at HEAD. hermiq's model runs locally
+  (Ollama/Qwen per project setup) — the sovereignty guarantee.
+- **DocuDesk owns the detection entry point.**
+  `AnonymizationService::extractAndDetectEntities()` drives OR extraction,
+  reads back entities and returns them to every DocuDesk flow; it also reads
+  document text directly via `readNodeTextSafely()`. Entities are written to
+  OR's catalogue through `EntityRelationMapper`.
+
+The consequence for design: DocuDesk must NOT implement OR's `detectWithLLM`
+(OR-owned) and must NOT modify hermiq's engine. It formalises a DocuDesk-side
+provider seam whose default just delegates to OR, and an LLM provider that
+integrates with hermiq via an agentflow — failing closed to the default with a
+visible warning whenever the LLM path cannot honestly run.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A per-organisation choice between OR's existing detection (default) and a
+  local LLM provider, with the LLM output landing in OR's exact entity shape.
+- Honest function: the operator always knows which engine produced the
+  entities; an LLM failure never silently downgrades quality.
+- Strict on-prem: no cloud calls; a non-local hermiq endpoint is refused.
+- A unit-testable resolver/mapper seam provable without a live NC or hermiq.
+
+**Non-Goals:**
+
+- No implementation of OR's `detectWithLLM` stub and no change to OR's global
+  method setting or `EntityRecognitionHandler` (OR-owned; declared dependency).
+- No new hermiq engine code; the text→entities agentflow / app-callable run
+  endpoint is a hermiq-side dependency (Open Questions).
+- No anonymisation-output changes — output modes are `anonymise-*` /
+  `reversible-pseudonymization` territory.
+- No cloud LLM support of any kind.
+
+## Decisions
+
+### D1 — The DetectionProvider seam
+
+```
+interface DetectionProviderInterface {
+    // Returns entities in OR's shape:
+    //   [ { value, type, category, positionStart, positionEnd,
+    //       confidence(0..1), detectionMethod }, ... ]
+    public function detect(int $fileId, string $text, ?array $entityTypes): DetectionResult;
+    public function id(): string;                 // 'default' | 'llm'
+    public function isAvailable(): bool;          // config/endpoint sanity
+}
+```
+
+`DetectionResult` = `{ entities: array, providerUsed: string,
+fellBack: bool, warning: ?string }`.
+
+- `DefaultDetectionProvider` (`id = default`): delegates to OR's existing
+  detection exactly as today — no behaviour change when the org is on the
+  default. This is the fallback target.
+- `LlmDetectionProvider` (`id = llm`): calls the configured local hermiq
+  agentflow (D3), maps its output into OR's shape (D4).
+
+### D2 — Per-organisation selection + resolver
+
+`DetectionProviderResolver::forOrganisation(?string $orgUuid): DetectionProviderInterface`
+reads `docudesk.detection.provider` as a per-organisation overlay
+(default `default`). The resolver is the single place the provider is chosen
+and the single place fallback happens (D5). OR's global method setting is left
+untouched — DocuDesk's overlay decides which DocuDesk provider drives the run;
+`DefaultDetectionProvider` still honours OR's global method (regex/presidio/…).
+
+### D3 — LLM provider ↔ hermiq contract (local only)
+
+`LlmDetectionProvider` POSTs to `docudesk.detection.hermiq_endpoint` with the
+configured `hermiq_agentflow` reference and the document text as the graph
+input, expecting a response whose `state` contains an `entities` array. The
+integration contract this change targets:
+
+- **Request**: agentflow reference + `{ text, entityTypes }` (the document's
+  extracted text and the enabled-type whitelist).
+- **Response**: `state.entities[]` = `{ value, type, start, end, score }`.
+
+HEAD reality (documented, not assumed away): hermiq's current
+`POST /api/graph/run` is admin-only and object-centric (`subjectUuid` over an
+OR object), so it cannot be called as-is with raw text by a non-admin request
+path. This change therefore **depends on** a hermiq agentflow-run endpoint
+that (a) accepts document text (or an OR chunk/object reference DocuDesk
+already has) and (b) is callable by DocuDesk's service context. Until that
+endpoint exists the LLM provider reports itself unavailable
+(`isAvailable() === false`) and the resolver uses the default provider with a
+warning — i.e. the feature ships fail-closed and lights up when the hermiq
+endpoint lands. `docudesk.detection.require_local` (default true) makes the
+provider **refuse** any endpoint that is not a loopback/private-network host —
+no document text may leave the perimeter.
+
+### D4 — Mapping LLM output into OR's shape
+
+The mapper converts each `state.entities[]` item into an OR
+`EntityRelationMapper` write:
+
+| LLM field | OR field | Rule |
+|---|---|---|
+| `type` | entity `type` | mapped to an OR type constant where known (PERSON, LOCATION, …); unknown types kept verbatim so nothing is dropped |
+| `value` | entity `value` | verbatim |
+| `start`/`end` | relation `positionStart`/`positionEnd` | verbatim; occurrences without positions are still stored (position-less) so redaction's literal-match still applies |
+| `score` | relation `confidence` | clamped to `0.0..1.0`; missing → a configured default confidence |
+| — | relation `detectionMethod` | constant `llm` |
+| — | entity `category` | derived from the mapped type (OR's category map), else `contextual_data` |
+
+Confidence is preserved end-to-end so DocuDesk's existing
+confidence-threshold filters (`minConfidence`, the high-confidence prohibition
+tier) behave identically whether the entity came from Presidio or the LLM.
+
+### D5 — Honest fallback (no silent degradation)
+
+The resolver wraps the chosen provider:
+
+1. If the org is on `default`, run it, done.
+2. If on `llm`: if `LlmDetectionProvider::isAvailable()` is false, OR the
+   `detect()` call throws / times out / returns malformed output, the resolver
+   runs `DefaultDetectionProvider` and sets
+   `fellBack = true`, `providerUsed = 'default'`,
+   `warning = "LLM detection unavailable — fell back to <default method>; results may miss context-dependent entities."`
+3. The `DetectionResult` (`providerUsed`, `fellBack`, `warning`) is threaded
+   into the payload `extractAndDetectEntities()` returns and into the
+   anonymisation report, so the review UI shows an explicit banner. A silent
+   downgrade — returning regex results while the operator believes the LLM
+   ran — is exactly the honest-function defect this change forbids.
+
+The default provider is **always** a working engine, so fallback degrades
+recall, never availability.
+
+### D6 — Config / admin UI
+
+Admin settings section (Manifest-V2 shell): per-organisation provider picker
+(`NcSelect` with `inputLabel`), hermiq endpoint URL, agentflow reference, a
+"require local endpoint" toggle (default on), and a "test connectivity" action
+that calls the provider's `isAvailable()` and reports the result. No secrets
+are stored beyond the endpoint URL/reference; if a hermiq auth token is later
+required it MUST use OR's writeOnly/`_render:false` secret boundary (out of
+scope here — this change stores no token).
+
+## OpenRegister / hermiq service usage (ADR-001)
+
+| Operation | Service |
+|---|---|
+| Default detection | OR path via `DefaultDetectionProvider` (unchanged) |
+| Catalogue writes | OR `EntityRelationMapper` (both providers), `detectionMethod` = `llm`/existing |
+| Document text | DocuDesk `readNodeTextSafely()` (already reads the node) |
+| LLM inference | hermiq agentflow via configured local endpoint (dependency) |
+
+ADR-011: no crypto in this change (no token stored). All processing is local;
+`require_local` enforces it.
+
+## Declarative vs imperative
+
+- **Declarative**: the per-org provider config; the manifest settings page.
+- **Imperative (justified)**: the resolver's selection + fallback decision, the
+  hermiq call, and the OR-shape mapping (all on the detection request path).
+
+## Seed Data
+
+None. Providers are code; config defaults to `default` (OR's existing
+behaviour), so an instance that never configures the LLM provider is
+byte-identical to today.
+
+## Security Considerations
+
+- `require_local` (default true) refuses any non-loopback/private endpoint —
+  document text never leaves the perimeter (the whole sovereignty pitch).
+- No cloud calls; no third-party SaaS.
+- Fallback is fail-closed to a working engine with a visible warning — never a
+  silent quality downgrade.
+- Admin-only config routes, explicit auth attributes, in-method guard.
+- No token stored in v1; a future token uses OR's `_render:false` boundary.
+
+## Risks / Trade-offs
+
+- [hermiq's `/api/graph/run` is admin-only/object-centric at HEAD] → the LLM
+  provider ships fail-closed (`isAvailable() === false`) until the hermiq
+  text→entities agentflow endpoint exists; the feature is honest and inert
+  rather than broken, and the default provider always runs.
+- [LLM latency vs Presidio] → accepted; detection is a deliberate step, and the
+  provider has a timeout that triggers the honest fallback.
+- [LLM output shape drift] → the mapper is defensive (unknown types kept,
+  missing positions/score handled) and malformed output triggers fallback, not
+  a crash.
+- [Per-org overlay vs OR's global method] → documented: DocuDesk's overlay
+  chooses the DocuDesk provider; `default` still honours OR's global method, so
+  there is one clear precedence.
+
+## Migration Plan
+
+Additive: new provider classes + resolver + one detection hook + config keys +
+a settings view. Default config = `default` = current behaviour, so no
+existing flow changes until an org opts in. Rollback = remove the hook and
+config; no data migration.
+
+## Open Questions
+
+- **hermiq text→entities agentflow / app-callable run endpoint** — the primary
+  dependency. Current `/api/graph/run` is admin-only + object-centric; a
+  variant accepting document text (or an OR chunk/object reference) and
+  callable from DocuDesk's service context is required for the LLM provider to
+  activate. Filed as a hermiq dependency.
+- **OR's `detectWithLLM` stub** — could alternatively be implemented OR-side so
+  `method=llm` works globally; this change deliberately keeps the choice
+  per-organisation in DocuDesk and leaves OR's stub as an OR follow-up.
+- **hermiq auth for a service-context call** — if a token is needed, store it
+  via OR's `_render:false` secret boundary (parallel to
+  reversible-pseudonymization's mapping store); not built here.

--- a/openspec/changes/llm-entity-detection-provider/proposal.md
+++ b/openspec/changes/llm-entity-detection-provider/proposal.md
@@ -1,0 +1,140 @@
+---
+kind: code
+---
+
+# Proposal: llm-entity-detection-provider
+
+## Why
+
+"Anonimiseren met LLM" is the narrative the Dutch government is actively
+writing, and DocuDesk should own it before a competitor does:
+
+- The rijksbrede innovatieproject **"Anonimiseren met LLM"** (Digitale
+  Overheid) and Binnenlands Bestuur's "Anonimiseren in de Woo met kunstmatige
+  intelligentie" (Reveal/ZyLAB) are pushing LLM-based anonymisation into
+  procurement conversations (R3 section C, demand_score 4).
+- The NL flagship **"anonimiseren bij de bron"** tool — a Conduction project
+  with Hoeksche Waard + 5 municipalities, built on **Nextcloud + LLM** — is
+  the exact position DocuDesk holds in market (R2 C2). Its selling point is
+  **on-prem sovereignty**: the model runs inside the organisation's perimeter,
+  no document ever leaves it.
+- The **Hoeksche Waard tool** and the MinBZK **maskeringsscript** (R2 A3/A5)
+  prove fully-local LLM/NLP anonymisation is real; ZyLAB/Reveal already
+  *market* the LLM angle. DocuDesk is Presidio/regex today (R2 D:
+  "COVERED — on-prem is core positioning" for sovereignty, but no LLM engine
+  option is specced).
+
+Regex and Presidio miss context-dependent PII an LLM catches — a person
+referred to only by role-plus-context, an address split across a sentence, an
+implicit identifier. Offering an LLM detection provider (running locally via
+hermiq, no cloud) is the differentiator; doing it **honestly** — never
+silently degrading to a weaker engine when the LLM fails — is the fleet's
+non-negotiable.
+
+Verified at HEAD (why this is a thin provider seam, not an engine):
+
+- OpenRegister already models an LLM detection method:
+  `EntityRecognitionHandler` has `METHOD_LLM = 'llm'`, `BackendState::METHODS`
+  includes `'llm'`, and `detectEntities()` dispatches to `detectWithLLM()` —
+  **but that method is a stub**: its body is `// TODO: Implement LLM-based
+  entity extraction. For now, fall back to regex.` and it silently returns the
+  regex result (`lib/Service/TextExtraction/EntityRecognitionHandler.php`).
+  The detection method is chosen by a **global** `IAppConfig` setting
+  (`AnonymisationBackendService`), not per organisation.
+- hermiq ships `POST /api/graph/run` (`lib/Controller/GraphController.php`)
+  which runs an agent graph and returns `{subjectUuid, state, trace}` — but at
+  HEAD it is **admin-only** and **object-centric**: it requires `graph`
+  (object), `subjectUuid`, `subjectRegister`, `subjectSchema` and runs over an
+  existing OpenRegister object, not raw text. There is no text→entities
+  endpoint yet.
+- DocuDesk already owns the detection entry point
+  (`AnonymizationService::extractAndDetectEntities`), reads document text
+  itself (`readNodeTextSafely()`) and writes entities into OR's catalogue via
+  `EntityRelationMapper`.
+
+So DocuDesk formalises a small **DetectionProvider** seam whose default
+implementation delegates to OpenRegister's existing detection (unchanged), and
+adds an LLM provider that calls a local hermiq agentflow, maps its output into
+OR's entity/confidence shape, and — critically — falls back to the default
+provider with an **explicit report warning** on any failure. The provider is
+chosen **per organisation** (the config surface OR does not have). We do not
+touch OR's stub or hermiq's engine; we own the DocuDesk-side selection,
+mapping and honest fallback.
+
+## What Changes
+
+- **DetectionProvider seam (DocuDesk)**: an interface with two
+  implementations — `DefaultDetectionProvider` (delegates to OR's existing
+  `extractAndDetectEntities` path; the default) and `LlmDetectionProvider`
+  (calls a configured local hermiq agentflow). Both return the same
+  entity/confidence shape OR persists.
+- **Per-organisation provider selection**: `docudesk.detection.provider`
+  resolved per organisation (default `default`), with the hermiq endpoint +
+  agentflow reference held in admin config. OR's global method setting is
+  unchanged; this is a DocuDesk overlay.
+- **LLM provider over hermiq (local only)**: `LlmDetectionProvider` sends the
+  document's extracted text to the configured hermiq graph endpoint and reads
+  detected entities from the returned state, mapping `{value, type, positions,
+  confidence}` into OR's `EntityRelationMapper` rows with
+  `detectionMethod = llm`. No cloud calls — hermiq runs the model on-prem
+  (Ollama/Qwen), and the provider refuses a non-local endpoint by config.
+- **Honest fallback (no silent degradation)**: on any LLM-provider failure
+  (endpoint down, timeout, malformed output, non-local endpoint) the run
+  falls back to `DefaultDetectionProvider` AND records an explicit warning that
+  is surfaced in the anonymisation report / review — the operator always knows
+  which engine actually produced the entities. Success also records which
+  provider ran.
+- **Admin config UI**: a settings section (Manifest-V2 shell) to pick the
+  provider per organisation, set the hermiq endpoint + agentflow reference, and
+  test connectivity.
+
+## Capabilities
+
+### New Capabilities
+
+- `llm-entity-detection-provider`: a per-organisation, pluggable
+  entity-detection provider seam over OpenRegister's existing detection, with a
+  local hermiq LLM provider, OR-shape entity mapping, and honest
+  fallback-with-warning to the default provider (no silent degradation, no
+  cloud calls).
+
+### Modified Capabilities
+
+<!-- none in DocuDesk. OR's detection engine, catalogue and the global
+     backend-method setting are consumed unchanged; OR's own detectWithLLM
+     stub and a hermiq text->entities agentflow endpoint are declared as
+     dependencies below, not modified here. -->
+
+## Impact
+
+- New `lib/Service/Detection/DetectionProviderInterface.php`,
+  `DefaultDetectionProvider.php` (delegates to OR),
+  `LlmDetectionProvider.php` (hermiq call + OR-shape mapping),
+  `DetectionProviderResolver.php` (per-organisation selection + fallback).
+- Hook the resolver into `AnonymizationService::extractAndDetectEntities` so
+  the chosen provider runs and the provider-used / fallback warning lands in
+  the returned payload and the report.
+- New `lib/Controller/DetectionProviderSettingsController.php` +
+  `api/detection-provider/*` (get/set per-org config, test connectivity);
+  fail-closed admin auth.
+- Admin config keys: `docudesk.detection.provider` (per-org overlay),
+  `docudesk.detection.hermiq_endpoint`, `docudesk.detection.hermiq_agentflow`,
+  `docudesk.detection.require_local` (default true).
+- `src/manifest.json` + settings view: provider picker + hermiq wiring.
+- Consumes / depends on (declared, not modified):
+  - OpenRegister `EntityRelationMapper`, `TextExtractionService`,
+    `AnonymisationBackendService` (global method) — presence-gated.
+  - **hermiq** `POST /api/graph/run` (admin-only, object-centric at HEAD) —
+    this change **depends on** a hermiq agentflow that accepts document text
+    and returns entities in OR's shape (or an app-callable variant of
+    `/api/graph/run`); the current admin-only/object-centric shape is the HEAD
+    reality and is documented as the integration contract + open question in
+    design.md. DocuDesk never assumes it can call the engine directly without
+    that endpoint — it fails closed to the default provider.
+- Non-overlap (declared dependencies, not re-specced):
+  `custom-dictionary-recognition` (sibling; both add recognizers into OR's
+  catalogue — orthogonal), `anonymization-review-workbench` (active; renders
+  the warning), `anonymise-*` output-mode changes (untouched).
+- Evidence: "Anonimiseren met LLM" (R3 C); Hoeksche Waard on-prem LLM tool +
+  Conduction (R2 C2); LLM-Anonymizer OSS / maskeringsscript (R2 A3/A5); R2 D
+  local/on-prem LLM anonymisation row.

--- a/openspec/changes/llm-entity-detection-provider/specs/llm-entity-detection-provider/spec.md
+++ b/openspec/changes/llm-entity-detection-provider/specs/llm-entity-detection-provider/spec.md
@@ -1,0 +1,164 @@
+# llm-entity-detection-provider Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Offer a per-organisation choice of entity-detection provider over
+OpenRegister's existing detection: a default provider that delegates to OR's
+Presidio/regex path unchanged, and an LLM provider that calls a **local**
+hermiq agentflow (no cloud calls — the on-prem sovereignty guarantee). LLM
+output maps into OpenRegister's exact entity/confidence shape so the rest of
+the pipeline is identical regardless of engine. Because degrading detection
+quality without telling the operator is dishonest, any LLM-provider failure
+MUST fall back to the default provider **with an explicit warning surfaced in
+the report** — never a silent downgrade. Verified at HEAD: OR's `detectWithLLM`
+is a stub that silently returns regex, OR's method is a global setting, and
+hermiq's `POST /api/graph/run` is admin-only + object-centric — so this change
+formalises a DocuDesk-side provider seam and depends on (does not modify) OR's
+engine and a hermiq text→entities agentflow endpoint.
+
+## ADDED Requirements
+
+### Requirement: A pluggable detection-provider seam with a default over OR (REQ-DDLED-001)
+
+The app MUST define a `DetectionProviderInterface` whose implementations return
+detected entities in OpenRegister's persisted shape (value, type, category,
+positions, confidence 0..1, detection method), and MUST ship a
+`DefaultDetectionProvider` that delegates to OpenRegister's existing detection
+with no behaviour change. The default provider MUST remain the fallback target
+and MUST always be a working engine. The seam MUST NOT implement or modify
+OpenRegister's own detection engine.
+
+#### Scenario: Default provider reproduces current detection
+
+- GIVEN an organisation left on the default detection provider
+- WHEN a document is extracted and detected
+- THEN the entities returned are exactly those OpenRegister's existing path produces, with no added or dropped entities
+- @e2e exclude equivalence to the existing OR path — covered by PHPUnit (tests/unit/Service/Detection/DefaultDetectionProviderTest.php)
+
+#### Scenario: Providers report a stable id
+
+- GIVEN the default and LLM providers
+- WHEN their `id()` is read
+- THEN they return `default` and `llm` respectively
+- @e2e exclude trivial identity accessor — covered by PHPUnit (tests/unit/Service/Detection/)
+
+### Requirement: Per-organisation provider selection (REQ-DDLED-002)
+
+The app MUST resolve the detection provider per organisation from
+`docudesk.detection.provider` (default `default`), through a single resolver
+that is the only place the provider is chosen. Selecting a provider for one
+organisation MUST NOT change another organisation's provider, and MUST NOT
+modify OpenRegister's global detection-method setting. The provider-selection
+configuration routes MUST be admin-gated and fail closed.
+
+#### Scenario: One organisation opts into the LLM provider
+
+- GIVEN organisation A set to provider `llm` and organisation B left on default
+- WHEN a document of each organisation is detected
+- THEN organisation A's run uses the LLM provider (or its honest fallback) and organisation B's run uses the default provider
+- @e2e tests/e2e/spec-coverage/llm-entity-detection-provider.spec.ts
+
+#### Scenario: Non-admin cannot change the provider config
+
+- GIVEN a non-admin user
+- WHEN they call the provider-configuration route
+- THEN the response is HTTP 403 and no configuration changes
+- @e2e exclude authorization matrix — covered by PHPUnit (tests/unit/Controller/DetectionProviderSettingsControllerTest.php)
+
+### Requirement: Local hermiq LLM provider with no cloud calls (REQ-DDLED-003)
+
+The `LlmDetectionProvider` MUST detect entities by calling a configured hermiq
+agentflow at `docudesk.detection.hermiq_endpoint`, sending the document's
+extracted text and enabled entity types and reading detected entities from the
+returned agent state. With `docudesk.detection.require_local` enabled (default
+true) the provider MUST refuse any endpoint that is not a loopback or
+private-network host, so document text never leaves the organisation's
+perimeter. The provider MUST report itself unavailable when it is unconfigured,
+when the endpoint is unreachable, or when `require_local` rejects the endpoint,
+so the resolver can fall back deterministically. The provider MUST NOT make any
+call to a third-party or cloud service.
+
+#### Scenario: A non-local endpoint is refused
+
+- GIVEN `require_local` is true and `hermiq_endpoint` points at a public host
+- WHEN the LLM provider is asked whether it is available
+- THEN it reports unavailable and no document text is transmitted
+- @e2e exclude endpoint-locality guard — covered by PHPUnit (tests/unit/Service/Detection/LlmDetectionProviderTest.php::testNonLocalEndpointRefused)
+
+#### Scenario: A configured local endpoint detects entities
+
+- GIVEN a reachable local hermiq agentflow returning entities in state
+- WHEN a document is detected through the LLM provider
+- THEN entities from the agent state are returned and persisted with detection method `llm`
+- @e2e exclude requires a live hermiq agentflow — covered by PHPUnit with a faked hermiq client (tests/unit/Service/Detection/LlmDetectionProviderTest.php)
+
+### Requirement: LLM output maps into OpenRegister's entity/confidence shape (REQ-DDLED-004)
+
+The LLM provider MUST map each returned entity into an OpenRegister
+`EntityRelationMapper` write: entity value verbatim; type mapped to an
+OpenRegister type constant where recognised and kept verbatim otherwise (never
+dropped); positions carried through, with position-less occurrences still
+stored; confidence clamped to 0..1 (a configured default when absent); category
+derived from the mapped type; and `detectionMethod = llm`. The mapped entities
+MUST be indistinguishable in shape from Presidio-produced entities so
+downstream confidence-threshold and prohibition logic behave identically.
+
+#### Scenario: Confidence is preserved and clamped
+
+- GIVEN the LLM returns an entity with score 1.4 and another with no score
+- WHEN they are mapped
+- THEN the first is stored with confidence 1.0 and the second with the configured default confidence
+- @e2e exclude pure mapping logic — covered by PHPUnit (tests/unit/Service/Detection/LlmDetectionProviderTest.php::testConfidenceClampAndDefault)
+
+#### Scenario: An unknown LLM type is kept, not dropped
+
+- GIVEN the LLM returns an entity of an unrecognised type
+- WHEN it is mapped
+- THEN the entity is persisted with its type kept verbatim and category `contextual_data`
+- @e2e exclude pure mapping logic — covered by PHPUnit (tests/unit/Service/Detection/LlmDetectionProviderTest.php)
+
+### Requirement: Honest fallback with an explicit report warning (REQ-DDLED-005)
+
+The resolver MUST fall back to the `DefaultDetectionProvider` whenever an
+organisation is on the LLM provider and that provider is unavailable, or its
+detection call throws, times out or returns malformed output, and MUST mark the
+result as having fallen back, naming the provider actually used and carrying an
+explicit warning. That warning MUST be surfaced in the returned detection payload and in
+the anonymisation report / review so the operator always knows which engine
+produced the entities. The system MUST NOT return default-provider results
+while presenting them as LLM results (no silent degradation).
+
+#### Scenario: LLM unavailable falls back with a visible warning
+
+- GIVEN an organisation on the LLM provider and an unreachable hermiq endpoint
+- WHEN a document is detected
+- THEN the default provider's entities are returned, the result is marked as fallen back to the default method, and the report shows an explicit warning
+- @e2e tests/e2e/spec-coverage/llm-entity-detection-provider.spec.ts
+
+#### Scenario: Malformed LLM output triggers fallback, not a crash
+
+- GIVEN the hermiq agentflow returns output that is not a valid entity list
+- WHEN a document is detected through the LLM provider
+- THEN detection falls back to the default provider with a warning and no error is raised to the operator
+- @e2e exclude fault-injection on the LLM response — covered by PHPUnit (tests/unit/Service/Detection/DetectionProviderResolverTest.php::testMalformedOutputFallsBack)
+
+### Requirement: Provider configuration UI (REQ-DDLED-006)
+
+The app MUST provide an admin settings section, registered in the Manifest-V2
+shell (`src/manifest.json` + `registry.js`, never `src/router/index.js`), to
+select the detection provider per organisation and set the hermiq endpoint,
+agentflow reference and the require-local toggle, with a test-connectivity
+action reporting the provider's availability. Every `NcSelect` MUST carry an
+`inputLabel`; colours and spacing MUST use Nextcloud CSS variables / NL Design
+tokens; the section MUST be visible only to admins.
+
+#### Scenario: Admin configures and tests the LLM provider
+
+- GIVEN an admin on the detection-provider settings section
+- WHEN they set the provider to LLM, enter a local hermiq endpoint and run the connectivity test
+- THEN the selection is saved and the test reports whether the provider is available
+- @e2e tests/e2e/spec-coverage/llm-entity-detection-provider.spec.ts

--- a/openspec/changes/llm-entity-detection-provider/tasks.md
+++ b/openspec/changes/llm-entity-detection-provider/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: llm-entity-detection-provider
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 11.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Provider seam
+
+- [ ] 1.1 Define `lib/Service/Detection/DetectionProviderInterface.php` + `DetectionResult` and `DefaultDetectionProvider.php` (REQ-DDLED-001)
+  - Interface `detect(fileId, text, entityTypes): DetectionResult`, `id()`, `isAvailable()`; `DetectionResult` carries `entities`, `providerUsed`, `fellBack`, `warning`. `DefaultDetectionProvider` delegates to OR's existing detection with no behaviour change; it is the fallback target.
+
+- [ ] 1.2 Implement `DetectionProviderResolver.php` per-organisation selection (REQ-DDLED-002)
+  - Read `docudesk.detection.provider` as a per-org overlay (default `default`); OR's global method setting untouched; single chokepoint for provider choice and fallback.
+
+## 2. LLM provider (hermiq, local)
+
+- [ ] 2.1 Implement `LlmDetectionProvider.php` calling the configured local hermiq agentflow (REQ-DDLED-003)
+  - POST text + agentflow ref to `docudesk.detection.hermiq_endpoint`; read `state.entities[]`; `require_local` (default true) refuses non-loopback/private hosts; `isAvailable()` false when unconfigured/unreachable so the resolver fails closed.
+
+- [ ] 2.2 Map LLM output into OR's entity/confidence shape (REQ-DDLED-004)
+  - Type mapped to OR constants where known (unknown kept verbatim), value verbatim, positions verbatim (position-less stored too), score clamped 0..1 (missing→default), `detectionMethod=llm`, category derived; written via OR `EntityRelationMapper`.
+
+## 3. Honest fallback + wiring
+
+- [ ] 3.1 Implement fallback-with-warning in the resolver (REQ-DDLED-005)
+  - On unavailable/throw/timeout/malformed LLM output, run `DefaultDetectionProvider`, set `fellBack=true`, `providerUsed=default`, and an explicit warning; never a silent downgrade.
+
+- [ ] 3.2 Thread the resolver + `DetectionResult` into `AnonymizationService::extractAndDetectEntities` and the report (REQ-DDLED-005)
+  - Provider-used and fallback warning appear in the returned payload and the anonymisation report so the review UI shows which engine ran.
+
+## 4. Config + UI
+
+- [ ] 4.1 `lib/Controller/DetectionProviderSettingsController.php` + `api/detection-provider/*` config routes (REQ-DDLED-002)
+  - Get/set per-org provider + hermiq endpoint/agentflow + `require_local`; test-connectivity action; fail-closed admin auth (explicit attributes + in-method guard); no secret stored in v1.
+
+- [ ] 4.2 Admin settings view in the Manifest-V2 shell (REQ-DDLED-006)
+  - Provider picker (`NcSelect` with `inputLabel`), endpoint/agentflow fields, require-local toggle, test button; registered in `src/manifest.json` + `registry.js` (not `src/router/index.js`); NL Design tokens.
+
+## 5. Quality
+
+- [ ] 5.1 PHPUnit unit tests: resolver selection + fallback (unavailable/throw/malformed → default + warning), LLM→OR mapping (types/positions/score clamp), `require_local` refusal — minimum 75% coverage on new code
+  - Provider seam is fully unit-testable with a faked hermiq client; run in the container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`.
+
+- [ ] 5.2 Playwright e2e `tests/e2e/spec-coverage/llm-entity-detection-provider.spec.ts` covering the `@e2e` scenarios
+  - Switch an org to the LLM provider, run detection with the endpoint unreachable, assert the report shows the explicit fallback warning and default entities; nldesign accessibility pass; test through the UI.
+
+- [ ] 5.3 i18n EN + NL for settings + the fallback warning banner, and documentation `docs/features/llm-entity-detection-provider.md` (ADR-010); run `openspec validate llm-entity-detection-provider --strict`
+  - Keys in English; docs cover on-prem/no-cloud positioning, the honest-fallback rule, and the hermiq endpoint dependency.

--- a/openspec/changes/orphaned-surface-restoration/.openspec.yaml
+++ b/openspec/changes/orphaned-surface-restoration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/orphaned-surface-restoration/design.md
+++ b/openspec/changes/orphaned-surface-restoration/design.md
@@ -1,0 +1,205 @@
+# Design: orphaned-surface-restoration
+
+## Context
+
+Verified at HEAD (DocuDesk `spec/market-gap-wave3-2026-07`):
+
+- The app boots the manifest-V2 shell. `src/main.js` builds the vue-router from
+  `manifest.pages` (`routesFromManifest()`, `mode:'history'`, base
+  `/apps/docudesk`) and mounts `App` with `{manifest, customComponents,
+  pageTypes, registry}`. `customComponents` is derived from the `kind:'page'`
+  entries of `src/registry.js`.
+- `src/router/index.js` (54 lines) declares Dashboard, Anonymization, Consent,
+  Templates, MyDocuments, Print, **Policy (Prohibitions/StandingConsents)**,
+  Signing (list/detail/**form/bulk/verify**), **Correspondence**, Comparison,
+  Gallery. It imports `vue-router` and exports a `new Router(...)`. **Nothing
+  imports it** — confirmed by grep. It is dead code that lists the orphans.
+- `src/registry.js` registers 14 page components. It does **not** include
+  `CorrespondenceIndex`, `SigningRequestForm`, `BulkSigningPanel`,
+  `SignatureVerification`, `ProhibitionIndex`, `StandingConsentIndex`.
+- `src/manifest.json` `pages[]` has no correspondence/policy/signing-authoring
+  pages; `menu[]` has no correspondence/policy entries.
+- Backend routes for all three families are live in `appinfo/routes.php`
+  (correspondence L121–123; `signing#bulkSign`/`#verify` L147–148; policy
+  L82–93). Components exist on disk (`ls src/views/{correspondence,policy,
+  signing}`).
+- Financial extraction (`extraction#*`, `glAccountSuggestion#*`, L152–156) and
+  print-job queue (`printJob#*`, L108–112) have live routes but **no Vue
+  component** — a distinct "headless backend" class, not a router-orphan.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the three built-UI orphan families reachable through the manifest shell.
+- Delete the dead router so it can no longer shadow the manifest router.
+- Add a reachability guard that turns "a built view is unreachable" from a
+  silent runtime 404 into a CI failure.
+- Keep signing trust semantics owned by the open security wave — restore
+  *reachability*, gate *mutation/trust* behind existing posture.
+
+**Non-Goals:**
+
+- No backend changes; no new controllers, services or routes.
+- No signing crypto / trust / identity work (owned by `signing-trust-rebuild`,
+  `signer-identity-rails`).
+- No bulk-sign field-placement builder (owned by `bulk-signing-field-builder`).
+- No policy menu labels/placement (owned by `publication-policy-labels-and-nav`).
+- No net-new financial-extraction or print-queue UI (headless class; out of
+  scope — allow-listed by the guard).
+
+## Decisions
+
+### D1 — Delete the dead router, keep the manifest router
+
+`src/router/index.js` is removed outright. `src/main.js` already owns routing
+(`routesFromManifest`), so deletion is inert at runtime and removes the shadow
+that made these views look "wired" while being unreachable. The reachability
+guard (D2) then enforces that no view depends on a re-introduced side router.
+
+### D2 — Reachability guard (durable core, the unit seam)
+
+A JS unit test (`tests/unit/reachability.spec.js`, Jest/vitest — the test
+runner already present for the shell) asserts, statically, against source files
+(no live NC, no browser):
+
+1. **Registry integrity**: every `src/registry.js` entry has a defined
+   `component` (import resolves) and a recognised `kind`
+   (`page|modal|widget|form-field|cell-renderer`).
+2. **Manifest ↔ registry**: every manifest page with `type:"custom"` has a
+   `component` string present as a `kind:"page"` registry entry; every
+   `kind:"page"` registry entry is referenced by at least one manifest page
+   (no dangling registrations).
+3. **No hidden orphans**: every top-level view file under `src/views/**/` whose
+   default export is a page-level view is EITHER reachable (referenced by a
+   manifest page through the registry) OR listed in an explicit
+   `KNOWN_HEADLESS` allow-list constant with a one-line reason.
+4. **`known-headless` allow-list** seeds with the two verified headless
+   backends (financial-extraction, print-queue) — documented as "backend live,
+   no built UI, tracked separately", so the guard neither false-positives on
+   them nor lets them pass invisibly.
+
+Rationale: the guard is what stops the orphan class recurring. It is
+file-static, so it runs in CI in milliseconds and is the change's testable
+seam. Legacy shell scaffolding (`src/views/Views.vue`,
+`src/navigation/MainMenu.vue`, `FileNavigation.vue`) that only ever imported the
+now-deleted router is removed alongside the router or allow-listed as
+`legacy-shell-unused` — the guard forces that decision to be explicit.
+
+### D3 — Correspondence restoration
+
+- `registry.js`: `CorrespondenceIndex: { kind:'page', component: CorrespondenceIndex }`.
+- `manifest.json` page: `{ id:"Correspondence", route:"/correspondence",
+  type:"custom", title:"Correspondence", component:"CorrespondenceIndex" }`.
+- `menu[]`: `{ id:"Correspondence", label:"Correspondence", icon:"icon-mail",
+  route:"Correspondence", order:55 }` (between Templates and Signing). Menu
+  `route` is the page id per the manifest contract (verified: existing menu
+  entries reference `route` = page id, e.g. `SigningRequests`).
+
+No new data path: `CorrespondenceIndex.vue` already calls the correspondence
+store/controller. This is pure re-wiring.
+
+### D4 — Signing authoring + verify restoration (gated)
+
+- `registry.js`: `SigningRequestForm` and `SignatureVerification` as
+  `kind:'page'`.
+- `manifest.json` pages (no new top-level menu — the Signing menu already
+  exists; these are reached from the Signing index/detail):
+  - `{ id:"SigningRequestForm", route:"/signing/new", type:"custom",
+    component:"SigningRequestForm" }` — the signer-chain create form, launched
+    from the Signing index "New" action.
+  - `{ id:"SignatureVerification", route:"/signing/verify/:fileId",
+    type:"custom", component:"SignatureVerification" }` — read-only verify page
+    over the live `signing#verify/{fileId}` route, linked from a request detail.
+- **Gating (touch discipline):** reachability ≠ new trust surface. The restored
+  form composes a request and the verify page displays what
+  `SigningController::verify()` already returns. Any action that *asserts or
+  mutates trust* — sending for signature, binding a provider, asserting signer
+  identity, presenting a verification verdict as authoritative — remains
+  governed by the in-flight security wave. Concretely: the create form's
+  send/provider/identity controls defer their semantics to
+  `signing-trust-rebuild` + `signer-identity-rails`; where those changes have
+  not yet landed, the restored form exposes only non-trust-bearing composition
+  (draft the request) and the verify page renders the backend verdict verbatim
+  with a "verification provided by the signing engine" attribution rather than
+  minting a new trust claim. This keeps restoration from silently re-opening the
+  forgeable-signer surface the security wave exists to close.
+- **`BulkSigningPanel`**: coordinated with `bulk-signing-field-builder`, which
+  owns the enriched bulk-sign + field-placement experience. To avoid speccing a
+  surface another active change is actively rebuilding, `BulkSigningPanel` is
+  **not** registered by this change; it stays on the guard's allow-list as
+  `owned-by:bulk-signing-field-builder` until that change registers its
+  successor. (Reachability of bulk-sign is delivered there, not duplicated
+  here.)
+
+### D5 — Policy reachability (labels deferred)
+
+- `registry.js`: `ProhibitionIndex`, `StandingConsentIndex` (kind:page); their
+  `ProhibitionFormModal`, `StandingConsentFormModal` (kind:modal).
+- `manifest.json` pages (deep-link reachable, **no menu entry here**):
+  - `{ id:"Prohibitions", route:"/policy/prohibitions", type:"custom",
+    component:"ProhibitionIndex" }`
+  - `{ id:"StandingConsents", route:"/policy/standing-consents", type:"custom",
+    component:"StandingConsentIndex" }`
+- The menu label/placement is **owned by `publication-policy-labels-and-nav`**
+  ("Publish always / never"). This change makes the pages resolvable and
+  deep-link reachable (fixing the orphan / satisfying the guard); that change
+  decides how they surface in navigation. Registering the pages without a menu
+  entry is a clean seam: the guard passes (components resolve, pages exist), and
+  no naming decision is pre-empted.
+
+## Registry / manifest contract (ADR-036)
+
+Registry keys equal the manifest `component` strings. Manifest schema refs (in
+`type:"index"` pages) use SLUG form — not touched here (all restored pages are
+`type:"custom"`, driven by existing stores/controllers). Modals live in their
+own files under `src/views/policy/` already and are imported by their index
+views; registering them as `kind:"modal"` follows the registry's documented
+modal-resolution path.
+
+## Declarative vs imperative
+
+- **Declarative**: registry entries + manifest pages/menu (the reachability is
+  data).
+- **Imperative (test)**: the reachability guard (static assertion over source).
+- No imperative backend logic is added.
+
+## Security Considerations
+
+- No new routes, so no new auth surface. All restored pages call controllers
+  that already enforce their own auth (`PolicyController`, `SigningController`,
+  `CorrespondenceController`).
+- Signing trust actions are gated (D4) so restoration cannot re-expose the
+  forgeable-signer path the security wave is closing.
+- The verify page renders the backend verdict verbatim; it does not compute or
+  assert its own signature validity.
+
+## Risks / Trade-offs
+
+- [Restoring the signing create form before `signing-trust-rebuild` lands could
+  imply trust the wave hasn't yet secured] → mitigated by D4: only non-trust
+  composition is enabled until the wave lands; trust controls defer to it.
+- [Policy pages reachable without a menu could look "half-wired"] → accepted:
+  the menu is owned by `publication-policy-labels-and-nav`; deep-link
+  reachability is the correct minimal fix and unblocks that change.
+- [The guard's `src/views/**` scan could false-positive on helper components] →
+  the guard only treats default-exported page-level views as candidates and
+  supports the explicit allow-list; helpers/sub-components are excluded.
+
+## Migration Plan
+
+Additive + one deletion. Delete `src/router/index.js` (+ any legacy shell files
+whose only importer was it); add registry/manifest entries; add the guard test.
+No data, no schema, no route changes. Rollback = restore the file and revert
+registry/manifest (the guard test would then fail, which is the point).
+
+## Open Questions
+
+- Financial-extraction and print-queue surfaces (headless) — net-new UI, a
+  separate change; allow-listed here so the gap is visible, not built.
+- Whether legacy shell files (`Views.vue`, `MainMenu.vue`,
+  `FolderFilesNavigation.vue`, `FileNavigation.vue`) should be deleted now or
+  allow-listed as `legacy-shell-unused` — provisional decision: delete the ones
+  whose sole importer was the dead router; allow-list any with a lingering
+  import until a follow-up removes it. The guard forces the choice to be
+  explicit either way.

--- a/openspec/changes/orphaned-surface-restoration/proposal.md
+++ b/openspec/changes/orphaned-surface-restoration/proposal.md
@@ -1,0 +1,145 @@
+---
+kind: code
+---
+
+# Proposal: orphaned-surface-restoration
+
+## Why
+
+DocuDesk ships more working software than a user can reach. The app mounts the
+manifest-V2 shell (`CnAppRoot` + a router built *from the manifest* in
+`src/main.js`, verified HEAD), yet a legacy `src/router/index.js` still lists a
+larger set of views — and that file is **imported nowhere** (verified:
+`grep -rn "router/index" src/` returns nothing; `src/main.js` builds its own
+routes via `routesFromManifest()`). Every view whose only wiring was that dead
+router is therefore green-but-dead: the backend runs, the component compiles,
+the route 404s.
+
+Verified orphans at HEAD (component present under `src/views/`, backend routes
+live in `appinfo/routes.php`, but absent from `src/registry.js` and
+`src/manifest.json`):
+
+- **Correspondence** — `src/views/correspondence/CorrespondenceIndex.vue`
+  exists; `CorrespondenceService` (873 LOC) + `CorrespondenceController` +
+  `BatchCorrespondenceJob` are live behind routes `correspondence#generate`,
+  `#generateBatch`, `#jobStatus` (routes.php L121–123). Zero reachable UI
+  (R1-code-inventory.md §4.2). Letter/correspondence generation is a shipped,
+  archived capability (`letter-correspondence-generation` canonical spec) with
+  no way in.
+- **Bespoke signing authoring** — `SigningRequestForm.vue` (signer-chain
+  create), `BulkSigningPanel.vue` (route `signing#bulkSign`, routes.php L147),
+  `SignatureVerification.vue` (route `signing#verify/{fileId}`, L148) all exist
+  and are unregistered. The only reachable "create" is the generic index Add,
+  which writes a bare `signingRequest` object with no signer chain, fields or
+  provider (R1 §2, §4.3). The multi-signer authoring, bulk-sign and verify
+  experiences are unreachable.
+- **Policy (prohibitions / standing consents)** — `ProhibitionIndex.vue`,
+  `StandingConsentIndex.vue` (+ their `*FormModal.vue`) exist; `PolicyController`
+  exposes 10 live routes (`policy#indexProhibitions` … `#deleteStandingConsent`,
+  routes.php L82–93) backed by `PolicyMatchService`/`PolicyRetroactiveService`.
+  Unreachable (R1 §4.4).
+
+This is a market-visible honesty gap, not a cosmetic one. The buyer research
+ranks a **human-in-the-loop redaction/authoring workbench** as NL table-stakes
+(R2-competitors.md §D, 4 competitors; dd-coverage-baseline "Human-review
+redaction UI is NL-market table stakes and DocuDesk lacks it"), and DocuDesk's
+own tracker requirements #45–64 describe exactly the review/authoring surfaces
+that already exist in code but cannot be opened (R3-user-wishes.md §A). Shipping
+the reachability that already-built code deserves is the cheapest possible
+capability delta.
+
+The root cause — a dead router shadowing the live manifest router — is a
+**regression trap**: any future view added only to the wrong file silently
+becomes an orphan. So the durable deliverable is not just re-registering three
+surfaces; it is a **reachability guard** that fails CI when a built top-level
+view is neither reachable through the manifest nor explicitly allow-listed as
+headless.
+
+### HEAD-verification surprise (scope boundary)
+
+The market baseline and brief also list **financial-extraction** and the
+**print-job queue** as orphans. Verified at HEAD they are a *different* class:
+their backends are live (`extraction#financial`/`#corrections`,
+`glAccountSuggestion#suggestAccount`, routes.php L152–156; `printJob#create` …
+`#updateStatus`, L108–112) but **no Vue component exists** for either
+(`find src -iname "*financ*" -o -iname "*print*"` yields only the already-
+registered `PrintPreview.vue`, which is unrelated). There is nothing to
+*restore*: giving them a surface is net-new UI, not re-registration. They are
+therefore **out of scope** here and recorded by the reachability guard's
+`known-headless` allow-list so the gap stays visible rather than silently
+passing. Building those surfaces is a separate change.
+
+## What Changes
+
+- **Delete the dead router**: remove `src/router/index.js`; the manifest-derived
+  router in `src/main.js` remains the only router.
+- **Reachability guard** (durable core): a build/CI unit test asserting that
+  every `src/registry.js` component imports successfully, every manifest
+  `type:"custom"` page `component` has a matching registry entry, and every
+  top-level view under `src/views/**/` is either reachable through the
+  manifest/registry or listed on an explicit `known-headless` allow-list with a
+  reason. A new orphan fails CI.
+- **Restore Correspondence**: register `CorrespondenceIndex` in `registry.js`,
+  add a `type:"custom"` manifest page and a Templates-adjacent menu entry.
+- **Restore signing authoring + verify**: register `SigningRequestForm`
+  (signer-chain create) and `SignatureVerification` (verify) as reachable pages
+  linked from the existing Signing surfaces; **mutation and identity actions are
+  gated behind the existing signing security posture** — the create form may
+  compose a request but its trust-bearing actions (send, provider binding,
+  signer-identity assertion) remain governed by `signing-trust-rebuild` /
+  `signer-identity-rails`, and `BulkSigningPanel` reachability is coordinated
+  with (not duplicated by) `bulk-signing-field-builder`.
+- **Restore policy reachability**: register `ProhibitionIndex`,
+  `StandingConsentIndex` and their modals so they resolve and are deep-link
+  reachable; **the user-facing menu label and placement are owned by
+  `publication-policy-labels-and-nav`** (declared dependency), not re-specced
+  here.
+
+## Capabilities
+
+### New Capabilities
+
+- `orphaned-surface-restoration`: the app's built-but-unreachable manifest
+  surfaces (correspondence, signing authoring/verify, policy) are reachable
+  through the manifest-V2 shell, the dead legacy router is removed, and a
+  reachability guard prevents the orphan class from recurring.
+
+### Modified Capabilities
+
+<!-- none. This change only registers existing views and deletes dead code. It
+     does NOT modify signing security (signing-trust-rebuild / signer-identity-
+     rails own that), the bulk field builder (bulk-signing-field-builder), or
+     policy nav labels (publication-policy-labels-and-nav) — those are declared
+     dependencies below, referenced not edited. -->
+
+## Impact
+
+- `src/router/index.js`: **deleted**.
+- `src/registry.js`: `+ CorrespondenceIndex, SigningRequestForm,
+  SignatureVerification, ProhibitionIndex, StandingConsentIndex` (kind:page) and
+  the two policy `*FormModal` entries (kind:modal).
+- `src/manifest.json`: new `type:"custom"` pages for the above; one new menu
+  entry for Correspondence (signing/policy pages are deep-link/linked, no new
+  top-level menu here — signing has a menu already; policy menu is owned by
+  `publication-policy-labels-and-nav`).
+- New `tests/unit/*` (JS): the reachability guard (Jest/vitest) — pure static
+  assertion over `registry.js` + `manifest.json` + a `src/views/**` scan; runs
+  without a live NC instance (the required unit seam).
+- Consumes unchanged (presence of backend routes verified at HEAD):
+  `CorrespondenceController`, `SigningController` (`bulkSign`/`verify`),
+  `PolicyController` (10 routes). No backend behaviour changes.
+- **Declared dependencies (referenced, not modified)**:
+  - `signing-trust-rebuild` — trust/verification honesty; the restored create
+    form and verify page must not present or mutate signatures in ways that
+    contradict the security wave. Restoration lands reachability; that change
+    lands the honest trust semantics.
+  - `signer-identity-rails` — identity binding on request creation.
+  - `bulk-signing-field-builder` — the enriched bulk-sign + field-placement
+    surface; `BulkSigningPanel` reachability is coordinated with it (see
+    design.md D4).
+  - `publication-policy-labels-and-nav` — owns the "Publish always / never"
+    labels and policy menu placement; this change supplies the reachable pages
+    it will label.
+- Evidence: R1-code-inventory.md §2 (dead-ended flows), §4 (verified orphans),
+  Appendix (file-path anchors); R2 §D (review/authoring table-stakes); R3 §A
+  (#45–64 authoring/review wishes); HEAD greps in this proposal.

--- a/openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md
+++ b/openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md
@@ -1,0 +1,163 @@
+# orphaned-surface-restoration Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Restore DocuDesk's built-but-unreachable manifest surfaces — letter
+correspondence, signing authoring/verify, and publication policy
+(prohibitions / standing consents) — to the manifest-V2 shell, delete the dead
+legacy `src/router/index.js` that shadowed the live manifest router, and add a
+reachability guard so the orphan class cannot recur. Backends for every restored
+surface are already live in `appinfo/routes.php` (verified at HEAD); this change
+adds no backend code. Signing trust and identity semantics remain owned by the
+in-flight security wave (`signing-trust-rebuild`, `signer-identity-rails`); the
+policy menu label is owned by `publication-policy-labels-and-nav`; the enriched
+bulk-sign builder is owned by `bulk-signing-field-builder` — all referenced, not
+modified.
+
+## ADDED Requirements
+
+### Requirement: The dead legacy router is deleted (REQ-DDOSR-001)
+
+The app MUST remove `src/router/index.js`, whose module is imported nowhere at
+HEAD and which shadows the manifest-derived router built in `src/main.js`. After
+removal the manifest-derived router (`routesFromManifest()`) MUST remain the
+app's only router and the app MUST boot and route identically to before. Any
+legacy shell file whose sole importer was the deleted router MUST also be
+removed or explicitly recorded on the reachability guard's allow-list.
+
+#### Scenario: Router file is gone and nothing imports it
+
+- GIVEN the app at HEAD where `grep -rn "router/index" src/` returns no matches
+- WHEN this change is applied
+- THEN `src/router/index.js` no longer exists AND the app still mounts `CnAppRoot` and routes every existing page via the manifest-derived router
+- @e2e exclude static source assertion — covered by the reachability guard unit test (tests/unit/reachability.spec.js) plus the existing e2e smoke that the app boots
+
+#### Scenario: Existing pages still route after deletion
+
+- GIVEN the dead router is deleted
+- WHEN a user navigates to Dashboard, Anonymization, Templates and Signing Requests
+- THEN each page renders exactly as before the change
+- @e2e tests/e2e/spec-coverage/orphaned-surface-restoration.spec.ts
+
+### Requirement: A reachability guard prevents orphaned surfaces (REQ-DDOSR-002)
+
+The app MUST ship a static unit test that fails when a built surface is
+unreachable. The guard MUST assert that every `src/registry.js` entry resolves a
+component with a recognised `kind`; that every manifest `type:"custom"` page
+`component` maps to a `kind:"page"` registry entry and every `kind:"page"`
+registry entry is referenced by at least one manifest page; and that every
+page-level view under `src/views/**/` is either reachable through the
+manifest/registry or listed on an explicit `KNOWN_HEADLESS` allow-list carrying
+a reason. The guard MUST run without a live Nextcloud instance or a browser. The
+allow-list MUST seed with the verified headless backends (financial-extraction,
+print-queue) and with `BulkSigningPanel` (owned by `bulk-signing-field-builder`)
+so those are neither flagged as regressions nor allowed to pass invisibly.
+
+#### Scenario: A newly orphaned view fails CI
+
+- GIVEN a page-level view added under `src/views/` that is neither registered nor allow-listed
+- WHEN the reachability guard runs
+- THEN the test fails naming the unreachable view
+- @e2e exclude build-time guard — covered by the guard's own unit test (tests/unit/reachability.spec.js::testUnregisteredViewFails)
+
+#### Scenario: Manifest custom page without a registry entry fails
+
+- GIVEN a manifest `type:"custom"` page whose `component` has no `kind:"page"` registry entry
+- WHEN the guard runs
+- THEN the test fails naming the missing registry key
+- @e2e exclude static manifest↔registry cross-check — covered by the guard unit test (tests/unit/reachability.spec.js)
+
+#### Scenario: Known-headless backends do not trip the guard
+
+- GIVEN the financial-extraction and print-queue views do not exist while their routes are live
+- WHEN the guard runs
+- THEN the guard passes because those backends are on the `KNOWN_HEADLESS` allow-list with a reason, and they remain visibly tracked
+- @e2e exclude allow-list assertion — covered by the guard unit test
+
+### Requirement: The Correspondence surface is reachable (REQ-DDOSR-003)
+
+The app MUST register `CorrespondenceIndex` in `src/registry.js`, add a
+`type:"custom"` manifest page at `/correspondence`, and add a navigation entry
+so a user can open letter/correspondence generation from the menu. The restored
+page MUST use the existing correspondence data path (its store /
+`CorrespondenceController` routes `generate`, `generateBatch`, `jobStatus`) with
+no backend change.
+
+#### Scenario: Correspondence opens from the menu
+
+- GIVEN the restored Correspondence menu entry
+- WHEN a user clicks it
+- THEN the `CorrespondenceIndex` page renders and can list/generate correspondence via the existing backend routes
+- @e2e tests/e2e/spec-coverage/orphaned-surface-restoration.spec.ts
+
+#### Scenario: Correspondence is registered and guard-clean
+
+- GIVEN the restored registration
+- WHEN the reachability guard runs
+- THEN `CorrespondenceIndex` is a reachable `kind:"page"` entry referenced by the `/correspondence` manifest page
+- @e2e exclude static registration assertion — covered by the reachability guard unit test
+
+### Requirement: Signing authoring and verify are reachable with trust actions gated (REQ-DDOSR-004)
+
+The app MUST register `SigningRequestForm` (signer-chain create) and
+`SignatureVerification` (verify) as reachable manifest pages linked from the
+existing Signing index and request-detail surfaces. Reachability MUST NOT
+introduce a new trust surface: actions that assert or mutate signing trust
+(send for signature, provider binding, signer-identity assertion, presenting a
+verification verdict as authoritative) MUST remain governed by the in-flight
+security wave — the restored create form MUST expose only non-trust-bearing
+composition until `signing-trust-rebuild` / `signer-identity-rails` land, and
+the verify page MUST render the `SigningController::verify()` result verbatim
+with an attribution to the signing engine rather than minting its own trust
+claim. `BulkSigningPanel` MUST NOT be registered by this change; its reachability
+is owned by `bulk-signing-field-builder`.
+
+#### Scenario: Signer-chain create form opens from the Signing index
+
+- GIVEN the restored `SigningRequestForm` page
+- WHEN a user clicks "New" on the Signing Requests index
+- THEN the signer-chain create form opens (multi-signer / field / provider composition) instead of the generic bare-object Add
+- @e2e tests/e2e/spec-coverage/orphaned-surface-restoration.spec.ts
+
+#### Scenario: Verify page renders the backend verdict verbatim
+
+- GIVEN a signed file and the restored verify page at `/signing/verify/:fileId`
+- WHEN a user opens it from a request detail
+- THEN it shows the `signing#verify/{fileId}` result attributed to the signing engine and does not compute or assert its own validity
+- @e2e tests/e2e/spec-coverage/orphaned-surface-restoration.spec.ts
+
+#### Scenario: Trust actions defer to the security wave
+
+- GIVEN `signing-trust-rebuild` / `signer-identity-rails` have not yet landed
+- WHEN a user reaches the restored create form
+- THEN only non-trust-bearing composition (draft the request) is available and no send/provider/identity assertion re-opens the forgeable-signer path
+- @e2e exclude cross-change gating state — covered by component tests asserting trust controls are disabled/deferred when the dependency capability is absent
+
+### Requirement: Policy surfaces are reachable, menu ownership deferred (REQ-DDOSR-005)
+
+The app MUST register `ProhibitionIndex` and `StandingConsentIndex` (as pages)
+and their `ProhibitionFormModal` / `StandingConsentFormModal` (as modals) in
+`src/registry.js`, and add deep-link-reachable `type:"custom"` manifest pages at
+`/policy/prohibitions` and `/policy/standing-consents` backed by the live
+`PolicyController` routes. This change MUST NOT add a policy navigation entry or
+decide policy labels — the menu placement and the "Publish always / never"
+labelling are owned by `publication-policy-labels-and-nav`; this change only
+makes the pages resolve and be reachable.
+
+#### Scenario: Policy pages are deep-link reachable
+
+- GIVEN the restored policy registrations
+- WHEN a user navigates to `/policy/prohibitions` or `/policy/standing-consents`
+- THEN the prohibition list and standing-consent list render against the live `PolicyController` routes, with their form modals functional
+- @e2e tests/e2e/spec-coverage/orphaned-surface-restoration.spec.ts
+
+#### Scenario: No policy menu label is introduced here
+
+- GIVEN this change is applied without `publication-policy-labels-and-nav`
+- WHEN the navigation menu is inspected
+- THEN no policy menu entry is added by this change (menu ownership belongs to the labels/nav change), while the pages remain deep-link reachable and guard-clean
+- @e2e exclude negative navigation assertion (absence of a menu entry) — covered by a manifest unit assertion in the reachability guard test

--- a/openspec/changes/orphaned-surface-restoration/tasks.md
+++ b/openspec/changes/orphaned-surface-restoration/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: orphaned-surface-restoration
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 10.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Remove dead code
+
+- [ ] 1.1 Delete `src/router/index.js` and any legacy shell file whose sole importer was it (REQ-DDOSR-001)
+  - Confirm `grep -rn "router/index" src/` is empty before and after; the manifest-derived router in `src/main.js` remains the only router; app boots unchanged; legacy files (`Views.vue`/`MainMenu.vue`/`FolderFilesNavigation.vue`/`FileNavigation.vue`) either deleted (sole importer was the router) or explicitly allow-listed (2.1).
+
+## 2. Reachability guard
+
+- [ ] 2.1 Add the reachability guard unit test `tests/unit/reachability.spec.js` (REQ-DDOSR-002)
+  - Static assertions (no live NC): every `registry.js` component resolves with a recognised `kind`; every manifest `type:"custom"` page `component` maps to a `kind:"page"` registry entry and vice-versa; every page-level view under `src/views/**/` is reachable or on the `KNOWN_HEADLESS` allow-list with a reason; allow-list seeded with financial-extraction + print-queue ("backend live, no built UI, tracked separately") and `BulkSigningPanel` (`owned-by:bulk-signing-field-builder`).
+
+## 3. Restore Correspondence
+
+- [ ] 3.1 Register `CorrespondenceIndex` and add its manifest page + menu entry (REQ-DDOSR-003)
+  - `registry.js` `kind:'page'`; manifest `type:"custom"` page `/correspondence`; menu entry `order:55` (route = page id); no data-path change (existing correspondence store/controller); reachable end-to-end.
+
+## 4. Restore signing authoring + verify (gated)
+
+- [ ] 4.1 Register `SigningRequestForm` + `SignatureVerification` as reachable pages (REQ-DDOSR-004)
+  - `registry.js` `kind:'page'`; manifest pages `/signing/new` and `/signing/verify/:fileId`; linked from the Signing index ("New") and request detail ("Verify"); no new top-level menu.
+- [ ] 4.2 Gate trust/mutation actions behind the existing security posture (REQ-DDOSR-004)
+  - Create-form send/provider/identity controls defer semantics to `signing-trust-rebuild`/`signer-identity-rails`; where unlanded, expose only non-trust composition (draft); verify page renders `SigningController::verify()` verdict verbatim with engine attribution, minting no new trust claim.
+
+## 5. Restore policy reachability (labels deferred)
+
+- [ ] 5.1 Register `ProhibitionIndex`, `StandingConsentIndex` (pages) + their `*FormModal` (modals) and add deep-link manifest pages (REQ-DDOSR-005)
+  - Manifest `type:"custom"` pages `/policy/prohibitions` and `/policy/standing-consents`, no menu entry (menu owned by `publication-policy-labels-and-nav`); modals registered `kind:"modal"`; pages resolve and are deep-link reachable; `PolicyController` routes consumed unchanged.
+
+## 6. Quality
+
+- [ ] 6.1 Run the guard + existing JS unit suite green; verify no manifest schema-ref regressions (REQ-DDOSR-002)
+  - `npm run test:unit` passes including `reachability.spec.js`; manifest validates against `app-manifest-v2.schema.json`; all restored `type:"custom"` pages resolve at build.
+- [ ] 6.2 Playwright e2e `tests/e2e/spec-coverage/orphaned-surface-restoration.spec.ts` proving each restored surface opens (REQ-DDOSR-003, REQ-DDOSR-004, REQ-DDOSR-005)
+  - Test through the UI on the dev instance: Correspondence menu opens the page; Signing "New" opens the signer-chain form; a request detail "Verify" opens the verify page; deep-linking `/policy/prohibitions` and `/policy/standing-consents` renders the lists; no 404/blank.
+- [ ] 6.3 i18n EN for any new UI strings (menu label, links, verify attribution) — keys in English (REQ-DDOSR-003)
+  - New strings added to `l10n/en.json` source; existing view strings unchanged.
+- [ ] 6.4 Documentation `docs/features/orphaned-surface-restoration.md` + run `openspec validate orphaned-surface-restoration --strict`
+  - Documents the reachability guard, the headless allow-list, and the signing-trust gating dependency; MCP screenshots of the restored surfaces (ADR-010).

--- a/openspec/changes/reversible-pseudonymization/.openspec.yaml
+++ b/openspec/changes/reversible-pseudonymization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/reversible-pseudonymization/design.md
+++ b/openspec/changes/reversible-pseudonymization/design.md
@@ -1,0 +1,225 @@
+# Design: reversible-pseudonymization
+
+## Context
+
+Verified at HEAD (DocuDesk `spec/market-gap-wave3-2026-07`, OpenRegister HEAD):
+
+- **OR already emits readable, stable placeholders.**
+  `DocumentProcessingHandler::anonymizeDocument()` replaces each entity with
+  `[<localized-type>: <number>]` — the type localized to the user's language
+  (`PERSON → PERSOON`, `localizeEntityType()`) and the number **scope-local**
+  via `PlaceholderIdTranslator` (`perDocument()` by default, per-dossier when
+  `scope=dossier`), so the same person is the same number within the scope and
+  is never linkable across documents. It records the exact emitted string in
+  `lastPlaceholderMap` keyed by the **global entity id**, exposed via
+  `FileService::getLastPlaceholderMap()` → `['<entityId>' => '[PERSOON: 1]', …]`.
+- **DocuDesk already consumes that map.**
+  `AnonymizationService::anonymizeDocument()` calls `getLastPlaceholderMap()`
+  and threads it into `attachGrondslagenSummary()` (Robert's merge, PR#314).
+  So the placeholder → readable-token half of pseudonymisation is live; what is
+  missing is the placeholder → **original value** reverse map and a restore.
+- **The pairing anchor exists.** `recordAnonymizationLink()` writes/updates one
+  `anonymizationLink` per source file (`sourceFileId`/`anonymizedFileId`
+  facetable, idempotent on `sourceFileId`); re-anonymise updates the same
+  record. This is the object a reversible mapping hangs off and shares a
+  lifecycle with.
+- **DocuDesk has no secret store today.** Grep of `lib/` + the register found
+  **zero** `writeOnly` / `_render:false` usage and no `ICrypto` use. OR's
+  render boundary is the documented mechanism: only a `_render:false` property
+  is withheld from read responses (fleet reference: writeOnly render boundary,
+  or#460/#462). A reversible map is a concentrated PII copy, so it needs both
+  that boundary **and** encryption at rest.
+- The original entity **values** are available at anonymise time: they arrive in
+  the `entities[]` argument to `anonymizeDocument()` (each carries `value`/`text`
+  and its `key`/entity id), so pairing a placeholder to its original value needs
+  no new detection.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A reversible output mode that reuses OR's placeholder emission and stores an
+  encrypted placeholder→original mapping keyed to the `anonymizationLink`.
+- An authorised, fail-closed, audit-logged restore that reconstructs the
+  original from the anonymised copy + the mapping.
+- Keep the default (irreversible) path byte-identical and store nothing for it.
+- A unit-testable encrypt/decrypt/restore seam provable without a live NC.
+
+**Non-Goals:**
+
+- No new placeholder format or replacement engine — OR owns emission; we read
+  its map (extend, not duplicate).
+- No change to `anonymizationLink`'s existing fields (only an additive pointer).
+- No image/redaction-at-scale work (those are `image-redaction` /
+  `redaction-at-scale`, active) — this is reversible **text** pseudonymisation.
+- No key-management UI; encryption uses Nextcloud's server secret via `ICrypto`.
+
+## Decisions
+
+### D1 — A `reversible` mode on the existing anonymise seam
+
+`AnonymizationService::anonymizeDocument()` gains a `reversible` flag (default
+false = today's behaviour). When true, after OR produces the anonymised file
+and returns `getLastPlaceholderMap()`, DocuDesk assembles the mapping from the
+placeholder map (entity id → placeholder) joined with the request `entities[]`
+(entity id → original value + type) into
+`placeholder → { originalValue, entityType }`, and calls `PseudonymMapService`
+to encrypt-and-store it. When false, nothing is stored — the placeholder output
+remains irreversible, exactly as now. The mode is orthogonal to `outputFormat`
+(pdf/pdf-only/…): reversibility is a *whether-we-keep-the-key* axis, not an
+output-format axis.
+
+### D2 — The `pseudonymMap` schema (encrypted, writeOnly)
+
+New schema in the `document` register:
+
+| Property | Type | Notes |
+|---|---|---|
+| `anonymizationLink` | string (uuid) | reference to the owning link — the lifecycle anchor |
+| `sourceFileId` | integer, facetable | mirror for lookup |
+| `mappings` | string | **`writeOnly` + `_render:false`** — the ICrypto-encrypted JSON of `placeholder → {originalValue, entityType}`; never returned in a read |
+| `algorithm` | string | e.g. `nextcloud-icrypto-v1` (what encrypted it) |
+| `entryCount` | integer | number of mapped placeholders (non-sensitive, for the UI) |
+| `scope` | string | `document`/`dossier` — mirrors the placeholder-numbering scope |
+
+`mappings` is doubly protected: `_render:false` keeps it out of every
+ObjectService read response (so even an authorised object read never leaks it),
+and its content is ICrypto-encrypted so a raw DB/backup read is also useless.
+The map is only ever decrypted inside `PseudonymRestoreService` on an
+authorised restore. Organisation scoping follows the source file's
+organisation (fail-closed like the rest of the catalogue).
+
+### D3 — `PseudonymMapService` (store)
+
+`store(int $linkId, int $sourceFileId, array $pairs, string $scope): void`:
+serialise `$pairs` to JSON, `ICrypto::encrypt()` it, write a `pseudonymMap`
+object via OR ObjectService with the ciphertext in the `_render:false`
+`mappings` field and `entryCount = count($pairs)`. Idempotent per
+`anonymizationLink` (re-anonymise overwrites the same map). `read()` returns the
+decrypted pairs and is **only** callable from the restore path (not exposed on
+any read route). Encrypt/decrypt round-trip is the primary phpunit seam.
+
+### D4 — `PseudonymRestoreService` (reverse)
+
+`restore(int $linkId, string $actor): File`:
+
+1. Resolve the `anonymizationLink` → the anonymised file + `pseudonymMap`.
+2. Decrypt the mapping (D3).
+3. Read the anonymised document's text and reverse each placeholder → original
+   value (longest-placeholder-first, mirroring OR's redaction ordering so
+   `[PERSOON: 1]` and `[PERSOON: 10]` cannot clobber each other), writing a
+   **restored copy** alongside the anonymised file (never overwriting the
+   anonymised file — both must remain).
+4. Return the restored node.
+
+Restore is a distinct copy, not an in-place edit, so the anonymised artefact is
+preserved for audit. Binary formats (PDF) reverse over the text layer where
+present; when the anonymised output is a format whose text cannot be safely
+rewritten, restore returns a text/JSON re-identification report
+(placeholder → original) rather than a corrupted document — honest partial
+result, never a silent no-op.
+
+### D5 — Fail-closed authorisation + audit (AVG accountability)
+
+Restore is re-identification — the most sensitive operation in the app:
+
+- Gated by `docudesk.pseudonymisation.restore_allowed_groups` (JSON array of NC
+  group ids; default `[]` = admins only). Enforced in the controller on the
+  restore route (`#[NoAdminRequired]` + explicit in-method gate — semantic-auth
+  pattern); a non-member gets 403 with a neutral body; a config read failure
+  denies (fail-closed).
+- **Every** restore — and every **denied** attempt — is audit-logged via OR's
+  audit trail (actor, timestamp, link/source reference, outcome). An unlogged
+  re-identification must not be possible; the audit write is on the request
+  path and a failed audit write refuses the restore.
+
+### D6 — Lifecycle tied to `anonymizationLink`
+
+The `pseudonymMap` is created/updated when its link is
+created/updated (reversible re-anonymise overwrites), and **deleted when the
+link is deleted** — so removing an anonymisation removes its re-identification
+key, never leaving an orphaned map. `anonymizationLink` gains one additive
+`mappingRef` pointer (nullable; absent = irreversible run). No other
+`anonymizationLink` field changes.
+
+### D7 — UI
+
+- Anonymise dialog: a mode choice "Reversible (pseudonymise — keeps an
+  encrypted key)" vs "Irreversible (redact)" (`NcSelect`/radio with
+  `inputLabel`), default irreversible so nothing changes unless chosen.
+- Document detail: a gated "Restore original" action, shown only to permitted
+  users, whose confirm dialog (own file under `src/dialogs/`) states that the
+  restore is audit-logged before it proceeds.
+
+## OpenRegister service usage (ADR-001)
+
+| Operation | Service |
+|---|---|
+| Placeholder emission + map | OR `DocumentProcessingHandler` / `FileService::getLastPlaceholderMap()` (unchanged) |
+| Anonymised/source pairing | OR `anonymizationLink` via existing `recordAnonymizationLink()` |
+| Map store/read | OR ObjectService `saveObject()` on `pseudonymMap` (`_render:false` payload) |
+| Encryption | Nextcloud `ICrypto` (`encrypt`/`decrypt`) — server secret |
+| Restore audit | OR audit trail |
+
+ADR-011 check: encryption uses Nextcloud `ICrypto` (server secret), not a
+hand-rolled cipher; no BSN/entity re-validation (values are verbatim from the
+detection that already validated them).
+
+## Declarative vs imperative
+
+- **Declarative**: the `pseudonymMap` schema + its `writeOnly`/`_render:false`
+  boundary; register-i18n; the additive `mappingRef` on `anonymizationLink`;
+  manifest pages.
+- **Imperative (justified)**: encryption, the restore reversal, the
+  authorisation gate and the audit write (all on the sensitive request path).
+
+## Seed Data
+
+None. A `pseudonymMap` by definition contains real placeholder↔value pairs;
+seeding one would fabricate PII. The demo `anonymizationLink` seeds keep
+`mappingRef` null (irreversible), and e2e tests create a real reversible run to
+exercise the store/restore.
+
+## Security Considerations
+
+- The mapping is the highest-value target in the app: it is `_render:false`
+  (never in a read response) **and** ICrypto-encrypted at rest — either alone
+  would be insufficient (per the fleet writeOnly-boundary reference).
+- Restore is fail-closed group-gated; empty config = admins only.
+- Every restore and every denial is audit-logged; a failed audit write refuses
+  the restore (no unlogged re-identification).
+- Restore writes a distinct copy — the anonymised artefact is never mutated.
+- Deleting the anonymisation deletes the key (D6) — no orphaned re-id material.
+- No cloud calls; all processing local.
+
+## Risks / Trade-offs
+
+- [Server-secret encryption means a server compromise can decrypt] → accepted
+  and documented; `_render:false` + audit narrow the exposure, and per-object
+  KMS keys are an OR-side follow-up (Open Questions). Still strictly better than
+  today (no reversible store at all) and matches how NC stores other secrets.
+- [Restoring a binary PDF's text layer is imperfect] → D4 returns a
+  re-identification report instead of a corrupted file when in-place text
+  rewrite is unsafe — honest partial result.
+- [Reversible mode concentrates PII] → mitigated by making irreversible the
+  default, encryption, the render boundary, the access gate and the audit; the
+  operator opts in deliberately.
+
+## Migration Plan
+
+Additive: one schema + one additive `anonymizationLink.mappingRef` pointer +
+register version bump (boot import), new services/controller/routes/views, one
+admin setting, one mode flag defaulting to today's behaviour. No data
+migration; existing anonymisations stay irreversible. Rollback = remove the
+restore route/UI and the reversible branch; existing `pseudonymMap` objects
+remain (encrypted, unreadable without the restore path).
+
+## Open Questions
+
+- **Per-object / KMS encryption keys** instead of the single server secret —
+  OR-side follow-up for stronger key separation.
+- **Retention of the mapping** (auto-expire the re-identification key after a
+  configurable period even while the anonymised file lives) — ties into
+  `archiefwet-retention-engine` (active); recorded, not built here.
+- **Restore of image/redacted-at-scale outputs** — out of scope; those paths
+  are irreversible by nature (`image-redaction` / `redaction-at-scale`).

--- a/openspec/changes/reversible-pseudonymization/proposal.md
+++ b/openspec/changes/reversible-pseudonymization/proposal.md
@@ -1,0 +1,140 @@
+---
+kind: code
+---
+
+# Proposal: reversible-pseudonymization
+
+## Why
+
+Buyers no longer accept black-box blackout as the only anonymisation mode.
+Reversible, readability-preserving pseudonymisation — replace each entity with
+a stable, human-readable placeholder, keep an encrypted mapping, restore it
+under authorisation — has become the default pattern the market converges on:
+
+- **Microsoft Presidio "PII Shield"** (Mar-2026) is a *reversible* privacy
+  proxy — pseudonymise on the way to an LLM, restore on the way back (R2 B, C6).
+- **xxllnc Anonimiseren** replaces PII with neutral terms **preserving
+  readability** rather than blacking it out; **anonymize.solutions** ships
+  Replace/Mask/Hash/Encrypt as first-class actions; the **Hoeksche Waard**
+  source-anonymisation tool works the same way (R2 C6, D row "Reversible /
+  pseudonymizing anonymization", demand_score **6** — the single
+  highest-demand capability in the wave).
+- R2 D marks DocuDesk **PARTIAL** here: "`anonymization` built (redaction-style);
+  reversible/pseudonymize not explicit." The demand is proven and the gap is
+  named.
+
+The use case is concrete: an operator pseudonymises a Woo dossier to share or
+process it, then — with a legal basis and an audit trail — needs to recover who
+"Persoon-1" was to answer an objection or a data-subject request. Blackout
+cannot do that; a reversible mapping can, and doing it with an **encrypted,
+access-gated, audit-logged** mapping is what keeps it AVG-defensible.
+
+Verified at HEAD — this is an EXTENSION, not a rebuild (the brief's
+"extend rather than duplicate"):
+
+- OpenRegister's redaction engine **already emits readable, stable, scope-local
+  placeholders**. `DocumentProcessingHandler::anonymizeDocument()` builds
+  `[<localized-type>: <number>]` (e.g. `[PERSOON: 1]`, `[ADRES: 2]`) via
+  `PlaceholderIdTranslator` (per-document or per-dossier numbering) and returns
+  the exact emitted map through `getLastPlaceholderMap()` — `global entity id →
+  placeholder string` (`lib/Service/File/DocumentProcessingHandler.php`,
+  `lib/Service/FileService.php`).
+- DocuDesk **already consumes that map**:
+  `AnonymizationService::anonymizeDocument()` reads
+  `getLastPlaceholderMap()` and threads it into the grondslagen summary
+  (Robert's `anonimiseren-bij-de-bron` merge, PR#314). The placeholder half of
+  "pseudonymise" already ships and is live.
+- DocuDesk **already records the source↔anonymised pairing**:
+  `recordAnonymizationLink()` writes an `anonymizationLink` object
+  (`sourceFileId`/`anonymizedFileId`, both facetable) — the anchor a reversible
+  mapping attaches to.
+- What is genuinely **missing**: (1) DocuDesk stores **no** reverse mapping
+  (placeholder → original value), so today's placeholder output is
+  irreversible; (2) there is **no** restore operation; (3) DocuDesk has **no**
+  encrypted/`writeOnly` secret store at all (grep: zero `_render:false` /
+  `writeOnly` usage in `lib/` + register).
+
+So this change adds the encrypted mapping store, the authorised restore, and a
+"reversible" output mode — reusing OR's existing placeholder emission and the
+existing `anonymizationLink`, not re-implementing replacement.
+
+## What Changes
+
+- **Reversible output mode**: `anonymizeDocument` gains a
+  `reversible` mode alongside the existing (irreversible) behaviour. In
+  reversible mode DocuDesk captures OR's `getLastPlaceholderMap()` plus the
+  original entity values and persists an encrypted mapping; the default mode is
+  unchanged and stores nothing (the irreversible guarantee is preserved).
+- **Encrypted mapping store (`pseudonymMap`)**: a new register object keyed to
+  the `anonymizationLink`, holding `placeholder → {originalValue, entityType}`
+  pairs. The sensitive payload is stored in a `writeOnly` / `_render:false`
+  property (OR's secret-render boundary — the only thing that keeps a secret
+  out of read responses) **and** encrypted at rest via Nextcloud `ICrypto`
+  before it is written (defence in depth: the map is a concentrated PII copy).
+- **Authorised restore operation**: `POST api/pseudonymisation/{link}/restore`
+  reverses the placeholders in the anonymised document, producing a restored
+  copy. Access is fail-closed group-gated; every restore (and every denied
+  attempt) is audit-logged via OR's audit trail — an unlogged re-identification
+  must never happen.
+- **Mapping lifecycle tied to the link**: the `pseudonymMap` is created,
+  updated (on re-anonymise) and deleted in lockstep with its
+  `anonymizationLink`, so a deleted anonymisation never leaves an orphaned
+  re-identification key.
+- **UI**: the anonymise dialog offers "reversible (pseudonymise)" vs
+  "irreversible (redact)"; the document detail offers a gated "Restore
+  original" action that states the audit-logging up front.
+
+## Capabilities
+
+### New Capabilities
+
+- `reversible-pseudonymization`: a reversible anonymisation output mode that
+  reuses OpenRegister's readable placeholder emission, stores an encrypted
+  `writeOnly` placeholder→original mapping keyed to the `anonymizationLink`,
+  and adds a fail-closed, audit-logged restore operation with a lifecycle tied
+  to the link.
+
+### Modified Capabilities
+
+<!-- none re-specced. OR's DocumentProcessingHandler placeholder emission,
+     getLastPlaceholderMap, FileService and the existing anonymizationLink
+     schema are consumed unchanged. The `anonymization` capability gains a
+     mode flag via its existing anonymizeDocument seam — extended through the
+     documented parameter, not modified in its canonical spec here. -->
+
+## Impact
+
+- `lib/Settings/docudesk_register.json`: new `pseudonymMap` schema in the
+  `document` register — `anonymizationLink` reference, `sourceFileId`,
+  a `writeOnly` / `_render:false` encrypted `mappings` payload, `entryCount`,
+  `algorithm`; register-i18n on user-facing labels; register version bump with
+  changelog. No change to `anonymizationLink`'s existing shape (a `mappingRef`
+  pointer is additive).
+- `lib/Service/AnonymizationService.php`: capture `getLastPlaceholderMap()` +
+  original values in reversible mode and delegate to a new
+  `PseudonymMapService` (encrypt + store); wire the map's create/update/delete
+  into the existing `recordAnonymizationLink()` lifecycle.
+- New `lib/Service/PseudonymMapService.php` (ICrypto encrypt/decrypt, OR
+  ObjectService store with `_render:false` payload, org-scoped) and
+  `lib/Service/PseudonymRestoreService.php` (reverse placeholders → restored
+  copy).
+- New `lib/Controller/PseudonymisationController.php` +
+  `api/pseudonymisation/{link}/restore` (fail-closed group gate, audit log).
+- Admin setting: `docudesk.pseudonymisation.restore_allowed_groups`
+  (default `[]` = admins only, fail-closed).
+- `src/manifest.json` + views: anonymise-mode choice + gated restore action;
+  restore-confirm dialog in its own `src/dialogs/` file.
+- Consumes (unchanged, presence-gated): OR `DocumentProcessingHandler`
+  placeholder emission + `getLastPlaceholderMap()`, `FileService`,
+  `anonymizationLink`, OR audit trail; Nextcloud `ICrypto`.
+- Non-overlap (declared dependencies, not re-specced):
+  `anonymization-review-workbench` (active; unaffected — mode is chosen at
+  anonymise time), `image-redaction` / `redaction-at-scale` /
+  `document-sanitization` (active; irreversible-redaction concerns, orthogonal
+  to reversible-text pseudonymisation), the `anonymise-*` output-format changes
+  (this adds a *reversibility* axis, not an output-format axis). The
+  irreversible/redaction path is explicitly left as the default and untouched.
+- Evidence: Presidio PII Shield + xxllnc readability-preserving + Hoeksche
+  Waard convergence (R2 C6); R2 D reversible-pseudonymization row (demand 6,
+  DocuDesk PARTIAL); Robert's `anonimiseren-bij-de-bron` placeholder work
+  (PR#314, extended here).

--- a/openspec/changes/reversible-pseudonymization/specs/reversible-pseudonymization/spec.md
+++ b/openspec/changes/reversible-pseudonymization/specs/reversible-pseudonymization/spec.md
@@ -1,0 +1,165 @@
+# reversible-pseudonymization Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Add a reversible anonymisation mode alongside the existing irreversible one:
+entities are replaced with the stable, readable placeholders OpenRegister
+already emits (`[PERSOON: 1]`, `[ADRES: 2]`, scope-local via
+`getLastPlaceholderMap()` — verified at HEAD), and DocuDesk additionally stores
+an encrypted `placeholder → original value` mapping keyed to the existing
+`anonymizationLink`. An authorised, fail-closed, audit-logged restore operation
+reconstructs the original from the anonymised copy plus the mapping. The
+mapping is stored in a `writeOnly`/`_render:false` property and encrypted at
+rest, and its lifecycle is tied to the `anonymizationLink` so a deleted
+anonymisation never leaves an orphaned re-identification key. The default mode
+stays irreversible and stores nothing. This extends OpenRegister's placeholder
+emission and the existing `anonymizationLink`; it does not re-implement
+entity replacement.
+
+## ADDED Requirements
+
+### Requirement: Encrypted, non-rendered pseudonym-mapping store (REQ-DDRPS-001)
+
+The app MUST provide a `pseudonymMap` register object (in the `document`
+register) that references its `anonymizationLink` and stores the
+`placeholder → {originalValue, entityType}` mapping in a property that is both
+`writeOnly` / `_render:false` (never returned in any ObjectService read
+response) and encrypted at rest via Nextcloud's `ICrypto`. The object MUST also
+carry a non-sensitive `entryCount`, the encrypting `algorithm` identifier and
+the placeholder-numbering `scope`. The encrypted mapping MUST only be decrypted
+on the authorised restore path and MUST NOT be exposed on any read route.
+`anonymizationLink` MUST gain only a nullable additive `mappingRef` pointer and
+no other field change.
+
+#### Scenario: The mapping payload is never returned in a read
+
+- GIVEN a stored pseudonymMap for a reversible anonymisation
+- WHEN the object is read through the ObjectService API
+- THEN the response contains entryCount and scope but not the mappings payload
+- @e2e exclude render-boundary behaviour of a `_render:false` property — covered by PHPUnit (tests/unit/Service/PseudonymMapServiceTest.php::testMappingsNeverRendered)
+
+#### Scenario: The mapping is stored encrypted
+
+- GIVEN a reversible anonymisation producing three placeholder mappings
+- WHEN the pseudonymMap is persisted
+- THEN the stored mappings value is ICrypto ciphertext, not the plaintext original values
+- @e2e exclude at-rest encryption — covered by PHPUnit (tests/unit/Service/PseudonymMapServiceTest.php)
+
+### Requirement: Reversible anonymisation mode reusing OR placeholders (REQ-DDRPS-003)
+
+Anonymisation MUST support a `reversible` mode alongside the existing
+irreversible behaviour, with irreversible as the default. In reversible mode
+the app MUST reuse OpenRegister's emitted placeholders
+(`FileService::getLastPlaceholderMap()`) joined with the original entity values
+from the request to build the mapping, and MUST persist it via the encrypted
+store (REQ-DDRPS-001); it MUST NOT re-implement entity replacement or introduce
+a new placeholder format. In the default (irreversible) mode the app MUST store
+no mapping, preserving the irreversibility guarantee. The reversibility choice
+MUST be independent of the output-format choice.
+
+#### Scenario: Reversible mode stores a mapping, irreversible does not
+
+- GIVEN a document anonymised once in reversible mode and once in irreversible mode
+- WHEN each run completes
+- THEN the reversible run has a pseudonymMap referenced by its anonymizationLink and the irreversible run has none
+- @e2e tests/e2e/spec-coverage/reversible-pseudonymization.spec.ts
+
+#### Scenario: Placeholders come from OpenRegister, not a new format
+
+- GIVEN a reversible anonymisation of a document containing a person
+- WHEN the anonymised output is produced
+- THEN the person is replaced with OpenRegister's scope-local readable placeholder (e.g. "[PERSOON: 1]") and that same placeholder is the key in the stored mapping
+- @e2e tests/e2e/spec-coverage/reversible-pseudonymization.spec.ts
+
+### Requirement: Authorised restore reconstructs the original (REQ-DDRPS-004)
+
+The app MUST provide a restore operation that, given an `anonymizationLink` with
+a `pseudonymMap`, decrypts the mapping and reverses every placeholder back to
+its original value, writing the result as a **distinct restored copy** without
+mutating the anonymised file. Reversal MUST apply placeholders longest-first so
+numbered placeholders cannot clobber one another. When the anonymised output is
+a format whose text cannot be safely rewritten in place, the operation MUST
+return a re-identification report (placeholder → original) rather than a
+corrupted document — never a silent no-op.
+
+#### Scenario: A permitted user restores the original text
+
+- GIVEN a reversibly anonymised text document and a permitted operator
+- WHEN they restore it
+- THEN a new restored copy is produced in which "[PERSOON: 1]" is back to the original name and the anonymised file still exists unchanged
+- @e2e tests/e2e/spec-coverage/reversible-pseudonymization.spec.ts
+
+#### Scenario: Unsafe binary format yields a report, not corruption
+
+- GIVEN a reversibly anonymised output whose text layer cannot be safely rewritten
+- WHEN a permitted operator restores it
+- THEN the operation returns a placeholder-to-original re-identification report and does not produce a corrupted document
+- @e2e exclude binary-format reversal branch — covered by PHPUnit (tests/unit/Service/PseudonymRestoreServiceTest.php::testUnsafeFormatReturnsReport)
+
+### Requirement: Restore is fail-closed gated and audit-logged (REQ-DDRPS-005)
+
+Every restore route MUST be restricted to admins and members of the groups in
+`docudesk.pseudonymisation.restore_allowed_groups` (default empty = admins
+only), enforced server-side with an explicit auth attribute plus an in-method
+gate; a non-member MUST receive HTTP 403 with a neutral body and a
+configuration read failure MUST deny access. Every restore AND every denied
+attempt MUST be written to OpenRegister's audit trail (actor, timestamp,
+link/source reference, outcome). If the audit write fails, the restore MUST be
+refused — an unlogged re-identification MUST NOT happen.
+
+#### Scenario: A non-member is refused and the denial is logged
+
+- GIVEN `restore_allowed_groups` is `["privacy-officers"]` and a user in neither that group nor admin
+- WHEN they call the restore route
+- THEN the response is HTTP 403, no restored copy is produced, and the denial is recorded in the audit trail
+- @e2e tests/e2e/spec-coverage/reversible-pseudonymization.spec.ts
+
+#### Scenario: A failed audit write blocks the restore
+
+- GIVEN the audit-trail write fails
+- WHEN a permitted operator attempts a restore
+- THEN the restore is refused and no restored copy is produced
+- @e2e exclude fault-injection on the audit write — covered by PHPUnit (tests/unit/Controller/PseudonymisationControllerTest.php::testFailedAuditRefusesRestore)
+
+### Requirement: Mapping lifecycle is tied to the anonymizationLink (REQ-DDRPS-002)
+
+The `pseudonymMap` MUST be created or overwritten together with its
+`anonymizationLink` (a reversible re-anonymisation MUST overwrite the same
+mapping, not append a second) and MUST be deleted when its `anonymizationLink`
+is deleted, so a removed anonymisation leaves no orphaned re-identification key.
+
+#### Scenario: Deleting the link deletes the key
+
+- GIVEN a reversible anonymisation with a stored pseudonymMap
+- WHEN its anonymizationLink is deleted
+- THEN the pseudonymMap is also deleted and no re-identification material remains
+- @e2e exclude cascade lifecycle — covered by PHPUnit (tests/unit/Service/PseudonymMapServiceTest.php::testMapDeletedWithLink)
+
+#### Scenario: Re-anonymising overwrites the same mapping
+
+- GIVEN a document already reversibly anonymised once
+- WHEN it is reversibly anonymised again
+- THEN its anonymizationLink still references exactly one pseudonymMap, updated to the new run
+- @e2e exclude idempotent overwrite — covered by PHPUnit (tests/unit/Service/PseudonymMapServiceTest.php)
+
+### Requirement: Reversible-mode and restore UI (REQ-DDRPS-006)
+
+The app MUST let the operator choose reversible vs irreversible anonymisation
+in the anonymise dialog (default irreversible) and MUST offer a gated "Restore
+original" action on the document detail, both in the Manifest-V2 shell
+(`src/manifest.json` + `registry.js`, never `src/router/index.js`). The restore
+action MUST be shown only to permitted users, and its confirmation dialog —
+living in its own file under `src/dialogs/` — MUST state that the restore is
+audit-logged before it proceeds. Every `NcSelect` MUST carry an `inputLabel`
+and colours/spacing MUST use Nextcloud CSS variables / NL Design tokens.
+
+#### Scenario: Restore action states it is audited before proceeding
+
+- GIVEN a permitted operator on a reversibly anonymised document
+- WHEN they trigger "Restore original"
+- THEN a confirmation dialog states the restore will be audit-logged before they confirm
+- @e2e tests/e2e/spec-coverage/reversible-pseudonymization.spec.ts

--- a/openspec/changes/reversible-pseudonymization/tasks.md
+++ b/openspec/changes/reversible-pseudonymization/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: reversible-pseudonymization
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 11.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Register + schema
+
+- [ ] 1.1 Add the `pseudonymMap` schema to the `document` register + additive `mappingRef` on `anonymizationLink` in `lib/Settings/docudesk_register.json` (REQ-DDRPS-001)
+  - `pseudonymMap` (`anonymizationLink` ref, `sourceFileId` facetable, `mappings` as `writeOnly` + `_render:false`, `algorithm`, `entryCount`, `scope`); nullable `mappingRef` added to `anonymizationLink` with no other field change; register-i18n on user-facing labels; register version bump with changelog; no seed map (would fabricate PII). Schema refs in slug form.
+
+## 2. Backend — store + reversible mode
+
+- [ ] 2.1 Implement `lib/Service/PseudonymMapService.php` encrypt-and-store (REQ-DDRPS-002)
+  - Join OR `getLastPlaceholderMap()` with request entity values into `placeholder → {originalValue, entityType}`; `ICrypto::encrypt()` the JSON into the `_render:false` `mappings` field via OR ObjectService; idempotent per `anonymizationLink`; `read()` decrypts and is callable only from the restore path.
+
+- [ ] 2.2 Wire a `reversible` mode into `AnonymizationService::anonymizeDocument` (REQ-DDRPS-003)
+  - Default false = today's irreversible behaviour, stores nothing; when true, capture the placeholder map + originals after OR anonymisation and store via 2.1; create/update/delete the map in lockstep with `recordAnonymizationLink()` (lifecycle tied to the link, orphan-free).
+
+## 3. Backend — restore (gated + audited)
+
+- [ ] 3.1 Implement `lib/Service/PseudonymRestoreService.php` reversal (REQ-DDRPS-004)
+  - Decrypt the map; reverse placeholders → originals longest-placeholder-first into a distinct restored copy (never mutate the anonymised file); return a re-identification report instead of a corrupted file when in-place text rewrite is unsafe.
+
+- [ ] 3.2 Implement `lib/Controller/PseudonymisationController.php` + `api/pseudonymisation/{link}/restore` fail-closed + audit (REQ-DDRPS-005)
+  - `docudesk.pseudonymisation.restore_allowed_groups` (default admins-only, fail-closed incl. config-read failure); explicit auth attributes + in-method gate (semantic-auth); audit-log every restore AND every denial via OR audit trail; a failed audit write refuses the restore.
+
+## 4. Frontend
+
+- [ ] 4.1 Anonymise-mode choice (reversible vs irreversible) in the anonymise dialog (REQ-DDRPS-003, REQ-DDRPS-006)
+  - `NcSelect`/radio with `inputLabel`, default irreversible; Manifest-V2 shell; NL Design tokens.
+
+- [ ] 4.2 Gated "Restore original" action + audit-notice confirm dialog (REQ-DDRPS-006)
+  - Shown only to permitted users; confirm dialog in its own file under `src/dialogs/` states the restore is audit-logged before proceeding; registered via `src/manifest.json` + `registry.js` (not `src/router/index.js`).
+
+## 5. Quality
+
+- [ ] 5.1 PHPUnit unit tests: `PseudonymMapService` encrypt/decrypt round-trip + `_render:false` payload never in a read, `PseudonymRestoreService` reversal (longest-first, copy-not-mutate, unsafe-format report), controller authz matrix + audit-on-deny + failed-audit-refuses — minimum 75% coverage on new code
+  - Run in the container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`.
+
+- [ ] 5.2 Playwright e2e `tests/e2e/spec-coverage/reversible-pseudonymization.spec.ts` covering the `@e2e` scenarios
+  - Reversibly anonymise a fixture, confirm placeholders, restore as a permitted user and get the original back, and assert a non-member is refused with 403; nldesign accessibility pass; test through the UI.
+
+- [ ] 5.3 i18n EN + NL for mode labels, restore action, audit notice, 403 message, and documentation `docs/features/reversible-pseudonymization.md` (ADR-010); run `openspec validate reversible-pseudonymization --strict`
+  - Keys in English; docs cover the reuse of OR's placeholder emission, the encrypted `_render:false` store, the fail-closed audited restore, and the Presidio-PII-Shield/xxllnc positioning.

--- a/openspec/changes/signature-verification-portal/.openspec.yaml
+++ b/openspec/changes/signature-verification-portal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/signature-verification-portal/design.md
+++ b/openspec/changes/signature-verification-portal/design.md
@@ -1,0 +1,242 @@
+# Design: signature-verification-portal
+
+## Context
+
+Verified at HEAD (DocuDesk `development`, branch
+`spec/market-gap-wave3-2026-07`):
+
+- **The verify primitive is authenticated + file-scoped.**
+  `SigningVerificationService::verifyDocument(int $fileId, string $userId)`
+  loads the file via `IRootFolder->getUserFolder($userId)->getById($fileId)`
+  and calls `extractSignatures()`. Both a UID and file-read access are
+  required, so this cannot serve an anonymous verifier. `extractSignatures()`
+  is fail-closed (finding #284): a `/DocuDesk-Signature(...)` blob is
+  `valid:false` unless `verifyAssertion()` confirms an HMAC over the
+  canonicalised content; external `/Type /Sig` entries are reported
+  `valid:false` today.
+- **The MAC excludes signer identity (open defect).**
+  `NativeSigningProvider::produceSignedArtifact()` computes
+  `$mac = hash_hmac('sha256', hash('sha256', $canonical), $secret)` where
+  `$canonical` is the document bytes with the marker payload blanked. The
+  assertion's `signer`/`timestamp`/`level`/`ip` are **not** in the MAC input.
+  `verifyAssertion()` recomputes the identical value. Result: a validly signed
+  artifact can have its signer field rewritten and still verify — forgeable
+  signer identity (tracked by `signing-trust-rebuild`, GH #284).
+- **The verify UI is orphaned.** `src/views/signing/SignatureVerification.vue`
+  is imported only by the dead `MainMenu.vue`; it is not in `registry.js` or
+  the manifest shell (R1 §4 item 3).
+- **The waarmerk change owns a public seal-verification surface.**
+  `document-waarmerk-certification` REQ-DDWMK-004 specs `GET /verify/{code}`
+  (human page) + `POST /api/waarmerk/verify` (`{code, sha256}`,
+  WebCrypto-hashed client-side, fail-closed, rate-limited, non-enumerable
+  codes, no oracle). That change owns seal verification; this portal must not
+  re-implement it.
+- **No group restriction** in `appinfo/info.xml` (version 0.0.37) — a
+  precondition for `#[PublicPage]` reachability (the app-group-vs-PublicPage
+  gotcha).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One public, account-free page that verifies a signed/waarmerked DocuDesk
+  document reached by scanning a QR.
+- Present **only guarantees the cryptography actually provides** — separate
+  "content integrity verified" from "signer identity verified", and never
+  claim identity while the MAC excludes identity fields.
+- Reach the anonymous verifier without granting file-read: verify from a
+  stored record keyed by a non-enumerable token, not from a live file handle.
+- Surface waarmerk seal status by consuming the waarmerk primitive, not
+  rebuilding it.
+
+**Non-Goals:**
+
+- No change to the signing crypto or the MAC — the identity-bound assertion is
+  `signing-trust-rebuild`'s job (dependency).
+- No re-implementation of waarmerk seal verification (consumed).
+- No re-registration of the internal operator verify page
+  (`orphaned-surface-restoration` owns it).
+- No full PAdES/CMS chain validation of external signatures (they render
+  `unverifiable`, per the tri-state model `signing-trust-rebuild` introduces).
+- No document bytes served publicly; no file download; no upload of the
+  document to the server.
+
+## Decisions
+
+### D1 — A verification record + non-enumerable token, not a live file handle
+
+Anonymous verification cannot use `verifyDocument(fileId, userId)`. Instead
+signing completion (and waarmerk sealing) mints a `signatureVerification`
+object in the `document` register carrying **the outcome, not the document**:
+
+| Field | Meaning |
+|---|---|
+| `token` | high-entropy (≥ 128-bit, `bin2hex(random_bytes(16))`) non-enumerable public handle |
+| `fileRef` | OR reference to the source object (for authenticated re-checks; never exposed publicly as a path) |
+| `contentHash` | sha256 of the canonical signed bytes at completion time |
+| `signatures[]` | captured summary per signature: `level`, `method`, `signerAsserted`, `integrityVerified` (bool), `identityBound` (bool) |
+| `waarmerkRef` | optional pointer to a `waarmerk` record (seal status shown via the waarmerk primitive) |
+| `createdAt`, `revoked` | lifecycle |
+
+The public endpoint resolves the record by `token` and renders it. The raw
+signing secret is never stored in the record; the record stores the *result*
+of verification computed server-side at mint time and re-confirmable on demand.
+`SignatureVerificationLinkService` owns mint/lookup; `SigningVerificationService`
+gains a record-based verify path (`verifyByRecord(array $record): array`) that
+does not require a `userId`.
+
+### D2 — Honest trust model (the MAC defect governs what the page may claim)
+
+The page distinguishes two guarantees and labels them separately:
+
+- **Content integrity** — `integrityVerified: true` iff the stored
+  `verifyAssertion()` MAC matched at mint time (and re-matches on demand). This
+  is what the current MAC actually proves.
+- **Signer identity** — shown as **asserted** with an explicit
+  `identityBound: false` badge while the MAC excludes identity fields. The page
+  copy reads e.g. *"Document content verified unchanged. Signer name as
+  asserted by the signer (not yet cryptographically bound to the signature)."*
+  The page MUST NOT render an unqualified "Verified: signed by X".
+
+Per-signature status is tri-state, matching the tri-state
+`signing-trust-rebuild` introduces:
+
+- `verified` — content integrity cryptographically confirmed.
+- `unverifiable` — an external `/Type /Sig` CMS signature DocuDesk cannot yet
+  validate (not tampering; honestly reported as such, not `invalid`).
+- `invalid` — a DocuDesk marker whose MAC does not match (tamper).
+
+**Dependency wiring:** once `signing-trust-rebuild` ships the identity-bound
+MAC, the mint step sets `identityBound: true` and the page promotes the signer
+field to a bound verdict — *no portal code change beyond reading the flag*.
+Until then the flag is false and the page is honest by construction.
+
+### D3 — Public endpoints: fail-closed, no oracle, rate-limited
+
+- `GET /verify/{token}` — `#[PublicPage] #[NoCSRFRequired]`, renders the portal
+  page (SPA entry; the page then calls the JSON endpoint).
+- `GET /api/verify/{token}` — `#[PublicPage] #[NoCSRFRequired]`, returns the
+  verdict JSON.
+- Unknown/malformed tokens return a verdict of shape identical to a known
+  token with a `status: unknown` body — **never a 404 that distinguishes
+  existence** (no enumeration oracle), mirroring the waarmerk change's
+  non-oracle rule.
+- Both public routes carry NC brute-force protection
+  (`OCP\IRequest` throttling / `BruteForceProtection` annotation on the
+  controller) keyed by token+IP.
+- The page serves no document bytes and offers no download; it shows file
+  *name* only (already public-safe metadata on a shared/published doc), never
+  path or content.
+
+### D4 — QR stamp linking to the portal
+
+Signed and waarmerked PDFs get a visible QR encoding the absolute
+`verify/{token}` URL (built from the instance base URL). QR rendering reuses
+the dependency-free approach the waarmerk change adopted (design.md D5 there —
+no new heavy dependency). Placement: a footer stamp on the completion artifact,
+composed by the same writer that assembles the signed bytes, so the QR travels
+with the file (paper or download). When both a signature and a waarmerk exist
+on one file, a single QR points at the unified portal token (D5).
+
+### D5 — Route unification with the waarmerk public surface (coordination)
+
+Two public `/verify/*` surfaces would confuse verifiers and risk a literal
+route collision (`verify/{code}` vs `verify/{token}`). Decision: **this portal
+is the intended single public verification home.** The portal token resolves a
+`signatureVerification` record which, when the document also carries a seal,
+links a `waarmerkRef` and the page renders seal status by calling the waarmerk
+verification primitive (`POST /api/waarmerk/verify` / `WaarmerkService`).
+The waarmerk change's `GET /verify/{code}` remains valid for seal-only
+documents; converging both under one `verify/{token}` surface is a
+**coordination follow-up** recorded here — the waarmerk change's files are not
+assigned to this change, so no edit is made to them. Namespacing note: to avoid
+a router clash before convergence, this portal registers `verify/{token}` and
+the JSON `api/verify/{token}`; the token namespace is disjoint from waarmerk
+codes by construction (different length/charset), and the resolver treats an
+unrecognised token as `unknown` (D3), so the surfaces coexist safely.
+
+## OpenRegister service usage (ADR-001)
+
+| Operation | Service |
+|---|---|
+| Mint / look up verification record | OR ObjectService `saveObject()` / `findAll()` on `signatureVerification` (`document` register) |
+| Seal status | consume `document-waarmerk-certification` verification primitive (presence-gated) |
+| Signature verdict | `SigningVerificationService` record-based path (D1) |
+| Audit summary | OR `AuditTrailMapper` read via existing `SigningAuditService` (bounded, object-scoped) |
+
+No custom tables; ADR-011: sha256/HMAC via PHP `hash()`/`hash_hmac()`, no
+re-implemented crypto.
+
+## Declarative vs imperative
+
+- **Declarative**: the `signatureVerification` schema + register-i18n tags; the
+  manifest portal page.
+- **Imperative (justified)**: token mint on signing/seal completion (must be
+  atomic with the artifact), the public fail-closed resolver + rate-limit, QR
+  composition into the PDF bytes.
+
+## Seed Data
+
+One nil-token demo verification record so the (dev-only) authenticated preview
+renders non-empty; the public portal for the nil token returns `unknown` by
+construction (nil token is not a valid public handle):
+
+```json
+{
+  "@self": {"register": "document", "schema": "signatureVerification", "slug": "seed-signature-verification-001"},
+  "token": "00000000000000000000000000000000",
+  "contentHash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "signatures": [{"level": "SES", "method": "native", "signerAsserted": "demo-signer", "integrityVerified": false, "identityBound": false}],
+  "revoked": false,
+  "createdAt": "2026-07-01T09:00:00+00:00"
+}
+```
+
+## Security Considerations
+
+- `#[PublicPage]` reachable only because the app is not group-restricted; the
+  change asserts this precondition and must not add a restriction.
+- Tokens high-entropy, non-enumerable; unknown tokens are non-oracle.
+- Public endpoints rate-limited (brute-force protection) keyed by token+IP.
+- Page serves no document bytes, no download, no path.
+- **Honest trust boundary**: identity claims are never asserted while the MAC
+  excludes identity fields (D2); the portal cannot be used to lend a forgeable
+  claim the appearance of proof — the single most important security property
+  of this change.
+- The stored record holds outcomes, never the signing secret and never
+  document bytes.
+
+## Risks / Trade-offs
+
+- [Depending on `signing-trust-rebuild` for real identity binding] → accepted:
+  the portal is honest with or without it (identity shown as asserted-not-bound
+  until the flag flips); shipping the portal first is safe and adds pressure to
+  land the fix.
+- [Two public verify surfaces until convergence] → mitigated by disjoint token
+  namespaces + non-oracle unknown handling (D5); convergence recorded as
+  coordination.
+- [A public page invites brute force / scraping] → rate-limited, non-
+  enumerable, no oracle, no content served.
+- [QR adds a footer to the artifact] → cosmetic, opt-outable per signing
+  request; does not alter the signed content hash (stamp is part of the
+  produced bytes whose hash is the recorded `contentHash`).
+
+## Migration Plan
+
+Additive: one schema + seed + version bump; new controller/service/routes/
+portal page; a mint hook on signing/seal completion. No existing schema
+changes. Rollback = remove the public routes + page; records remain readable.
+
+## Open Questions
+
+- **Route convergence** of `verify/{code}` (waarmerk) and `verify/{token}`
+  (portal) into one public surface — coordination with
+  `document-waarmerk-certification`; provisional decision: portal is the home,
+  waarmerk seal status is consumed (D5).
+- Whether the audit summary shown publicly should be the full chain or a
+  redacted "N steps, all approved, on <date>" rollup — provisional: redacted
+  rollup only (no signer emails/UIDs publicly), pending privacy review.
+- Whether to offer an optional WebCrypto client-side re-hash of a locally
+  selected file (as the waarmerk page does) to prove the held copy matches the
+  recorded `contentHash` — provisional: yes, reusing the waarmerk page's
+  no-upload pattern (kept as a should within REQ-DDSVP-001).

--- a/openspec/changes/signature-verification-portal/proposal.md
+++ b/openspec/changes/signature-verification-portal/proposal.md
@@ -1,0 +1,143 @@
+---
+kind: code
+---
+
+# Proposal: signature-verification-portal
+
+## Why
+
+A signature is only worth as much as a third party's ability to *check* it.
+DocuDesk can produce signed and waarmerked PDFs, but a citizen, a journalist
+or a counterparty who holds one has **no way to verify it** without a
+Nextcloud account and file-read access — the exact eIDAS "trust loop" the
+market is now closing:
+
+- **LibreSign#2617** ("present validation info with QR code on a signature
+  information page", research-user-wishes.md B) is open demand for precisely
+  this surface: scan a QR on the document, land on a public page that states
+  what the signature guarantees.
+- **Collabora Online + eID Easy** now ship in-editor eIDAS QES (R2 A6/B,
+  announced 2025-06-26) and every serious signer (ValidSign "evidence
+  summary", Zynyo "Deed of Signing") pairs signing with a *public
+  verification* artifact. A signer without a verifier is not competitive.
+- The **European Accessibility Act deadline (2025-06-28)** and the eIDAS
+  trust framework (R2 C4/C7) make a stored, checkable verdict — not "we hope
+  it's valid" — a procurement expectation.
+
+The pieces already exist but are **orphaned or inward-facing**, verified at
+HEAD:
+
+- `SigningVerificationService::verifyDocument(int $fileId, string $userId)`
+  extracts `/DocuDesk-Signature(...)` markers and returns a per-signature
+  `valid` verdict — but it requires an authenticated `userId` *and* file-read
+  access (`IRootFolder->getUserFolder($userId)->getById($fileId)`), so it can
+  never serve an anonymous verifier.
+- The bespoke verify UI (`src/views/signing/SignatureVerification.vue`) is
+  **orphaned** — imported only by the dead `MainMenu.vue`, absent from
+  `registry.js`/the manifest shell (R1 §4 item 3). The verify capability is
+  built and unreachable.
+- `signing#verify/{fileId}` is `@NoAdminRequired` (account-gated), not a
+  `#[PublicPage]`.
+
+Critically, the trust the page may claim is **bounded by a known open
+defect**. Verified at HEAD in `NativeSigningProvider::produceSignedArtifact()`
+and `SigningVerificationService::verifyAssertion()`: the HMAC covers only the
+canonicalised **content hash** (`hash_hmac('sha256', $contentHash, $secret)`);
+the assertion fields — `signer`, `timestamp`, `level`, `ip` — are **excluded
+from the MAC input**. Anyone holding a validly signed artifact can rewrite the
+signer identity or claimed level and the MAC still validates (tracked by the
+active `signing-trust-rebuild` change, GH #284). A public page that printed
+"signed by X" from that blob would be **publishing a forgeable claim as fact**.
+This portal therefore treats *content integrity* and *signer identity* as
+distinct guarantees and refuses to assert identity the cryptography does not
+yet cover — it depends on `signing-trust-rebuild` to make identity-bound
+assertions real, and until then presents identity as *asserted, not
+cryptographically bound*.
+
+## What Changes
+
+- **Public verification portal** (`#[PublicPage]`, no NC account): a route
+  `verify/{token}` rendering one signed/waarmerked document's verification
+  outcome — content-integrity verdict, signature level, signer assertions
+  (honestly qualified, see below), an audit summary, and waarmerk seal status.
+- **Verification record + token**: signing completion mints a `document`-
+  register `signatureVerification` object keyed by a high-entropy,
+  non-enumerable `token`, carrying the captured signature summary (never the
+  document bytes, never the raw signing secret) so an anonymous verifier gets
+  a verdict without file-read access. Non-matching tokens return a verdict
+  shape identical to any other, so the endpoint is not an existence oracle.
+- **Honest trust model**: per-signature status is presented as `verified`
+  (content integrity cryptographically confirmed) vs `unverifiable` (external
+  `/Type /Sig` we cannot yet validate) vs `invalid` (tamper detected); signer
+  identity is shown as **asserted** and flagged *not cryptographically bound*
+  until `signing-trust-rebuild` lands, after which the same field reflects the
+  identity-bound MAC. The page never renders "signer identity verified" while
+  the MAC excludes those fields.
+- **QR stamp**: signed and waarmerked PDFs carry a visible QR encoding the
+  portal `verify/{token}` URL, so a paper or downloaded copy is checkable.
+- **Manifest re-registration**: the (public) portal page is registered in the
+  V2 manifest shell; the orphaned *internal* `SignatureVerification.vue`
+  re-registration for logged-in operators is owned by the parallel
+  `orphaned-surface-restoration` change — this change references it and does
+  not double-spec the internal page.
+
+## Capabilities
+
+### New Capabilities
+
+- `signature-verification-portal`: a public, account-free QR-linked page that
+  verifies a signed/waarmerked DocuDesk document, presenting content-integrity
+  and signer-identity as distinct (honestly-bounded) guarantees plus waarmerk
+  seal status, backed by a non-enumerable verification token and rate-limited
+  fail-closed endpoints.
+
+### Modified Capabilities
+
+<!-- none — SigningVerificationService's verify logic and the waarmerk
+     verification primitive are consumed, not modified. The honest
+     identity-bound MAC is delivered by the active signing-trust-rebuild
+     change (dependency, not re-specced here). -->
+
+## Impact
+
+- **Backend**: new `PublicVerificationController` (`#[PublicPage]`,
+  `#[NoCSRFRequired]` on the GET page + verify API, rate-limited) resolving a
+  `signatureVerification` record by token and calling
+  `SigningVerificationService` (extended with a token/record-based path that
+  does not require a `userId`/file-read); new `SignatureVerificationLinkService`
+  minting/looking up tokens; QR generation reusing the waarmerk change's
+  dependency-free QR approach (no new heavy dep).
+- **Register**: new `signatureVerification` schema in the `document` register
+  of `lib/Settings/docudesk_register.json` (token, fileRef, contentHash,
+  captured signature summary, level, waarmerkRef?, createdAt, revoked) with
+  register-i18n tags and a register **version bump**; one nil-token seed.
+- **Signing path**: signing completion (`SigningService`) and the waarmerk
+  seal path mint the verification record + stamp the QR — additive hook, no
+  change to the OR ApprovalChain contract.
+- **Frontend**: public portal page registered in `src/manifest.json` +
+  `src/registry.js` (manifest V2 shell, NOT the dead `src/router/index.js`);
+  ADR-012 Cn components, NL Design tokens.
+- **Routes**: `verify/{token}` (page) + `api/verify/{token}` (JSON) as
+  `#[PublicPage]` in `appinfo/routes.php`.
+- **Depends on**:
+  - `signing-trust-rebuild` (active) — identity-bound assertion MAC; until it
+    lands the portal shows identity as asserted-not-bound (declared, not
+    re-specced).
+  - `document-waarmerk-certification` (active) — owns the `waarmerk` record and
+    its own `GET /verify/{code}` seal-verification surface; this portal
+    **consumes** the waarmerk verification primitive to show seal status and
+    is the intended single public `/verify` home. Route unification of the two
+    public surfaces is a coordination point recorded in design.md, not an edit
+    to the waarmerk change's files.
+  - `orphaned-surface-restoration` (parallel) — owns re-registering the
+    internal, logged-in `SignatureVerification.vue` operator page; this change
+    owns only the public portal + QR.
+- **Security**: `#[PublicPage]` + NC rate-limiting; app MUST NOT be group-
+  restricted in `info.xml` (the app-group-vs-PublicPage gotcha: a group
+  restriction makes public pages unreachable to anonymous visitors); tokens
+  high-entropy/non-enumerable; no existence oracle; page serves no document
+  bytes and offers no download.
+- **Evidence**: LibreSign#2617 QR verification (R3 B); eIDAS trust loop,
+  Collabora+eID Easy encroachment, EAA live (R2 A6/C4/C7); MAC-excludes-
+  identity defect verified at HEAD (`signing-trust-rebuild` GH #284); orphaned
+  verify UI (R1 §4 item 3).

--- a/openspec/changes/signature-verification-portal/specs/signature-verification-portal/spec.md
+++ b/openspec/changes/signature-verification-portal/specs/signature-verification-portal/spec.md
@@ -1,0 +1,170 @@
+# signature-verification-portal Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+A public, account-free verification page — reached by scanning a QR stamped on
+a signed or waarmerked DocuDesk PDF — that states what a document's signature
+actually guarantees. Because the native signing MAC covers only the content
+hash and **excludes the signer-identity assertion fields** (verified at HEAD in
+`NativeSigningProvider::produceSignedArtifact()`; the forgeable-signer defect
+tracked by the active `signing-trust-rebuild` change), the portal presents
+*content integrity* and *signer identity* as distinct guarantees and never
+asserts an identity the cryptography does not cover. The page is backed by a
+non-enumerable verification token (so an anonymous verifier needs no file-read
+access), consumes the `document-waarmerk-certification` primitive to show seal
+status, and is served fail-closed and rate-limited. This change owns the public
+portal + QR only; the internal operator verify page is owned by the parallel
+`orphaned-surface-restoration` change, and the identity-bound MAC by
+`signing-trust-rebuild`.
+
+## ADDED Requirements
+
+### Requirement: Public verification portal page (REQ-DDSVP-001)
+
+The app MUST provide a `#[PublicPage]` route `verify/{token}` that renders,
+with no Nextcloud account and no file-read access, the verification outcome of
+one signed or waarmerked document: an overall verdict, per-signature status,
+signature level, the signer as asserted, an audit summary, and — when the
+document carries a seal — its waarmerk status. The page MUST serve no document
+bytes, MUST offer no download, and MUST expose the file name only (never a path
+or content). The page MAY offer an optional client-side WebCrypto re-hash of a
+locally selected copy so a verifier can confirm their file matches the recorded
+`contentHash` without uploading it. When the token is unknown the page MUST
+render a neutral "unknown" outcome, never a 404 or any response that reveals
+whether a token exists.
+
+#### Scenario: Anonymous visitor verifies a signed document via its QR
+
+- GIVEN a signed DocuDesk PDF whose QR encodes `verify/{token}`
+- AND a visitor with no Nextcloud session
+- WHEN they open `verify/{token}`
+- THEN the page renders the verification outcome including signature level and an audit summary
+- AND no document bytes are served and no download is offered
+- @e2e tests/e2e/spec-coverage/signature-verification-portal.spec.ts
+
+#### Scenario: Unknown token is not an existence oracle
+
+- GIVEN a syntactically plausible token that matches no record
+- WHEN `verify/{token}` (or `GET /api/verify/{token}`) is requested
+- THEN the response is a neutral `unknown` outcome with a shape identical to a valid verdict, not a 404
+- @e2e exclude oracle/shape-parity is asserted at the API layer — covered by PHPUnit (tests/unit/Controller/PublicVerificationControllerTest.php)
+
+### Requirement: Content integrity and signer identity are presented as distinct guarantees (REQ-DDSVP-002)
+
+The portal MUST distinguish "content integrity verified" from "signer identity
+verified" and MUST NOT assert signer identity that the signature MAC does not
+cover. While the native signing MAC excludes the assertion fields (`signer`,
+`timestamp`, `level`, `ip`) — the state at HEAD until the active
+`signing-trust-rebuild` change lands — each signature's `identityBound` flag
+MUST be false and the page MUST show the signer as *asserted, not
+cryptographically bound*, never as an unqualified "signed by X". Per-signature
+status MUST be tri-state: `verified` (content integrity cryptographically
+confirmed), `unverifiable` (an external `/Type /Sig` signature DocuDesk cannot
+yet validate — reported as such, never as tamper), or `invalid` (a DocuDesk
+marker whose MAC does not match). When `signing-trust-rebuild` ships the
+identity-bound MAC and the mint step records `identityBound: true`, the same
+signer field MUST reflect the bound verdict without further portal changes.
+
+#### Scenario: Signer identity shown as asserted while the MAC excludes it
+
+- GIVEN a natively signed document whose verification record has `identityBound: false`
+- WHEN the portal renders it
+- THEN content integrity is shown as verified AND the signer name is labelled "as asserted (not cryptographically bound)"
+- AND the page never renders an unqualified "signer identity verified"
+- @e2e tests/e2e/spec-coverage/signature-verification-portal.spec.ts
+
+#### Scenario: A rewritten signer field is not presented as verified identity
+
+- GIVEN a validly signed artifact whose assertion `signer` field was rewritten while the content-hash MAC still matches
+- WHEN the portal verifies it
+- THEN content integrity may report verified but the signer identity is never presented as cryptographically verified
+- @e2e exclude tamper-mutation of the assertion blob is backend crypto logic — covered by PHPUnit (tests/unit/Service/SigningVerificationServiceTest.php::testRewrittenSignerNotVerifiedIdentity)
+
+#### Scenario: External CMS signature reports unverifiable, not invalid
+
+- GIVEN a document carrying a genuine `/Type /Sig` CMS signature with no DocuDesk marker
+- WHEN the portal verifies it
+- THEN the signature status is `unverifiable`, not `invalid`
+- @e2e exclude external-signature classification is backend logic — covered by PHPUnit (tests/unit/Service/SigningVerificationServiceTest.php)
+
+### Requirement: Non-enumerable verification token backs anonymous verification (REQ-DDSVP-003)
+
+Signing completion and waarmerk sealing MUST mint a `signatureVerification`
+object (`document` register) keyed by a high-entropy (≥ 128-bit),
+non-enumerable `token`, carrying the captured signature summary, `contentHash`,
+optional `waarmerkRef`, and lifecycle flags — and MUST NOT store the signing
+secret or the document bytes in that record. The public verify endpoints MUST
+resolve outcomes from this record so that no file-read access is required of
+the verifier. The `signatureVerification` schema MUST be added to the register
+with a register version bump and register-i18n tags on user-facing string
+fields.
+
+#### Scenario: Signing completion mints a verification record
+
+- GIVEN a signing request that completes and produces a signed artifact
+- WHEN completion is processed
+- THEN a `signatureVerification` object exists with a non-enumerable token, the artifact `contentHash`, and the captured signature summary
+- AND the record contains neither the signing secret nor the document bytes
+- @e2e tests/e2e/spec-coverage/signature-verification-portal.spec.ts
+
+#### Scenario: Tokens are non-enumerable
+
+- GIVEN two verification records minted in sequence
+- WHEN their tokens are compared
+- THEN neither is derivable from the other and both are ≥ 128-bit random
+- @e2e exclude entropy/non-derivability is a unit property — covered by PHPUnit (tests/unit/Service/SignatureVerificationLinkServiceTest.php)
+
+### Requirement: Public endpoints are fail-closed and rate-limited (REQ-DDSVP-004)
+
+The public routes `verify/{token}` and `GET /api/verify/{token}` MUST be
+`#[PublicPage]`, MUST carry Nextcloud brute-force/rate-limit protection keyed by
+token and client IP, and MUST fail closed — any unverifiable state (unknown
+token, malformed token, verification failure) MUST NOT report a valid outcome.
+The application MUST NOT be group-restricted in `appinfo/info.xml`, because a
+group restriction makes public pages unreachable to anonymous visitors (the
+app-group-vs-PublicPage constraint). No public endpoint may act as an existence
+oracle.
+
+#### Scenario: Repeated verification attempts are throttled
+
+- GIVEN many verification requests for varying tokens from one client
+- WHEN the rate threshold is exceeded
+- THEN further requests are throttled by Nextcloud brute-force protection
+- @e2e exclude throttling is not reliably browser-testable — covered by PHPUnit (tests/unit/Controller/PublicVerificationControllerTest.php)
+
+#### Scenario: Public page is reachable logged out and the app is not group-restricted
+
+- GIVEN a logged-out browser
+- WHEN `verify/{token}` is requested
+- THEN the page loads (not redirected to login) AND `appinfo/info.xml` declares no group restriction
+- @e2e tests/e2e/spec-coverage/signature-verification-portal.spec.ts
+
+### Requirement: Signed and waarmerked PDFs carry a QR to the portal (REQ-DDSVP-005)
+
+Signed and waarmerked PDFs MUST carry a visible QR code encoding the absolute
+`verify/{token}` URL, composed into the produced PDF bytes so a printed or
+downloaded copy remains verifiable. When a document carries both a signature
+and a waarmerk, a single QR/token MUST resolve to the unified portal outcome
+(signature + seal status). QR rendering MUST NOT introduce a new heavy
+dependency (reusing the dependency-free approach of the
+`document-waarmerk-certification` change). The internal, logged-in operator
+verify page is out of scope here and is owned by the parallel
+`orphaned-surface-restoration` change.
+
+#### Scenario: A downloaded signed PDF is verifiable from its stamped QR
+
+- GIVEN a completed signed PDF downloaded to a device
+- WHEN its stamped QR is scanned
+- THEN it opens the portal `verify/{token}` for that document
+- @e2e tests/e2e/spec-coverage/signature-verification-portal.spec.ts
+
+#### Scenario: One QR resolves both signature and seal status
+
+- GIVEN a document that is both signed and waarmerked
+- WHEN its QR is opened
+- THEN the portal shows the signature verdict and the waarmerk seal status on one page
+- @e2e exclude requires a live waarmerk seal fixture — covered by PHPUnit presence-gated integration (tests/unit/Service/SignatureVerificationLinkServiceTest.php)

--- a/openspec/changes/signature-verification-portal/tasks.md
+++ b/openspec/changes/signature-verification-portal/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: signature-verification-portal
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 10.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Register + seed data
+
+- [ ] 1.1 Add the `signatureVerification` schema to the `document` register in `lib/Settings/docudesk_register.json` (REQ-DDSVP-003)
+  - Properties per design.md D1 (`token`, `fileRef`, `contentHash`, `signatures[]` with `level`/`method`/`signerAsserted`/`integrityVerified`/`identityBound`, `waarmerkRef`, `createdAt`, `revoked`); register-i18n tags on user-facing strings; register version bump with changelog entry; one nil-token seed (design.md Seed Data); schema refs use slugs.
+
+## 2. Backend
+
+- [ ] 2.1 Implement `SignatureVerificationLinkService` (mint + lookup by token) (REQ-DDSVP-003)
+  - High-entropy non-enumerable token (`bin2hex(random_bytes(16))`); mint on signing completion and on waarmerk sealing; store outcome (never the signing secret, never document bytes); OR ObjectService save/find on `signatureVerification`.
+
+- [ ] 2.2 Add a record-based verify path to `SigningVerificationService` (REQ-DDSVP-001, REQ-DDSVP-002)
+  - `verifyByRecord(array $record)` returning tri-state per-signature (`verified`/`unverifiable`/`invalid`) with separate `integrityVerified` and `identityBound` flags; no `userId`/file-read dependency; external `/Type /Sig` reported `unverifiable`, not `invalid`.
+
+- [ ] 2.3 Implement `PublicVerificationController` with `verify/{token}` + `api/verify/{token}` as `#[PublicPage]` (REQ-DDSVP-001, REQ-DDSVP-004)
+  - `#[PublicPage] #[NoCSRFRequired]` + brute-force/rate-limit keyed by token+IP; unknown/malformed token returns a `status:unknown` body identical in shape to a valid verdict (no existence oracle); serves file name only, no bytes, no download; consumes the waarmerk verification primitive (presence-gated) to include seal status.
+
+- [ ] 2.4 Mint the verification record + stamp the QR on signing/seal completion (REQ-DDSVP-005)
+  - Hook `SigningService` completion and the waarmerk seal path to mint a record and compose a footer QR encoding the absolute `verify/{token}` URL into the produced PDF bytes (dependency-free QR per waarmerk D5); a single QR/token when both a signature and a seal exist.
+
+## 3. Frontend
+
+- [ ] 3.1 Public portal page registered in the manifest V2 shell (REQ-DDSVP-001, REQ-DDSVP-002)
+  - Register in `src/manifest.json` + `src/registry.js` (NOT `src/router/index.js`); ADR-012 Cn components, NL Design tokens; renders content-integrity vs signer-identity as distinct guarantees with an explicit "not cryptographically bound" badge while `identityBound` is false; tri-state per-signature chips; audit rollup; waarmerk seal status; optional WebCrypto no-upload re-hash of a locally selected file.
+
+## 4. Quality
+
+- [ ] 4.1 PHPUnit unit tests: token non-enumerability, unknown-token non-oracle parity, record-based tri-state verify, honest identity boundary (identity never `verified` while `identityBound` false), presence-gated waarmerk status — min 75% on new code
+  - Run in the container: `docker exec -w /var/www/html/custom_apps/docudesk nextcloud php vendor/bin/phpunit -c phpunit-unit.xml`; include a mutation-style test that a rewritten signer field is NOT presented as verified identity.
+
+- [ ] 4.2 Playwright e2e `tests/e2e/spec-coverage/signature-verification-portal.spec.ts` covering the `@e2e` scenarios anonymously (logged-out browser context) (REQ-DDSVP-001, REQ-DDSVP-004)
+  - Scans/opens a QR-linked `verify/{token}`; asserts the honest-trust copy; asserts unknown token shows `unknown` not 404; nldesign-theme accessibility pass; test through the UI.
+
+- [ ] 4.3 Assert the `#[PublicPage]` precondition and rate-limit (REQ-DDSVP-004)
+  - Test the public routes are reachable logged-out; assert `info.xml` carries no group restriction (regression guard for the app-group-vs-PublicPage gotcha); assert brute-force throttling engages.
+
+- [ ] 4.4 i18n (EN + NL) for all portal strings incl. the trust-boundary copy; docs `docs/features/signature-verification-portal.md` with MCP screenshots; run `openspec validate signature-verification-portal --strict`
+  - Keys in English; document the MAC-defect boundary, the signing-trust-rebuild dependency, the waarmerk consumption, and the LibreSign#2617 positioning.

--- a/openspec/changes/unified-search-provider/.openspec.yaml
+++ b/openspec/changes/unified-search-provider/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/unified-search-provider/design.md
+++ b/openspec/changes/unified-search-provider/design.md
@@ -1,0 +1,162 @@
+# Design: unified-search-provider
+
+## Context
+
+Verified at HEAD (OpenRegister + DocuDesk):
+
+- **OR owns the only provider.** `openregister/lib/Search/ObjectsProvider.php`
+  implements `OCP\Search\IProvider` (`openregister_objects`). Its class docblock:
+  leaf apps *do not* register their own `IProvider`; they participate by (a)
+  flagging schemas `searchable = true` in their register and (b) claiming
+  `(register, schema)` deep-link pairs. Non-searchable schemas are opted out via
+  a request-scoped cache (`ObjectsProvider` L86, L361–383). Results run through
+  `ObjectService::searchObjectsPaginated(_rbac: true, _multitenancy: true)`, so
+  RBAC and organisation isolation apply; excerpts come from the rendered
+  (redacted) object.
+- **Deep links.** `openregister/lib/Service/DeepLinkRegistryService.php`
+  registers `(registerSlug, schemaSlug) → urlTemplate` (+ displayName) and
+  resolves result URLs. The manifest shape (verified in `procest/src/manifest.json`)
+  is an array of `{ registerSlug, schemaSlug, urlTemplate, displayName }`.
+- **Procest precedent.** `procest/openspec/specs/case-search-via-or-unified-search`
+  flags exactly the schemas with a reachable detail route, adds matching
+  `deepLinks`, and version-bumps both the register and `info.xml`. Config-only,
+  no PHP.
+- **DocuDesk state.** `docudesk_register.json` already has `searchable:true` on
+  ~13 schemas but the manifest has **no** `deepLinks`. Reachable detail routes at
+  HEAD (from `src/manifest.json`): `/templates/:id` (schema `template`, register
+  `templates`) and `/signing/:id` (schema `signingRequest`, register `signing`).
+  Dossier and document objects have no detail route (dossier-management-ui /
+  document-detail-leaf-widgets are active).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make DocuDesk's navigable objects findable in NC global search, deep-linking
+  into the manifest shell, by opting into OR's provider the fleet way.
+- Stop the register's over-broad `searchable` flags from producing dead results.
+- Guarantee register↔manifest consistency with a unit seam that runs offline.
+
+**Non-Goals:**
+
+- No `OCP\Search\IProvider` in DocuDesk (would duplicate OR's provider — the
+  exact ADR-022 failure mode; the brief's "IProvider(s)" framing is superseded by
+  this HEAD finding).
+- No DocuDesk-side scoping/RBAC code — inherited from the OR provider contract.
+- No full-text/PII-entity search (entity-search owns gated PII discovery over
+  the entity catalogue; this is object title/subject search over the object
+  catalogue).
+- No new detail routes — dossier/document deep-links wait on their owning changes.
+
+## Decisions
+
+### D1 — Consume OR's provider; contribute only config
+
+DocuDesk adds `deepLinks` to `src/manifest.json` and corrects `searchable` flags
+in `docudesk_register.json`. It registers no provider and writes no search PHP.
+Organisation scoping fail-closed is satisfied *because* results are served by
+OR's `searchObjectsPaginated(_rbac:true,_multitenancy:true)` — the leaf can only
+narrow (via `searchable`), never widen. This is the ADR-022-correct shape and
+matches procest.
+
+### D2 — Deep-link only navigable schemas
+
+Add `deepLinks` entries for the two schemas with a reachable detail route today:
+
+| registerSlug | schemaSlug | urlTemplate | displayName |
+|---|---|---|---|
+| `templates` | `template` | `/apps/docudesk/templates/{uuid}` | Template |
+| `signing` | `signingRequest` | `/apps/docudesk/signing/{uuid}` | Signing request |
+
+URLs are history-mode paths (DocuDesk's router is `mode:'history'`, base
+`/apps/docudesk`; detail routes `/templates/:id`, `/signing/:id` accept the
+object uuid). `registerSlug`/`schemaSlug` use SLUG form (lowercase) per the
+manifest contract. Display names are English source strings (register-i18n /
+l10n localise the Dutch).
+
+### D3 — Correct the searchable opt-in
+
+`searchable:true` is retained only where a hit is navigable and identifiable;
+otherwise set to `searchable:false`:
+
+- **Keep true**: `template`, `signingRequest` (deep-linked, D2).
+- **Set false** (no reachable detail route → would be a dead result):
+  `generatedDocument`, `correspondence`, `financialExtraction`,
+  `glAccountBooking`, `glAccountMappingRule`, `signerRecord`,
+  `signingAuditEntry`, `batchCorrespondenceJob`, `anonymizationLink`, and `base`
+  (grondslag reference data, never a user search target).
+- **Deferred true**: `dossier` — remains `searchable:false` here; flips to
+  `true` + gains a deepLink when `dossier-management-ui` ships a detail route.
+  The document-object surface likewise waits on `document-detail-leaf-widgets`.
+
+Rationale: the OR provider indexes any `searchable:true` schema; leaving audit
+entries / sessions / mapping rules searchable pollutes global search with rows
+users cannot open. Procest's requirement 1 ("schemas without a standalone detail
+route SHALL NOT be flagged") is the governing discipline.
+
+### D4 — Version-gated re-import
+
+Bump `docudesk_register.json` `info.version` (7.3.0 → next) and
+`appinfo/info.xml` `<version>` (0.0.37 → next) together, because OR's register
+repair step only re-imports schema definitions when the version advances. Both
+must move or the corrected flags never reach OR.
+
+## Data / contract shapes
+
+`deepLinks[]` entry (manifest):
+
+```json
+{ "registerSlug": "signing", "schemaSlug": "signingRequest",
+  "urlTemplate": "/apps/docudesk/signing/{uuid}", "displayName": "Signing request" }
+```
+
+Consumed by `DeepLinkRegistryService::register(registerSlug, schemaSlug,
+urlTemplate, displayName)`; `{uuid}` is substituted per result.
+
+## Unit seam (the testable contract)
+
+`tests/unit/Settings/UnifiedSearchConsistencyTest.php` (PHPUnit, no live NC):
+
+- loads `docudesk_register.json` + `src/manifest.json`;
+- asserts every schema with `searchable:true` has exactly one `deepLinks` entry
+  whose `schemaSlug`/`registerSlug` match and whose `urlTemplate` base path
+  corresponds to an existing manifest page `route`;
+- asserts no `deepLinks` entry references a `searchable:false`/absent schema;
+- asserts `info.version` and `info.xml` `<version>` both advanced vs the merge
+  base (guards the re-import gate).
+
+## Security Considerations
+
+- Scoping is inherited fail-closed from OR's provider (`_rbac`,
+  `_multitenancy`); DocuDesk adds no path that could widen results.
+- Excerpts are derived by OR from the rendered/redacted object — no raw sensitive
+  field is exposed by the leaf.
+- Setting audit/session/mapping schemas `searchable:false` also removes them from
+  a surface where their contents could otherwise be skimmed via search snippets.
+
+## Risks / Trade-offs
+
+- [Corrected flags don't reach OR without a version bump] → D4 bumps both; the
+  unit seam asserts it.
+- [Deferred dossier/document search leaves two target types unsurfaced now] →
+  accepted: deep-linking a routeless schema yields dead results; they land with
+  their owning UI changes (dependencies declared).
+- [`{uuid}` vs `{id}` mismatch in the detail route] → detail routes resolve OR
+  objects by uuid; verified against the existing `/templates/:id` / `/signing/:id`
+  data paths; e2e asserts an activated result navigates and renders.
+
+## Migration Plan
+
+Config-only + version bumps. On upgrade the OR repair step re-imports the
+register with corrected `searchable` flags; the manifest ships the `deepLinks`.
+Rollback = revert the JSON edits and version bumps (search reverts to today's
+un-deep-linked, over-broad state).
+
+## Open Questions
+
+- Should `correspondence`/`generatedDocument` become searchable once
+  orphaned-surface-restoration gives correspondence a reachable page? Provisional:
+  yes for correspondence when it has a detail route; tracked as a follow-up, not
+  pre-flagged here (avoid dead results before the route exists).
+- OR-side: whether the provider should expose a per-app display-name override
+  for register vs schema — OR follow-up, not required here.

--- a/openspec/changes/unified-search-provider/proposal.md
+++ b/openspec/changes/unified-search-provider/proposal.md
@@ -1,0 +1,118 @@
+---
+kind: code
+---
+
+# Proposal: unified-search-provider
+
+## Why
+
+A user who types a template name, a signing-request subject, a dossier or a
+document title into the Nextcloud global search bar finds nothing from DocuDesk
+today. "Surface documents/dossiers/signing-requests via a search provider" is an
+explicit unspecced leaf opportunity (R4-ecosystem-leaves.md §B.6 and §E.5:
+"Unified Search provider … mirrors procest `case-search-via-or-unified-search`;
+currently no search-provider spec"), and cross-object findability is a recurring
+market/user signal (R3-user-wishes.md ranks fast filterable search highly; the
+whole IDP/e-discovery category — Rossum, Reveal, ZyLAB — sells on "find it
+across the corpus", R2-competitors.md §A.8/§A.10).
+
+The correct way to deliver this is **consume, not build** (ADR-022). Verified at
+OpenRegister HEAD: OR ships the **single fleet-wide** Nextcloud unified-search
+provider — `openregister/lib/Search/ObjectsProvider.php` (30 KB,
+`OCP\Search\IProvider` `openregister_objects`), with a `DeepLinkRegistryService`
+that resolves result URLs/labels from each app's manifest `deepLinks`. Its
+docblock is explicit: *"leaf apps do not register their own OCP\Search\IProvider;
+they participate by claiming (register, schema) pairs and flagging schemas
+searchable = true. Excerpts are derived exclusively from the rendered [redacted]
+object."* Results flow through
+`ObjectService::searchObjectsPaginated(_rbac: true, _multitenancy: true)`, so
+RBAC and tenant (organisation) scoping apply fail-closed — a leaf never widens
+the set, it only opts in. Procest already did exactly this
+(`procest/openspec/specs/case-search-via-or-unified-search`): flag schemas
+searchable + add `deepLinks` + version-bump; **zero PHP, zero bespoke provider**.
+
+### HEAD-verification surprise (this is a cleanup, not a greenfield)
+
+DocuDesk's register already carries `"searchable": true` on ~13 schemas
+(`lib/Settings/docudesk_register.json`: `template` L596, `signingRequest` L1664,
+`dossier` L2445, `generatedDocument` L1071, `correspondence` L892,
+`financialExtraction` L1190, `glAccountBooking` L1319, `glAccountMappingRule`
+L1402, `signerRecord` L1923, `signingAuditEntry` L2082, `base` L2367,
+`batchCorrespondenceJob` L2586, `anonymizationLink` L2889) — but the manifest has
+**zero `deepLinks`** (`grep -n "deepLink" src/manifest.json` is empty). Per the
+OR provider contract and procest's opt-in discipline, a schema flagged
+`searchable:true` with **no reachable detail route** produces a *dead result*: a
+hit the user can neither navigate to nor identify. DocuDesk today has many such
+schemas (audit entries, sessions, mapping rules, base grondslagen) that would
+surface as unnavigable noise the moment the provider indexes them. So this change
+is as much **correcting an over-broad, un-deep-linked opt-in** as it is adding
+the four target surfaces.
+
+## What Changes
+
+- **Deep-link registry** (`src/manifest.json`, new `deepLinks[]`): map each
+  genuinely-navigable schema to its detail route + display name, following the
+  procest `{ registerSlug, schemaSlug, urlTemplate, displayName }` shape
+  (verified in `procest/src/manifest.json` and consumed by OR's
+  `DeepLinkRegistryService::register()`):
+  - `templates / template → /apps/docudesk/templates/{uuid}` ("Template") —
+    reachable detail page exists (`/templates/:id`).
+  - `signing / signingRequest → /apps/docudesk/signing/{uuid}` ("Signing
+    request") — reachable detail page exists (`/signing/:id`).
+- **Searchable opt-in correction** (`lib/Settings/docudesk_register.json`): keep
+  `searchable:true` only on schemas that have (or will imminently have) a
+  reachable detail surface; set `searchable:false` on schemas with no detail
+  route so they never produce dead search results (audit entries, sessions,
+  mapping rules, base grondslagen, job records, etc.). `dossier` and the
+  document-object schema are deep-linked/kept-searchable only when their detail
+  routes land (see dependencies).
+- **Version-gated re-import**: bump `docudesk_register.json` `info.version`
+  (currently 7.3.0) and `appinfo/info.xml` `<version>` (currently 0.0.37) so the
+  OR register repair step re-imports the corrected `searchable` flags on upgrade
+  (OR import is version-gated — procest requirement 3).
+- **No bespoke provider, no PHP service**: DocuDesk registers no
+  `OCP\Search\IProvider`; it consumes OR's `openregister_objects` provider. The
+  organisation-scoping-fail-closed requirement is met *by consuming the provider*
+  (its `_rbac`/`_multitenancy` contract), not by re-implementing scoping.
+
+## Capabilities
+
+### New Capabilities
+
+- `unified-search-provider`: DocuDesk's navigable business objects (templates and
+  signing requests now; dossiers and documents as their detail routes land) are
+  findable from the Nextcloud global search bar via OpenRegister's single search
+  leaf, deep-linking into DocuDesk's manifest shell pages, with RBAC/organisation
+  scoping inherited fail-closed from the OR provider.
+
+### Modified Capabilities
+
+<!-- none. OR's ObjectsProvider + DeepLinkRegistryService are consumed
+     unchanged. The register's searchable flags are DocuDesk-owned config
+     (this register is DocuDesk's), so correcting them is not an OR spec edit. -->
+
+## Impact
+
+- `src/manifest.json`: new `deepLinks[]` block (template, signingRequest now).
+- `lib/Settings/docudesk_register.json`: `searchable` flags corrected to match
+  navigability; `info.version` bump + changelog entry.
+- `appinfo/info.xml`: `<version>` bump (register re-import gate).
+- New `tests/unit/Settings/UnifiedSearchConsistencyTest.php` (PHPUnit, the unit
+  seam): loads the two JSON files and asserts every `searchable:true` schema has
+  a `deepLinks` entry whose `urlTemplate` points at an existing manifest page
+  route, and no `deepLinks` entry names a non-searchable schema. Pure file
+  assertion — no live NC.
+- Consumes unchanged: OR `openregister_objects` provider, `DeepLinkRegistryService`,
+  `ObjectService::searchObjectsPaginated` (RBAC + multitenancy).
+- **Declared dependencies (referenced, not modified)**:
+  - `dossier-management-ui` — until a dossier detail route exists, `dossier` is
+    not deep-linked (kept `searchable:false` here to avoid dead results); when
+    that change lands its detail route, a `dossier` deepLink + `searchable:true`
+    follow.
+  - `document-detail-leaf-widgets` — same for the document-object detail surface.
+  - `entity-search` (sibling wave-2 change) — distinct capability (gated PII
+    discovery over OR's entity catalogue); this change is title/subject
+    object-search over the object catalogue. No overlap.
+- Evidence: R4 §B.6, §E.5; R2 §A.8/§A.10 (discovery category); R3 search demand;
+  OR `ObjectsProvider.php` docblock + `DeepLinkRegistryService.php`; procest
+  `case-search-via-or-unified-search` spec; HEAD greps above.

--- a/openspec/changes/unified-search-provider/specs/unified-search-provider/spec.md
+++ b/openspec/changes/unified-search-provider/specs/unified-search-provider/spec.md
@@ -1,0 +1,127 @@
+# unified-search-provider Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Make DocuDesk's navigable business objects — templates and signing requests now,
+dossiers and documents as their detail routes land — findable from the Nextcloud
+global search bar, by opting into OpenRegister's single fleet unified-search
+provider (`openregister_objects`, verified at HEAD) the fleet way: flag the
+navigable schemas `searchable`, contribute `deepLinks` so results get URLs and
+display names, and correct DocuDesk's currently over-broad, un-deep-linked
+`searchable` flags so search never returns rows a user cannot open. DocuDesk
+registers no `OCP\Search\IProvider` of its own (that would duplicate OR's
+provider — ADR-022); RBAC and organisation scoping are inherited fail-closed from
+the OR provider's `searchObjectsPaginated(_rbac:true,_multitenancy:true)`
+contract. Mirrors procest's `case-search-via-or-unified-search`.
+
+## ADDED Requirements
+
+### Requirement: Only navigable schemas are searchable (REQ-DDUSP-001)
+
+The DocuDesk register definition MUST flag `searchable: true` only on schemas
+whose objects have a reachable detail surface — at HEAD `template` (route
+`/templates/:id`) and `signingRequest` (route `/signing/:id`). Schemas without a
+reachable detail route MUST be `searchable: false` so OpenRegister's provider
+does not return results a user can neither navigate to nor identify; this
+includes audit entries, signing sessions, GL-account mapping rules, batch job
+records, anonymisation links, generated-document/correspondence records and base
+grondslag reference data. `dossier` MUST remain `searchable: false` until a
+dossier detail route exists (owned by `dossier-management-ui`).
+
+#### Scenario: Audit and session schemas are not searchable
+
+- GIVEN the register at HEAD flags signing audit entries and sessions `searchable:true` with no detail route
+- WHEN this change is applied
+- THEN `signingAuditEntry`, `signingSession`, `glAccountMappingRule`, `base` and the other route-less schemas are `searchable:false`, and only `template` and `signingRequest` remain `searchable:true`
+- @e2e exclude declarative register flag — asserted by the consistency unit test (tests/unit/Settings/UnifiedSearchConsistencyTest.php)
+
+#### Scenario: A route-less schema produces no search result
+
+- GIVEN a `signingAuditEntry` object exists
+- WHEN a user searches for a term contained in it
+- THEN it does not appear as a DocuDesk result in unified search (schema not flagged searchable)
+- @e2e exclude provider indexing behaviour is owned by OpenRegister; DocuDesk supplies only the declarative flag, asserted by the unit test
+
+### Requirement: Deep links resolve result URLs for searchable schemas (REQ-DDUSP-002)
+
+For every schema flagged `searchable: true`, `src/manifest.json` MUST contain a
+`deepLinks` entry `{ registerSlug, schemaSlug, urlTemplate, displayName }` (SLUG
+form, lowercase) whose `urlTemplate` deep-links into the manifest shell detail
+page, so OpenRegister's `DeepLinkRegistryService` can render each result's URL
+and display name. At HEAD this MUST cover `templates/template →
+/apps/docudesk/templates/{uuid}` ("Template") and `signing/signingRequest →
+/apps/docudesk/signing/{uuid}` ("Signing request"). No `deepLinks` entry MUST
+reference a schema that is not `searchable: true`.
+
+#### Scenario: Signing request is findable and deep-links
+
+- GIVEN a signing request whose document subject contains "Kapvergunning" and which the user may read
+- WHEN the user types "Kapvergunning" in the Nextcloud global search bar
+- THEN the signing request appears under the OpenRegister objects provider labelled "Signing request"
+- AND activating it navigates to `/apps/docudesk/signing/{uuid}` and renders the request detail
+- @e2e tests/e2e/spec-coverage/unified-search-provider.spec.ts
+
+#### Scenario: Deep links cover exactly the searchable schemas
+
+- GIVEN the register and manifest at HEAD
+- WHEN the searchable schema slugs are compared to `deepLinks[].schemaSlug`
+- THEN `template` and `signingRequest` each have a `deepLinks` entry with the correct `urlTemplate`, and no `deepLinks` entry names a non-searchable schema
+- @e2e exclude declarative cross-file consistency — asserted by the unit test (tests/unit/Settings/UnifiedSearchConsistencyTest.php)
+
+### Requirement: DocuDesk consumes OR's provider without registering its own (REQ-DDUSP-003)
+
+DocuDesk MUST NOT register a Nextcloud `OCP\Search\IProvider`; it MUST
+participate in unified search solely through OpenRegister's `openregister_objects`
+provider. Result scoping — RBAC read access and organisation (tenant) isolation —
+MUST be inherited fail-closed from the OR provider's
+`searchObjectsPaginated(_rbac:true, _multitenancy:true)` path; DocuDesk MUST add
+no code that could widen the result set beyond what OR would return.
+
+#### Scenario: No bespoke provider is registered
+
+- GIVEN this change is applied
+- WHEN the app's registrations are inspected
+- THEN DocuDesk registers no `OCP\Search\IProvider` and adds no search PHP service — only register flags and manifest deep links
+- @e2e exclude static registration assertion — covered by the unit test and code review (no IProvider in Application.php / info.xml)
+
+#### Scenario: RBAC-restricted object is hidden from search
+
+- GIVEN a signing request the searching user has no OR RBAC read access to
+- WHEN they search for its subject
+- THEN it does not appear (OR provider delegates to `searchObjectsPaginated(_rbac:true)`), and DocuDesk adds no path that reveals it
+- @e2e exclude enforced and tested in OpenRegister's provider security contract; DocuDesk adds no code path
+
+### Requirement: Version-gated re-import of corrected flags (REQ-DDUSP-004)
+
+This change MUST bump both the register `info.version` in
+`lib/Settings/docudesk_register.json` and the app `<version>` in
+`appinfo/info.xml`, because OpenRegister's register repair step only re-imports
+schema definitions when the version advances. Without both bumps the corrected
+`searchable` flags never reach OpenRegister.
+
+#### Scenario: Upgrade re-imports the corrected flags
+
+- GIVEN an instance running the previous DocuDesk version with the register already imported
+- WHEN the app upgrades and the OR repair step runs
+- THEN the register import re-runs (version gate passes) and the corrected `searchable` flags are applied in OpenRegister
+- @e2e exclude repair-step import mechanics are owned and tested by OpenRegister; the paired version bump is asserted by the unit test comparing `info.xml` and register versions advanced together
+
+### Requirement: Register↔manifest consistency is unit-tested offline (REQ-DDUSP-005)
+
+The app MUST ship a PHPUnit test that, without a live Nextcloud instance, loads
+`docudesk_register.json` and `src/manifest.json` and asserts: every
+`searchable:true` schema has exactly one matching `deepLinks` entry whose
+`urlTemplate` corresponds to an existing manifest page route; no `deepLinks`
+entry references a non-searchable or absent schema; and the register
+`info.version` and `info.xml` `<version>` both advanced versus the merge base.
+
+#### Scenario: Inconsistent config fails the test
+
+- GIVEN a schema flagged `searchable:true` with no corresponding `deepLinks` entry
+- WHEN the consistency test runs
+- THEN it fails naming the schema missing a deep link
+- @e2e exclude offline file-consistency assertion — this requirement IS the unit test (tests/unit/Settings/UnifiedSearchConsistencyTest.php)

--- a/openspec/changes/unified-search-provider/tasks.md
+++ b/openspec/changes/unified-search-provider/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: unified-search-provider
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 8.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Deep-link registry
+
+- [ ] 1.1 Add the `deepLinks[]` block to `src/manifest.json` (REQ-DDUSP-002)
+  - Two entries (procest `{registerSlug, schemaSlug, urlTemplate, displayName}` shape): `templates/template → /apps/docudesk/templates/{uuid}` ("Template") and `signing/signingRequest → /apps/docudesk/signing/{uuid}` ("Signing request"); slugs lowercase; display names English source strings.
+
+## 2. Searchable opt-in correction
+
+- [ ] 2.1 Correct `searchable` flags in `lib/Settings/docudesk_register.json` (REQ-DDUSP-001)
+  - Keep `true` on `template` + `signingRequest`; set `false` on schemas with no reachable detail route (`generatedDocument`, `correspondence`, `financialExtraction`, `glAccountBooking`, `glAccountMappingRule`, `signerRecord`, `signingAuditEntry`, `batchCorrespondenceJob`, `anonymizationLink`, `base`); keep `dossier` `false` pending `dossier-management-ui` (design.md D3).
+
+## 3. Version-gated re-import
+
+- [ ] 3.1 Bump register `info.version` and `appinfo/info.xml` `<version>` together (REQ-DDUSP-004)
+  - `docudesk_register.json` `info.version` 7.3.0 → next with changelog entry; `info.xml` 0.0.37 → next; both advance so the OR repair step re-imports the corrected flags.
+
+## 4. Consume OR's provider (no bespoke provider)
+
+- [ ] 4.1 Confirm no `OCP\Search\IProvider` is registered by DocuDesk (REQ-DDUSP-003)
+  - No new PHP provider/service; scoping inherited from OR `openregister_objects` (`searchObjectsPaginated` `_rbac`/`_multitenancy`); `info.xml`/`Application.php` register nothing search-related.
+
+## 5. Quality
+
+- [ ] 5.1 PHPUnit unit seam `tests/unit/Settings/UnifiedSearchConsistencyTest.php` (REQ-DDUSP-005)
+  - Loads register + manifest JSON; asserts every `searchable:true` schema has a matching `deepLinks` entry whose `urlTemplate` maps to an existing manifest page route, no `deepLinks` entry names a non-searchable/absent schema, and both versions advanced vs merge base. Runs offline (no live NC).
+- [ ] 5.2 Playwright e2e `tests/e2e/spec-coverage/unified-search-provider.spec.ts` (REQ-DDUSP-002, REQ-DDUSP-003)
+  - On the OR-backed dev instance: create a template + a signing request, type a fragment of each into the NC global search bar, assert both appear under the OpenRegister objects provider and activating a result navigates to `/apps/docudesk/templates/{uuid}` / `/apps/docudesk/signing/{uuid}`; assert an RBAC-restricted object does not appear. Test through the UI.
+- [ ] 5.3 i18n EN + NL for the two `displayName` strings (REQ-DDUSP-002)
+  - English source keys; NL via register-i18n / `l10n`.
+- [ ] 5.4 Documentation `docs/features/unified-search-provider.md` + run `openspec validate unified-search-provider --strict`
+  - Documents the consume-OR-provider posture, the deep-link contract, the searchable-opt-in discipline, and the dossier/document deferrals; MCP screenshot of a search result deep-linking into DocuDesk (ADR-010).


### PR DESCRIPTION
Nine apply-ready OpenSpec changes from the 2026-07-23 docudesk deep-research round (competitor delta, user wishes, NC ecosystem, code-reality audit; findings logged to the OpenBuild spectr register).

**must**: orphaned-surface-restoration · accessible-redaction-output · custom-dictionary-recognition
**should**: llm-entity-detection-provider · reversible-pseudonymization · signature-verification-portal · libresign-signing-provider · unified-search-provider
**could**: files-confidential-labels

All pass `openspec validate --strict`. Markdown-only (openspec/changes/). Engine half tag-preserving-redaction is specced in openregister (companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)