### PR TITLE
perf(enrichment): stop building the admin-settings payload on every object write

### DIFF
--- a/lib/EventListener/EnrichmentRunner.php
+++ b/lib/EventListener/EnrichmentRunner.php
@@ -45,6 +45,13 @@ class EnrichmentRunner
     /**
      * Check if enrichment is enabled based on settings
      *
+     * Reads the three toggles ONLY. It must not call `getAllSettings()`: that
+     * assembles the admin-settings payload, including a walk of every register
+     * and every schema on the instance. This runs inside an unrelated app's
+     * object save, and that walk issued 1,471 `SchemaMapper::find()` calls per
+     * create — 96% of all schema reads during an OpenRegister create, measured
+     * 2026-07-29, on a code path whose entire job is to answer a boolean.
+     *
      * @param SettingsService $settingsService The settings service
      *
      * @return bool True if at least one enrichment feature is enabled
@@ -53,7 +60,7 @@ class EnrichmentRunner
      */
     public function isEnrichmentEnabled(SettingsService $settingsService): bool
     {
-        $settings       = $settingsService->getAllSettings();
+        $settings       = $settingsService->getFeatureToggles();
         $enableLanguage = $settings['enable_language_detection'] ?? true;
         $enableKeywords = $settings['enable_keyword_extraction'] ?? true;
         $enableTopic    = $settings['enable_topic_classification'] ?? true;

--- a/lib/Service/GrondslagProposalService.php
+++ b/lib/Service/GrondslagProposalService.php
@@ -319,7 +319,16 @@ class GrondslagProposalService
                 $slug = (string) ($self['slug'] ?? '');
             }
 
-            $name = (string) ($base['name'] ?? '');
+            // Cast only scalars. An OpenRegister object property may legally be
+            // an array (multi-value / nested), and `(string) $array` emits a
+            // PHP "Array to string conversion" warning for EVERY such field.
+            // Measured 2026-07-28: a single object create produced 6,240 of
+            // these warnings (6,623 log lines total) because this runs on the
+            // OR object-write path — which made every
+            // `POST /apps/openregister/api/objects/...` hang fleet-wide and
+            // grew nextcloud.log without bound (cf. the 163GB log incident
+            // that filled the Docker disk and PANICked Postgres).
+            $name = self::asString($base['name'] ?? '');
             if ($slug === '' || $name === '') {
                 continue;
             }
@@ -327,7 +336,7 @@ class GrondslagProposalService
             $bases[] = [
                 'slug'        => $slug,
                 'name'        => $name,
-                'description' => (string) ($base['description'] ?? ''),
+                'description' => self::asString($base['description'] ?? ''),
             ];
         }//end foreach
 
@@ -512,6 +521,32 @@ class GrondslagProposalService
      * flattened via `jsonSerialize()`, which yields the `@self` + property
      * payload this service reads.
      *
+     * Coerce an OpenRegister property to a string without warning on arrays.
+     *
+     * OR object properties are `mixed`: a field may be a scalar, null, or an
+     * array (multi-value / nested object). A bare `(string) $value` cast on an
+     * array raises "Array to string conversion" — harmless-looking, but on the
+     * object-write path it fires once per field per object and buries the
+     * request (and the log) under thousands of warnings.
+     *
+     * @param mixed $value The raw property value.
+     *
+     * @return string The scalar rendering, or '' when the value is not scalar.
+     *
+     * @psalm-pure
+     */
+    private static function asString(mixed $value): string
+    {
+        if (is_scalar($value) === true) {
+            return (string) $value;
+        }
+
+        return '';
+
+    }//end asString()
+
+
+    /**
      * @param mixed $result The raw search result.
      *
      * @return array<int, array<string, mixed>> The list of object arrays.

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -206,6 +206,33 @@ class SettingsService
     }//end initialize()
 
     /**
+     * The feature toggles alone, without the rest of the settings payload.
+     *
+     * {@see getAllSettings()} assembles what the ADMIN SETTINGS PAGE needs:
+     * every available register with its schemas, the object-type
+     * configuration, OCR status and the grondslag selector data. That is
+     * correct for a settings screen and catastrophic on a write path — the
+     * register/schema discovery alone issued 1,471 `SchemaMapper::find()`
+     * calls (one per schema on the instance) when it was reached from
+     * {@see \OCA\DocuDesk\EventListener\EnrichmentRunner}, which runs inside
+     * an unrelated app's object save. Measured 2026-07-29: 96% of ALL schema
+     * reads during an OpenRegister object create originated there, and the
+     * create took 9-17s.
+     *
+     * Anything that only needs a toggle MUST call this instead. These are
+     * plain IAppConfig reads and touch no register or schema.
+     *
+     * @return array<string, mixed> Feature toggle settings.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function getFeatureToggles(): array
+    {
+        return $this->loadFeatureToggles();
+
+    }//end getFeatureToggles()
+
+    /**
      * Load feature toggle settings from app config
      *
      * @return array<string, mixed> Feature toggle settings


### PR DESCRIPTION
`EnrichmentRunner` listens on OpenRegister's object-created event — i.e. it runs inside an unrelated app's save. To answer the boolean *is enrichment enabled*, it called `SettingsService::getAllSettings()`, which assembles what the **admin settings page** needs: every available register with its schemas, the object-type configuration, OCR status, grondslag selector data.

Measured on the dev instance, one OpenRegister object create:

| | |
|---|---|
| `SchemaMapper::find()` calls from this path | **1,471** |
| share of all schema reads during a create | **96%** |

1,471 *distinct* schemas, so OpenRegister's request cache could not help — the caller was genuinely walking nearly every schema on the instance (1,917) to read three `IAppConfig` booleans.

Added `getFeatureToggles()` and pointed the listener at it. Same three values, no register or schema touched.

Effect on an OpenRegister create (median of 3, identical payload):

| | before | after |
|---|---|---|
| wall | 13.7s | 3.2s |
| schema sequential scans | 3,019 | 58 |

Part of openregister `openspec/changes/object-write-sub-500ms` task 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)