### PR TITLE
chore(deps): nc-vue beta.221 — activate schema-label translation (live-verified EN)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@ Create a [feature request](https://codeberg.org/Conduction/docudesk/issues/new)
 
 **Support:** For support, contact support@conduction.nl. For a Service Level Agreement (SLA), contact sales@conduction.nl.
     ]]></description>
-    <version>0.0.43</version>
+    <version>0.0.44</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>DocuDesk</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@babel/core": "^7.29.0",
-        "@conduction/nextcloud-vue": "^1.0.0-beta.213",
+        "@conduction/nextcloud-vue": "^1.0.0-beta.221",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.5.0",
         "@nextcloud/dialogs": "^6.4.2",
@@ -1977,9 +1977,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "1.0.0-beta.213",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.213.tgz",
-      "integrity": "sha512-L3E7kT3AvVb8HvxRWc2nSA6aYXbuMOj9f7HiGiJQOJ9om6ImCrdreMqACB4pEbHGy49FeRnmX5aHI1qt8o1SaQ==",
+      "version": "1.0.0-beta.221",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.221.tgz",
+      "integrity": "sha512-2sNPtUYlQNrFg3yVqXHvOwOHeXiOHsjmWhHPc3WCsAq8hpJj1v/T+XeGKFBmUEi4mJ/9UtR+NrrT8Zke0FKcug==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
@@ -25612,9 +25612,9 @@
       }
     },
     "@conduction/nextcloud-vue": {
-      "version": "1.0.0-beta.213",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.213.tgz",
-      "integrity": "sha512-L3E7kT3AvVb8HvxRWc2nSA6aYXbuMOj9f7HiGiJQOJ9om6ImCrdreMqACB4pEbHGy49FeRnmX5aHI1qt8o1SaQ==",
+      "version": "1.0.0-beta.221",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.221.tgz",
+      "integrity": "sha512-2sNPtUYlQNrFg3yVqXHvOwOHeXiOHsjmWhHPc3WCsAq8hpJj1v/T+XeGKFBmUEi4mJ/9UtR+NrrT8Zke0FKcug==",
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@babel/core": "^7.29.0",
-    "@conduction/nextcloud-vue": "^1.0.0-beta.213",
+    "@conduction/nextcloud-vue": "^1.0.0-beta.221",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.5.0",
     "@nextcloud/dialogs": "^6.4.2",


### PR DESCRIPTION
Bumps `@conduction/nextcloud-vue` to `^1.0.0-beta.221` (published, carries the cnTranslate display-layer translation) and rebuilds. With docudesk's property titles now English (#343) + EN/NL l10n, index/table labels resolve per user language.

**Live-verified on 8080**: the Templates table header row now renders `Name · Category · Page format · Namespace · Description` (English) — previously Dutch `NAAM · CATEGORIE · PAGINAFORMAAT` (#341). Dutch chrome confirmed active (Kaarten/Tabel/Zoeken/Filters/Kolommen); NL header resolution proven against the real register + nl.json through the published helper. App version 0.0.43→0.0.44 to bust the ?v= cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)