### PR TITLE
fix(documents): listRefs must use searchObjectsPaginated, not searchObjectsBySlug

### DIFF
--- a/lib/Service/ListReferenceResolver.php
+++ b/lib/Service/ListReferenceResolver.php
@@ -386,20 +386,29 @@ class ListReferenceResolver
     }//end slugToIdentifier()
 
     /**
-     * Resolve a single listRef against OpenRegister's slug-aware search.
+     * Resolve a single listRef against OpenRegister's paginated search.
      *
-     * Uses {@see \OCA\OpenRegister\Service\ObjectService::searchObjectsBySlug()}
-     * so register/schema slugs (including external DBAL-backed registers,
-     * e.g. 'spectr-live') resolve the same way the rest of the fleet's
-     * slug-aware callers do. Filter keys are passed through as top-level
-     * query keys; 'limit' becomes '_limit' and 'order' becomes '_order'.
+     * Uses `setRegister()`/`setSchema()` (both slug-aware) to put the
+     * ObjectService instance into register/schema context, then
+     * {@see \OCA\OpenRegister\Service\ObjectService::searchObjectsPaginated()}
+     * — the SAME method + context pattern OpenRegister's own
+     * `ObjectsController::index()` uses. This matters: the sibling
+     * `searchObjects()`/`searchObjectsBySlug()` path never consults a
+     * schema's `x-openregister-object-source` and silently returns nothing
+     * for schemas backed by an external DBAL register (e.g. `spectr-live`)
+     * — only `searchObjectsPaginated()` checks `$this->currentSchema`
+     * (set by `setSchema()`) and delegates to the object-source provider
+     * when one is configured. `setRegister()`/`setSchema()` in turn
+     * auto-inject the resolved numeric `_register`/`_schema` into the
+     * query, so `filter` stays plain top-level keys.
      *
      * @param array $ref The listRef, already validated by {@see validateListReference()}
      *
      * @return array The resolved objects, each serialized via jsonSerialize()
      *               where available
      *
-     * @throws Exception If the OpenRegister search fails (e.g. unknown slug)
+     * @throws Exception If the register/schema slug does not resolve, or the
+     *                    OpenRegister search fails
      *
      * @spec openspec/changes/document-generation-list-refs/specs/document-creatie-sjablonen/spec.md
      */
@@ -421,11 +430,10 @@ class ListReferenceResolver
         }
 
         try {
-            $result = $objectService->searchObjectsBySlug(
-                registerSlug: (string) $ref['register'],
-                schemaSlug: (string) $ref['schema'],
-                filters: $query
-            );
+            $objectService->setRegister(register: (string) $ref['register']);
+            $objectService->setSchema(schema: (string) $ref['schema']);
+
+            $result = $objectService->searchObjectsPaginated(query: $query);
         } catch (Exception $e) {
             throw new Exception(
                 message: "List resolution failed for register={$ref['register']}, "
@@ -433,14 +441,10 @@ class ListReferenceResolver
             );
         }
 
-        if (is_array($result) === false) {
-            // SearchObjectsBySlug() only returns a plain int for _count
-            // queries, which listRefs never issue.
-            return [];
-        }
+        $rows = $result['results'] ?? [];
 
         $items = [];
-        foreach ($result as $item) {
+        foreach ($rows as $item) {
             if (is_object($item) === true
                 && method_exists(object_or_class: $item, method: 'jsonSerialize') === true
             ) {

--- a/openspec/changes/document-generation-list-refs/proposal.md
+++ b/openspec/changes/document-generation-list-refs/proposal.md
@@ -18,12 +18,20 @@ server-side resolution (no audit trail of what was queried, no reuse of
 OpenRegister's filtering/sorting, and the caller needs read access to the
 raw register itself).
 
-OpenRegister's `ObjectService::searchObjectsBySlug()` already resolves
-register/schema slugs and delegates to `searchObjects()` on the standard
-search path — including external DBAL-backed virtual registers (e.g. a
-`spectr-live` register backed by an external Postgres table), which became
-searchable through this exact path as of openregister#2043. So the resolver
-data is a single new method away; the data source is already there.
+OpenRegister's `ObjectService::searchObjectsPaginated()` — the same method
++ `setRegister()`/`setSchema()` context pattern `ObjectsController::index()`
+itself uses — already resolves register/schema slugs (both setters accept
+slug strings) and, when the resolved schema declares an
+`x-openregister-object-source`, delegates live to that provider instead of
+the magic table/generic storage. External DBAL-backed virtual registers
+(e.g. a `spectr-live` register backed by an external Postgres table) are
+searchable through this exact path. (Note: the sibling
+`searchObjects()`/`searchObjectsBySlug()` methods do NOT check for an
+object-source — they only ever read the magic table / generic object
+storage, so they silently return nothing for a DBAL-backed schema; verified
+live against `spectr-live` during implementation, see design note below.)
+So the resolver data is a couple of method calls away; the data source is
+already there.
 
 Priority **should-have**.
 
@@ -83,3 +91,25 @@ Priority **should-have**.
   already passed through opaquely).
 - No register/schema/manifest changes; no new routes (existing
   generate/preview routes gain a new optional request field).
+
+## Design note: searchObjectsBySlug() vs. searchObjectsPaginated()
+
+The first implementation of `ListReferenceResolver::resolveList()` used
+`ObjectService::searchObjectsBySlug()` (a slug-aware wrapper the task
+guidance suggested). Live verification against the real `spectr-live`
+register (`app_id`-filterable `competitors` schema) returned an empty array
+every time, with no error. Tracing `searchObjectsBySlug()` →
+`searchObjects()` → `QueryHandler::searchObjects()` showed this path never
+consults `Schema::getObjectSource()` — it only reads the magic table or
+generic object storage, both empty for a purely-external DBAL-backed
+schema. Only `ObjectService::searchObjectsPaginated()` checks
+`$this->currentSchema` (set via `setRegister()`/`setSchema()`, both of
+which accept slug strings directly) and delegates to the object-source
+provider via `paginateObjectSource()` when one is configured — the exact
+mechanism `ObjectsController::index()` itself uses for the real
+`GET /apps/openregister/api/objects/{register}/{schema}` endpoint. Fixed to
+use `setRegister()`/`setSchema()` + `searchObjectsPaginated()`; re-verified
+live with real rows returned. `tests/stubs/OpenRegisterStubs.php` (the
+PHPUnit-mocking stand-in for `OCA\OpenRegister\Service\ObjectService`)
+gained `setRegister()`/`setSchema()`/`getRegister()`/`getSchema()` stubs
+to make this mockable.

--- a/openspec/changes/document-generation-list-refs/specs/document-creatie-sjablonen/spec.md
+++ b/openspec/changes/document-generation-list-refs/specs/document-creatie-sjablonen/spec.md
@@ -21,17 +21,22 @@ ADDs.
 
 `DataResolverService::resolve()` MUST accept an optional `listRefs`
 parameter: an array of `{register, schema, filter?, limit?, order?, as?}`
-entries. Each entry MUST resolve, via
-`OCA\OpenRegister\Service\ObjectService::searchObjectsBySlug()`, to an array
-of the matching objects (each serialized via `jsonSerialize()` where
-available), placed in the merged data context under the key `as`. When `as`
-is omitted it MUST default to the schema slug converted to a legal Twig
-identifier (every character outside `[a-zA-Z0-9_]` replaced with `_`, a
-leading digit prefixed with `_`) with `_list` appended — e.g. schema
-`v-app-competitors` defaults to `v_app_competitors_list`. `filter` entries
-(if present) MUST be passed through as top-level search filter keys;
-`limit` MUST be forwarded as the search's `_limit`; `order` (if an array)
-MUST be forwarded as `_order`.
+entries. Each entry MUST resolve via
+`OCA\OpenRegister\Service\ObjectService::setRegister()` /
+`::setSchema()` (both slug-aware) followed by `::searchObjectsPaginated()`
+— the register/schema-context pattern that also reaches a schema's
+`x-openregister-object-source` provider when one is configured (unlike
+the sibling `searchObjects()`/`searchObjectsBySlug()` methods, which never
+consult the object-source and return nothing for a DBAL-backed schema) —
+to an array of the matching objects (each serialized via `jsonSerialize()`
+where available), placed in the merged data context under the key `as`.
+When `as` is omitted it MUST default to the schema slug converted to a
+legal Twig identifier (every character outside `[a-zA-Z0-9_]` replaced
+with `_`, a leading digit prefixed with `_`) with `_list` appended — e.g.
+schema `v-app-competitors` defaults to `v_app_competitors_list`. `filter`
+entries (if present) MUST be passed through as top-level search filter
+keys; `limit` MUST be forwarded as the search's `_limit`; `order` (if an
+array) MUST be forwarded as `_order`.
 
 #### Scenario: Resolve a DBAL-backed collection with an explicit `as` key
 

--- a/openspec/changes/document-generation-list-refs/tasks.md
+++ b/openspec/changes/document-generation-list-refs/tasks.md
@@ -2,7 +2,9 @@
 
 ## 1. Backend
 
-- [x] 1.1 New `lib/Service/ListReferenceResolver.php`: validates + resolves `listRefs` entries against `OCA\OpenRegister\Service\ObjectService::searchObjectsBySlug()` — guardrails (max 10 entries, scalar-only filter values, limit 1-500, `as` pattern + collision check, all fail-fast before any search runs), default `as` = sanitised schema slug + `_list`, per-item search failures collected as soft errors (REQ-DDLR-001, REQ-DDLR-003)
+- [x] 1.1 New `lib/Service/ListReferenceResolver.php`: validates + resolves `listRefs` entries against `OCA\OpenRegister\Service\ObjectService::setRegister()`/`::setSchema()` + `::searchObjectsPaginated()` (the object-source-aware path — `searchObjectsBySlug()` was tried first, live-verification against `spectr-live` caught that it never reaches a DBAL-backed schema's provider, see proposal.md design note) — guardrails (max 10 entries, scalar-only filter values, limit 1-500, `as` pattern + collision check, all fail-fast before any search runs), default `as` = sanitised schema slug + `_list`, per-item search failures collected as soft errors (REQ-DDLR-001, REQ-DDLR-003)
+
+- [x] 1.1a `tests/stubs/OpenRegisterStubs.php`: add `setRegister()`/`setSchema()`/`getRegister()`/`getSchema()` to the `ObjectService` PHPUnit-mocking stub (were missing — `createMock(ObjectService::class)` could not configure them)
 
 - [x] 1.2 `DataResolverService::resolve()`: new optional `listRefs` parameter, resolved after `dataRefs` and before `adHocData` via `ListReferenceResolver` (lazily constructed, no constructor-injection churn); existing named-argument call sites (`CorrespondenceService`, `DocumentService`) unaffected by the additive parameter (REQ-DDLR-002)
 

--- a/tests/stubs/OpenRegisterStubs.php
+++ b/tests/stubs/OpenRegisterStubs.php
@@ -179,6 +179,60 @@ class ObjectService
         return [];
 
     }//end searchObjectsBySlug()
+
+    /**
+     * Set the current register context.
+     *
+     * Loosely typed (vs. the real `Register|string|int`) so the stub does
+     * not need to know about OpenRegister's `Register` entity class.
+     *
+     * @param mixed $register Register slug/ID, or a Register-shaped object
+     *
+     * @return static
+     */
+    public function setRegister($register)
+    {
+        return $this;
+
+    }//end setRegister()
+
+    /**
+     * Set the current schema context.
+     *
+     * Loosely typed (vs. the real `Schema|string|int`) so the stub does not
+     * need to know about OpenRegister's `Schema` entity class.
+     *
+     * @param mixed $schema Schema slug/ID, or a Schema-shaped object
+     *
+     * @return static
+     */
+    public function setSchema($schema)
+    {
+        return $this;
+
+    }//end setSchema()
+
+    /**
+     * Get the current register context's resolved numeric ID.
+     *
+     * @return int|null
+     */
+    public function getRegister()
+    {
+        return null;
+
+    }//end getRegister()
+
+    /**
+     * Get the current schema context's resolved numeric ID.
+     *
+     * @return int|null
+     */
+    public function getSchema()
+    {
+        return null;
+
+    }//end getSchema()
 }//end class
 
 /**

--- a/tests/unit/Service/DataResolverServiceTest.php
+++ b/tests/unit/Service/DataResolverServiceTest.php
@@ -268,8 +268,8 @@ class DataResolverServiceTest extends TestCase
 
         $competitor = $this->createMock(ObjectEntity::class);
         $competitor->method('jsonSerialize')->willReturn(['id' => 'c-1', 'name' => 'Acme']);
-        $this->objectService->method('searchObjectsBySlug')
-            ->willReturn([$competitor]);
+        $this->objectService->method('searchObjectsPaginated')
+            ->willReturn(['results' => [$competitor], 'total' => 1]);
 
         $result = $this->service->resolve(
             dataRefs: [
@@ -302,8 +302,8 @@ class DataResolverServiceTest extends TestCase
      */
     public function testAdHocDataOverridesListRef(): void
     {
-        $this->objectService->method('searchObjectsBySlug')
-            ->willReturn([]);
+        $this->objectService->method('searchObjectsPaginated')
+            ->willReturn(['results' => [], 'total' => 0]);
 
         $result = $this->service->resolve(
             dataRefs: [],
@@ -359,7 +359,7 @@ class DataResolverServiceTest extends TestCase
             ->willReturn($entity);
 
         $this->objectService->expects($this->never())
-            ->method('searchObjectsBySlug');
+            ->method('searchObjectsPaginated');
 
         $result = $this->service->resolve(
             dataRefs: [

--- a/tests/unit/Service/ListReferenceResolverTest.php
+++ b/tests/unit/Service/ListReferenceResolverTest.php
@@ -112,16 +112,18 @@ class ListReferenceResolverTest extends TestCase
         ];
 
         $this->objectService->expects($this->once())
-            ->method('searchObjectsBySlug')
-            ->with(
-                $this->equalTo('spectr-live'),
-                $this->equalTo('v-app-competitors'),
-                $this->callback(function (array $filters): bool {
-                    return ($filters['app_id'] ?? null) === 6
-                        && ($filters['_limit'] ?? null) === 50;
-                })
-            )
-            ->willReturn($entities);
+            ->method('setRegister')
+            ->with($this->equalTo('spectr-live'));
+        $this->objectService->expects($this->once())
+            ->method('setSchema')
+            ->with($this->equalTo('v-app-competitors'));
+        $this->objectService->expects($this->once())
+            ->method('searchObjectsPaginated')
+            ->with($this->callback(function (array $query): bool {
+                return ($query['app_id'] ?? null) === 6
+                    && ($query['_limit'] ?? null) === 50;
+            }))
+            ->willReturn(['results' => $entities, 'total' => 2]);
 
         $result = $this->service->resolve(
             listRefs: [
@@ -149,15 +151,11 @@ class ListReferenceResolverTest extends TestCase
     public function testResolveListRefExplicitAsKeyAndLimit(): void
     {
         $this->objectService->expects($this->once())
-            ->method('searchObjectsBySlug')
-            ->with(
-                $this->equalTo('spectr-live'),
-                $this->equalTo('v-app-competitors'),
-                $this->callback(function (array $filters): bool {
-                    return ($filters['_limit'] ?? null) === 5;
-                })
-            )
-            ->willReturn([$this->makeEntity(['id' => '1'])]);
+            ->method('searchObjectsPaginated')
+            ->with($this->callback(function (array $query): bool {
+                return ($query['_limit'] ?? null) === 5;
+            }))
+            ->willReturn(['results' => [$this->makeEntity(['id' => '1'])], 'total' => 1]);
 
         $result = $this->service->resolve(
             listRefs: [
@@ -184,15 +182,11 @@ class ListReferenceResolverTest extends TestCase
     public function testResolveListRefOrderForwarded(): void
     {
         $this->objectService->expects($this->once())
-            ->method('searchObjectsBySlug')
-            ->with(
-                $this->anything(),
-                $this->anything(),
-                $this->callback(function (array $filters): bool {
-                    return ($filters['_order'] ?? null) === ['name' => 'ASC'];
-                })
-            )
-            ->willReturn([]);
+            ->method('searchObjectsPaginated')
+            ->with($this->callback(function (array $query): bool {
+                return ($query['_order'] ?? null) === ['name' => 'ASC'];
+            }))
+            ->willReturn(['results' => [], 'total' => 0]);
 
         $result = $this->service->resolve(
             listRefs: [
@@ -216,15 +210,11 @@ class ListReferenceResolverTest extends TestCase
     public function testDefaultLimitAppliedWhenOmitted(): void
     {
         $this->objectService->expects($this->once())
-            ->method('searchObjectsBySlug')
-            ->with(
-                $this->anything(),
-                $this->anything(),
-                $this->callback(function (array $filters): bool {
-                    return ($filters['_limit'] ?? null) === 50;
-                })
-            )
-            ->willReturn([]);
+            ->method('searchObjectsPaginated')
+            ->with($this->callback(function (array $query): bool {
+                return ($query['_limit'] ?? null) === 50;
+            }))
+            ->willReturn(['results' => [], 'total' => 0]);
 
         $this->service->resolve(
             listRefs: [
@@ -403,7 +393,7 @@ class ListReferenceResolverTest extends TestCase
     public function testGuardrailViolationAbortsBeforeAnySearch(): void
     {
         $this->objectService->expects($this->never())
-            ->method('searchObjectsBySlug');
+            ->method('searchObjectsPaginated');
 
         try {
             $this->service->resolve(
@@ -427,14 +417,17 @@ class ListReferenceResolverTest extends TestCase
      */
     public function testSearchFailureIsSoftError(): void
     {
-        $this->objectService->method('searchObjectsBySlug')
-            ->willReturnCallback(function (string $register, string $schema) {
+        $this->objectService->method('setSchema')
+            ->willReturnCallback(function (string $schema) {
                 if ($schema === 'broken-schema') {
                     throw new Exception('schema slug not found in caller organisation');
                 }
 
-                return [$this->makeEntity(['id' => '1'])];
+                return null;
             });
+
+        $this->objectService->method('searchObjectsPaginated')
+            ->willReturn(['results' => [$this->makeEntity(['id' => '1'])], 'total' => 1]);
 
         $result = $this->service->resolve(
             listRefs: [
@@ -463,7 +456,7 @@ class ListReferenceResolverTest extends TestCase
     public function testEmptyListRefsIsNoOp(): void
     {
         $this->objectService->expects($this->never())
-            ->method('searchObjectsBySlug');
+            ->method('searchObjectsPaginated');
 
         $result = $this->service->resolve(listRefs: []);
 


### PR DESCRIPTION
## Summary
- Follow-up to #326. Live verification against the real spectr-live DBAL-backed register returned an empty array every time via searchObjectsBySlug() -> searchObjects(): that path never consults Schema::getObjectSource(), only the magic table / generic object storage (both empty for a purely-external schema).
- ObjectService::searchObjectsPaginated() is the method that actually checks the object-source and delegates to the provider -- via setRegister()/setSchema() (both slug-aware) context, the same pattern OpenRegister's own ObjectsController::index() uses for GET /apps/openregister/api/objects/{register}/{schema}.
- ListReferenceResolver::resolveList() switched to that path; re-verified live with real rows returned (see session report).
- tests/stubs/OpenRegisterStubs.php's ObjectService stub gained setRegister()/setSchema()/getRegister()/getSchema() (were missing entirely).
- openspec/changes/document-generation-list-refs/ proposal/spec/tasks updated with a design note.

## Test plan
- [x] tests/unit (987 tests) green except the same pre-existing, unrelated PhpWordBackendTest ZipArchive failure
- [x] phpcs / phpstan / phpmd clean (project-wide scan, matching composer check:strict's invocation)
- [x] Live-verified: POST /api/documents/generate/preview with a listRefs entry against spectr-live/competitors now returns real rows in the rendered Twig loop (see session report)