### PR TITLE
perf(settings): persist configuration_version — ~100ms off every request on the instance

### DIFF
--- a/lib/EventListener/EnrichmentRunner.php
+++ b/lib/EventListener/EnrichmentRunner.php
@@ -45,6 +45,13 @@ class EnrichmentRunner
     /**
      * Check if enrichment is enabled based on settings
      *
+     * Reads the three toggles ONLY. It must not call `getAllSettings()`: that
+     * assembles the admin-settings payload, including a walk of every register
+     * and every schema on the instance. This runs inside an unrelated app's
+     * object save, and that walk issued 1,471 `SchemaMapper::find()` calls per
+     * create — 96% of all schema reads during an OpenRegister create, measured
+     * 2026-07-29, on a code path whose entire job is to answer a boolean.
+     *
      * @param SettingsService $settingsService The settings service
      *
      * @return bool True if at least one enrichment feature is enabled
@@ -53,7 +60,7 @@ class EnrichmentRunner
      */
     public function isEnrichmentEnabled(SettingsService $settingsService): bool
     {
-        $settings       = $settingsService->getAllSettings();
+        $settings       = $settingsService->getFeatureToggles();
         $enableLanguage = $settings['enable_language_detection'] ?? true;
         $enableKeywords = $settings['enable_keyword_extraction'] ?? true;
         $enableTopic    = $settings['enable_topic_classification'] ?? true;

--- a/lib/Service/GrondslagProposalService.php
+++ b/lib/Service/GrondslagProposalService.php
@@ -319,7 +319,16 @@ class GrondslagProposalService
                 $slug = (string) ($self['slug'] ?? '');
             }
 
-            $name = (string) ($base['name'] ?? '');
+            // Cast only scalars. An OpenRegister object property may legally be
+            // an array (multi-value / nested), and `(string) $array` emits a
+            // PHP "Array to string conversion" warning for EVERY such field.
+            // Measured 2026-07-28: a single object create produced 6,240 of
+            // these warnings (6,623 log lines total) because this runs on the
+            // OR object-write path — which made every
+            // `POST /apps/openregister/api/objects/...` hang fleet-wide and
+            // grew nextcloud.log without bound (cf. the 163GB log incident
+            // that filled the Docker disk and PANICked Postgres).
+            $name = self::asString($base['name'] ?? '');
             if ($slug === '' || $name === '') {
                 continue;
             }
@@ -327,7 +336,7 @@ class GrondslagProposalService
             $bases[] = [
                 'slug'        => $slug,
                 'name'        => $name,
-                'description' => (string) ($base['description'] ?? ''),
+                'description' => self::asString($base['description'] ?? ''),
             ];
         }//end foreach
 
@@ -512,6 +521,32 @@ class GrondslagProposalService
      * flattened via `jsonSerialize()`, which yields the `@self` + property
      * payload this service reads.
      *
+     * Coerce an OpenRegister property to a string without warning on arrays.
+     *
+     * OR object properties are `mixed`: a field may be a scalar, null, or an
+     * array (multi-value / nested object). A bare `(string) $value` cast on an
+     * array raises "Array to string conversion" — harmless-looking, but on the
+     * object-write path it fires once per field per object and buries the
+     * request (and the log) under thousands of warnings.
+     *
+     * @param mixed $value The raw property value.
+     *
+     * @return string The scalar rendering, or '' when the value is not scalar.
+     *
+     * @psalm-pure
+     */
+    private static function asString(mixed $value): string
+    {
+        if (is_scalar($value) === true) {
+            return (string) $value;
+        }
+
+        return '';
+
+    }//end asString()
+
+
+    /**
      * @param mixed $result The raw search result.
      *
      * @return array<int, array<string, mixed>> The list of object arrays.

--- a/lib/Service/SettingsInitializer.php
+++ b/lib/Service/SettingsInitializer.php
@@ -244,6 +244,22 @@ class SettingsInitializer
                 version: $settings['info']['version']
             );
 
+            // Persist the version we just imported. Nothing else writes this
+            // key — not this app, not OpenRegister — so without it
+            // `$currentVersion` above stays at its '0.0.0' default forever, the
+            // version gate can never close, and this import runs on EVERY
+            // request. It is reached from Application::boot(), so that is every
+            // request to the whole instance, not just DocuDesk's own.
+            //
+            // Measured 2026-07-29 on the dev instance, an OpenRegister object
+            // create: 354ms median with the key absent, 255ms with it set —
+            // ~100ms per request, ~28%, plus 14 schema lookups.
+            $this->config->setValueString(
+                $this->appName,
+                'configuration_version',
+                (string) $settings['info']['version']
+            );
+
             $results['configuration'] = true;
             $results['info'][]        = 'Configuration updated to version '.$settings['info']['version'];
         } catch (Exception $e) {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -206,6 +206,33 @@ class SettingsService
     }//end initialize()
 
     /**
+     * The feature toggles alone, without the rest of the settings payload.
+     *
+     * {@see getAllSettings()} assembles what the ADMIN SETTINGS PAGE needs:
+     * every available register with its schemas, the object-type
+     * configuration, OCR status and the grondslag selector data. That is
+     * correct for a settings screen and catastrophic on a write path — the
+     * register/schema discovery alone issued 1,471 `SchemaMapper::find()`
+     * calls (one per schema on the instance) when it was reached from
+     * {@see \OCA\DocuDesk\EventListener\EnrichmentRunner}, which runs inside
+     * an unrelated app's object save. Measured 2026-07-29: 96% of ALL schema
+     * reads during an OpenRegister object create originated there, and the
+     * create took 9-17s.
+     *
+     * Anything that only needs a toggle MUST call this instead. These are
+     * plain IAppConfig reads and touch no register or schema.
+     *
+     * @return array<string, mixed> Feature toggle settings.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function getFeatureToggles(): array
+    {
+        return $this->loadFeatureToggles();
+
+    }//end getFeatureToggles()
+
+    /**
      * Load feature toggle settings from app config
      *
      * @return array<string, mixed> Feature toggle settings


### PR DESCRIPTION
`SettingsInitializer::initialize()` reads `configuration_version` to decide whether its OpenRegister configuration is already imported. **Nothing ever wrote that key** — not this app, not OpenRegister — so `$currentVersion` stayed at its `'0.0.0'` default forever, `version_compare` never short-circuited, and the full `importFromApp` ran again on every call.

It is called from `Application::boot()`, so that is **every request to the whole Nextcloud instance**, not just DocuDesk's own pages.

## Measured

OpenRegister object create, 10 runs, app-token auth:

| | median |
|---|---|
| `configuration_version` absent | 354 ms |
| `configuration_version` present | **255 ms** |

**~100 ms per request, ~28%.** Confirmed independently by call-path attribution — the create's schema lookups drop **23 → 9**, of which the ImportHandler contribution goes **14 → 0**:

```
OC::handleRequest → AppManager->loadApps → Coordinator->bootApp
  → DocuDesk\Application->boot
    → SettingsService->initialize
      → SettingsInitializer->initialize
        → OpenRegister\ConfigurationService->importFromApp
          → ImportHandler->autoCreateRegisterIfApplication
            → SchemaMapper::find() ×14        ← every request
```

## Why this fix rather than removing the boot call

DocuDesk is the **only** app in the fleet that runs a settings import from `boot()` — the others do it from cron or a repair step, which is the safer pattern and worth considering separately. But keeping the call and making the gate actually work is the smaller, lower-risk change, and it self-heals: the first request after an upgrade imports once and records the version.

Note the import itself was never wrong — it is idempotent. It was just never told it had already run.

## Related

Second cost this pattern has produced today. The sibling fix in `0495b9ec` (#350) addressed an `isEnrichmentEnabled()` boolean that reached `getAllSettings()` and issued **1,471** schema reads per object create. Same shape: cheap-looking call, expensive discovery behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)