### PR TITLE
fix(routes): repair 500 on /api/preferences/{key}; harden e2e harness

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -183,6 +183,11 @@ return \OCA\OpenRegister\AppHost\Routes::standard([
         // Generic per-user preferences (used by shared nextcloud-vue widgets, e.g.
         // CnSupportDialog) — served by OpenRegister's AppHost
         // GenericPreferencesController (aliased in Application::register).
-        ['name' => 'AppHost\Controller\GenericPreferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
-        ['name' => 'AppHost\Controller\GenericPreferences#setPreference', 'url' => '/api/preferences/{key}', 'verb' => 'PUT'],
+        // Served by lib/Controller/PreferencesController (a thin subclass of
+        // OpenRegister's GenericPreferencesController). The route name MUST
+        // stay `preferences#…`: Nextcloud resolves `foo#bar` to
+        // OCA\DocuDesk\Controller\FooController, so a namespaced name here
+        // resolves to a class that does not exist and 500s.
+        ['name' => 'preferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
+        ['name' => 'preferences#setPreference', 'url' => '/api/preferences/{key}', 'verb' => 'PUT'],
 ]);

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Per-user preferences controller.
+ *
+ * Thin subclass of OpenRegister's AppHost `GenericPreferencesController`,
+ * mirroring the existing `HealthController` / `MetricsController` pattern.
+ *
+ * WHY THIS CLASS EXISTS: Nextcloud resolves a route `name` of the form
+ * `foo#bar` to the class `OCA\<App>\Controller\FooController` — it always
+ * prefixes the app's own `Controller` namespace. A route named
+ * `AppHost\Controller\GenericPreferences#getPreference` therefore does NOT
+ * resolve to OpenRegister's class (nor to the container alias registered for
+ * it in `Application::register()`); Nextcloud looked for
+ * `OCA\DocuDesk\Controller\PreferencesController`, which did not exist, and
+ * every request to `/api/preferences/{key}` failed with
+ * `QueryNotFoundException` → HTTP 500.
+ *
+ * That broke the shared `CnSupportDialog` widget, which reads and writes the
+ * `support-dialog-seen` preference on every app load. Caught by the e2e 5xx
+ * guard on 2026-07-24, not by unit tests (no test exercised the route).
+ *
+ * Declaring the subclass here gives Nextcloud exactly the class name it
+ * derives from the route, while the behaviour stays OpenRegister's (ADR-022 —
+ * consume, don't reimplement).
+ *
+ * @category Controller
+ * @package  OCA\DocuDesk\Controller
+ *
+ * @author  Conduction Development Team <info@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/preferences-api/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Controller;
+
+use OCA\OpenRegister\AppHost\Controller\GenericPreferencesController;
+
+/**
+ * Serves `GET|PUT /api/preferences/{key}` for DocuDesk.
+ *
+ * Behaviour (auth posture, key sanitisation, per-user scoping) is inherited
+ * unchanged from OpenRegister's generic implementation.
+ */
+class PreferencesController extends GenericPreferencesController
+{
+
+}//end class

--- a/openspec/specs/files-confidential-labels/spec.md
+++ b/openspec/specs/files-confidential-labels/spec.md
@@ -55,7 +55,7 @@ any block, redaction, gate or enforcement.
 - GIVEN a file tagged "Confidential" is opened for entity review
 - WHEN the entity-review context loads
 - THEN the appraisal result carries `confidentialityLabel: "Confidential"` and `confidentialityLevel: 2`, and the review surface shows a read-only confidentiality chip beside the risk chip
-- @e2e tests/e2e/spec-coverage/files-confidential-labels.spec.ts
+- @e2e exclude requires the optional `files_confidential` app, which is not installed on the dev/CI instance — with it absent the label service correctly returns null and no chip can ever render, so a browser assertion would be vacuous. The positive path is covered by `tests/unit/Service/ConfidentialityLabelServiceTest.php`; the absent-app path is asserted in the e2e spec.
 
 #### Scenario: Unlabelled file shows no chip and no fields
 

--- a/openspec/specs/unified-search-provider/spec.md
+++ b/openspec/specs/unified-search-provider/spec.md
@@ -46,7 +46,7 @@ reference a schema that is not `searchable: true`.
 - WHEN the user types "Kapvergunning" in the Nextcloud global search bar
 - THEN the signing request appears under the OpenRegister objects provider labelled "Signing request"
 - AND activating it navigates to `/apps/docudesk/signing/{uuid}` and renders the request detail
-- @e2e tests/e2e/spec-coverage/unified-search-provider.spec.ts
+- @e2e exclude blocked upstream — OpenRegister's shared search provider ignores manifest deepLinks and returns the raw `/apps/openregister/api/objects/...` URL (ConductionNL/openregister#2060, live-verified 2026-07-24). Re-enable this scenario as a real e2e once that lands; asserting it today would either fail or have to assert the wrong URL.
 
 #### Scenario: Deep links cover exactly the searchable schemas
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,8 +30,14 @@ import * as path from 'path'
 export default defineConfig({
 	testDir: './tests/e2e',
 	globalSetup: path.resolve(__dirname, 'tests/e2e/global-setup.ts'),
-	timeout: 30_000,
-	expect: { timeout: 10_000 },
+	// A shared dev instance running many Conduction apps can take several
+	// seconds just to serve /index.php/login, and DocuDesk ships a ~3 MB
+	// bundle that Playwright loads with a cold cache on every run. The
+	// original 30s budget made the whole suite time out on navigation even
+	// when the app was healthy, so it is generous by design; a real hang
+	// still fails, just later. Override with PW_TEST_TIMEOUT if needed.
+	timeout: Number(process.env.PW_TEST_TIMEOUT || 120_000),
+	expect: { timeout: 15_000 },
 	fullyParallel: false,
 	retries: process.env.CI ? 1 : 0,
 	workers: 1,
@@ -46,6 +52,8 @@ export default defineConfig({
 		storageState: path.resolve(__dirname, 'tests/e2e/.auth/admin.json'),
 		trace: 'on-first-retry',
 		screenshot: 'only-on-failure',
+		navigationTimeout: 60_000,
+		actionTimeout: 20_000,
 	},
 
 	projects: [

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -44,22 +44,51 @@ function ensureBundleBuilt(): void {
 	execSync('npm run build', { cwd: APP_ROOT, stdio: 'inherit' })
 }
 
+/**
+ * Wait until Nextcloud is actually serving requests.
+ *
+ * A shared dev instance is routinely mid-flight: another deploy flips it into
+ * maintenance mode, an app version bump sets needsDbUpgrade (which makes NC
+ * answer 503 on every route), or Postgres is still finishing crash recovery.
+ * All three are transient and clear within minutes, but a single-shot check
+ * turns them into a hard suite failure — observed three times on 2026-07-24.
+ *
+ * Poll until the instance reports installed, out of maintenance and not
+ * awaiting a DB upgrade. Tune with E2E_HEALTH_TIMEOUT_MS (default 10 min).
+ *
+ * @param {string} baseURL Instance base URL.
+ * @return {Promise<void>} Resolves once healthy; rejects on timeout.
+ */
 async function ensureNextcloudReachable(baseURL: string): Promise<void> {
+	const deadline = Date.now() + Number(process.env.E2E_HEALTH_TIMEOUT_MS || 600_000)
 	const ctx = await request.newContext()
+	let last = 'no response yet'
 	try {
-		const res = await ctx.get(`${baseURL}/status.php`, { failOnStatusCode: false })
-		if (!res.ok()) {
-			throw new Error(
-				`Nextcloud status.php returned ${res.status()} at ${baseURL}. ` +
-				`Make sure the docker container is running and reachable.`,
-			)
+		while (Date.now() < deadline) {
+			try {
+				const res = await ctx.get(`${baseURL}/status.php`, { failOnStatusCode: false })
+				if (res.ok()) {
+					const body = await res.json().catch(() => ({}))
+					if (body && body.installed === true
+						&& body.maintenance === false
+						&& body.needsDbUpgrade === false) {
+						return
+					}
+					last = `status.php = ${JSON.stringify(body)}`
+				} else {
+					// 503 while an app upgrade is pending, 500 while the DB recovers.
+					last = `status.php returned ${res.status()}`
+				}
+			} catch (err) {
+				last = `request failed: ${(err as Error).message}`
+			}
+			// eslint-disable-next-line no-await-in-loop
+			await new Promise((resolve) => setTimeout(resolve, 5_000))
 		}
-		const body = await res.json().catch(() => ({}))
-		if (!body || body.installed !== true) {
-			throw new Error(
-				`Nextcloud at ${baseURL} is not installed (status.php = ${JSON.stringify(body)}).`,
-			)
-		}
+		throw new Error(
+			`Nextcloud at ${baseURL} did not become healthy in time — last seen: ${last}. `
+			+ 'Check for a concurrent deploy (occ upgrade), maintenance mode, or a recovering database.',
+		)
 	} finally {
 		await ctx.dispose()
 	}
@@ -81,11 +110,44 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 	const context = await browser.newContext({ baseURL })
 	const page = await context.newPage()
 
-	await page.goto('/index.php/login')
-	await page.locator('input[name="user"]').fill(username)
-	await page.locator('input[name="password"]').fill(password)
-	await page.locator('button[type="submit"]').first().click()
-	await page.waitForSelector('#header, header.header', { timeout: 20_000 })
+	// The instance can flip back into maintenance between the health check and
+	// this navigation; re-check health and retry rather than failing the suite.
+	for (let attempt = 1; ; attempt++) {
+		try {
+			await page.goto('/index.php/login')
+			break
+		} catch (err) {
+			if (attempt >= 3) {
+				throw err
+			}
+			await ensureNextcloudReachable(baseURL)
+		}
+	}
+	// Nextcloud's login form is client-rendered and its markup has drifted
+	// between releases: on NC 34 the fields carry `id="user"` / `id="password"`
+	// but no `name` attribute, so a `input[name="user"]` selector never resolves
+	// and globalSetup times out — which is why this suite could not run at all.
+	// Match either shape, and wait for the field to be attached first.
+	const userField = page.locator('input#user, input[name="user"]').first()
+	const passwordField = page.locator('input#password, input[name="password"]').first()
+	await userField.waitFor({ state: 'visible', timeout: 30_000 })
+	// The login form is a Vue app: the markup exists before its submit handler
+	// is attached, so clicking too early silently does nothing and the page
+	// simply stays on /login. Let the login bundle settle before interacting.
+	await page.waitForLoadState('networkidle').catch(() => {})
+	await userField.fill(username)
+	await passwordField.fill(password)
+	// Bind the navigation wait BEFORE clicking, so a fast redirect cannot be
+	// missed between the click returning and the wait starting.
+	await Promise.all([
+		page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 60_000 }).catch(() => {}),
+		page.locator('button[type="submit"]').first().click(),
+	])
+	// Wait for the authenticated shell. NC 34 no longer guarantees the legacy
+	// `#header` / `header.header` markup, so accept any banner-role header and
+	// give the (slow, shared) instance room to finish the post-login redirect.
+	await page.waitForURL((url) => /\/login(\?|$|\/)/.test(url.pathname) === false, { timeout: 60_000 })
+	await page.waitForSelector('#header, header.header, header, [role="banner"]', { timeout: 60_000 })
 	const currentUrl = page.url()
 	if (/\/login(\?|$|\/)/.test(currentUrl)) {
 		throw new Error(

--- a/tests/e2e/spec-coverage/_helpers.ts
+++ b/tests/e2e/spec-coverage/_helpers.ts
@@ -82,6 +82,29 @@ export async function dismissOverlays(page: Page): Promise<void> {
 		}
 		await support.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {})
 	}
+
+	// The onboarding walkthrough ("Welcome to DocuDesk") renders a full-viewport
+	// dim layer (.cn-walkthrough__dim--full) that intercepts pointer events, so
+	// every left-navigation click fails with "subtree intercepts pointer events"
+	// even though the target link is visible and enabled. Close it via its own
+	// button; Escape alone does not always dismiss it.
+	const walkthrough = page.locator('.cn-walkthrough, [aria-label="Welcome to DocuDesk"]').first()
+	for (let i = 0; i < 3 && await walkthrough.isVisible().catch(() => false); i++) {
+		const closeTour = page.getByRole('button', { name: /close tour/i }).first()
+		if (await closeTour.isVisible().catch(() => false)) {
+			await closeTour.click().catch(() => {})
+		} else {
+			await page.keyboard.press('Escape').catch(() => {})
+		}
+		await walkthrough.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {})
+	}
+
+	// Belt and braces: if any full-viewport dim layer survived the loops above,
+	// a click would still be swallowed. Wait for it to detach rather than
+	// letting the next action fail with a confusing interception error.
+	await page.locator('.cn-walkthrough__dim--full')
+		.waitFor({ state: 'detached', timeout: 3000 })
+		.catch(() => {})
 }
 
 export async function go(page: Page, route: string): Promise<void> {


### PR DESCRIPTION
**The first defect found by a working e2e run.**

### 1. `/api/preferences/{key}` returned 500 on every call
Nextcloud resolves a route name `foo#bar` to `OCA\<App>\Controller\FooController` — it always prefixes the app's own `Controller` namespace. The route named `AppHost\Controller\GenericPreferences#getPreference` therefore resolved to `OCA\DocuDesk\Controller\PreferencesController` (nonexistent), **not** to OpenRegister's class or the container alias registered for it → `QueryNotFoundException` → HTTP 500.

This broke the shared `CnSupportDialog` widget, which reads/writes `support-dialog-seen` on every app load. Fixed with a thin `PreferencesController` subclass — the pattern already used for `HealthController`/`MetricsController` — plus a `preferences#…` route name. **Live-verified**: now `200 {"value":"1"}`.

### 2. e2e harness repairs — the suite had never executed once
- login selectors (NC 34 uses `id`, not `name`)
- **Vue hydration race**: submit clicked before the handler attached, so the page silently stayed on `/login`
- post-login shell selector (NC 34 dropped guaranteed `#header`)
- `dismissOverlays` now closes the walkthrough, whose full-viewport dim layer **intercepted every navigation click** — the real cause of most "failures"
- health check polls through maintenance / needsDbUpgrade / DB-recovery windows instead of failing the run
- timeouts sized for a loaded shared instance (`PW_TEST_TIMEOUT` override)

### 3. e2e traceability
The two wave-3 scenarios that cannot pass today carry reason-bearing `@e2e exclude`s rather than tests that would fake green (deep-links blocked by openregister#2060; confidentiality chip needs `files_confidential`, not installed).

Local: **phpunit 1118 green**, phpcs clean on the new controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)