### PR TITLE
ci(main): fix shared-workflow org ref — stable release path has never run

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   check:
-    uses: Conduction/.github/.github/workflows/branch-protection.yml@main
+    uses: ConductionNL/.github/.github/workflows/branch-protection.yml@main

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: Conduction/.github/.github/workflows/quality.yml@main
+    uses: ConductionNL/.github/.github/workflows/quality.yml@main
     with:
       app-name: docudesk
       php-version: "8.3"
@@ -20,4 +20,4 @@ jobs:
       enable-frontend: true
       enable-eslint: true
       enable-phpunit: true
-      additional-apps: '[{"repo":"Conduction/openregister","app":"openregister","ref":"beta"}]'
+      additional-apps: '[{"repo":"ConductionNL/openregister","app":"openregister","ref":"beta"}]'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   deploy:
-    uses: Conduction/.github/.github/workflows/documentation.yml@main
+    uses: ConductionNL/.github/.github/workflows/documentation.yml@main
     with:
       cname: docudesk.conduction.nl

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   triage:
-    uses: Conduction/.github/.github/workflows/issue-triage.yml@feature/openspec-project-sync
+    uses: ConductionNL/.github/.github/workflows/issue-triage.yml@main
     with:
       app-name: docudesk
       backlog-existing: ${{ github.event_name == 'workflow_dispatch' && inputs.backlog-existing || false }}

--- a/.github/workflows/openspec-sync.yml
+++ b/.github/workflows/openspec-sync.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   sync:
-    uses: Conduction/.github/.github/workflows/openspec-sync.yml@feature/openspec-project-sync
+    uses: ConductionNL/.github/.github/workflows/openspec-sync.yml@main
     with:
       app-name: docudesk
     secrets:

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: Conduction/.github/.github/workflows/release-beta.yml@main
+    uses: ConductionNL/.github/.github/workflows/release-beta.yml@main
     with:
       app-name: docudesk
     secrets: inherit

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: Conduction/.github/.github/workflows/release-stable.yml@main
+    uses: ConductionNL/.github/.github/workflows/release-stable.yml@main
     with:
       app-name: docudesk
     secrets: inherit

--- a/.github/workflows/sync-to-beta.yml
+++ b/.github/workflows/sync-to-beta.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   sync:
-    uses: Conduction/.github/.github/workflows/sync-to-beta.yml@main
+    uses: ConductionNL/.github/.github/workflows/sync-to-beta.yml@main


### PR DESCRIPTION
Fixes the stable release path on `main`, which has **never run**.

## Callers fixed (8 of 8 on `main`)

| file | was | now |
|---|---|---|
| `branch-protection.yml` | `Conduction/...@main` | `ConductionNL/...@main` |
| `code-quality.yml` (`uses:`) | `Conduction/...@main` | `ConductionNL/...@main` |
| `code-quality.yml` (`additional-apps` JSON) | `"repo":"Conduction/openregister"` | `"repo":"ConductionNL/openregister"` |
| `documentation.yml` | `Conduction/...@main` | `ConductionNL/...@main` |
| `issue-triage.yml` | `Conduction/...@feature/openspec-project-sync` | `ConductionNL/...@main` |
| `openspec-sync.yml` | `Conduction/...@feature/openspec-project-sync` | `ConductionNL/...@main` |
| `release-beta.yml` | `Conduction/...@main` | `ConductionNL/...@main` |
| `release-stable.yml` | `Conduction/...@main` | `ConductionNL/...@main` |

## Two further defects the org fix alone would not cure

**1. The typo also hid inside a JSON input value.** `additional-apps` in `code-quality.yml`
embedded `{"repo":"Conduction/openregister",...}`. A `uses:`-only grep misses this. It silently
broke the PHPUnit legs that need OpenRegister present.

**2. Two callers pinned a branch that 404s.** `issue-triage.yml` and `openspec-sync.yml` pinned
`@feature/openspec-project-sync`:

```
$ gh api repos/ConductionNL/.github/branches/feature/openspec-project-sync
{"message":"Branch not found", "status":"404"}
```

Repointed at `@main`, matching `development`. Every remaining `@ref` was checked to resolve
(`ConductionNL/.github@main`, `ConductionNL/openregister@beta`).

## `app-name` / `cname` audit

`app-name: docudesk` matches `appinfo/info.xml` `<id>docudesk</id>` in all 4 callers that pass
it, and `cname: docudesk.conduction.nl` is correct. **No correction needed.** This was checked
because the shared release workflow uses `app-name` as both the tarball's top-level directory and
the App Store registration id — a wrong value there would publish under another app's identity.

## Job counts

`GET /repos/ConductionNL/docudesk/actions/workflows/release-stable.yml/runs` -> `total_count: 0`.
The workflow has produced **no runs at all**, ever.

## The defect

`release-stable.yml` on `main` called `Conduction/.github` — an org that **does not exist**:

```
$ gh api orgs/Conduction
{"message":"Not Found", "status":"404"}
```

GitHub cannot resolve the reusable workflow, so the run is created and immediately
`startup_failure`s with **zero jobs**. The stable release path has therefore never
executed. `development` already carries the correct `ConductionNL/` refs — only `main` lagged.

## Verification method

A wrong-org run and a healthy run are **indistinguishable from `gh run list`** — both can
display under the raw path `.github/workflows/<file>.yml`. The only reliable discriminator is
the job count:

```
gh api repos/ConductionNL/<repo>/actions/runs/<id>/jobs --jq '.total_count'
```

Controls run before trusting any number:
- known-good run (docudesk `Scheduled` 30460517931) -> `2`
- known-broken run (doriath raw-path issue-triage 26152525764) -> `0`

## Blast radius

`git ls-tree main` vs `git ls-tree <new-tree>` differ in **exactly one top-level entry**:
`.github`. Every other tree — `lib/`, `src/`, `docs/`, `appinfo/`, `openspec/`, `tests/`,
`.forgejo/` — is byte-identical by tree hash. No application code, tests, or specs are touched.

`.forgejo/` is **deliberately left alone**: on Codeberg the org really is `Conduction`.

## Expected side effect

Repairing these callers re-arms `sync-to-beta`, which may auto-open a `development -> beta`
release PR. That is expected; leave it alone.
