### PR TITLE
fix(ci): make composer check:strict able to fail on tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 		"psalm": "if [ -f vendor/bin/psalm ]; then ./vendor/bin/psalm --threads=1 --no-cache; else echo 'Psalm not installed, skipping...'; fi",
 		"phpstan": "if [ -f vendor/bin/phpstan ]; then ./vendor/bin/phpstan analyse --memory-limit=1G; else echo 'PHPStan not installed, skipping...'; fi",
 		"test:unit": "./vendor/bin/phpunit --configuration ./phpunit.xml tests/unit --colors=always --fail-on-warning --fail-on-risky",
-		"test:all": "./vendor/bin/phpunit --colors=always || echo 'Tests require Nextcloud environment, skipping...'",
+		"test:all": "if [ -f vendor/bin/phpunit ]; then ./vendor/bin/phpunit --colors=always --no-coverage; else echo 'phpunit not installed, skipping...'; fi",
 		"check": "E=0; for CMD in lint phpcs psalm test:unit; do echo; echo \"=== $CMD ===\"; composer $CMD || E=1; done; echo; if [ $E -eq 0 ]; then echo \"ALL CHECKS PASSED\"; else echo \"SOME CHECKS FAILED (see above)\"; fi; exit $E",
 		"check:full": "E=0; for CMD in lint phpcs psalm phpstan test:all; do echo; echo \"=== $CMD ===\"; composer $CMD || E=1; done; echo; if [ $E -eq 0 ]; then echo \"ALL CHECKS PASSED\"; else echo \"SOME CHECKS FAILED (see above)\"; fi; exit $E",
 		"check:strict": "E=0; for CMD in lint phpcs phpmd psalm phpstan test:all; do echo; echo \"=== $CMD ===\"; composer $CMD || E=1; done; echo; if [ $E -eq 0 ]; then echo \"ALL CHECKS PASSED\"; else echo \"SOME CHECKS FAILED (see above)\"; fi; exit $E",


### PR DESCRIPTION
## Problem

`test:all` ended in:

```
./vendor/bin/phpunit --colors=always || echo 'Tests require Nextcloud environment, skipping...'
```

phpunit's exit status was discarded **unconditionally**, so `composer check:strict` could never fail on a test failure. The excuse in the message is not true for this repo — the suite runs standalone.

This matters because `check:strict` is about to be the thing an agent checks before deciding its job is done. A step that cannot fail satisfies that instruction with a no-op.

## Positive control — measured on this tree

PHP 8.3.32 container, `vendor/` freshly installed from `composer.lock`. One deliberately failing test added to `tests/`:

| state | `composer check:strict` |
|---|---|
| **old** `composer.json` + failing test | exit 1 (other tools) — `test:all` **never named**, `Tests require Nextcloud environment, skipping...` printed instead |
| **new** `composer.json` + failing test | fails **naming `test:all`** |
| **new** `composer.json`, test removed | `test:all` passes — 1118 tests, 3425 assertions |

The control test is **not** in this PR — the diff is `composer.json` only.

## Change

`composer.json` only, using the guard already shipped in `shillinq` and `openregister`, plus `--no-coverage`:

```
if [ -f vendor/bin/phpunit ]; then ./vendor/bin/phpunit --colors=always --no-coverage; else echo 'phpunit not installed, skipping...'; fi
```

`--no-coverage` is deliberate: this repo's `phpunit.xml` requests coverage, and without a coverage driver PHPUnit emits a runner warning and exits non-zero. Without the flag the newly-live gate would go red on any machine lacking pcov/xdebug — for an environment reason, not a code reason, which is the fastest way to get a gate ignored again. `shillinq` and `decidesk` already pass `--no-coverage` here.

## Policy / state after this PR

**Tooling only — no findings are fixed here.** `test:all` now **passes** (1118 tests, 3425 assertions). `check:strict` is still red for **pre-existing reasons unrelated to this change**: `phpmd` (11 violations), `psalm` (1 error), `phpstan` (`Found 4 errors`). `lint` and `phpcs` pass.
