### PR TITLE
fix(ui): render register-i18n label/description values, not raw objects

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@ Create a [feature request](https://codeberg.org/Conduction/docudesk/issues/new)
 
 **Support:** For support, contact support@conduction.nl. For a Service Level Agreement (SLA), contact sales@conduction.nl.
     ]]></description>
-    <version>0.0.38</version>
+    <version>0.0.39</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>DocuDesk</namespace>

--- a/src/utils/registerI18n.js
+++ b/src/utils/registerI18n.js
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Helpers for rendering OpenRegister register-i18n values.
+ *
+ * Fields tagged for register-i18n are stored by OpenRegister's TranslationHandler
+ * as a per-language map (`{"nl": "Projectnamen", "en": "Project names"}`) rather
+ * than a plain string. Binding such a value straight into a template renders
+ * nothing (Vue stringifies the object into the DOM as `[object Object]`, and an
+ * empty text node when interpolated through a slot), which is how a seeded
+ * dictionary showed an empty Label column on a live instance while every unit
+ * test — which used plain strings — stayed green.
+ *
+ * Use `resolveI18nValue()` anywhere a register-backed, i18n-tagged string field
+ * is rendered.
+ *
+ * @spec openspec/specs/register-i18n/spec.md
+ */
+
+import { getLanguage } from '@nextcloud/l10n'
+
+/**
+ * Resolve a register-i18n value to a displayable string.
+ *
+ * Accepts either a plain string (returned unchanged) or a per-language map, and
+ * picks, in order: the active Nextcloud language, its base language (`nl` for
+ * `nl_NL`), English, then the first non-empty entry. Returns `fallback` when
+ * nothing usable is present.
+ *
+ * @param {string|object|null|undefined} value    The raw field value from OpenRegister.
+ * @param {string}                       fallback Value to return when nothing resolves.
+ * @return {string} A displayable string, never an object.
+ */
+export function resolveI18nValue(value, fallback = '') {
+	if (value === null || value === undefined) {
+		return fallback
+	}
+
+	if (typeof value === 'string') {
+		return value
+	}
+
+	if (typeof value !== 'object' || Array.isArray(value) === true) {
+		return String(value)
+	}
+
+	const active = typeof getLanguage === 'function' ? (getLanguage() || '') : ''
+	const base = active.split(/[-_]/)[0]
+
+	const candidates = [active, base, 'en']
+	for (const key of candidates) {
+		if (key && typeof value[key] === 'string' && value[key].length > 0) {
+			return value[key]
+		}
+	}
+
+	const first = Object.values(value).find(
+		(entry) => typeof entry === 'string' && entry.length > 0,
+	)
+
+	return first !== undefined ? first : fallback
+}

--- a/src/views/customDictionary/CustomDictionaryDetail.vue
+++ b/src/views/customDictionary/CustomDictionaryDetail.vue
@@ -14,7 +14,7 @@
 			</NcButton>
 			<h2 class="custom-dictionary-detail__title">
 				<span class="custom-dictionary-detail__swatch" :style="{ backgroundColor: dictionary.colour || '#0082C9' }" />
-				{{ dictionary.label || t('docudesk', 'Custom dictionary') }}
+				{{ displayValue(dictionary.label, t('docudesk', 'Custom dictionary')) }}
 			</h2>
 			<div class="custom-dictionary-detail__header-actions">
 				<NcButton type="secondary" @click="openEditDialog">
@@ -28,7 +28,7 @@
 		<template v-else>
 			<div class="custom-dictionary-detail__meta">
 				<p v-if="dictionary.description" class="custom-dictionary-detail__description">
-					{{ dictionary.description }}
+					{{ displayValue(dictionary.description) }}
 				</p>
 				<div class="custom-dictionary-detail__badges">
 					<CnStatusBadge
@@ -82,7 +82,7 @@
 					<tbody>
 						<tr v-for="term in terms" :key="term['@self']?.id || term.id">
 							<td>{{ term.value }}</td>
-							<td>{{ term.label || '-' }}</td>
+							<td>{{ displayValue(term.label, '-') }}</td>
 							<td>
 								<NcButton type="tertiary" @click="removeTerm(term)">
 									<template #icon>
@@ -120,6 +120,7 @@ import { translate as t } from '@nextcloud/l10n'
 import { CnStatusBadge, NcButton, NcEmptyContent, NcLoadingIcon, NcTextField } from '@conduction/nextcloud-vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
 import { customDictionaryStore } from '../../store/store.js'
+import { resolveI18nValue } from '../../utils/registerI18n.js'
 import CustomDictionaryFormDialog from '../../dialogs/CustomDictionaryFormDialog.vue'
 import CustomDictionaryImportDialog from '../../dialogs/CustomDictionaryImportDialog.vue'
 
@@ -181,6 +182,17 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Resolve a register-i18n field (label/description) for display.
+		 *
+		 * @param {string|object|null} value    The raw field value.
+		 * @param {string}             fallback Shown when nothing resolves.
+		 * @return {string} The displayable string.
+		 * @spec openspec/specs/custom-dictionary-recognition/spec.md
+		 */
+		displayValue(value, fallback = '') {
+			return resolveI18nValue(value, fallback)
+		},
 		matchModeLabel(mode) {
 			const labels = {
 				exact: t('docudesk', 'Exact'),

--- a/src/views/customDictionary/CustomDictionaryIndex.vue
+++ b/src/views/customDictionary/CustomDictionaryIndex.vue
@@ -10,6 +10,7 @@
 <script setup>
 import { translate as t } from '@nextcloud/l10n'
 import { customDictionaryStore } from '../../store/store.js'
+import { resolveI18nValue } from '../../utils/registerI18n.js'
 </script>
 
 <template>
@@ -44,7 +45,7 @@ import { customDictionaryStore } from '../../store/store.js'
 			<template #column-label="{ row }">
 				<span class="custom-dictionary-index__label">
 					<span class="custom-dictionary-index__swatch" :style="{ backgroundColor: row.colour || '#0082C9' }" />
-					{{ row.label }}
+					{{ displayLabel(row) }}
 				</span>
 			</template>
 
@@ -164,6 +165,16 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Resolve a dictionary's register-i18n label for display.
+		 *
+		 * @param {object} row The dictionary row.
+		 * @return {string} The displayable label.
+		 * @spec openspec/specs/custom-dictionary-recognition/spec.md
+		 */
+		displayLabel(row) {
+			return resolveI18nValue(row.label, t('docudesk', 'Custom dictionary'))
+		},
 		matchModeLabel(mode) {
 			const labels = {
 				exact: t('docudesk', 'Exact'),

--- a/tests/vitest/registerI18n.spec.js
+++ b/tests/vitest/registerI18n.spec.js
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Regression tests for resolveI18nValue().
+ *
+ * Live-verify finding (2026-07-24, dev instance 8080): the seeded custom
+ * dictionary rendered an EMPTY Label column because OpenRegister stores
+ * register-i18n tagged fields as a per-language map (`{"nl":"Projectnamen"}`)
+ * while the table bound the raw value. Every unit test passed because the
+ * fixtures used plain strings — only a live run exposed it.
+ *
+ * @spec openspec/specs/register-i18n/spec.md
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@nextcloud/l10n', () => ({
+	getLanguage: () => 'en',
+}))
+
+const { resolveI18nValue } = await import('../../src/utils/registerI18n.js')
+
+describe('resolveI18nValue', () => {
+	it('returns a plain string unchanged', () => {
+		expect(resolveI18nValue('Projectnamen')).toBe('Projectnamen')
+	})
+
+	it('resolves the active language from a per-language map', () => {
+		expect(resolveI18nValue({ en: 'Project names', nl: 'Projectnamen' })).toBe('Project names')
+	})
+
+	it('falls back to the only available language (the live failure case)', () => {
+		// This is exactly what was stored on the dev instance and rendered blank.
+		expect(resolveI18nValue({ nl: 'Projectnamen' })).toBe('Projectnamen')
+	})
+
+	it('never returns an object', () => {
+		const out = resolveI18nValue({ nl: 'Projectnamen' })
+		expect(typeof out).toBe('string')
+	})
+
+	it('uses the fallback for null, undefined and empty maps', () => {
+		expect(resolveI18nValue(null, 'Custom dictionary')).toBe('Custom dictionary')
+		expect(resolveI18nValue(undefined, 'Custom dictionary')).toBe('Custom dictionary')
+		expect(resolveI18nValue({}, 'Custom dictionary')).toBe('Custom dictionary')
+	})
+
+	it('ignores empty-string translations when picking a fallback', () => {
+		expect(resolveI18nValue({ en: '', nl: 'Projectnamen' })).toBe('Projectnamen')
+	})
+
+	it('defaults to an empty string when no fallback is given', () => {
+		expect(resolveI18nValue(null)).toBe('')
+	})
+})


### PR DESCRIPTION
**Live-verify finding on the 8080 dev instance.** The seeded custom dictionary rendered an **empty Label column**: OpenRegister's TranslationHandler stores register-i18n tagged fields as a per-language map (`{"nl":"Projectnamen"}`), but the index table and detail view bound the raw value. Every unit test stayed green because the fixtures used plain strings — only a live run exposed it.

Adds `src/utils/registerI18n.js#resolveI18nValue` (active language → base language → `en` → first non-empty → fallback; plain strings pass through; never returns an object) and applies it to the dictionary label, description and term labels. Also bumps to 0.0.39 — the fix is js-only and NC derives its `?v=` cache-buster from `info.xml`, so without a bump browsers keep serving the stale bundle.

Local: vitest **42 green** (7 new, including the exact nl-only live failure) · eslint clean · l10n OK · build OK.
**Live-verified on 8080**: label now renders "Projectnamen" with swatch, 2 terms, Case-insensitive, Active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)