### PR TITLE
spec: document-register (docudesk#217)

### DIFF
--- a/openspec/changes/document-register/.openspec.yaml
+++ b/openspec/changes/document-register/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/document-register/design.md
+++ b/openspec/changes/document-register/design.md
@@ -1,0 +1,101 @@
+# Design: document-register
+
+## Context
+
+DocuDesk owns the document content type for the Conduction fleet (ADR-001,
+ADR-022: content types live in leaf apps; OpenRegister supplies storage and
+abstraction). Its `document` register today holds operational data
+(correspondence audit logs, huisstijl config, batch-job tracking, financial
+extractions) but no first-class governed *document* object. This change adds two
+schemas — `document` and `documentType` — to the existing register envelope in
+`lib/Settings/docudesk_register.json`, with zero PHP code and zero OpenRegister
+change. All runtime behaviour (lifecycle, archival retention, file binding,
+cross-register relations) is delegated to OpenRegister capabilities that already
+exist at OR HEAD.
+
+Verified against OpenRegister HEAD before authoring:
+- `x-openregister-lifecycle` state-machine runtime — consumed for `status`.
+- `x-openregister-archival` / schema `archive` config — consumed for retention.
+- `@self.folder` + File Attachment contract — consumed for the file body.
+- Cross-register `$ref` + `x-external-register` — already used by
+  `correspondence.caseReference`; reused for `relatedCases`.
+- `configuration.objectNameField` — controls list-title rendering.
+
+## Goals / Non-goals
+
+**Goals:** a queryable, governed document object with business metadata,
+classification (informatieobjecttype), confidentiality, retention class, and
+relations to cases/objects; a seeded classification vocabulary aligned to VNG
+ZTC *InformatieObjectType*; idempotent re-import on version bump.
+
+**Non-goals:** UI (deferred to a `document-detail` frontend change); hard
+referential integrity on relations (string-slug references resolved at read
+time, per the `dossier-register` precedent — opis/json-schema rejects internal
+`$ref` at register-import); auto-classification of inbound documents (tracked by
+`inbound-auto-classification`); backfill of existing File-Attachment report data
+into `document` objects (separate change once the schema is live).
+
+## Decisions
+
+### D1 — `document` schema (VNG DRC *EnkelvoudigInformatieObject* aligned)
+
+Fields (schema.org-aligned, Dutch titles per ADR-006):
+`title` (string, required, name field), `identifier` (string, business key),
+`description`, `author`, `language` (ISO 639-1), `format` (MIME), `creationDate`
+/ `receiptDate` / `sendDate` (date), `status` (enum, lifecycle-governed:
+`concept` → `in_bewerking` → `ter_vaststelling` → `definitief` → `gearchiveerd`),
+`confidentiality` (enum VNG vertrouwelijkheidaanduiding:
+`openbaar`|`intern`|`vertrouwelijk`|`geheim`, default `intern`),
+`documentType` (string slug/uuid → `documentType`), `retentionClass` (string →
+selectielijst category), `relatedCases` (array of string, `$ref: "case"` +
+`x-external-register: "procest"`), `relatedObjects` (array of string, free
+slug/uuid). `hardValidation: true`. `x-openregister-lifecycle` on `status`.
+`x-openregister-archival` binding default retention (overridable per object via
+`retentionClass`). `configuration.objectNameField: "title"`.
+
+### D2 — `documentType` schema (VNG ZTC *InformatieObjectType* aligned)
+
+Fields: `name` (required, name field), `description`, `identifier` (unique
+business key), `category`, `retentionPeriod` (ISO-8601 duration, e.g. `P7Y`),
+`selectielijstCategory` (Archiefwet 1995 reference string), `confidentiality`
+(default enum, same domain as D1), `active` (boolean, default true).
+`hardValidation: true`.
+
+### D3 — relations resolved at read time, not enforced at import
+
+`documentType`, `relatedObjects`, `relatedCases` are string references, not
+internal JSON-Schema `$ref` to sibling schemas (which register-import rejects).
+Consumers resolve them via a second object fetch. This matches the
+`dossier-register` D1 precedent and keeps import validation green.
+
+### D4 — idempotent re-import via version bump
+
+Bump `document` register `info.version` in `docudesk_register.json`.
+`SettingsInitializer::initialize()` → `ConfigurationService::importFromApp()`
+re-imports on upgrade; seed objects upsert by slug. No DB migration.
+
+### D5 — seed data (ADR-016)
+
+Seed `documentType` with a canonical Dutch-gov starter set (e.g. `brief`,
+`besluit`, `rapport`, `factuur`, `contract`, `notulen`, `beleidsstuk`), each
+with a realistic `retentionPeriod` + placeholder `selectielijstCategory`
+(`TODO-*` during authoring, replaced before apply — records-appraisal
+sign-off, same posture as `archiefwet-retention-engine` task 1.4). Seed 3–5
+`document` objects referencing them.
+
+## Risks / Trade-offs
+
+- **Retention placeholders**: `selectielijstCategory` codes are records-management
+  master data; authoring uses `TODO-*` and an apply-blocker task requires real
+  VNG codes before done (a seed-lint PHPUnit test fails on any `TODO-`).
+- **Import drops `archive`/lifecycle keys**: pinned by an import-roundtrip unit
+  test; if a key is dropped, file an OpenRegister issue (degradation is OR-side
+  schema config, never a DocuDesk-side code workaround).
+- **Relation integrity is soft**: acceptable for v1; hard FK is an explicit
+  non-goal and a possible OR-core follow-up.
+
+## Migration / Rollout
+
+Additive. On upgrade the register re-imports; existing operational schemas
+(`correspondence` etc.) are untouched. Downstream apps (Procest, OpenCatalogi)
+gain a document object to relate to; nothing they depend on changes.

--- a/openspec/changes/document-register/proposal.md
+++ b/openspec/changes/document-register/proposal.md
@@ -1,0 +1,131 @@
+## Why
+
+DocuDesk owns the "document" domain across the Conduction fleet, yet a document
+today is only ever a **file plus derived analysis** — an OpenRegister File
+Attachment enriched with `x-openregister-calculations` (risk score, OCR
+confidence, anonymisation coverage). The `document` register (title "Document
+Register") holds correspondence audit logs, huisstijl config, batch-job
+tracking, financial extractions and GL bookings — but **no first-class,
+governed document object**. There is nowhere to record a document's business
+identifier, its classification (informatieobjecttype), its confidentiality
+level, its retention class, or its relations to the cases and objects it
+belongs to. Consumers who want "attach this document to that case/object", "list
+all documents of type X", or "which documents fall under selectielijst category
+3.2" have no queryable object to hit.
+
+Demand for exactly this is the strongest signal in the intelligence-db tender
+corpus (research-A5 of the 2026-07-23 OpenRegister market-gap synthesis, W6
+row): the top recurring themes are **document-type management**
+(informatieobjecttype), **attach-document-to-object**, **classification**, and
+**retention**. Per the fleet rule that *content types live in leaf apps while
+OpenRegister provides storage and abstraction* (ADR-001, ADR-022), the document
+content type belongs in DocuDesk, not in OpenRegister core.
+
+## What Changes
+
+Add two schemas to DocuDesk's existing `document` register in
+`lib/Settings/docudesk_register.json`, making documents first-class governed
+objects:
+
+- A **`document`** schema — the governed document object (VNG ZGW/DRC
+  *EnkelvoudigInformatieObject* equivalent). Carries business metadata
+  (`title`, `identifier`, `description`, `author`, `language`, `format`,
+  key dates), a lifecycle-governed `status` (concept → in review → definitive →
+  archived), a `confidentiality` level (VNG *vertrouwelijkheidaanduiding*:
+  openbaar / intern / vertrouwelijk / geheim), a `documentType` classification
+  reference, `relatedCases` / `relatedObjects` relations, and a
+  `retentionClass` that binds it to an archival category.
+- A **`documentType`** schema — the classification vocabulary (VNG ZTC
+  *InformatieObjectType* equivalent). Carries `name`, `description`,
+  `identifier`, `category`, a default `retentionPeriod` (ISO-8601 duration,
+  e.g. `P7Y`), a `selectielijstCategory` (Archiefwet 1995 reference), a default
+  `confidentiality`, and an `active` flag. Seeded with a canonical set of Dutch
+  government document types.
+
+Additional mechanics:
+
+- The `document` schema declares `hardValidation: true`, an
+  `x-openregister-lifecycle` on `status`, an `x-openregister-archival`
+  annotation for the default retention, and `configuration.objectNameField:
+  "title"` so list UIs render the document title.
+- File binding uses OpenRegister's native `@self.folder` / file-attachment
+  contract — no new DocuDesk endpoint. Attaching a document to a case/object is
+  done through `relatedCases` / `relatedObjects` slug/UUID arrays plus the
+  `$ref` cross-register convention already used by `correspondence.caseReference`
+  (`$ref: "case"`, `x-external-register: "procest"`).
+- The register `info.version` is bumped so `SettingsInitializer::initialize()`
+  re-imports the config idempotently via `ConfigurationService::importFromApp()`
+  on upgrade.
+- `documentType` is seeded with a canonical starter set per ADR-016 (mandatory
+  seed data), and a handful of realistic `document` objects reference them.
+
+Not in scope (deliberate follow-ups):
+
+- UI for a document list / detail surface (deferred to a `document-detail`
+  frontend change — data model only here).
+- Hard referential integrity on `documentType` / `relatedObjects` — string-slug
+  references resolved at read time, per the `dossier-register` D1 precedent
+  (opis/json-schema rejects internal `$ref` at register-import time).
+- Auto-classification of inbound documents (already tracked by
+  `inbound-auto-classification`).
+- Migration of existing File-Attachment-based report data into `document`
+  objects — a separate backfill change once the schema is live.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `document-register`: the existing capability (correspondence, huisstijl,
+  batchCorrespondenceJob audit-log data model) gains new requirements defining
+  the first-class `document` object and the `documentType` classification
+  vocabulary, their lifecycle / retention / confidentiality annotations, the
+  relation model to cases and objects, and the register version bump. All new
+  requirements are **ADDED**; no existing requirement changes.
+
+### New Capabilities
+
+None. The document register already exists as a capability; this change extends
+it rather than creating a parallel one.
+
+## Impact
+
+**Affected code (DocuDesk):**
+
+- `lib/Settings/docudesk_register.json` — add `document` and `documentType`
+  under `components.schemas`; add both slugs to the `document` register's
+  `schemas` array; add seed objects under `components.objects`; bump
+  `info.version`.
+- No PHP code change. All CRUD flows through OpenRegister's generic
+  `/api/objects/{register}` routes and `ObjectEntityService`; DocuDesk does not
+  add a `DocumentService`.
+
+**Affected code (OpenRegister):** None. The `@self.folder` file binding, the
+lifecycle runtime (`x-openregister-lifecycle`), the archival runtime
+(`x-openregister-archival`), and the cross-register `$ref` convention all
+already exist and are consumed here — not modified.
+
+**Affected downstream apps:** Additive only. Procest (cases), OpenCatalogi
+(publication) and other consumers gain a queryable `document` object to relate
+to; nothing they depend on today changes.
+
+**APIs / dependencies:** New endpoints surface automatically via OpenRegister's
+generic object routes — `POST /api/objects/document`,
+`GET /api/objects/documentType`, etc. No new OCS controllers.
+
+**Data / migrations:** DocuDesk's `SettingsInitializer` / repair step re-imports
+the register on the version bump; seed objects are upserted. No database
+migration — everything lives in OpenRegister's `object` table.
+
+**Architectural alignment:**
+
+- ADR-001 / ADR-022: content type in the leaf app (DocuDesk); OpenRegister
+  supplies storage and abstraction only.
+- ADR-006 (Schema Standards): schema.org-aligned vocabulary, explicit types,
+  OpenAPI 3.0.0 shape, Dutch property titles.
+- ADR-013 (Loadable Register Templates): schemas + seed data ship in the
+  `docudesk_register.json` envelope.
+- ADR-016 (Mandatory Seed Data): `documentType` seeded with canonical types;
+  realistic `document` seeds reference them.
+- ADR-031 (Schema-declarative logic): status is governed by
+  `x-openregister-lifecycle`, retention by `x-openregister-archival` — not by
+  ad-hoc service writes.

--- a/openspec/changes/document-register/specs/document-register/spec.md
+++ b/openspec/changes/document-register/specs/document-register/spec.md
@@ -1,0 +1,136 @@
+# document-register Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose delta
+
+The document register gains a first-class, governed **document** object and a
+**documentType** classification vocabulary, so that documents become queryable
+OpenRegister objects with business metadata, lifecycle-governed status,
+confidentiality, archival retention, and relations to cases and objects — built
+entirely on OpenRegister capabilities that already exist at OR HEAD (lifecycle
+runtime, archival annotation, `@self.folder` file binding, cross-register
+`$ref`). DocuDesk ships schemas + seed data only: no PHP code, no OpenRegister
+change, no database migration.
+
+## ADDED Requirements
+
+### Requirement: Governed document object schema (REQ-DREG-D01)
+
+The document register MUST declare a `document` schema in
+`lib/Settings/docudesk_register.json` under `components.schemas`, aligned to the
+VNG DRC *EnkelvoudigInformatieObject*, with `hardValidation: true` and
+`configuration.objectNameField: "title"`.
+
+The schema MUST carry business metadata (`title` required, `identifier`,
+`description`, `author`, `language`, `format`, `creationDate`, `receiptDate`,
+`sendDate`), a `status` property governed by an `x-openregister-lifecycle`
+state machine over the states `concept` → `in_bewerking` → `ter_vaststelling`
+→ `definitief` → `gearchiveerd`, a `confidentiality` enum
+(`openbaar`|`intern`|`vertrouwelijk`|`geheim`, default `intern`), a
+`documentType` reference, a `retentionClass` reference, and relation arrays
+`relatedCases` (`$ref: "case"`, `x-external-register: "procest"`) and
+`relatedObjects`.
+
+The schema MUST declare an `x-openregister-archival` annotation providing a
+default retention that is overridable per object via `retentionClass`.
+
+The document body MUST bind through OpenRegister's native `@self.folder` /
+File Attachment contract; the change MUST NOT add a DocuDesk document upload
+endpoint.
+
+#### Scenario: Create and govern a document
+
+- **GIVEN** the document register is imported with the `document` schema
+- **WHEN** a client POSTs a document to `/api/objects/document` with `title`,
+  `documentType` and `confidentiality`
+- **THEN** the object is created with `status` at the lifecycle initial state
+  and its name renders as `title`
+- **AND** transitioning `status` follows the `x-openregister-lifecycle`
+  machine (illegal transitions are rejected)
+- **AND** an `x-openregister-archival` retention is stamped at creation.
+
+### Requirement: Document type classification vocabulary (REQ-DREG-D02)
+
+The document register MUST declare a `documentType` schema in
+`docudesk_register.json` under `components.schemas`, aligned to the VNG ZTC
+*InformatieObjectType*, with `hardValidation: true`. It MUST carry `name`
+(required, name field), `description`, `identifier` (unique business key),
+`category`, `retentionPeriod` (ISO-8601 duration), `selectielijstCategory`
+(Archiefwet 1995 reference), a default `confidentiality`, and an `active`
+boolean (default true).
+
+A `document.documentType` value MUST reference a `documentType` object by slug
+or UUID; the reference is resolved at read time and is NOT enforced by an
+internal JSON-Schema `$ref` at register-import.
+
+#### Scenario: Classify a document by type
+
+- **GIVEN** a seeded `documentType` `besluit` with `retentionPeriod: P7Y`
+- **WHEN** a `document` is created with `documentType: "besluit"`
+- **THEN** the reference resolves on read to the `besluit` type object
+- **AND** the type's `retentionPeriod` and `selectielijstCategory` are
+  available to consumers for retention decisions.
+
+### Requirement: Seeded canonical document types and sample documents (REQ-DREG-D03)
+
+The document register MUST seed, under `components.objects`, a canonical Dutch
+government `documentType` starter set (at minimum `brief`, `besluit`, `rapport`,
+`factuur`, `contract`, `notulen`, `beleidsstuk`), each with a realistic
+`retentionPeriod`, and 3–5 realistic `document` objects that reference the
+seeded types with distinct `status` and `confidentiality` values.
+
+#### Scenario: Seed data present after import
+
+- **GIVEN** a clean DocuDesk install or an upgrade
+- **WHEN** `SettingsInitializer::initialize()` imports the register
+- **THEN** the canonical `documentType` set and the sample `document` objects
+  exist and are queryable via the generic object routes.
+
+### Requirement: Selectielijst placeholders resolved before production (REQ-DREG-D04)
+
+Any `selectielijstCategory` seeded as a `TODO-*` placeholder MUST be replaced
+with a real VNG selectielijst category (records-appraisal sign-off) before the
+change is applied/done. A seed-lint unit test MUST FAIL while any `TODO-`
+category remains.
+
+#### Scenario: Gate blocks placeholder categories
+
+- **GIVEN** a seeded `documentType` still carries `selectielijstCategory:
+  "TODO-brief"`
+- **WHEN** the seed-lint test runs
+- **THEN** it fails, blocking apply/done until real categories are supplied.
+
+### Requirement: Idempotent register re-import on version bump (REQ-DREG-D05)
+
+Adding the two schemas MUST include a bump of the `document` register's
+`info.version` so `ConfigurationService::importFromApp()` re-imports the
+configuration idempotently on upgrade. An import-roundtrip test MUST pin that
+the imported `document` schema retains `hardValidation`, its
+`x-openregister-lifecycle` block, its `x-openregister-archival` block, and
+`configuration.objectNameField`. If the import path drops any key, an
+OpenRegister issue MUST be filed rather than a DocuDesk-side workaround added.
+
+#### Scenario: Upgrade re-imports without duplication
+
+- **GIVEN** an existing install with the pre-change register
+- **WHEN** the app upgrades to the bumped `info.version`
+- **THEN** the two new schemas and their seeds are imported once (upsert by
+  slug), with lifecycle/archival/config keys intact and no duplicate objects.
+
+### Requirement: Documents relate to cases and objects (REQ-DREG-D06)
+
+The `document` schema MUST support relating a document to one or more cases
+(`relatedCases`) and arbitrary objects (`relatedObjects`) via string slug/UUID
+arrays, enabling "attach this document to that case/object" and "list all
+documents of type X" queries through OpenRegister's generic object search
+without a bespoke DocuDesk endpoint.
+
+#### Scenario: Attach a document to a case
+
+- **GIVEN** a `document` object and a Procest `case`
+- **WHEN** the document's `relatedCases` includes the case slug/UUID
+- **THEN** a consumer can query documents by related case and resolve the
+  reference at read time.

--- a/openspec/changes/document-register/tasks.md
+++ b/openspec/changes/document-register/tasks.md
@@ -1,0 +1,43 @@
+# Tasks: document-register
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 10.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Schemas + register wiring
+
+- [ ] 1.1 Add the `document` schema to `lib/Settings/docudesk_register.json` under `components.schemas` (REQ-DREG-D01)
+  - Field contracts exactly per design.md D1; `hardValidation: true`; `x-openregister-lifecycle` on `status` with the five-state machine; `x-openregister-archival` default retention; `configuration.objectNameField: "title"`; `relatedCases` uses `$ref: "case"` + `x-external-register: "procest"`.
+  - Drift-pin: verify every lifecycle/archival key against OpenRegister HEAD, not against this spec snapshot.
+
+- [ ] 1.2 Add the `documentType` schema to `docudesk_register.json` under `components.schemas` (REQ-DREG-D02)
+  - Field contracts exactly per design.md D2; `hardValidation: true`; `identifier` unique.
+
+- [ ] 1.3 Add both slugs (`document`, `documentType`) to the `document` register's `schemas` array and bump `info.version` (REQ-DREG-D05)
+  - The version bump drives idempotent re-import via `SettingsInitializer::initialize()` → `ConfigurationService::importFromApp()`.
+
+## 2. Seed data (ADR-016)
+
+- [ ] 2.1 Seed the canonical `documentType` starter set under `components.objects` (REQ-DREG-D03)
+  - `brief`, `besluit`, `rapport`, `factuur`, `contract`, `notulen`, `beleidsstuk` (minimum); each with realistic `retentionPeriod` + placeholder `selectielijstCategory`.
+
+- [ ] 2.2 Seed 3–5 realistic `document` objects referencing the seeded types (REQ-DREG-D03)
+  - Distinct `status`, `confidentiality`, and `documentType` values; at least one with a `relatedCases`/`relatedObjects` reference.
+
+- [ ] 2.3 APPLY-BLOCKER — replace every `TODO-*` `selectielijstCategory` placeholder with a real VNG selectielijst category before apply/done (REQ-DREG-D04)
+  - Add a PHPUnit seed-lint test that FAILS on any `TODO-` category so the gate enforces it (production-enablement gate).
+
+## 3. Verification
+
+- [ ] 3.1 Import-roundtrip unit test: `document` + `documentType` import via `ConfigurationService::importFromApp()` and the imported schemas expose `hardValidation`, the `x-openregister-lifecycle` block, the `x-openregister-archival` block, and `configuration.objectNameField` intact (REQ-DREG-D01, REQ-DREG-D05)
+  - If any key is dropped on import, file an OpenRegister issue; do not add a DocuDesk-side workaround.
+
+- [ ] 3.2 Register-validity test: the full `docudesk_register.json` still validates and imports cleanly with the two new schemas + seeds present (REQ-DREG-D05)
+  - Run in the `nextcloud:34` container (host PHP too old): `docker run --rm -v $PWD:/app -w /app <nc-image> php vendor/bin/phpunit`.
+
+- [ ] 3.3 Lifecycle/relation smoke: create a `document` via the generic `/api/objects/document` route, transition `status` through the lifecycle, and resolve a `documentType` + `relatedObjects` reference (REQ-DREG-D01, REQ-DREG-D06)
+
+Acceptance criteria:
+- A governed `document` object exists as an OpenRegister object, queryable via generic object routes, with no new DocuDesk PHP controller or service.
+- `documentType` classification vocabulary is seeded and referenceable.
+- `status` is lifecycle-governed and retention is archival-annotation-driven — no ad-hoc service writes.
+- No OpenRegister-core change; no database migration.


### PR DESCRIPTION
OpenSpec change adding a first-class governed **document** object and a **documentType** classification vocabulary to DocuDesk's existing `document` register, as docudesk-owned OpenRegister schemas.

Part of the OpenRegister market-gap wave (2026-07-23). Records/document management is the single strongest demand signal in the tender corpus (informatieobjecttype management, attach-document-to-object, classification, retention). Per the fleet leaf rule, the document content type belongs in DocuDesk while OpenRegister supplies storage and abstraction (ADR-001/022).

**Scope:** data model only — two schemas + seed data in `docudesk_register.json`, zero PHP, zero OpenRegister change.
- `document` — VNG DRC EnkelvoudigInformatieObject aligned; lifecycle-governed `status`, `confidentiality`, `documentType`/`retentionClass` refs, `relatedCases`/`relatedObjects`, `x-openregister-archival` retention, `@self.folder` file binding.
- `documentType` — VNG ZTC InformatieObjectType aligned; seeded canonical Dutch-gov types.

Deferred: UI (document-detail), hard relation FKs, auto-classification, backfill. Closes #217.