### PR TITLE
feat(portal): portal signing surface — signer rowActions (sign/decline)

### DIFF
--- a/lib/Portal/PortalContributionProvider.php
+++ b/lib/Portal/PortalContributionProvider.php
@@ -4,8 +4,9 @@
  * DocuDesk Portal Contribution Provider
  *
  * DocuDesk's contribution to the shared Portaliq external portal (hydra
- * ADR-046, contribution contract v2.1). Portaliq — the ONE shared portal for
- * people WITHOUT Nextcloud accounts — discovers this class by convention FQCN
+ * ADR-046, contribution contract v2.1, extended by v2.2 `rowActions`).
+ * Portaliq — the ONE shared portal for people WITHOUT Nextcloud accounts —
+ * discovers this class by convention FQCN
  * (`OCA\{Namespace}\Portal\PortalContributionProvider`) and duck-types it via
  * method_exists(), never instanceof. This class is therefore deliberately
  * PLAIN: no portaliq imports, no `implements` clause, no info.xml dependency,
@@ -18,9 +19,29 @@
  * and the field whitelists projected onto each. All scoping uses the STABLE
  * claim contract `claims.docudesk.contactId` / `claims.docudesk.signerEmail`;
  * see openspec/changes/portal-contribution/design.md. No create/endpoint
- * actions ship in this wave (see design.md "Deferred actions"): consent
- * objection and document signing are UPDATE / A6 flows the create-action
- * vocabulary cannot express safely, and are deferred to a follow-up.
+ * actions ship at the manifest top level (see design.md "Deferred actions"):
+ * consent objection and document signing are UPDATE / A6 flows the
+ * create-action vocabulary cannot express safely, and remain deferred.
+ *
+ * `portal-signing-surface` (this file, extended) adds the ONE additive seam
+ * that IS safe to ship without the A6 receiver: contract-v2.2 `rowActions`
+ * (`sign`, `decline`) declared directly on the `signerSigningRequests`
+ * collection — pure data, no I/O, no new imports. The endpoints they name
+ * (`/apps/docudesk/api/portal/signing/{sign,decline}`) are the ones
+ * `portal-signing-actions`'s receiver is designed to expose; AT HEAD that
+ * receiver, its `PortalAssertionVerifier`, and `signing-trust-rebuild`'s
+ * identity-bound `v: 2` assertion MAC are NOT YET IMPLEMENTED (spec-only, 0 of
+ * their tasks checked, no controller/route/verifier code in this repo). The
+ * rowActions are declared here anyway (forward-compatible, dead until the
+ * receiver ships — calling them 404s today) so the manifest and the future
+ * receiver land in sync; the portal-subject identity binding into the
+ * signature evidence (REQ-DDPSS-004) is intentionally NOT implemented in this
+ * class or in `NativeSigningProvider`/`SigningVerificationService` because
+ * doing so before `signing-trust-rebuild`'s MAC rebuild lands would silently
+ * decorate the assertion with unenforced fields — the exact forgeable-signer
+ * shape (portaliq#3) this surface exists to close, not a fix for it. See
+ * `openspec/changes/portal-signing-surface/design.md` "Open questions" and the
+ * apply-time PR for the full dependency-state note.
  *
  * @category  Portal
  * @package   OCA\DocuDesk\Portal
@@ -34,6 +55,7 @@
  * SPDX-License-Identifier: EUPL-1.2
  *
  * @spec openspec/changes/portal-contribution/specs/portal-contribution/spec.md
+ * @spec openspec/specs/portal-signing-surface/spec.md
  */
 
 declare(strict_types=1);
@@ -84,6 +106,43 @@ class PortalContributionProvider
      * @var string
      */
     private const LABEL = 'DocuDesk';
+
+    /**
+     * Instance-local relative endpoint the `sign` rowAction resolves to.
+     *
+     * Targets the `portal-signing-actions` receiver's `signDocument` act
+     * (design.md "The identity chain"). NOT YET implemented at HEAD (see this
+     * class's docblock) — declared here so the manifest and the future
+     * receiver ship in sync.
+     *
+     * @var string
+     */
+    private const SIGN_ENDPOINT = '/apps/docudesk/api/portal/signing/sign';
+
+    /**
+     * Instance-local relative endpoint the `decline` rowAction resolves to.
+     *
+     * Targets the `portal-signing-actions` receiver's `declineDocument` act.
+     * NOT YET implemented at HEAD — see `SIGN_ENDPOINT`.
+     *
+     * @var string
+     */
+    private const DECLINE_ENDPOINT = '/apps/docudesk/api/portal/signing/decline';
+
+    /**
+     * Minimum eIDAS-aligned portal trust required to sign or decline.
+     *
+     * An advanced-electronic-signature-grade act requires a
+     * substantial-assurance portal session (design.md "eIDAS levels"). This
+     * surface exposes SES/AES assurance only and never claims QES
+     * (qualified electronic signature, eIDAS Article 3(12)) — QES is
+     * certificate-backed via an external QTSP and is explicitly out of scope
+     * (REQ-DDPSS-005); the exposed assurance MUST NOT exceed this session
+     * trust.
+     *
+     * @var string
+     */
+    private const SIGNING_MIN_TRUST = 'substantial';
 
     /**
      * The audiences this provider contributes to (contract v2, preferred).
@@ -222,9 +281,29 @@ class PortalContributionProvider
      * co-signer roster (`signerIds`) and the internal Nextcloud `documentFileId`
      * — every other-party and system-internal column.
      *
+     * `signerSigningRequests` additionally carries contract-v2.2 `rowActions`
+     * — `sign` and `decline` (REQ-DDPSS-001) — so portaliq renders a
+     * per-document sign/decline control on exactly the rows awaiting the
+     * subject. Each rowAction is gated `minTrust: substantial`
+     * (eIDAS-aligned: an AES-grade act needs a substantial-assurance
+     * session — `SIGNING_MIN_TRUST`) and resolves to an instance-local
+     * relative endpoint (`SIGN_ENDPOINT` / `DECLINE_ENDPOINT`). This surface
+     * exposes SES/AES assurance only; QES (qualified electronic signature,
+     * certificate-backed via an external QTSP, eIDAS Article 3(12)) is
+     * delegated and never claimed here (REQ-DDPSS-005). The rowActions are
+     * pure data — no I/O, no callbacks — keeping this class plain and
+     * dependency-free; the `signerRecords` collection and the entire
+     * `data-subject` manifest carry no write action. The endpoints they name
+     * target the `portal-signing-actions` receiver, which is NOT YET
+     * implemented at HEAD (see this file's top-of-file docblock) — a row
+     * already in a terminal state (`signed`/`declined`) must not offer the
+     * actions, which is the receiver's terminal-state guard to enforce once
+     * it ships, not something this pure-data manifest can express.
+     *
      * @return array<string, mixed> The signer manifest.
      *
      * @spec openspec/changes/portal-contribution/specs/portal-contribution/spec.md
+     * @spec openspec/specs/portal-signing-surface/spec.md
      */
     private function signerContribution(): array
     {
@@ -269,6 +348,22 @@ class PortalContributionProvider
                         'status',
                         'deadline',
                         'provider',
+                    ],
+                    'rowActions' => [
+                        [
+                            'id'       => 'sign',
+                            'label'    => 'Sign',
+                            'endpoint' => self::SIGN_ENDPOINT,
+                            'method'   => 'POST',
+                            'minTrust' => self::SIGNING_MIN_TRUST,
+                        ],
+                        [
+                            'id'       => 'decline',
+                            'label'    => 'Decline to sign',
+                            'endpoint' => self::DECLINE_ENDPOINT,
+                            'method'   => 'POST',
+                            'minTrust' => self::SIGNING_MIN_TRUST,
+                        ],
                     ],
                 ],
             ],

--- a/openspec/changes/portal-signing-surface/tasks.md
+++ b/openspec/changes/portal-signing-surface/tasks.md
@@ -2,31 +2,54 @@
 
 <!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 10. -->
 
+<!--
+APPLY-TIME STATUS (2026-07-23): T01's dependencies are NOT met — neither
+sibling change is implemented at HEAD (both 0/N tasks checked, no
+controller/route/verifier/v2-MAC code in this repo at apply time). Per the
+apply brief's hard rule ("if a dependency change is NOT yet implemented at
+HEAD, implement only what your change specifies... do not silently absorb the
+other changes' scope"), only T02/T07 (the self-contained declarative
+rowActions + their pinning tests) and the eIDAS posture documentation are
+implemented this pass. T03/T04 extend a `portal-signing-actions` receiver that
+does not exist; T05/T06/T08/T09 extend/verify a `signing-trust-rebuild` v2 MAC
+that does not exist — implementing them now would mean either re-implementing
+the sibling changes' own scope, or shipping fields that LOOK identity-bound but
+aren't actually covered by any MAC (the exact forgeable-signer shape this
+surface exists to close). They are left unchecked and blocked below.
+-->
+
 ## Prerequisites (apply-blockers, shared with the sibling changes)
 
 - [ ] T01 — Confirm `portal-signing-actions` (receiver, `PortalAssertionVerifier`, invited-signer IDOR guard, verified-actor `SigningService` entrypoint) and `signing-trust-rebuild` (`v: 2` identity-bound MAC + honest verification) are applied first; confirm the A6 assertion carries the resolved `signerEmail` scope claim + the portal subject claims (`subjectRef`/`identityRef`, trust, `jti`) server-side (design.md Open Q1/Q2).
+  **BLOCKED (not met, verified 2026-07-23)**: `portal-signing-actions` 0/13 tasks checked, no `PortalSigningReceiverController`/`PortalAssertionVerifier`/route in this repo. `signing-trust-rebuild` 0/16 tasks checked; `NativeSigningProvider::produceSignedArtifact()` still writes the pre-fix `v: 1`-shaped assertion (`mac = HMAC(secret, contentHash)`, no signer/portal fields covered at all) and `SigningVerificationService::verifyAssertion()` still verifies only that flat form.
 
 ## Implementation
 
-- [ ] T02 — Extend `lib/Portal/PortalContributionProvider.php` — signer `rowActions` (REQ-DDPSS-001). Reference exactly `sign` + `decline` as `rowActions` on the `signerSigningRequests` collection, each `minTrust: substantial`, instance-local relative endpoints; keep `signerRecords` + `data-subject` write-action-free; class stays plain/dependency-free. EUPL-1.2/SPDX docblock + `@spec` tags.
+- [x] T02 — Extend `lib/Portal/PortalContributionProvider.php` — signer `rowActions` (REQ-DDPSS-001). Reference exactly `sign` + `decline` as `rowActions` on the `signerSigningRequests` collection, each `minTrust: substantial`, instance-local relative endpoints; keep `signerRecords` + `data-subject` write-action-free; class stays plain/dependency-free. EUPL-1.2/SPDX docblock + `@spec` tags.
 
 - [ ] T03 — Extend the `portal-signing-actions` receiver to accept `signDocument` (REQ-DDPSS-002). Record the `consent` confirmation + optional drawn-signature payload into `signerRecord.signatureData`; re-verify invited-signer ownership; drive `SigningService::sign()` via the verified-actor entrypoint; transition `status → signed`; preserve the terminal-state machine and uniform not-authorised result.
+  **BLOCKED**: the receiver this task extends does not exist (`portal-signing-actions` unimplemented). Out of this change's scope per proposal "Out of Scope" — not built.
 
 - [ ] T04 — Extend the receiver to accept `declineDocument` (REQ-DDPSS-003). Record the client `reason` into `signerRecord.declineReason`; drive `SigningService::decline()`; same invited-signer scope + terminal-state guards.
+  **BLOCKED**: same receiver dependency as T03 — not built.
 
 - [ ] T05 — Bind the portal subject identity into the signature evidence MAC (REQ-DDPSS-004). Add the verified assertion's `subjectRef`/`identityRef`, trust and `jti` to the `v: 2` assertion's canonical JSON BEFORE the MAC is computed (coordinate the exact key names with `signing-trust-rebuild`'s writer); source them ONLY from the verified assertion. No new verifier — the existing `hash_equals()` MAC recompute now covers the portal identity.
+  **BLOCKED**: there is no `v: 2` assertion/MAC to extend — `signing-trust-rebuild` is unimplemented. Adding the four portal-identity fields to the CURRENT flat assertion would not be covered by the existing MAC (`hash_hmac('sha256', $contentHash, $secret)` covers only the content hash, no assertion field at all today), so it would decorate the evidence with unenforced fields — the exact bug class (portaliq#3) this requirement exists to close. Not built; documented instead (design note added to `PortalContributionProvider.php`'s docblock).
 
 - [ ] T06 — Enforce SES/AES-only assurance (REQ-DDPSS-005). Record/expose an assurance level that never exceeds the session trust; never represent a portal signature as QES.
+  **PARTIALLY DONE (declarative only)**: the `SIGNING_MIN_TRUST = 'substantial'` constant + docblock posture notes on `PortalContributionProvider.php` state the SES/AES-only, no-QES posture and gate the rowActions at eIDAS-substantial. Runtime enforcement (recording/exposing an actual assurance level on a signature) depends on the unbuilt receiver/MAC (T03-T05) and is not implemented.
 
 ## Testing & quality
 
-- [ ] T07 — Unit tests `tests/unit/Portal/PortalContributionProviderTest.php` (extend): pin the `sign`/`decline` rowActions on `signerSigningRequests` (ids, `minTrust: substantial`, relative endpoints); assert `signerRecords` + `data-subject` carry no write action.
+- [x] T07 — Unit tests `tests/unit/Portal/PortalContributionProviderTest.php` (extend): pin the `sign`/`decline` rowActions on `signerSigningRequests` (ids, `minTrust: substantial`, relative endpoints); assert `signerRecords` + `data-subject` carry no write action.
 
 - [ ] T08 — Unit tests for the receiver acts (REQ-DDPSS-002/003): happy-path `signDocument` (consent + drawn signature recorded, `SigningService::sign()` called, status → signed); `declineDocument` (reason recorded, `decline()` called); terminal-state rejection unchanged; non-invited signer → uniform not-authorised, `SigningService` never called; body-supplied identity ignored.
+  **BLOCKED**: no receiver exists to test (T03/T04 not built).
 
 - [ ] T09 — Portaliq#3 regression + eIDAS tests (REQ-DDPSS-004/005): a stored portal-signature evidence record with a rewritten `subjectRef` (original MAC kept) verifies as `invalid`; evidence omitting the portal signer identity is rejected, never `verified`; a substantial-session signature records at most AES and never claims QES.
+  **BLOCKED**: no MAC binding exists to regression-test (T05 not built).
 
-- [ ] T10 — Quality gates: `php -l`, `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) and the unit suite pass with zero new violations; relevant Hydra gates (route-auth, route-reachability, security-change-has-tests, spec-coverage) green; `openspec validate portal-signing-surface --strict` exits 0.
+- [x] T10 — Quality gates (scoped to what this pass touched): `php -l`, `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan run in the `nextcloud:34.0.0-apache` container) and the full unit suite (939 tests) pass with zero new violations; `openspec validate portal-signing-surface --strict` (both `--type change` and `--type spec`) exits 0. Hydra gate script itself was not run (not present/invoked in this workflow); route-auth/route-reachability are not applicable — no route was added.
 
 ## Quality checklist
 

--- a/openspec/specs/portal-signing-surface/spec.md
+++ b/openspec/specs/portal-signing-surface/spec.md
@@ -1,0 +1,63 @@
+---
+capability: portal-signing-surface
+status: in-progress
+built_by: openspec/changes/portal-signing-surface
+---
+
+# portal-signing-surface Specification
+
+**Status**: in-progress
+**Scope**: docudesk
+**OpenSpec changes**:
+- [portal-signing-surface](../../changes/portal-signing-surface/) _(active)_ — contract-v2.2 `rowActions` on the signer manifest + portal-subject evidence binding (kind: code)
+
+## Purpose
+
+DocuDesk gives an external, accountless **signer** a real signing surface
+through **portaliq** (hydra ADR-046, contribution contract v2.2): `sign` and
+`decline` rendered as per-document `rowActions` on the documents-awaiting-me
+collection, at eIDAS-aligned substantial trust. Closing the forgeable-signer
+class of bug filed as portaliq#3, a portal-originated signature's evidence is
+meant to cryptographically bind the PORTAL signer's identity so it can never be
+re-attributed. This change consumes the receiver, verifier, invited-signer
+guard and verified-actor entrypoint from `portal-signing-actions` and the
+`v: 2` identity-bound MAC from `signing-trust-rebuild`; it does not
+re-implement them.
+
+## Requirements
+
+Detailed requirements (REQ-DDPSS-001 … REQ-DDPSS-005) are defined in the active
+change's delta spec —
+[`openspec/changes/portal-signing-surface/specs/portal-signing-surface/spec.md`](../../changes/portal-signing-surface/specs/portal-signing-surface/spec.md)
+— and are merged here by `openspec sync` when the change is archived. The
+umbrella requirement below anchors the capability until then and records the
+**apply-time dependency state honestly**: at HEAD, `portal-signing-actions`
+(the receiver, `PortalAssertionVerifier`, invited-signer guard, verified-actor
+`SigningService` entrypoint) and `signing-trust-rebuild` (the `v: 2`
+identity-bound assertion MAC) are BOTH spec-only — zero of either change's
+tasks are implemented, no receiver/verifier code exists in this repo. Only
+REQ-DDPSS-001 (the declarative `rowActions` on the manifest) is implemented by
+this capability so far; REQ-DDPSS-002/003/004/005 remain unimplemented pending
+those two sibling changes and are NOT claimed as done.
+
+### Requirement: Signer manifest declares sign and decline as substantial-gated rowActions (REQ-DDPSS-000)
+
+`OCA\DocuDesk\Portal\PortalContributionProvider`'s `signer` manifest MUST
+reference exactly two contract-v2.2 `rowActions` — `sign` and `decline` — on
+the `signerSigningRequests` collection (the documents-awaiting-me rows), each
+gated at `minTrust: substantial`, each resolving to an instance-local relative
+receiver endpoint. The `signerRecords` collection and the entire `data-subject`
+manifest MUST carry no write action. The provider MUST stay a plain,
+dependency-free class (no portaliq import, no `implements`, no constructor).
+The declared endpoints target the `portal-signing-actions` receiver, which is
+NOT YET implemented at HEAD — calling the declared endpoints 404s until that
+change lands; declaring them now is forward-compatible, inert, pure-data and
+introduces no I/O.
+
+#### Scenario: The signer collection carries the sign and decline rowActions
+
+- GIVEN a constructed `PortalContributionProvider` and a subject with `audience: 'signer'`
+- WHEN `getContribution($subject)` is called
+- THEN the `signerSigningRequests` collection references exactly `sign` and `decline` as `rowActions`, each `minTrust: substantial`, each pointing at an instance-local relative receiver endpoint
+- AND the `signerRecords` collection and the `data-subject` manifest carry no write action
+- @e2e exclude backend-only manifest rendered inside portaliq, not DocuDesk — covered by PHPUnit (tests/unit/Portal/PortalContributionProviderTest.php)

--- a/tests/unit/Portal/PortalContributionProviderTest.php
+++ b/tests/unit/Portal/PortalContributionProviderTest.php
@@ -13,6 +13,12 @@
  * instead of silently scoping portal reads to nothing or dropping a projected
  * column.
  *
+ * Also pins the contract-v2.2 `portal-signing-surface` extension
+ * (REQ-DDPSS-001): the `sign`/`decline` `rowActions` on `signerSigningRequests`
+ * (ids, `minTrust: substantial`, relative-endpoint shape) and the invariant
+ * that `signerRecords` and the entire `data-subject` manifest carry no write
+ * action.
+ *
  * Subjects use nil-pattern UUIDs per the change design.md Seed Data section —
  * self-evidently fake, never colliding with live data. The provider is
  * constructed directly — it is a plain dependency-free class by contract
@@ -29,6 +35,7 @@
  * SPDX-License-Identifier: EUPL-1.2
  *
  * @spec openspec/changes/portal-contribution/specs/portal-contribution/spec.md
+ * @spec openspec/specs/portal-signing-surface/spec.md
  */
 
 declare(strict_types=1);
@@ -212,6 +219,12 @@ final class PortalContributionProviderTest extends TestCase
             $this->assertNotContains($field, $consent['fields'], "Consent projection must never expose '{$field}'");
         }
 
+        $this->assertArrayNotHasKey(
+            'rowActions',
+            $consent,
+            'The entire data-subject manifest carries no write action (REQ-DDPSS-001)'
+        );
+
     }//end testDataSubjectConsentCollectionIsScopedAndProjected()
 
 
@@ -239,6 +252,11 @@ final class PortalContributionProviderTest extends TestCase
             ['displayName', 'status', 'order', 'signedAt', 'declineReason'],
             $record['fields'],
             'Only the signer own participation facts are projected'
+        );
+        $this->assertArrayNotHasKey(
+            'rowActions',
+            $record,
+            'signerRecords is a read-only collection — no write action (REQ-DDPSS-001)'
         );
 
         $forbidden = ['signatureData', 'ipAddress', 'userId', 'signingRequestId', 'email'];
@@ -300,7 +318,51 @@ final class PortalContributionProviderTest extends TestCase
 
 
     /**
-     * Neither audience ships create or endpoint actions in this wave.
+     * `signerSigningRequests` carries exactly the `sign` and `decline`
+     * contract-v2.2 rowActions, each gated `minTrust: substantial`, each
+     * resolving to an instance-local relative endpoint (REQ-DDPSS-001).
+     *
+     * @return void
+     */
+    public function testSignerSigningRequestsCarriesSignAndDeclineRowActions(): void
+    {
+        $manifest = $this->provider->getContribution(self::SIGNER_SUBJECT);
+        $this->assertIsArray($manifest);
+
+        $request = $this->indexById($manifest['collections'])['signerSigningRequests'];
+        $this->assertArrayHasKey('rowActions', $request, 'The awaiting-signature collection must carry the sign/decline rowActions');
+
+        $rowActions = $this->indexById($request['rowActions']);
+        $this->assertSame(['decline', 'sign'], $this->sortedKeys($rowActions), 'Exactly sign + decline, no other rowAction');
+
+        foreach (['sign', 'decline'] as $id) {
+            $action = $rowActions[$id];
+            $this->assertSame($id, $action['id']);
+            $this->assertSame('substantial', $action['minTrust'], "rowAction '{$id}' must be eIDAS-substantial gated");
+            $this->assertSame('POST', $action['method']);
+            $this->assertIsString($action['endpoint']);
+            $this->assertNotSame('', $action['endpoint']);
+            $this->assertStringStartsWith('/', $action['endpoint'], "rowAction '{$id}' endpoint must be instance-local relative (leading slash)");
+            $this->assertStringNotContainsStringIgnoringCase('://', $action['endpoint'], "rowAction '{$id}' endpoint must carry no scheme");
+            $this->assertStringNotContainsString('..', $action['endpoint'], "rowAction '{$id}' endpoint must not traverse ('..')");
+            $this->assertNotEmpty($action['label']);
+        }
+
+        $this->assertNotSame(
+            $rowActions['sign']['endpoint'],
+            $rowActions['decline']['endpoint'],
+            'sign and decline must resolve to distinct endpoints'
+        );
+
+    }//end testSignerSigningRequestsCarriesSignAndDeclineRowActions()
+
+
+    /**
+     * Neither audience ships top-level create/endpoint actions; only the
+     * `signerSigningRequests` collection carries the sign/decline rowActions
+     * (a distinct, per-collection contract-v2.2 concept, REQ-DDPSS-001), and
+     * no read-only collection (`signerRecords`, the entire `data-subject`
+     * manifest) carries any write action.
      *
      * @return void
      */
@@ -309,10 +371,17 @@ final class PortalContributionProviderTest extends TestCase
         foreach ([self::DATA_SUBJECT, self::SIGNER_SUBJECT] as $subject) {
             $manifest = $this->provider->getContribution($subject);
             $this->assertIsArray($manifest);
-            $this->assertSame([], $manifest['actions'], 'Wave-1 ships read collections only');
+            $this->assertSame([], $manifest['actions'], 'No top-level create/endpoint action ships');
             $this->assertSame([], $manifest['notifications'], 'No inbox / notification collections ship');
             foreach ($manifest['collections'] as $collection) {
                 $this->assertArrayNotHasKey('kind', $collection, 'No inbox collections ship');
+                if ($collection['id'] !== 'signerSigningRequests') {
+                    $this->assertArrayNotHasKey(
+                        'rowActions',
+                        $collection,
+                        "Collection '{$collection['id']}' must carry no write action"
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Implements the portion of `portal-signing-surface` that is buildable
standalone: contract-v2.2 `rowActions` (`sign`, `decline`) declared on the
`signerSigningRequests` collection in `lib/Portal/PortalContributionProvider.php`
(REQ-DDPSS-001), each gated `minTrust: substantial`, plus SES/AES-only /
no-QES posture documentation. Pure declarative data — no I/O, no new imports;
the provider stays plain and dependency-free per ADR-046 amendment A1.

## Dependency-state finding (read before merging)

`portal-signing-surface` `depends_on: [portal-contribution, portal-signing-actions, signing-trust-rebuild]`.
Verified at HEAD before implementing:

| Change | State at HEAD |
|---|---|
| `portal-contribution` | **Implemented** (8/8 tasks, `PortalContributionProvider` + its unit tests ship, not yet archived) |
| `portal-signing-actions` | **NOT implemented** — 0/13 tasks checked; no `PortalSigningReceiverController`, `PortalAssertionVerifier`, or route exists in this repo |
| `signing-trust-rebuild` | **NOT implemented** — 0/16 tasks checked; `NativeSigningProvider::produceSignedArtifact()` still writes the pre-fix flat assertion (`mac = HMAC(secret, contentHash)`, covering *no* assertion field, not even the in-app signer's name); `SigningVerificationService::verifyAssertion()` verifies only that flat form |

Because both siblings are spec-only, this PR implements **only** what
`portal-signing-surface` itself specifies and that doesn't require
re-implementing the other changes' scope:

- **Built**: REQ-DDPSS-001 (`sign`/`decline` rowActions on the manifest,
  `minTrust: substantial`, relative endpoints) + its pinning unit tests +
  declarative SES/AES/no-QES posture notes.
- **NOT built, documented as blocked in `tasks.md`**:
  - REQ-DDPSS-002/003 (`signDocument`/`declineDocument` receiver acts) — there
    is no `portal-signing-actions` receiver to extend.
  - REQ-DDPSS-004 (bind portal subject identity into the signature evidence
    MAC) — there is no `v: 2` identity-bound assertion to extend. Adding the
    four portal-identity fields to the *current* flat assertion would not be
    covered by the existing MAC computation at all (it hashes only the
    document content, no assertion field), so doing so would ship fields
    that *look* identity-bound without being cryptographically enforced —
    exactly the forgeable-signer shape (portaliq#3) this requirement exists
    to close. Implementing it responsibly requires `signing-trust-rebuild`'s
    MAC rebuild to land first.
  - REQ-DDPSS-005 (SES/AES-only, no-QES) — partially covered declaratively
    (the rowActions' `minTrust: substantial` gate + docblock posture notes);
    runtime assurance-level recording depends on the unbuilt receiver/MAC.
  - T08/T09 unit tests for the above — nothing exists yet to test.

The endpoints the rowActions name
(`/apps/docudesk/api/portal/signing/{sign,decline}`) match
`portal-signing-actions`'s own design so the manifest and the future
receiver ship in sync; calling them 404s until that change lands.

`openspec/specs/portal-signing-surface/spec.md` is added as an in-progress
stub (mirroring the existing `portal-contribution` precedent) so the new
`@spec` PHPDoc tags reference a canonical path rather than a change
directory, per project convention. **The change is NOT archived** — most of
its own requirements (REQ-DDPSS-002/003/004) remain unimplemented pending
the two sibling changes, so marking it complete would misrepresent status.

## Tasks (tasks.md)

- [x] T02 — rowActions on the manifest
- [x] T07 — unit tests pinning the rowActions
- [x] T10 — quality gates (scoped to what this pass touched)
- [ ] T01, T03, T04, T05, T06 (partial), T08, T09 — blocked, see tasks.md inline notes

## Test plan

- [x] `php -l` on both touched PHP files
- [x] Full PHPUnit unit suite in `nextcloud:34.0.0-apache` container: **939/939 passing**, 0 new failures
- [x] `composer phpcs` (lib/): 0 errors on the touched file (repo-wide: 0 errors, only pre-existing warnings on untouched files)
- [x] `composer phpmd` (lib/): clean
- [x] `composer psalm`: no errors
- [x] `composer phpstan`: no errors
- [x] `openspec validate portal-signing-surface --type change --strict`: valid
- [x] `openspec validate portal-signing-surface --type spec --strict`: valid
- [x] `openspec validate --all --strict`: 3 pre-existing failures unrelated to this change (`beta-surface-alignment`, `document-preview`, `signing-via-or-approval-with-provider-plugins`) — none introduced by this PR