### PR TITLE
perf(events): declare DossierCheckedOnListener's register/schema interest

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -23,6 +23,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCA\DocuDesk\Dashboard\AnonymizationWidget;
 use OCA\DocuDesk\Dashboard\FileEntitiesWidget;
 use OCA\DocuDesk\Event\DocumentSigningRequestedEvent;
@@ -121,22 +122,6 @@ class Application extends App implements IBootstrap
         $context->registerEventListener(ApprovalStepApprovedEvent::class, ApprovalStepListener::class);
         $context->registerEventListener(ApprovalStepRejectedEvent::class, ApprovalStepListener::class);
         $context->registerEventListener(ApprovalStepCompletedEvent::class, ApprovalStepListener::class);
-
-        // Auto-regen dossier grondslagen summary when checkedOn is updated.
-        //
-        // Declares its register/schema interest at REGISTRATION time: the
-        // listener only ever acts on `docudesk`/`dossier` objects (see
-        // DossierCheckedOnListener::REGISTER / ::DOSSIER_SCHEMA), so an
-        // unrelated app's object write no longer constructs it at all. The
-        // in-handler `isDossierObject()` guard stays in place as defence in
-        // depth.
-        $this->registerFilteredObjectListener(
-            context: $context,
-            event: ObjectUpdatedEvent::class,
-            listener: DossierCheckedOnListener::class,
-            registers: ['docudesk'],
-            schemas: ['dossier']
-        );
 
         // Cross-app delegated-signing contract (docudesk-signing-events): any
         // installed consumer app (e.g. shillinq) dispatches
@@ -275,16 +260,26 @@ class Application extends App implements IBootstrap
      * degrades to the plain global registration it replaced, which is exactly
      * the behaviour every listener had before.
      *
-     * @param IRegistrationContext $context   Registration context.
-     * @param string               $event     OpenRegister event class name.
-     * @param string               $listener  Listener class name.
-     * @param array<int,string>    $registers Register slugs the listener reacts to.
-     * @param array<int,string>    $schemas   Schema slugs the listener reacts to.
+     * MUST be called from boot(), never from register(). Nextcloud enables each
+     * app's autoloader immediately before calling that app's own register()
+     * (`OC\AppFramework\Bootstrap\Coordinator::registerApps()`), so at register()
+     * time OpenRegister's classes are only autoloadable to apps that boot after
+     * it. DocuDesk is app 21 of 92 and OpenRegister is 52, so the class_exists()
+     * guard below was ALWAYS false here and this app silently fell back to an
+     * unfiltered registration — one of seven fleet conversions that looked
+     * successful while being inert. boot() runs only after every app's
+     * register() has completed, which makes the guard order-independent.
+     *
+     * @param IEventDispatcher  $dispatcher The live event dispatcher.
+     * @param string            $event      OpenRegister event class name.
+     * @param string            $listener   Listener class name.
+     * @param array<int,string> $registers  Register slugs the listener reacts to.
+     * @param array<int,string> $schemas    Schema slugs the listener reacts to.
      *
      * @return void
      */
     private function registerFilteredObjectListener(
-        IRegistrationContext $context,
+        IEventDispatcher $dispatcher,
         string $event,
         string $listener,
         array $registers,
@@ -292,8 +287,8 @@ class Application extends App implements IBootstrap
     ): void {
         $subscription = '\\OCA\\OpenRegister\\Event\\ObjectEventSubscription';
         if (class_exists($subscription) === true) {
-            $subscription::register(
-                context: $context,
+            $subscription::subscribe(
+                dispatcher: $dispatcher,
                 event: $event,
                 listener: $listener,
                 registers: $registers,
@@ -302,7 +297,16 @@ class Application extends App implements IBootstrap
             return;
         }
 
-        $context->registerEventListener(event: $event, listener: $listener);
+        // Loud on purpose. This fallback is correct but UNFILTERED, and while it
+        // was silent it was indistinguishable from a working narrowing.
+        \OCP\Server::get(LoggerInterface::class)->warning(
+            'OpenRegister ObjectEventSubscription unavailable: '.$listener
+            .' fell back to an UNFILTERED registration for '.$event
+            .' and will be invoked on every object write instance-wide.',
+            ['app' => self::APP_ID]
+        );
+
+        $dispatcher->addServiceListener($event, $listener);
 
     }//end registerFilteredObjectListener()
 
@@ -380,6 +384,17 @@ class Application extends App implements IBootstrap
     public function boot(IBootContext $context): void
     {
         $container = $context->getServerContainer();
+
+        // Auto-regen dossier grondslagen summary when checkedOn is updated.
+        // Declared here rather than in register() so the OpenRegister guard is
+        // independent of this app's position in the bootstrap order.
+        $this->registerFilteredObjectListener(
+            dispatcher: $container->get(IEventDispatcher::class),
+            event: ObjectUpdatedEvent::class,
+            listener: DossierCheckedOnListener::class,
+            registers: ['docudesk'],
+            schemas: ['dossier']
+        );
 
         // Initialize OpenRegister configuration on boot.
         try {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -100,6 +100,12 @@ class Application extends App implements IBootstrap
         // Register event listeners for OpenRegister events.
         // When documents are created/updated/deleted in OpenRegister,
         // DocuDesk will enrich metadata and manage consent tracking.
+        //
+        // Deliberately NOT narrowed to a register/schema set: DocuDeskEventHandler
+        // identifies its work by PAYLOAD SHAPE (`looksLikeDossier()`,
+        // `detectPolicyShape()`) rather than by schema, and EnrichmentRunner
+        // enriches metadata on EVERY object on the instance regardless of
+        // register. Declaring any slug list here would silently drop work.
         $context->registerEventListener(ObjectCreatedEvent::class, DocuDeskEventListener::class);
         $context->registerEventListener(ObjectUpdatedEvent::class, DocuDeskEventListener::class);
         $context->registerEventListener(ObjectDeletedEvent::class, DocuDeskEventListener::class);
@@ -117,7 +123,20 @@ class Application extends App implements IBootstrap
         $context->registerEventListener(ApprovalStepCompletedEvent::class, ApprovalStepListener::class);
 
         // Auto-regen dossier grondslagen summary when checkedOn is updated.
-        $context->registerEventListener(ObjectUpdatedEvent::class, DossierCheckedOnListener::class);
+        //
+        // Declares its register/schema interest at REGISTRATION time: the
+        // listener only ever acts on `docudesk`/`dossier` objects (see
+        // DossierCheckedOnListener::REGISTER / ::DOSSIER_SCHEMA), so an
+        // unrelated app's object write no longer constructs it at all. The
+        // in-handler `isDossierObject()` guard stays in place as defence in
+        // depth.
+        $this->registerFilteredObjectListener(
+            context: $context,
+            event: ObjectUpdatedEvent::class,
+            listener: DossierCheckedOnListener::class,
+            registers: ['docudesk'],
+            schemas: ['dossier']
+        );
 
         // Cross-app delegated-signing contract (docudesk-signing-events): any
         // installed consumer app (e.g. shillinq) dispatches
@@ -245,6 +264,47 @@ class Application extends App implements IBootstrap
             }
         );
     }//end register()
+
+    /**
+     * Register an object-lifecycle listener that declares its interest up front.
+     *
+     * OpenRegister's `ObjectEventSubscription` records the register/schema slugs
+     * a listener reacts to and routes dispatches through a single shared proxy,
+     * so an uninterested listener is neither constructed nor invoked. When
+     * OpenRegister is absent — DocuDesk carries no hard dependency on it — this
+     * degrades to the plain global registration it replaced, which is exactly
+     * the behaviour every listener had before.
+     *
+     * @param IRegistrationContext $context   Registration context.
+     * @param string               $event     OpenRegister event class name.
+     * @param string               $listener  Listener class name.
+     * @param array<int,string>    $registers Register slugs the listener reacts to.
+     * @param array<int,string>    $schemas   Schema slugs the listener reacts to.
+     *
+     * @return void
+     */
+    private function registerFilteredObjectListener(
+        IRegistrationContext $context,
+        string $event,
+        string $listener,
+        array $registers,
+        array $schemas
+    ): void {
+        $subscription = '\\OCA\\OpenRegister\\Event\\ObjectEventSubscription';
+        if (class_exists($subscription) === true) {
+            $subscription::register(
+                context: $context,
+                event: $event,
+                listener: $listener,
+                registers: $registers,
+                schemas: $schemas
+            );
+            return;
+        }
+
+        $context->registerEventListener(event: $event, listener: $listener);
+
+    }//end registerFilteredObjectListener()
 
     /**
      * Wire the AppHost-backed health + metrics controllers.


### PR DESCRIPTION
## What

`DossierCheckedOnListener` was registered globally on `ObjectUpdatedEvent`, so **every object update anywhere on the instance** constructed the listener (and its `GrondslagenSummaryService` dependency) only for `isDossierObject()` to reject it. It now declares its interest — register `docudesk`, schema `dossier` — through OpenRegister's `ObjectEventSubscription`, which resolves the slugs once per request and dispatches through one shared proxy.

## Listener-by-listener

| Listener | Verdict | Declared | Evidence |
|---|---|---|---|
| `DossierCheckedOnListener` | **CONVERTED** | registers `['docudesk']`, schemas `['dossier']` | `private const REGISTER = 'docudesk';` / `private const DOSSIER_SCHEMA = 'dossier';`, used by `isDossierObject()` — the only gate in the handler |
| `DocuDeskEventListener` (Created/Updated/Deleted) | **NOT converted** | — | Interest is not schema-scoped. `DocuDeskEventHandler::looksLikeDossier()` / `::detectPolicyShape()` identify work by **payload shape** ("avoids a round-trip to OR's SchemaMapper for every ObjectUpdatedEvent"), and `EnrichmentRunner::enrichObject()` enriches metadata on **every** object regardless of register/schema. Any slug list would silently drop work. |

## Slug verification (dev instance)

```
oc_openregister_registers slug=docudesk -> ids 7, 2483, 2484
oc_openregister_schemas   slug=dossier  -> ids 228, 5083
register 7 schemas: [... 228 ...]   register 2483 schemas: [... 228 ...]
```
Cross-checked against `lib/Settings/docudesk_register.json` (`"slug": "dossier"`). Both slugs resolve; the combination is live.

## Safety

- Guarded on `class_exists('\OCA\OpenRegister\Event\ObjectEventSubscription')` — openregister#2223 is **not merged**, so on an instance without it this degrades to the exact `registerEventListener()` call it replaced. No hard cross-app reference.
- The in-handler `isDossierObject()` guard is left in place (defence in depth).

## ⚠️ Pre-existing bug found while reading (NOT fixed here)

`DossierCheckedOnListener::isDossierObject()` compares `$object->getRegister()` / `->getSchema()` against the **slug** strings. On `OCA\OpenRegister\Db\ObjectEntity` those fields are `?string` holding the register/schema **id** (`"7"`, `"228"`), and they are never objects, so neither `$register === 'docudesk'` nor the `getSlug()` branch can ever be true. **The listener's body has therefore never run.** This is the same failure class as procest's `BezwaarLifecycleListener::resolveSchemaSlug()`. This PR is behaviour-neutral with respect to it (the guard still rejects everything); it deserves its own fix + test.

## Checks

- `php -l`: clean
- `phpcs --standard=phpcs.xml lib/AppInfo/Application.php`: **0 errors**, 3 warnings — byte-identical to the pre-change baseline (all `@spec` tag warnings on pre-existing `Application`/`register()`/`boot()`)
- `phpstan analyse lib/AppInfo/Application.php`: **No errors**
- `psalm lib/AppInfo/Application.php`: **No errors found**
- `phpmd lib/AppInfo/Application.php text phpmd.xml`: no findings
- Full `composer check:strict` (incl. `test:all`) not run — the checks above were run per-tool in a `nextcloud:34` container.