### PR TITLE
docs(openspec): add portal-signing-surface ff change

### DIFF
--- a/openspec/changes/portal-signing-surface/.openspec.yaml
+++ b/openspec/changes/portal-signing-surface/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/portal-signing-surface/design.md
+++ b/openspec/changes/portal-signing-surface/design.md
@@ -1,0 +1,145 @@
+# Design: portal-signing-surface
+
+## Context
+
+hydra ADR-046 makes **portaliq** the ONE external portal for people without a
+Nextcloud account. Contribution contract v2.2 now expresses, beyond read
+collections: per-collection `rowActions` (an action id rendered as a per-row
+control), `type: update` actions with server-stamped `set`, and A6
+`endpoint-forward` actions. `portal-contribution`'s `signer` manifest deferred
+all of these (`actions: []`, `REQ-DDPORT-006`). Two sibling changes now supply
+the plumbing; this change supplies the SURFACE and the portal-identity evidence
+binding.
+
+### Verified facts (HEAD, docudesk)
+
+- **The signer manifest** (`lib/Portal/PortalContributionProvider.php`,
+  `signerContribution()`) exposes `signerRecords` (schema `signerRecord`, scope
+  `email` via `signerEmail` claim) and `signerSigningRequests` (schema
+  `signingRequest`, reached by a one-hop `via` join over the subject's own
+  `signerRecord` rows, `targetField: signingRequestId`, `minTrust: substantial`).
+  Both ship `actions: []` today.
+- **`SigningService::sign(string $requestId, string $signerId): array`**
+  (`lib/Service/SigningService.php:352`) and
+  **`decline(string $requestId, string $signerId, string $reason): array`**
+  (`:441`) are the honest signing primitives. Per `signing-trust-rebuild` they
+  route terminal transitions through the status machine and emit the `v: 2`
+  identity-bound assertion.
+- **`signerRecord`** properties (register `signing`): `signingRequestId, userId,
+  displayName, email, order, status, signedAt, declineReason, ipAddress,
+  signatureData`. `signatureData` (schema `visible:false`) is where a drawn
+  signature payload lands; the invited `email` is the only stable external
+  identity (no external contact UUID).
+- **`signingRequest`** properties: `documentFileId, documentName,
+  initiatorUserId, signatureLevel, signingMode, status, provider, deadline,
+  signerIds`.
+- **`portal-signing-actions`** (sibling change) supplies the
+  `PortalSigningReceiverController`, `PortalAssertionVerifier`, the server-side
+  invited-signer resolution (`signerRecord.email == assertion signerEmail AND
+  signingRequestId == target`), and the `SigningService` verified-actor
+  entrypoint. This change extends that receiver rather than adding a new one.
+- **`signing-trust-rebuild`** (`REQ-DDSTR-001`) defines the `v: 2` assertion MAC
+  over `sha256(canonical-document) . "\n" . canonical-JSON(assertion-minus-mac)`
+  with sorted keys, binding `signer`, `timestamp`, `level`. This change adds the
+  portal subject claims to that same canonical-JSON so they are MAC-covered.
+
+## The two additive seams
+
+### 1. rowActions on the collection (declarative, pure data)
+
+`portal-signing-actions` declared `sign`/`decline`/`viewDocument` on the
+manifest's top-level `actions[]`. The contract-v2.2 way to render a per-document
+control is a `rowActions` reference on the collection that owns the rows. This
+change adds `rowActions: [sign, decline]` to the `signerSigningRequests`
+collection (the documents-awaiting-me rows), each `minTrust: substantial`
+(eIDAS-aligned: an AES-grade act needs a substantial-assurance session). This is
+constant data — no I/O — keeping the provider plain and duck-typed (ADR-046 A1).
+A row already in a terminal state (`signed`/`declined`) MUST NOT offer the
+actions; the manifest declares the actions and portaliq + the receiver enforce
+state (the receiver's terminal-state guard is authoritative).
+
+### 2. Portal-subject evidence binding (imperative, the portaliq#3 fix)
+
+The forgeable-signer bug class (portaliq#3) is: a signature evidence/MAC that
+does not cover the signer's identity can be re-attributed to a different signer
+while still validating. `REQ-DDSTR-001` fixes this for the in-app signer's
+name/level/timestamp. For a PORTAL-originated signature the true signer identity
+is the portaliq subject — `subjectRef`/`identityRef`, the eIDAS trust level, and
+the assertion `jti` (the one-time act id) — resolved server-side by the
+`portal-signing-actions` receiver from the verified assertion. This change
+requires those claims to be added to the `v: 2` assertion's canonical-JSON
+BEFORE the MAC is computed, so the MAC covers them:
+
+```
+mac = HMAC-SHA256(
+        secret,
+        sha256(canonical-document) . "\n" .
+        canonical-JSON({ ...signer, timestamp, level,
+                         portalSubjectRef, portalIdentityRef,
+                         portalTrust, portalJti } minus mac))
+```
+
+Verification (the `signing-trust-rebuild` verifier) already recomputes and
+`hash_equals()`-compares the MAC over the canonical assertion; because the
+portal identity fields are now part of that canonical JSON, rewriting any of
+them (e.g. swapping `portalSubjectRef` to another subject) changes the recomputed
+MAC and the evidence reports `invalid`. No new verifier is needed — the binding
+is achieved by INCLUDING the fields in the MAC input. An evidence record that
+validates while OMITTING the portal signer identity for a portal-originated
+signature is, by this spec, a violation.
+
+## Consent + drawn signature
+
+`signDocument`'s body carries a `consent` confirmation (the signer's explicit
+"I agree to sign" — recorded as evidence of intent, an eIDAS SES/AES
+requirement) and an OPTIONAL drawn-signature payload that lands in the
+`signerRecord.signatureData` field (already `visible:false`, never projected to
+the read manifest). Neither is trusted for identity — identity is the
+server-derived assertion subject; the drawn signature is decorative/evidentiary
+only. `declineDocument` carries a `reason` recorded in `signerRecord.declineReason`.
+
+## eIDAS levels
+
+This surface delivers **SES** (simple electronic signature — consent + audit
+trail) and, when the portal session is substantial-assurance (the
+`minTrust: substantial` gate), **AES**-grade evidence (identity-bound,
+tamper-evident via the MAC binding above). **QES** (qualified, certificate-backed
+via an eIDAS QTSP, Article 3(12)) is explicitly delegated to an external QTSP and
+out of scope — the manifest MUST NOT claim QES assurance for a portal signature,
+and the exposed assurance level MUST NOT exceed the session trust.
+
+## Security Considerations
+
+- **Fail closed** inherits from `portal-signing-actions` (401 invalid assertion,
+  403 wrong audience / not an invited signer, uniform not-authorised with no
+  existence oracle, 502 downstream). This change adds no new fall-open path.
+- **Identity is server-derived**: the bound portal claims come ONLY from the
+  verified assertion, never the request body. A body-supplied `subjectRef` /
+  `email` / `identityRef` never influences the evidence.
+- **Terminal-state**: `SigningService`'s status machine still rejects a
+  sign/decline on an already-terminal request; the rowAction manifest does not
+  weaken it.
+- **portaliq#3 regression**: a unit test MUST rewrite the portal signer identity
+  in a stored evidence record and assert verification reports `invalid`.
+- **No QES over-claim**: the assurance exposed on the evidence MUST NOT exceed
+  the session trust; QES is refused.
+
+## Seed Data
+
+No new OpenRegister schema or register — reuses `signerRecord` /
+`signingRequest` verified at HEAD (the drawn signature reuses the existing
+`signatureData` field). The `v: 2` assertion gains the four portal-identity keys
+inside its existing evidence JSON (no schema change; the assertion is an
+embedded artifact field). Unit tests construct the provider/receiver directly
+and build synthetic assertions on the nil-UUID pattern so fixtures are
+self-evidently fake.
+
+## Open questions (apply-time)
+
+1. **Scope-claim forwarding** (shared with `portal-signing-actions`): the A6
+   assertion must carry the resolved `signerEmail` scope claim + the portal
+   subject claims server-side; the receiver fails closed without them, so
+   shipping early is safe.
+2. **Assertion field names**: confirm the exact key names for the portal subject
+   claims inside the `v: 2` canonical JSON at apply, coordinated with
+   `signing-trust-rebuild`'s writer.

--- a/openspec/changes/portal-signing-surface/proposal.md
+++ b/openspec/changes/portal-signing-surface/proposal.md
@@ -1,0 +1,134 @@
+---
+kind: code
+depends_on: [portal-contribution, portal-signing-actions, signing-trust-rebuild]
+---
+
+# Proposal: portal-signing-surface
+
+## Why
+
+DocuDesk's `portal-contribution` gives an external **signer** (a person WITHOUT
+a Nextcloud account) a READ-ONLY window into their signing work through
+**portaliq**, the shared external portal (hydra ADR-046, contribution contract
+v2.2). Its `signer` manifest ships `actions: []` (`REQ-DDPORT-006`): it exposes
+`signerRecords` and the `signerSigningRequests` via-join, but the subject can
+look, not act. `onderteken*` is the single highest demand signal in the tender
+corpus — **358 tenders** — so "let the invited counterparty actually sign from
+the portal" is the headline follow-up.
+
+Two sibling changes already land the plumbing this surface stands on, hence the
+`depends_on`:
+
+- `portal-signing-actions` (`REQ-DDPSA-*`) adds the bearer-guarded DocuDesk
+  receiver, the `PortalAssertionVerifier`, the server-derived invited-signer
+  IDOR guard, and the verified-actor entrypoint that drives the honest
+  `SigningService::sign()` / `decline()` primitive from a `#[PublicPage]`
+  endpoint. It declares `sign` / `decline` / `viewDocument` at the manifest's
+  top-level `actions[]`.
+- `signing-trust-rebuild` (`REQ-DDSTR-001`) makes the native signed-artifact
+  assertion bind the SIGNER identity into a `v: 2` MAC
+  (`HMAC-SHA256(secret, sha256(canonical-document) . "\n" .
+  canonical-JSON(assertion-without-mac))`) so a rewritten signer name fails
+  verification — the in-app half of the forgeable-signer fix.
+
+This change closes the two gaps those leave, and both are grounded in the
+now-richer contract:
+
+1. **The contribution SURFACE the subject sees.** The contract now expresses
+   per-collection `rowActions` (contract v2.2), `type: update` actions, and
+   `set` server-stamping. `portal-signing-actions` wired the receiver but left
+   the actions as a bare top-level `actions[]` list; this change wires **`sign`
+   and `decline` as `rowActions` on the `signerSigningRequests` collection**, at
+   `minTrust: substantial`, so portaliq renders a per-document sign / decline
+   control on exactly the rows awaiting the subject — the eIDAS-aligned signing
+   surface a signer actually uses.
+2. **The forgeable-signer fix extended to the PORTAL identity chain
+   (portaliq#3).** `REQ-DDSTR-001` binds the in-app signer's *name/level/
+   timestamp* into the MAC, and `portal-signing-actions` records the portal
+   assertion `jti` in the AUDIT — but neither binds the PORTAL SUBJECT's claims
+   (`subjectRef`/`identityRef`, trust level, `jti`) into the cryptographic
+   signature EVIDENCE. A portal-originated signature whose evidence validates
+   without the portal signer's identity is exactly the class of bug filed as
+   portaliq#3 ("signing MAC excludes identity ⇒ forgeable signer"). This change
+   makes the evidence for a portal signature cryptographically bind the portal
+   subject identity + document hash + timestamp, so the recorded signer cannot
+   be swapped after the fact.
+
+## What Changes
+
+- **`sign` + `decline` become rowActions on `signerSigningRequests`.** Extend
+  `lib/Portal/PortalContributionProvider.php` (still plain, dependency-free) so
+  the `signer` manifest references contract-v2.2 `rowActions`
+  `[sign, decline]` on the `signerSigningRequests` collection, each `minTrust:
+  substantial` (eIDAS-aligned), pointing at the instance-local relative
+  receiver endpoints. The `data-subject` manifest stays read-only.
+- **`signDocument` records consent + optional drawn signature and transitions to
+  `signed`.** The receiver body carries a consent confirmation and an optional
+  drawn-signature payload; the server re-verifies ownership via the
+  `signerRecord` scope (the `portal-signing-actions` invited-signer guard),
+  records the signature evidence, and drives the honest
+  `SigningService::sign()` primitive to transition the request `status → signed`.
+- **`declineDocument` records a reason** and drives `SigningService::decline()`.
+- **Portal signature evidence binds the portal subject identity (portaliq#3).**
+  For a portal-originated signature, the evidence assertion MUST additionally
+  carry and MAC-cover the portal subject claims (`subjectRef`/`identityRef`,
+  trust level, `jti`) alongside the document hash and timestamp; verification
+  MUST fail if any bound identity field is altered.
+- **eIDAS posture is explicit.** This delivers a simple / advanced electronic
+  signature (SES / AES) surface; qualified electronic signatures (QES) are
+  delegated to external QTSPs and are out of scope.
+
+## Capabilities
+
+### Added Capabilities
+
+- `portal-signing-surface`: an external, accountless signer signs or declines a
+  document from portaliq's SPA through `rowActions` on the documents-awaiting-me
+  collection, at eIDAS-aligned substantial trust, and the recorded signature
+  evidence cryptographically binds the portal signer's identity so it cannot be
+  forged or re-attributed.
+
+## Affected Projects
+
+- [x] Project: `docudesk` — extend `lib/Portal/PortalContributionProvider.php` (signer `rowActions`); extend the `portal-signing-actions` receiver + verified-actor `SigningService` entrypoint to record consent + optional drawn signature and to bind the portal subject claims into the signature evidence MAC; unit tests under `tests/unit/Portal/` + `tests/unit/Service/`; this OpenSpec change.
+- Depends on: `portal-contribution` (signer manifest), `portal-signing-actions` (receiver, `PortalAssertionVerifier`, invited-signer IDOR guard, verified-actor entrypoint), `signing-trust-rebuild` (`v: 2` identity-bound MAC + honest verification).
+- Contract: `apps-extra/portaliq` — the contract-v2.2 `rowActions` + A6 endpoint-forward + frozen assertion requirements this surface is templated against; runtime consumer that renders the rowActions and forwards the acts.
+- Reference: `hydra` ADR-046 (portaliq external portal); portaliq#3 (forgeable-signer class of bug).
+
+## Out of Scope
+
+- The receiver, `PortalAssertionVerifier`, invited-signer IDOR/SSRF guard and
+  the verified-actor `SigningService` entrypoint — owned by
+  `portal-signing-actions`; this change consumes them and adds the rowAction
+  surface + the portal-subject evidence binding on top.
+- The in-app signer identity MAC and honest verification states — owned by
+  `signing-trust-rebuild` (`REQ-DDSTR-001`); this change extends the SAME
+  assertion to additionally bind the portal subject claims for portal-originated
+  signatures, not re-specify the in-app binding.
+- **Qualified electronic signatures (QES).** Certificate-backed QES via an
+  external QTSP (eIDAS Article 3(12)), PAdES-LTV, and NL identity rails are out
+  of scope; this surface delivers SES / AES only.
+- Any portal UI, session, auth edge or rendering — portaliq owns the entire
+  external surface (ADR-046); DocuDesk ships zero portal frontend.
+- The `data-subject` objection-intake write path — still deferred
+  (`portal-contribution` design.md); this change touches the `signer` audience
+  only.
+
+## Success Criteria
+
+- `openspec validate portal-signing-surface --strict` exits 0.
+- The `signer` manifest references exactly `sign` + `decline` as `rowActions` on
+  the `signerSigningRequests` collection at `minTrust: substantial`; the
+  `signerRecords` and `data-subject` collections carry no write action.
+- A verified invited signer's `signDocument` records the consent confirmation +
+  optional drawn signature, transitions the request `status → signed` through
+  the honest `SigningService::sign()` primitive, and preserves every
+  `portal-signing-actions` guard (assertion validity, invited-signer scope,
+  terminal-state machine).
+- The signature evidence for a portal signature cryptographically binds the
+  portal subject identity (`subjectRef`/`identityRef`, trust, `jti`) + document
+  hash + timestamp; an evidence record whose bound signer identity is altered
+  fails validation (portaliq#3 regression test).
+- QES is explicitly refused / delegated; only SES / AES assurance is claimed.
+- `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) and the unit suite pass
+  on the new files with zero new violations.

--- a/openspec/changes/portal-signing-surface/specs/portal-signing-surface/spec.md
+++ b/openspec/changes/portal-signing-surface/specs/portal-signing-surface/spec.md
@@ -1,0 +1,126 @@
+# portal-signing-surface Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+DocuDesk gives an external, accountless **signer** a real signing surface
+through **portaliq** (hydra ADR-046, contribution contract v2.2): `sign` and
+`decline` rendered as per-document `rowActions` on the documents-awaiting-me
+collection, at eIDAS-aligned substantial trust. It records the signer's consent
+and optional drawn signature, drives the honest `SigningService` primitive to
+transition the request, and — closing the forgeable-signer class of bug filed as
+portaliq#3 — cryptographically binds the PORTAL signer's identity into the
+signature evidence so a recorded portal signature can never be re-attributed.
+This change consumes the receiver, verifier, invited-signer guard and
+verified-actor entrypoint from `portal-signing-actions` and the `v: 2`
+identity-bound MAC from `signing-trust-rebuild`; it does not re-implement them.
+
+## ADDED Requirements
+
+### Requirement: Signer manifest declares sign and decline as substantial-gated rowActions (REQ-DDPSS-001)
+
+`OCA\DocuDesk\Portal\PortalContributionProvider`'s `signer` manifest MUST
+reference exactly two contract-v2.2 `rowActions` — `sign` and `decline` — on the
+`signerSigningRequests` collection (the documents-awaiting-me rows), each gated
+at `minTrust: substantial` (eIDAS-aligned: an advanced-electronic-signature act
+requires a substantial-assurance portal session). Each referenced action MUST
+resolve to an instance-local RELATIVE receiver endpoint (leading slash, no
+scheme, no host, no `..`). The `signerRecords` collection and the entire
+`data-subject` manifest MUST carry no write action. The provider MUST stay a
+plain, dependency-free class (no portaliq import, no `implements`, no
+constructor) — it only adds pure-data rowAction declarations.
+
+#### Scenario: The signer collection carries the sign and decline rowActions
+
+- GIVEN a constructed `PortalContributionProvider` and a subject with `audience: 'signer'`
+- WHEN `getContribution($subject)` is called
+- THEN the `signerSigningRequests` collection references exactly `sign` and `decline` as `rowActions`, each `minTrust: substantial`, each pointing at an instance-local relative receiver endpoint
+- AND the `signerRecords` collection and the `data-subject` manifest carry no write action
+- @e2e exclude e2e added in apply phase - spec-only PR
+
+### Requirement: signDocument records consent plus optional drawn signature and transitions to signed (REQ-DDPSS-002)
+
+The `signDocument` receiver act MUST, for a verified invited signer, record the
+signer's explicit consent confirmation (evidence of intent) and an OPTIONAL
+drawn-signature payload into the existing `signerRecord.signatureData` field
+(schema `visible:false`, never projected to the read manifest), then drive the
+honest `OCA\DocuDesk\Service\SigningService::sign()` primitive to transition the
+request `status → signed`. Server-side ownership MUST be re-verified via the
+`portal-signing-actions` invited-signer scope (`signerRecord.email == verified
+assertion signerEmail AND signingRequestId == target`) before any act; the
+`SigningService` terminal-state status machine MUST still reject a sign on an
+already-terminal request. The consent flag and drawn signature MUST NOT be
+trusted for identity — identity is the server-derived assertion subject, never
+the request body.
+
+#### Scenario: A verified invited signer signs with consent
+
+- GIVEN a valid `signer` assertion resolving to an invited signer on a still-pending request, a body carrying an affirmative `consent` and an optional drawn-signature payload
+- WHEN the receiver processes `signDocument`
+- THEN it records the consent + drawn signature into `signerRecord.signatureData`, calls `SigningService::sign()` acting as the resolved signer, and the request transitions `status → signed`
+- AND a `signDocument` on an already-terminal request is rejected by the status machine unchanged, and a signer not invited on the target gets the uniform not-authorised result with `SigningService` never called
+- @e2e exclude e2e added in apply phase - spec-only PR
+
+### Requirement: declineDocument records a reason and transitions through the honest primitive (REQ-DDPSS-003)
+
+The `declineDocument` receiver act MUST, for a verified invited signer, record
+the client-supplied `reason` into `signerRecord.declineReason` and drive
+`SigningService::decline()` to transition the request, preserving the same
+invited-signer scope check and terminal-state machine as `signDocument`. A
+missing reason MUST be handled per the `SigningService` contract (not silently
+dropped). Ownership and identity MUST be server-derived exactly as for
+`signDocument`.
+
+#### Scenario: A verified invited signer declines with a reason
+
+- GIVEN a valid `signer` assertion resolving to an invited signer on a still-pending request and a body carrying a decline `reason`
+- WHEN the receiver processes `declineDocument`
+- THEN it records the `reason` and calls `SigningService::decline()`, transitioning the request out of pending through the status machine
+- AND a decline on an already-terminal request is rejected unchanged, and a non-invited signer gets the uniform not-authorised result
+- @e2e exclude e2e added in apply phase - spec-only PR
+
+### Requirement: Portal signature evidence cryptographically binds the portal signer identity (REQ-DDPSS-004)
+
+For a portal-originated signature the recorded signature evidence MUST
+cryptographically bind the PORTAL signer's identity — the verified assertion's
+`subjectRef` / `identityRef`, eIDAS trust level, and act `jti` — together with
+the document hash and the signing timestamp, into the `v: 2` assertion MAC
+(`signing-trust-rebuild` `REQ-DDSTR-001`). Those portal-identity claims MUST be
+included in the canonical JSON that the MAC is computed over BEFORE the MAC is
+taken, and MUST be sourced ONLY from the verified assertion, never the request
+body. An evidence record that validates while OMITTING the portal signer
+identity for a portal-originated signature is a spec violation. Rewriting any
+bound portal-identity field (e.g. swapping the `subjectRef` to a different
+subject) while keeping the original MAC MUST cause verification to report
+`invalid`. This is the portal half of the forgeable-signer fix (portaliq#3); the
+in-app signer binding remains owned by `REQ-DDSTR-001`.
+
+#### Scenario: A rewritten portal signer identity fails evidence validation
+
+- GIVEN a portal-originated signature whose `v: 2` evidence binds the assertion `subjectRef`/`identityRef`, trust and `jti` plus the document hash and timestamp into the MAC
+- WHEN the stored evidence is rewritten to name a DIFFERENT portal subject while keeping the original MAC, and the artifact is verified
+- THEN verification reports status `invalid` (the recomputed MAC no longer matches)
+- AND a portal signature whose evidence omits the portal signer identity entirely is treated as a spec violation, never `verified`
+- AND the bound identity fields are taken only from the verified assertion; a body-supplied `subjectRef`/`identityRef` never changes the evidence
+- @e2e exclude e2e added in apply phase - spec-only PR
+
+### Requirement: The surface claims SES/AES only and refuses QES over-claim (REQ-DDPSS-005)
+
+This surface MUST expose only simple / advanced electronic signature (SES / AES)
+assurance and MUST NOT claim qualified electronic signature (QES) assurance for a
+portal signature. The assurance level recorded and exposed on a portal signature
+MUST NOT exceed the portal session's trust level (a `substantial` session yields
+at most AES-grade evidence). Qualified signatures via an external eIDAS QTSP
+(Article 3(12)), PAdES-LTV and certificate rails are delegated to an external
+provider and MUST NOT be represented as delivered by this surface.
+
+#### Scenario: A substantial-trust portal signature is AES, never QES
+
+- GIVEN a portal signer acting on a `minTrust: substantial` session
+- WHEN the signature evidence records the assurance level
+- THEN the recorded/exposed assurance is at most AES and never claims QES
+- AND the surface does not represent a QES as delivered — QES is delegated to an external QTSP
+- @e2e exclude e2e added in apply phase - spec-only PR

--- a/openspec/changes/portal-signing-surface/tasks.md
+++ b/openspec/changes/portal-signing-surface/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: portal-signing-surface
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 10. -->
+
+## Prerequisites (apply-blockers, shared with the sibling changes)
+
+- [ ] T01 — Confirm `portal-signing-actions` (receiver, `PortalAssertionVerifier`, invited-signer IDOR guard, verified-actor `SigningService` entrypoint) and `signing-trust-rebuild` (`v: 2` identity-bound MAC + honest verification) are applied first; confirm the A6 assertion carries the resolved `signerEmail` scope claim + the portal subject claims (`subjectRef`/`identityRef`, trust, `jti`) server-side (design.md Open Q1/Q2).
+
+## Implementation
+
+- [ ] T02 — Extend `lib/Portal/PortalContributionProvider.php` — signer `rowActions` (REQ-DDPSS-001). Reference exactly `sign` + `decline` as `rowActions` on the `signerSigningRequests` collection, each `minTrust: substantial`, instance-local relative endpoints; keep `signerRecords` + `data-subject` write-action-free; class stays plain/dependency-free. EUPL-1.2/SPDX docblock + `@spec` tags.
+
+- [ ] T03 — Extend the `portal-signing-actions` receiver to accept `signDocument` (REQ-DDPSS-002). Record the `consent` confirmation + optional drawn-signature payload into `signerRecord.signatureData`; re-verify invited-signer ownership; drive `SigningService::sign()` via the verified-actor entrypoint; transition `status → signed`; preserve the terminal-state machine and uniform not-authorised result.
+
+- [ ] T04 — Extend the receiver to accept `declineDocument` (REQ-DDPSS-003). Record the client `reason` into `signerRecord.declineReason`; drive `SigningService::decline()`; same invited-signer scope + terminal-state guards.
+
+- [ ] T05 — Bind the portal subject identity into the signature evidence MAC (REQ-DDPSS-004). Add the verified assertion's `subjectRef`/`identityRef`, trust and `jti` to the `v: 2` assertion's canonical JSON BEFORE the MAC is computed (coordinate the exact key names with `signing-trust-rebuild`'s writer); source them ONLY from the verified assertion. No new verifier — the existing `hash_equals()` MAC recompute now covers the portal identity.
+
+- [ ] T06 — Enforce SES/AES-only assurance (REQ-DDPSS-005). Record/expose an assurance level that never exceeds the session trust; never represent a portal signature as QES.
+
+## Testing & quality
+
+- [ ] T07 — Unit tests `tests/unit/Portal/PortalContributionProviderTest.php` (extend): pin the `sign`/`decline` rowActions on `signerSigningRequests` (ids, `minTrust: substantial`, relative endpoints); assert `signerRecords` + `data-subject` carry no write action.
+
+- [ ] T08 — Unit tests for the receiver acts (REQ-DDPSS-002/003): happy-path `signDocument` (consent + drawn signature recorded, `SigningService::sign()` called, status → signed); `declineDocument` (reason recorded, `decline()` called); terminal-state rejection unchanged; non-invited signer → uniform not-authorised, `SigningService` never called; body-supplied identity ignored.
+
+- [ ] T09 — Portaliq#3 regression + eIDAS tests (REQ-DDPSS-004/005): a stored portal-signature evidence record with a rewritten `subjectRef` (original MAC kept) verifies as `invalid`; evidence omitting the portal signer identity is rejected, never `verified`; a substantial-session signature records at most AES and never claims QES.
+
+- [ ] T10 — Quality gates: `php -l`, `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) and the unit suite pass with zero new violations; relevant Hydra gates (route-auth, route-reachability, security-change-has-tests, spec-coverage) green; `openspec validate portal-signing-surface --strict` exits 0.
+
+## Quality checklist
+
+- Every MUST in the spec has a unit test; the portaliq#3 identity-binding regression (rewritten portal signer identity ⇒ `invalid`) and the no-write-action-on-read-collections invariant are explicitly asserted.
+- No receiver/verifier/entrypoint is re-implemented — this change consumes `portal-signing-actions` + `signing-trust-rebuild`; the boundary is stated in the proposal Out of Scope.
+- Manifest labels ship in English source (i18n policy); portaliq owns portal-side translation.
+- No register JSON change — `signerRecord.signatureData/declineReason`, `signingRequest.status` verified against HEAD; the portal identity keys live inside the existing `v: 2` evidence JSON.
+- QES is explicitly out of scope; the surface claims SES/AES only.
+- No DocuDesk UI ships (portaliq owns the SPA) — no Playwright; covered by PHPUnit.


### PR DESCRIPTION
## What

Spec-only OpenSpec `ff` change **`portal-signing-surface`** (proposal + design + delta spec + tasks) — no code yet; tests + implementation land in the apply phase.

Gives an accountless **signer** a real sign / decline surface from the portaliq portal: `sign` and `decline` as per-document `rowActions` on the `signerSigningRequests` collection at eIDAS-aligned `minTrust: substantial`, recording consent + an optional drawn signature and driving the honest `SigningService` primitive. Closes the **portaliq#3** forgeable-signer class of bug for portal signatures by binding the portal signer identity into the evidence MAC.

## Evidence

- `onderteken*` is the single highest tender demand signal — **358 tenders**.
- Scoped to the genuine, non-duplicative delta and depends on two existing active changes rather than re-specifying them:
  - `portal-signing-actions` (`REQ-DDPSA-*`) already ships the receiver, `PortalAssertionVerifier`, invited-signer IDOR guard and verified-actor `SigningService` entrypoint — this change adds the **rowActions** surface (contract v2.2) on top.
  - `signing-trust-rebuild` (`REQ-DDSTR-001`) already binds the **in-app** signer identity into a `v: 2` MAC — this change extends the SAME assertion to additionally bind the **portal subject** claims (`subjectRef`/`identityRef`, trust, `jti`) for portal-originated signatures.
- Verified code paths: `SigningService::sign()` (`lib/Service/SigningService.php:352`) / `decline()` (`:441`); `signerRecord.signatureData`/`declineReason`; `signingRequest.status`.
- eIDAS: delivers SES/AES only; QES delegated to external QTSPs (out of scope).
- portaliq#3 regression asserted: rewriting the stored portal signer identity while keeping the MAC ⇒ verification `invalid`.
- `openspec validate portal-signing-surface --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)