### PR TITLE
fix(policy,i18n): orphaned-surface-restoration verify findings

### DIFF
--- a/l10n/en.json
+++ b/l10n/en.json
@@ -474,7 +474,7 @@
         "Batch (multiple recipients)": "Batch (multiple recipients)",
         "Batch job status": "Batch job status",
         "Bold": "Bold",
-        "Brieven & correspondentie": "Brieven & correspondentie",
+        "Letters & correspondence": "Letters & correspondence",
         "Case reference": "Case reference",
         "Category filter": "Category filter",
         "Change note": "Change note",

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -1,6 +1,7 @@
 OC.L10N.register(
 	"docudesk",
 	{
+		"Letters & correspondence": "Brieven & correspondentie",
 		"Add publish-always rule": "Altijd-publiceren-regel toevoegen",
 		"Add publish-never rule": "Nooit-publiceren-regel toevoegen",
 		"Edit publish-always rule": "Altijd-publiceren-regel bewerken",

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -1,5 +1,6 @@
 {
     "translations": {
+        "Letters & correspondence": "Brieven & correspondentie",
         "Add publish-always rule": "Altijd-publiceren-regel toevoegen",
         "Add publish-never rule": "Nooit-publiceren-regel toevoegen",
         "Edit publish-always rule": "Altijd-publiceren-regel bewerken",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -49,7 +49,7 @@
 		},
 		{
 			"id": "Correspondence",
-			"label": "Brieven & correspondentie",
+			"label": "Letters & correspondence",
 			"icon": "icon-mail",
 			"route": "Correspondence",
 			"order": 55
@@ -185,7 +185,7 @@
 			"id": "Correspondence",
 			"route": "/correspondence",
 			"type": "custom",
-			"title": "Brieven & correspondentie",
+			"title": "Letters & correspondence",
 			"component": "CorrespondenceIndex",
 			"_note": "Letter/correspondence generation from templates with merge data (single or batch), via correspondenceStore + CorrespondenceController (generate/generateBatch/jobStatus). Hybrid data path; type:custom preserves it. Restored reachability — openspec/changes/orphaned-surface-restoration (REQ-DDOSR-003); the component and backend already existed, only the manifest/registry/menu wiring was missing."
 		},

--- a/src/views/correspondence/CorrespondenceIndex.vue
+++ b/src/views/correspondence/CorrespondenceIndex.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: EUPL-1.2
 <template>
 	<div class="correspondence-index">
 		<div class="correspondence-index__header">
-			<h2>{{ t('docudesk', 'Brieven & correspondentie') }}</h2>
+			<h2>{{ t('docudesk', 'Letters & correspondence') }}</h2>
 			<p class="correspondence-index__subtitle">
 				{{ t('docudesk', 'Generate letters and correspondence from templates with merge data.') }}
 			</p>

--- a/src/views/policy/StandingConsentIndex.vue
+++ b/src/views/policy/StandingConsentIndex.vue
@@ -217,12 +217,23 @@ export default {
 			}
 			return rules.map(r => `${r.type}:${r.value}`).join(', ')
 		},
+		/**
+		 * Open the extracted standing-consent modal in create mode.
+		 *
+		 * @spec openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#requirement-policy-surfaces-are-reachable-menu-ownership-deferred-req-ddosr-005
+		 */
 		openCreateDialog() {
 			this.editing = null
 			this.editingRecord = null
 			this.formError = ''
 			this.dialogOpen = true
 		},
+		/**
+		 * Open the extracted standing-consent modal in edit mode for a row.
+		 *
+		 * @param {object} row The standing-consent object to edit.
+		 * @spec openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#requirement-policy-surfaces-are-reachable-menu-ownership-deferred-req-ddosr-005
+		 */
 		openEditDialog(row) {
 			this.editing = row['@self']?.id || row.id || row.uuid
 			this.editingRecord = {
@@ -245,6 +256,12 @@ export default {
 			this.formError = ''
 			this.dialogOpen = true
 		},
+		/**
+		 * Persist the modal form via the standing-consent store (create or update).
+		 *
+		 * @param {object} formData The submitted standing-consent form payload.
+		 * @spec openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#requirement-policy-surfaces-are-reachable-menu-ownership-deferred-req-ddosr-005
+		 */
 		async onModalSubmit(formData) {
 			this.saving = true
 			this.formError = ''

--- a/tests/e2e/spec-coverage/orphaned-surface-restoration.spec.ts
+++ b/tests/e2e/spec-coverage/orphaned-surface-restoration.spec.ts
@@ -34,9 +34,9 @@ test.describe('orphaned-surface-restoration — correspondence', () => {
 		// @e2e openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#scenario-correspondence-opens-from-the-menu
 		const guard = attachConsoleGuard(page)
 		await go(page, '')
-		await navClick(page, 'Brieven & correspondentie')
+		await navClick(page, 'Letters & correspondence')
 		await expect(page).toHaveURL(/\/apps\/docudesk\/correspondence/)
-		await expect(page.getByRole('heading', { name: 'Brieven & correspondentie' })).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Letters & correspondence' })).toBeVisible()
 
 		expect(guard.errors, `console errors: ${guard.errors.join(' | ')}`).toEqual([])
 		expect(guard.server5xx, `5xx: ${guard.server5xx.join(' | ')}`).toEqual([])
@@ -45,7 +45,7 @@ test.describe('orphaned-surface-restoration — correspondence', () => {
 	test('Correspondence deep-links directly', async ({ page }) => {
 		await go(page, 'correspondence')
 		await expect(page).toHaveURL(/\/apps\/docudesk\/correspondence/)
-		await expect(page.getByRole('heading', { name: 'Brieven & correspondentie' })).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Letters & correspondence' })).toBeVisible()
 		// Real field from CorrespondenceIndex.vue — proves the component
 		// (not a manifest-empty-state fallback) actually rendered.
 		await expect(page.getByText('Template ID')).toBeVisible()


### PR DESCRIPTION
Addresses the two blocking findings from the opsx-verify pass on #321: English i18n source key for the Correspondence label, and `@spec` tags on the three StandingConsentIndex modal methods. Local: vitest 35/35, manifest Ajv PASS, l10n OK, eslint clean, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)