### PR TITLE
chore(deps): @conduction/nextcloud-vue 2.1.0-vue3.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@babel/core": "^7.29.0",
-        "@conduction/nextcloud-vue": "2.1.0-vue3.13",
+        "@conduction/nextcloud-vue": "2.1.0-vue3.16",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.5.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2165,9 +2165,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.1.0-vue3.13",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.1.0-vue3.13.tgz",
-      "integrity": "sha512-6UZMd9Rmjcbisx3sLBWS6T0frZlcx5nS5Iqip4ljVVQwXNfPY3RE0BBdspcTlFbxDdpcc0mMg5epreqdrK0SDQ==",
+      "version": "2.1.0-vue3.16",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.1.0-vue3.16.tgz",
+      "integrity": "sha512-YPGG5iIdBHRydqwnYbjrSVqriBmdTmjxp5HZiSmT+Ab1eLZ1D5Sv1OAq32kVNJ6ax/SmPjQK+ujMU2bb+wJxOA==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",
@@ -2215,7 +2215,7 @@
         "@nextcloud/auth": "^2.0.0 || ^3.0.0",
         "@nextcloud/axios": "^2.0.0",
         "@nextcloud/capabilities": "^1.2.1",
-        "@nextcloud/initial-state": "^2.2.0",
+        "@nextcloud/initial-state": "^2.2.0 || ^3.0.0",
         "@nextcloud/l10n": "^2.0.0 || ^3.0.0",
         "@nextcloud/router": "^2.0.0 || ^3.0.0",
         "@nextcloud/vue": "^9.0.0",
@@ -4476,9 +4476,9 @@
       "license": "MIT"
     },
     "node_modules/@lezer/css": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.4.tgz",
-      "integrity": "sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.5.tgz",
+      "integrity": "sha512-PrlQ8glBdWS5UOqgnFCmPxAJbhuOhb0WoDnSAXiNQPjivlDujhuUQ1K/fxyk2vFoq4VTBgFtFZOc8sOpiYjz5g==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -6117,6 +6117,21 @@
       "license": "MIT",
       "dependencies": {
         "eslint-scope": "5.1.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodable/entities": {
@@ -7849,9 +7864,9 @@
       "peer": true
     },
     "node_modules/@types/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
       "license": "MIT"
     },
     "node_modules/@types/send": {
@@ -10138,9 +10153,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.9",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.9.tgz",
-      "integrity": "sha512-cp447VUsGS07+n1Dqf7YSQ8maeJrjEhaDxTm1ZefbqDtypHBC5GzGMQbklR6IPR13Y8OAJRHZWEMtZipJLCttg==",
+      "version": "2.11.11",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.11.tgz",
+      "integrity": "sha512-/yImnXwyTvgMkhgekLHok/Rx5vO6E0BmStWlSqKWMVm2a2ITuZ1Tn+9bgLS+gZRdZmWtd8nxuhHpdmCUOWsTQQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -14329,9 +14344,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+      "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23719,23 +23734,6 @@
         "url": "https://opencollective.com/stylelint"
       }
     },
-    "node_modules/stylelint-config-html": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-html/-/stylelint-config-html-1.1.0.tgz",
-      "integrity": "sha512-IZv4IVESjKLumUGi+HWeb7skgO6/g4VMuAYrJdlqQFndgbj6WJAXPhaysvBiXefX79upBdQVumgYcdd17gCpjQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12 || >=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ota-meshi"
-      },
-      "peerDependencies": {
-        "postcss-html": "^1.0.0",
-        "stylelint": ">=14.0.0"
-      }
-    },
     "node_modules/stylelint-config-recommended": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz",
@@ -23803,6 +23801,23 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/stylelint-config-recommended-vue/node_modules/stylelint-config-html": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-html/-/stylelint-config-html-2.0.0.tgz",
+      "integrity": "sha512-Lk1NPEdUxzHkPv3ehktjpiOk4MPaqQ3H8fkvhxdWlQpaZCm9ze0SoMbRQLqkUxEMfPE1G9/x968uxm/+d2njoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.12 || >=24"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "postcss-html": "^2.0.0",
+        "stylelint": ">=16.0.0"
       }
     },
     "node_modules/stylelint-scss": {
@@ -25917,16 +25932,15 @@
       }
     },
     "node_modules/vue-codemirror6": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/vue-codemirror6/-/vue-codemirror6-1.5.2.tgz",
-      "integrity": "sha512-SJRW0r8776zdqIVSZZsHuTXErmql1PKATupN+RPs4IXSTAzzKl4Sl/804BazVb9OYrd2Ym5Yv97AmwPRVD4zeg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vue-codemirror6/-/vue-codemirror6-1.6.1.tgz",
+      "integrity": "sha512-0Ue6nWy055UKP/6LkT0I7nW5SRSFJ+3mokwBdHePQsj11T02mrg3A0jtHyBqH23nRHQFxd3NKw63sZJ1ygo5dA==",
       "license": "MIT",
       "dependencies": {
         "vue-demi": "latest"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0",
-        "pnpm": ">=10.3.0"
+        "node": "^22.18.0 || >=24.12.0"
       },
       "peerDependencies": {
         "@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@babel/core": "^7.29.0",
-    "@conduction/nextcloud-vue": "2.1.0-vue3.13",
+    "@conduction/nextcloud-vue": "2.1.0-vue3.16",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.5.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
Version alignment onto the current nc-vue vue3 release. `2.1.0-vue3.13` -> `2.1.0-vue3.16`, pinned exactly (no caret).

## Lockfile-verified (not just package.json)

| package | resolved |
|---|---|
| `@conduction/nextcloud-vue` | **`2.1.0-vue3.16`** — single entry |
| `vue3-apexcharts` | `1.8.0` — **below** the proprietary 1.9.0 line |
| `@nextcloud/l10n` | `3.4.1` — single entry, no duplicate |

`vue3-apexcharts@1.9.0+` forbids sublicensing, which is incompatible with our EUPL-1.2 apps. **No licence override is used** — core `apexcharts` is MIT and reports an identical `Custom: <url>` symptom, so an override would have masked the real signal.

Rebuilt with the required sequence: `rm -rf package-lock.json node_modules`, `npm install` (npm 11), `npm install --package-lock-only` (npm 10), `npm ci` (npm 10). Both removals matter — with a stale `node_modules` npm ERESOLVEs while blaming `vue@3.5.40`, which sends you after the wrong dependency entirely.

## Opt-ins checked

- **`@nextcloud/initial-state` `overrides` entry** — none present. vue3.16 widens that peer from `^2.2.0` to `^2.2.0 || ^3.0.0`; this app never carried the override, so there is nothing to drop.
- **local `vue/no-multiple-template-root: off`** — none present. Swept the whole repo, not just `eslint.config.js`, with a positive control confirming the sweep could match.
- **`CnTabs`/`CnTab`** — this app has no local tab strip.

## Gates

| gate | result | positive control |
|---|---|---|
| eslint | clean | a throwaway **`.vue`** probe fired `vue/no-deprecated-slot-attribute`, `vue/no-deprecated-filter` and `vue/no-deprecated-v-on-native-modifier` (exit 1), then exit 0 again once removed. A `.js` probe would not exercise the Vue-3 deprecation rules at all. |
| vitest | **45/45** | fully green, so there is no failing-name set a swap could hide |
| webpack production build | clean (exit 0) | — |

Unit tests run in a `node:20-bookworm` container: this host is glibc 2.31 and `@rollup/rollup-linux-x64-gnu@4.62` requires GLIBC_2.32, so vitest cannot start on the host **at baseline either**. Environmental, not caused by this change.

## Not done

No live 2-route browser smoke on this PR — see the batch report.
