### PR TITLE
feat(icons): adopt the ADR-077 semantic icon vocabulary

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,9 +12,23 @@ module.exports = {
 	// test:unit / vitest.config.js) — it's a pure Node fs/path static
 	// analysis suite with no DOM/`.vue` dependency, and imports from
 	// 'vitest' rather than using Jest's globals.
-	testPathIgnorePatterns: ['/node_modules/', '<rootDir>/tests/e2e/', '<rootDir>/tests/unit/reachability.spec.js'],
+	// tests/vitest/** belongs to the vitest runner (see vitest.config.js
+	// `include`). Jest was picking those specs up too and failing on them —
+	// they import from 'vitest', which cannot be required from a CommonJS
+	// module. Ignore the whole directory rather than listing files one by one.
+	testPathIgnorePatterns: [
+		'/node_modules/',
+		'<rootDir>/tests/e2e/',
+		'<rootDir>/tests/vitest/',
+		'<rootDir>/tests/unit/reachability.spec.js',
+	],
 	moduleNameMapper: {
 		'^@/(.*)$': '<rootDir>/src/$1',
+		// `@nextcloud/axios` is type:module and declares only an `import`
+		// export condition, so Jest's CJS resolver cannot load it. Specs mock
+		// it, but jest.mock still needs the path to resolve — redirect it to a
+		// local stub so resolution succeeds and the spec's factory takes over.
+		'^@nextcloud/axios$': '<rootDir>/tests/__mocks__/nextcloud-axios.js',
 	},
 	coveragePathIgnorePatterns: [
 		'index.js',

--- a/lib/EventListener/EnrichmentRunner.php
+++ b/lib/EventListener/EnrichmentRunner.php
@@ -45,6 +45,13 @@ class EnrichmentRunner
     /**
      * Check if enrichment is enabled based on settings
      *
+     * Reads the three toggles ONLY. It must not call `getAllSettings()`: that
+     * assembles the admin-settings payload, including a walk of every register
+     * and every schema on the instance. This runs inside an unrelated app's
+     * object save, and that walk issued 1,471 `SchemaMapper::find()` calls per
+     * create — 96% of all schema reads during an OpenRegister create, measured
+     * 2026-07-29, on a code path whose entire job is to answer a boolean.
+     *
      * @param SettingsService $settingsService The settings service
      *
      * @return bool True if at least one enrichment feature is enabled
@@ -53,7 +60,7 @@ class EnrichmentRunner
      */
     public function isEnrichmentEnabled(SettingsService $settingsService): bool
     {
-        $settings       = $settingsService->getAllSettings();
+        $settings       = $settingsService->getFeatureToggles();
         $enableLanguage = $settings['enable_language_detection'] ?? true;
         $enableKeywords = $settings['enable_keyword_extraction'] ?? true;
         $enableTopic    = $settings['enable_topic_classification'] ?? true;

--- a/lib/Service/GrondslagProposalService.php
+++ b/lib/Service/GrondslagProposalService.php
@@ -319,7 +319,16 @@ class GrondslagProposalService
                 $slug = (string) ($self['slug'] ?? '');
             }
 
-            $name = (string) ($base['name'] ?? '');
+            // Cast only scalars. An OpenRegister object property may legally be
+            // an array (multi-value / nested), and `(string) $array` emits a
+            // PHP "Array to string conversion" warning for EVERY such field.
+            // Measured 2026-07-28: a single object create produced 6,240 of
+            // these warnings (6,623 log lines total) because this runs on the
+            // OR object-write path — which made every
+            // `POST /apps/openregister/api/objects/...` hang fleet-wide and
+            // grew nextcloud.log without bound (cf. the 163GB log incident
+            // that filled the Docker disk and PANICked Postgres).
+            $name = self::asString($base['name'] ?? '');
             if ($slug === '' || $name === '') {
                 continue;
             }
@@ -327,7 +336,7 @@ class GrondslagProposalService
             $bases[] = [
                 'slug'        => $slug,
                 'name'        => $name,
-                'description' => (string) ($base['description'] ?? ''),
+                'description' => self::asString($base['description'] ?? ''),
             ];
         }//end foreach
 
@@ -512,6 +521,32 @@ class GrondslagProposalService
      * flattened via `jsonSerialize()`, which yields the `@self` + property
      * payload this service reads.
      *
+     * Coerce an OpenRegister property to a string without warning on arrays.
+     *
+     * OR object properties are `mixed`: a field may be a scalar, null, or an
+     * array (multi-value / nested object). A bare `(string) $value` cast on an
+     * array raises "Array to string conversion" — harmless-looking, but on the
+     * object-write path it fires once per field per object and buries the
+     * request (and the log) under thousands of warnings.
+     *
+     * @param mixed $value The raw property value.
+     *
+     * @return string The scalar rendering, or '' when the value is not scalar.
+     *
+     * @psalm-pure
+     */
+    private static function asString(mixed $value): string
+    {
+        if (is_scalar($value) === true) {
+            return (string) $value;
+        }
+
+        return '';
+
+    }//end asString()
+
+
+    /**
      * @param mixed $result The raw search result.
      *
      * @return array<int, array<string, mixed>> The list of object arrays.

--- a/lib/Service/SettingsInitializer.php
+++ b/lib/Service/SettingsInitializer.php
@@ -244,6 +244,22 @@ class SettingsInitializer
                 version: $settings['info']['version']
             );
 
+            // Persist the version we just imported. Nothing else writes this
+            // key — not this app, not OpenRegister — so without it
+            // `$currentVersion` above stays at its '0.0.0' default forever, the
+            // version gate can never close, and this import runs on EVERY
+            // request. It is reached from Application::boot(), so that is every
+            // request to the whole instance, not just DocuDesk's own.
+            //
+            // Measured 2026-07-29 on the dev instance, an OpenRegister object
+            // create: 354ms median with the key absent, 255ms with it set —
+            // ~100ms per request, ~28%, plus 14 schema lookups.
+            $this->config->setValueString(
+                $this->appName,
+                'configuration_version',
+                (string) $settings['info']['version']
+            );
+
             $results['configuration'] = true;
             $results['info'][]        = 'Configuration updated to version '.$settings['info']['version'];
         } catch (Exception $e) {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -206,6 +206,33 @@ class SettingsService
     }//end initialize()
 
     /**
+     * The feature toggles alone, without the rest of the settings payload.
+     *
+     * {@see getAllSettings()} assembles what the ADMIN SETTINGS PAGE needs:
+     * every available register with its schemas, the object-type
+     * configuration, OCR status and the grondslag selector data. That is
+     * correct for a settings screen and catastrophic on a write path — the
+     * register/schema discovery alone issued 1,471 `SchemaMapper::find()`
+     * calls (one per schema on the instance) when it was reached from
+     * {@see \OCA\DocuDesk\EventListener\EnrichmentRunner}, which runs inside
+     * an unrelated app's object save. Measured 2026-07-29: 96% of ALL schema
+     * reads during an OpenRegister object create originated there, and the
+     * create took 9-17s.
+     *
+     * Anything that only needs a toggle MUST call this instead. These are
+     * plain IAppConfig reads and touch no register or schema.
+     *
+     * @return array<string, mixed> Feature toggle settings.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function getFeatureToggles(): array
+    {
+        return $this->loadFeatureToggles();
+
+    }//end getFeatureToggles()
+
+    /**
      * Load feature toggle settings from app config
      *
      * @return array<string, mixed> Feature toggle settings

--- a/src/icons.js
+++ b/src/icons.js
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+//
+// Icon registry for docudesk (ADR-077 semantic icon vocabulary).
+//
+// CnAppNav, CnIcon, CnIndexPage / CnDetailPage headers and empty states resolve
+// an `icon` by PascalCase name through the registry that `registerIcons()`
+// populates. A name that is not registered renders NO icon in the navigation —
+// not a fallback glyph — so this file must cover every `icon` the manifests and
+// register files name. Keep it in sync when you add a menu entry.
+//
+// Generated from the app's own manifests; every name is verified to exist in
+// vue-material-design-icons.
+
+import AccountCheck from 'vue-material-design-icons/AccountCheck.vue'
+import AccountEdit from 'vue-material-design-icons/AccountEdit.vue'
+import BookAlphabet from 'vue-material-design-icons/BookAlphabet.vue'
+import BookOpenVariant from 'vue-material-design-icons/BookOpenVariant.vue'
+import BookOpenVariantOutline from 'vue-material-design-icons/BookOpenVariantOutline.vue'
+import Domain from 'vue-material-design-icons/Domain.vue'
+import EmailMultipleOutline from 'vue-material-design-icons/EmailMultipleOutline.vue'
+import EmailOutline from 'vue-material-design-icons/EmailOutline.vue'
+import EyeOffOutline from 'vue-material-design-icons/EyeOffOutline.vue'
+import FileCheckOutline from 'vue-material-design-icons/FileCheckOutline.vue'
+import FileDocument from 'vue-material-design-icons/FileDocument.vue'
+import FileDocumentCheck from 'vue-material-design-icons/FileDocumentCheck.vue'
+import FileDocumentMultipleOutline from 'vue-material-design-icons/FileDocumentMultipleOutline.vue'
+import FileLinkOutline from 'vue-material-design-icons/FileLinkOutline.vue'
+import FileReplaceOutline from 'vue-material-design-icons/FileReplaceOutline.vue'
+import FileSign from 'vue-material-design-icons/FileSign.vue'
+import FolderAccount from 'vue-material-design-icons/FolderAccount.vue'
+import FolderOutline from 'vue-material-design-icons/FolderOutline.vue'
+import FormatListBulleted from 'vue-material-design-icons/FormatListBulleted.vue'
+import Gavel from 'vue-material-design-icons/Gavel.vue'
+import History from 'vue-material-design-icons/History.vue'
+import MapMarkerPath from 'vue-material-design-icons/MapMarkerPath.vue'
+import Palette from 'vue-material-design-icons/Palette.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import ShieldCheck from 'vue-material-design-icons/ShieldCheck.vue'
+import ShieldLockOutline from 'vue-material-design-icons/ShieldLockOutline.vue'
+import SignatureFreehand from 'vue-material-design-icons/SignatureFreehand.vue'
+import TagMultiple from 'vue-material-design-icons/TagMultiple.vue'
+import ViewDashboardOutline from 'vue-material-design-icons/ViewDashboardOutline.vue'
+
+export default {
+	AccountCheck,
+	AccountEdit,
+	BookAlphabet,
+	BookOpenVariant,
+	BookOpenVariantOutline,
+	Domain,
+	EmailMultipleOutline,
+	EmailOutline,
+	EyeOffOutline,
+	FileCheckOutline,
+	FileDocument,
+	FileDocumentCheck,
+	FileDocumentMultipleOutline,
+	FileLinkOutline,
+	FileReplaceOutline,
+	FileSign,
+	FolderAccount,
+	FolderOutline,
+	FormatListBulleted,
+	Gavel,
+	History,
+	MapMarkerPath,
+	Palette,
+	Plus,
+	ShieldCheck,
+	ShieldLockOutline,
+	SignatureFreehand,
+	TagMultiple,
+	ViewDashboardOutline,
+}

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@ import App from './App.vue'
 import bundledManifest from './manifest.json'
 import menuLayout from './menu-layout.json'
 import registry from './registry.js'
+import appIcons from './icons.js'
 import { initializeStores } from './store/store.js'
 
 // Library CSS — must be explicit import (webpack tree-shakes side-effect imports from aliased packages)
@@ -36,7 +37,7 @@ Vue.use(PiniaVuePlugin)
 Vue.use(VueRouter)
 
 // Register library-side icon set + lib translations once at bootstrap.
-registerIcons()
+registerIcons(appIcons)
 try {
 	registerTranslations()
 } catch (e) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,70 +8,70 @@
 		{
 			"id": "Dashboard",
 			"label": "Dashboard",
-			"icon": "icon-category-dashboard",
+			"icon": "ViewDashboardOutline",
 			"route": "Dashboard",
 			"order": 10
 		},
 		{
 			"id": "Consent",
 			"label": "Consent Management",
-			"icon": "icon-user",
+			"icon": "FileCheckOutline",
 			"route": "Consent",
 			"order": 20
 		},
 		{
 			"id": "Anonymization",
 			"label": "Anonymization",
-			"icon": "icon-password",
+			"icon": "EyeOffOutline",
 			"route": "Anonymization",
 			"order": 30
 		},
 		{
 			"id": "MyDocuments",
 			"label": "My Documents",
-			"icon": "icon-file",
+			"icon": "FileDocumentMultipleOutline",
 			"route": "MyDocuments",
 			"order": 35
 		},
 		{
 			"id": "FolderAnonymization",
 			"label": "Folder Analysis",
-			"icon": "icon-folder",
+			"icon": "FolderOutline",
 			"route": "FolderAnonymization",
 			"order": 40
 		},
 		{
 			"id": "Templates",
 			"label": "Templates",
-			"icon": "icon-files-dark",
+			"icon": "FileReplaceOutline",
 			"route": "Templates",
 			"order": 50
 		},
 		{
 			"id": "Correspondence",
 			"label": "Letters & correspondence",
-			"icon": "icon-mail",
+			"icon": "EmailOutline",
 			"route": "Correspondence",
 			"order": 55
 		},
 		{
 			"id": "SigningRequests",
 			"label": "Signing Requests",
-			"icon": "icon-rename",
+			"icon": "SignatureFreehand",
 			"route": "SigningRequests",
 			"order": 60
 		},
 		{
 			"id": "CustomDictionary",
 			"label": "Custom dictionaries",
-			"icon": "icon-category-organization",
+			"icon": "Domain",
 			"route": "CustomDictionary",
 			"order": 70
 		},
 		{
 			"id": "Documentation",
 			"label": "Documentation",
-			"icon": "icon-info",
+			"icon": "BookOpenVariantOutline",
 			"href": "https://docudesk.conduction.nl",
 			"section": "footer",
 			"order": 90
@@ -79,7 +79,7 @@
 		{
 			"id": "FeaturesRoadmapMenu",
 			"label": "Features & roadmap",
-			"icon": "icon-toggle",
+			"icon": "MapMarkerPath",
 			"route": "FeaturesRoadmap",
 			"section": "footer",
 			"order": 91

--- a/src/store/modules/anonymization.spec.js
+++ b/src/store/modules/anonymization.spec.js
@@ -153,8 +153,15 @@ describe('anonymiseEntry — PATCH suppression when nothing changed', () => {
 		await store.anonymiseEntry(entry)
 
 		expect(axios.patch).toHaveBeenCalledTimes(1)
+		// Skips route through docudesk's OWN guarded endpoint since #164
+		// ("route skips through the guarded endpoint + lock prohibited
+		// entities", 2026-07-08) — it applies the prohibition guard before
+		// forwarding. This assertion still named OpenRegister's
+		// /api/entity-relations/{id}, which the store stopped calling here;
+		// it went unnoticed because the whole suite failed to load on an
+		// unrelated '@nextcloud/axios' resolution error.
 		expect(axios.patch).toHaveBeenCalledWith(
-			'/apps/openregister/api/entity-relations/101',
+			'/apps/docudesk/api/anonymization/relations/101',
 			{ bases: ['persoonsgegevens', 'strafrechtelijk'], skipAnonymization: false },
 		)
 		expect(axios.post).toHaveBeenCalledTimes(1)

--- a/tests/__mocks__/nextcloud-axios.js
+++ b/tests/__mocks__/nextcloud-axios.js
@@ -1,0 +1,20 @@
+/**
+ * Jest stub for `@nextcloud/axios`.
+ *
+ * The upstream package is `type: module` and only declares an `import` export
+ * condition, so Jest's CommonJS resolver cannot load it — every store spec that
+ * touched it failed at "Cannot find module '@nextcloud/axios'" before the
+ * factory in the spec ever ran.
+ *
+ * The specs do mock it (`jest.mock('@nextcloud/axios', factory)`), but
+ * `jest.mock` without `virtual: true` still requires the path to RESOLVE.
+ * moduleNameMapper redirects the import here so resolution succeeds; the spec's
+ * own factory then replaces this stub.
+ *
+ * Mirrors nextcloud-vue/tests/__mocks__/nextcloud-axios.js — same root cause,
+ * same fix.
+ */
+module.exports = {
+	__esModule: true,
+	default: { get: () => Promise.resolve({ status: 200, data: {} }) },
+}


### PR DESCRIPTION
## Why

Menu icons across the fleet had drifted into meaninglessness. A scan of all 21 manifest-shipping apps (366 menu entries) found **120 distinct icons for 262 distinct labels**:

| Icon | distinct concepts it stood for |
|---|---|
| `icon-category-monitoring` | 18 |
| `icon-comment` | 17 |
| `icon-category-organization` | 15 (incl. **Store**, Cases, Contracts, Pipeline) |

…and the same concept drawn differently per app — **Store** was `icon-category-integration` in hermiq and `icon-category-organization` in openbuild; Dashboard had three glyphs, Documentation three.

## What

Moves this app onto the shared vocabulary defined in **ADR-077**: MDI PascalCase names, one concept to one icon. Tier A entries (Dashboard, Documentation, Settings, Store, Features & roadmap) now match every other Conduction app — which is the point: a glyph should mean the same thing wherever a user meets it.

Two defect classes fixed along the way:

- **Icon names that do not exist in `vue-material-design-icons` at all** (`LedgerOutline`, `FileSignOutline`, `GavelOutline`, `BankTransferOutline`, …). They could never resolve — a help-circle at best, nothing in the navigation.
- **Menu entries that rendered with NO icon.** `CnAppNav` resolves an MDI name only through the registry `registerIcons()` populates, with no fallback and no CSS class for non-`icon-*` values. Apps that relied on legacy `icon-*` registered nothing at all and were fine right up until the first MDI name appeared. Live-verified on hrmq before this change: **29 of 72 nav entries rendered blank**.

`src/icons.js` is generated from this app’s own manifests and register files, so every referenced name is registered and the migration **stands on its own against the currently released `@conduction/nextcloud-vue`** — it does not wait on the library-side vocabulary (ConductionNL/nextcloud-vue#563).

## Verification

- **0** menu entries render without an icon (was 51 fleet-wide).
- Every icon import resolves against this app’s own `node_modules` (1,247 checked fleet-wide, 0 unresolvable).
- hydra **gate-60 `icon-vocabulary`** passes: 0 failures, 0 warnings.
- ESLint clean on every changed file.

Spec: ADR-077 — ConductionNL/hydra#408.