### PR TITLE
fix(routing): unshadow /signing/new; guard against route shadowing

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@ Create a [feature request](https://codeberg.org/Conduction/docudesk/issues/new)
 
 **Support:** For support, contact support@conduction.nl. For a Service Level Agreement (SLA), contact sales@conduction.nl.
     ]]></description>
-    <version>0.0.39</version>
+    <version>0.0.40</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>DocuDesk</namespace>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -211,20 +211,20 @@
 			"_note": "Decomposed to type:index (Phase 8): signingRequest is OR-registered (register docudesk), so CnIndexPage lists the requests directly. Per-request signing actions live on SigningRequestDetail. actionToggles.showAdd:false + primaryAction (openspec/changes/orphaned-surface-restoration, REQ-DDOSR-004) replace the generic bare-object Add dialog with the signer-chain SigningRequestForm page — the index's own create path was a dead end (writes a signingRequest with no signer chain, fields or provider)."
 		},
 		{
-			"id": "SigningRequestDetail",
-			"route": "/signing/:id",
-			"type": "custom",
-			"title": "Signing Request Detail",
-			"component": "SigningRequestDetail",
-			"_note": "Signing request detail view driven by signingStore. Links to SignatureVerification (restored — REQ-DDOSR-004) for the document's file id."
-		},
-		{
 			"id": "SigningRequestForm",
 			"route": "/signing/new",
 			"type": "custom",
 			"title": "New Signing Request",
 			"component": "SigningRequestForm",
 			"_note": "Signer-chain create form (documentFileId/documentName/signatureLevel/signingMode via signingStore.createSigningRequest — POST signing#createRequest, which drafts a signingRequest record; it does not send/sign/bind a provider — those remain separate signing#sign / not-yet-built provider-binding actions). Reachable from the SigningRequests index primaryAction. Restored — openspec/changes/orphaned-surface-restoration (REQ-DDOSR-004); trust/identity-assertion controls are gated to signing-trust-rebuild / signer-identity-rails per design.md D4 — this page composes a draft only."
+		},
+		{
+			"id": "SigningRequestDetail",
+			"route": "/signing/:id",
+			"type": "custom",
+			"title": "Signing Request Detail",
+			"component": "SigningRequestDetail",
+			"_note": "Signing request detail view driven by signingStore. Links to SignatureVerification (restored — REQ-DDOSR-004) for the document's file id. MUST stay declared AFTER the static /signing/new route: vue-router matches in declaration order, so a leading :id route swallows /signing/new."
 		},
 		{
 			"id": "SignatureVerification",

--- a/tests/unit/reachability.spec.js
+++ b/tests/unit/reachability.spec.js
@@ -298,6 +298,50 @@ function findOrphanedViews(viewFilesAbsolute, reachableSet, allowList) {
 	return orphans
 }
 
+/**
+ * Detect static routes shadowed by an earlier dynamic-parameter route.
+ *
+ * vue-router matches in declaration order, so `/signing/:id` declared before
+ * `/signing/new` swallows the static route and its page becomes unreachable by
+ * URL — a reachability failure the component-resolution checks cannot see.
+ * Observed live on 2026-07-24: `/signing/new` rendered the detail page with
+ * id="new" instead of the create form.
+ *
+ * @param {object} manifest The parsed src/manifest.json.
+ * @return {Array<string>} Human-readable descriptions of each shadowed route.
+ */
+function findShadowedRoutes(manifest) {
+	const routes = (manifest.pages || [])
+		.map((p) => p.route || p.path)
+		.filter((r) => typeof r === 'string')
+
+	const segmentsOf = (route) => route.split('/').filter(Boolean)
+	const shadowed = []
+
+	routes.forEach((route, index) => {
+		const segs = segmentsOf(route)
+		// Only static routes can be shadowed; a route containing a param is the shadower.
+		if (segs.some((s) => s.startsWith(':'))) {
+			return
+		}
+		for (let earlier = 0; earlier < index; earlier++) {
+			const prevSegs = segmentsOf(routes[earlier])
+			if (prevSegs.length !== segs.length) {
+				continue
+			}
+			const matches = prevSegs.every(
+				(seg, i) => seg.startsWith(':') || seg === segs[i],
+			)
+			if (matches && prevSegs.some((s) => s.startsWith(':'))) {
+				shadowed.push(`"${route}" is shadowed by earlier route "${routes[earlier]}"`)
+				break
+			}
+		}
+	})
+
+	return shadowed
+}
+
 // ---------------------------------------------------------------------------
 // Real-repo assertions — the guard as it runs against the current tree.
 // ---------------------------------------------------------------------------
@@ -329,6 +373,14 @@ describe('reachability guard — current repo state', () => {
 		const { missingRegistryEntry, danglingRegistryEntries } = crossCheckManifestRegistry(manifest, registryEntries)
 		expect(missingRegistryEntry, `manifest pages with no registry entry:\n${missingRegistryEntry.join('\n')}`).toEqual([])
 		expect(danglingRegistryEntries, `registry kind:"page" entries referenced by no manifest page:\n${danglingRegistryEntries.join('\n')}`).toEqual([])
+	})
+
+	it('no shadowed routes: a static page route is never preceded by a matching :param route', () => {
+		const shadowed = findShadowedRoutes(manifest)
+		expect(
+			shadowed,
+			`static routes unreachable because an earlier :param route matches them first:\n${shadowed.join('\n')}`,
+		).toEqual([])
 	})
 
 	it('no hidden orphans: every src/views/** file is reachable or explicitly allow-listed', () => {
@@ -412,6 +464,31 @@ describe('reachability guard — detector correctness (synthetic cases)', () => 
 		const allowListedAbs = path.resolve(REPO_ROOT, 'src/views/signing/BulkSigningPanel.vue')
 		const orphans = findOrphanedViews([allowListedAbs], new Set(), KNOWN_HEADLESS)
 		expect(orphans).toEqual([])
+	})
+
+	it('findShadowedRoutes flags a static route declared after a matching :param route', () => {
+		const shadowed = findShadowedRoutes({
+			pages: [
+				{ route: '/signing' },
+				{ route: '/signing/:id' },
+				{ route: '/signing/new' },
+			],
+		})
+		expect(shadowed).toHaveLength(1)
+		expect(shadowed[0]).toContain('/signing/new')
+		expect(shadowed[0]).toContain('/signing/:id')
+	})
+
+	it('findShadowedRoutes accepts the corrected order and differing segment counts', () => {
+		expect(findShadowedRoutes({
+			pages: [
+				{ route: '/signing' },
+				{ route: '/signing/new' },
+				{ route: '/signing/:id' },
+				// 3 segments — cannot be swallowed by the 2-segment :id route.
+				{ route: '/signing/verify/:fileId' },
+			],
+		})).toEqual([])
 	})
 
 	it('extractRelativeImportSpecifiers finds a brace-wrapped multi-line import', () => {


### PR DESCRIPTION
**Live-verify finding on 8080.** `/signing/new` rendered the *Signing Request Detail* page with `id="new"` instead of the create form: vue-router matches in declaration order and `/signing/:id` was declared **before** `/signing/new`, so the param route swallowed the static one. The form was unreachable by URL despite being correctly registered — the reachability guard only checked component resolution, not route shadowing.

- Reorders the manifest so the static route precedes the param route (with a `_note` recording why the order matters).
- Extends `tests/unit/reachability.spec.js` with `findShadowedRoutes()`, a real-repo assertion, and two synthetic self-tests (the buggy order **is** flagged; the corrected order and differing segment counts are not).
- Bumps to 0.0.40 so NC's `?v=` cache-buster serves the rebuilt bundle.

Local: vitest **45 green** (+3) · manifest Ajv PASS.
**Live-verified on 8080**: the create form now renders with its draft-only trust disclosure, file id / name / signature level (SES–AdES–QES) / signing mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)