### PR TITLE
fix(quality): clear the remaining phpmd debt (6 -> 0) and un-gate PHPUnit

### DIFF
--- a/lib/Controller/CustomDictionaryController.php
+++ b/lib/Controller/CustomDictionaryController.php
@@ -361,7 +361,9 @@ class CustomDictionaryController extends Controller
      * before OpenRegister availability (503), and only then does the
      * operation run.
      *
-     * @param callable():array<string, mixed> $operation       The gated operation.
+     * @param callable():array<array-key, mixed> $operation    The gated operation. Returns either a
+     *                                                         single record (string-keyed) or a list
+     *                                                         of records (int-keyed).
      * @param string                          $failureMessage  Log/response prefix for an unexpected failure.
      * @param string                          $notFoundMessage Already-translated 404 message.
      * @param int                             $status          Success HTTP status.

--- a/lib/Controller/CustomDictionaryController.php
+++ b/lib/Controller/CustomDictionaryController.php
@@ -87,20 +87,11 @@ class CustomDictionaryController extends Controller
      */
     public function index(): JSONResponse
     {
-        $unauthenticated = $this->requireAuthenticated();
-        if ($unauthenticated !== null) {
-            return $unauthenticated;
-        }
-
-        if ($this->service->isAvailable() === false) {
-            return $this->unavailable();
-        }
-
-        try {
-            return new JSONResponse($this->service->listDictionaries());
-        } catch (Exception $e) {
-            return $this->error(message: 'Failed to list custom dictionaries: ', exception: $e);
-        }
+        return $this->dispatch(
+            operation: fn (): array => $this->service->listDictionaries(),
+            failureMessage: 'Failed to list custom dictionaries: ',
+            notFoundMessage: $this->l10n->t('Custom dictionary not found')
+        );
 
     }//end index()
 
@@ -120,24 +111,11 @@ class CustomDictionaryController extends Controller
      */
     public function show(string $id): JSONResponse
     {
-        $unauthenticated = $this->requireAuthenticated();
-        if ($unauthenticated !== null) {
-            return $unauthenticated;
-        }
-
-        if ($this->service->isAvailable() === false) {
-            return $this->unavailable();
-        }
-
-        try {
-            return new JSONResponse($this->service->getDictionary(uuid: $id));
-        } catch (DoesNotExistException $e) {
-            return new JSONResponse(['error' => $this->l10n->t('Custom dictionary not found')], Http::STATUS_NOT_FOUND);
-        } catch (RuntimeException $e) {
-            return $this->forbidden();
-        } catch (Exception $e) {
-            return $this->error(message: 'Failed to load custom dictionary: ', exception: $e);
-        }
+        return $this->dispatch(
+            operation: fn (): array => $this->service->getDictionary(uuid: $id),
+            failureMessage: 'Failed to load custom dictionary: ',
+            notFoundMessage: $this->l10n->t('Custom dictionary not found')
+        );
 
     }//end show()
 
@@ -153,23 +131,12 @@ class CustomDictionaryController extends Controller
      */
     public function create(): JSONResponse
     {
-        $unauthenticated = $this->requireAuthenticated();
-        if ($unauthenticated !== null) {
-            return $unauthenticated;
-        }
-
-        if ($this->service->isAvailable() === false) {
-            return $this->unavailable();
-        }
-
-        try {
-            $data = $this->request->getParams();
-            return new JSONResponse($this->service->createDictionary(data: $data), 201);
-        } catch (InvalidArgumentException $e) {
-            return new JSONResponse(['error' => $e->getMessage()], 400);
-        } catch (Exception $e) {
-            return $this->error(message: 'Failed to create custom dictionary: ', exception: $e);
-        }
+        return $this->dispatch(
+            operation: fn (): array => $this->service->createDictionary(data: $this->request->getParams()),
+            failureMessage: 'Failed to create custom dictionary: ',
+            notFoundMessage: $this->l10n->t('Custom dictionary not found'),
+            status: Http::STATUS_CREATED
+        );
 
     }//end create()
 
@@ -189,27 +156,14 @@ class CustomDictionaryController extends Controller
      */
     public function update(string $id): JSONResponse
     {
-        $unauthenticated = $this->requireAuthenticated();
-        if ($unauthenticated !== null) {
-            return $unauthenticated;
-        }
-
-        if ($this->service->isAvailable() === false) {
-            return $this->unavailable();
-        }
-
-        try {
-            $data = $this->request->getParams();
-            return new JSONResponse($this->service->updateDictionary(uuid: $id, data: $data));
-        } catch (DoesNotExistException $e) {
-            return new JSONResponse(['error' => $this->l10n->t('Custom dictionary not found')], Http::STATUS_NOT_FOUND);
-        } catch (RuntimeException $e) {
-            return $this->forbidden();
-        } catch (InvalidArgumentException $e) {
-            return new JSONResponse(['error' => $e->getMessage()], 400);
-        } catch (Exception $e) {
-            return $this->error(message: 'Failed to update custom dictionary: ', exception: $e);
-        }
+        return $this->dispatch(
+            operation: fn (): array => $this->service->updateDictionary(
+                uuid: $id,
+                data: $this->request->getParams()
+            ),
+            failureMessage: 'Failed to update custom dictionary: ',
+            notFoundMessage: $this->l10n->t('Custom dictionary not found')
+        );
 
     }//end update()
 
@@ -229,25 +183,14 @@ class CustomDictionaryController extends Controller
      */
     public function destroy(string $id): JSONResponse
     {
-        $unauthenticated = $this->requireAuthenticated();
-        if ($unauthenticated !== null) {
-            return $unauthenticated;
-        }
-
-        if ($this->service->isAvailable() === false) {
-            return $this->unavailable();
-        }
-
-        try {
-            $this->service->deleteDictionary(uuid: $id);
-            return new JSONResponse(['deleted' => $id]);
-        } catch (DoesNotExistException $e) {
-            return new JSONResponse(['error' => $this->l10n->t('Custom dictionary not found')], Http::STATUS_NOT_FOUND);
-        } catch (RuntimeException $e) {
-            return $this->forbidden();
-        } catch (Exception $e) {
-            return $this->error(message: 'Failed to delete custom dictionary: ', exception: $e);
-        }
+        return $this->dispatch(
+            operation: function () use ($id): array {
+                $this->service->deleteDictionary(uuid: $id);
+                return ['deleted' => $id];
+            },
+            failureMessage: 'Failed to delete custom dictionary: ',
+            notFoundMessage: $this->l10n->t('Custom dictionary not found')
+        );
 
     }//end destroy()
 
@@ -267,24 +210,11 @@ class CustomDictionaryController extends Controller
      */
     public function indexTerms(string $id): JSONResponse
     {
-        $unauthenticated = $this->requireAuthenticated();
-        if ($unauthenticated !== null) {
-            return $unauthenticated;
-        }
-
-        if ($this->service->isAvailable() === false) {
-            return $this->unavailable();
-        }
-
-        try {
-            return new JSONResponse($this->service->listTerms(dictionaryUuid: $id));
-        } catch (DoesNotExistException $e) {
-            return new JSONResponse(['error' => $this->l10n->t('Custom dictionary not found')], Http::STATUS_NOT_FOUND);
-        } catch (RuntimeException $e) {
-            return $this->forbidden();
-        } catch (Exception $e) {
-            return $this->error(message: 'Failed to list terms: ', exception: $e);
-        }
+        return $this->dispatch(
+            operation: fn (): array => $this->service->listTerms(dictionaryUuid: $id),
+            failureMessage: 'Failed to list terms: ',
+            notFoundMessage: $this->l10n->t('Custom dictionary not found')
+        );
 
     }//end indexTerms()
 
@@ -304,27 +234,15 @@ class CustomDictionaryController extends Controller
      */
     public function createTerm(string $id): JSONResponse
     {
-        $unauthenticated = $this->requireAuthenticated();
-        if ($unauthenticated !== null) {
-            return $unauthenticated;
-        }
-
-        if ($this->service->isAvailable() === false) {
-            return $this->unavailable();
-        }
-
-        try {
-            $data = $this->request->getParams();
-            return new JSONResponse($this->service->createTerm(dictionaryUuid: $id, data: $data), 201);
-        } catch (DoesNotExistException $e) {
-            return new JSONResponse(['error' => $this->l10n->t('Custom dictionary not found')], Http::STATUS_NOT_FOUND);
-        } catch (RuntimeException $e) {
-            return $this->forbidden();
-        } catch (InvalidArgumentException $e) {
-            return new JSONResponse(['error' => $e->getMessage()], 400);
-        } catch (Exception $e) {
-            return $this->error(message: 'Failed to create term: ', exception: $e);
-        }
+        return $this->dispatch(
+            operation: fn (): array => $this->service->createTerm(
+                dictionaryUuid: $id,
+                data: $this->request->getParams()
+            ),
+            failureMessage: 'Failed to create term: ',
+            notFoundMessage: $this->l10n->t('Custom dictionary not found'),
+            status: Http::STATUS_CREATED
+        );
 
     }//end createTerm()
 
@@ -345,25 +263,14 @@ class CustomDictionaryController extends Controller
      */
     public function deleteTerm(string $id, string $termId): JSONResponse
     {
-        $unauthenticated = $this->requireAuthenticated();
-        if ($unauthenticated !== null) {
-            return $unauthenticated;
-        }
-
-        if ($this->service->isAvailable() === false) {
-            return $this->unavailable();
-        }
-
-        try {
-            $this->service->deleteTerm(dictionaryUuid: $id, termUuid: $termId);
-            return new JSONResponse(['deleted' => $termId]);
-        } catch (DoesNotExistException $e) {
-            return new JSONResponse(['error' => $this->l10n->t('Term not found')], Http::STATUS_NOT_FOUND);
-        } catch (RuntimeException $e) {
-            return $this->forbidden();
-        } catch (Exception $e) {
-            return $this->error(message: 'Failed to delete term: ', exception: $e);
-        }
+        return $this->dispatch(
+            operation: function () use ($id, $termId): array {
+                $this->service->deleteTerm(dictionaryUuid: $id, termUuid: $termId);
+                return ['deleted' => $termId];
+            },
+            failureMessage: 'Failed to delete term: ',
+            notFoundMessage: $this->l10n->t('Term not found')
+        );
 
     }//end deleteTerm()
 
@@ -385,31 +292,25 @@ class CustomDictionaryController extends Controller
      */
     public function import(string $id): JSONResponse
     {
-        $unauthenticated = $this->requireAuthenticated();
-        if ($unauthenticated !== null) {
-            return $unauthenticated;
-        }
+        $noContentMessage = $this->l10n->t('No import content provided');
 
-        if ($this->service->isAvailable() === false) {
-            return $this->unavailable();
-        }
+        return $this->dispatch(
+            operation: function () use ($id, $noContentMessage): array {
+                [$content, $isCsv] = $this->readImportPayload();
+                if ($content === null) {
+                    // Mapped to HTTP 400 with this message by dispatch().
+                    throw new InvalidArgumentException($noContentMessage);
+                }
 
-        try {
-            [$content, $isCsv] = $this->readImportPayload();
-            if ($content === null) {
-                return new JSONResponse(['error' => $this->l10n->t('No import content provided')], 400);
-            }
-
-            return new JSONResponse($this->service->importTerms(dictionaryUuid: $id, content: $content, isCsv: $isCsv));
-        } catch (DoesNotExistException $e) {
-            return new JSONResponse(['error' => $this->l10n->t('Custom dictionary not found')], Http::STATUS_NOT_FOUND);
-        } catch (RuntimeException $e) {
-            return $this->forbidden();
-        } catch (InvalidArgumentException $e) {
-            return new JSONResponse(['error' => $e->getMessage()], 400);
-        } catch (Exception $e) {
-            return $this->error(message: 'Failed to import terms: ', exception: $e);
-        }
+                return $this->service->importTerms(
+                    dictionaryUuid: $id,
+                    content: $content,
+                    isCsv: $isCsv
+                );
+            },
+            failureMessage: 'Failed to import terms: ',
+            notFoundMessage: $this->l10n->t('Custom dictionary not found')
+        );
 
     }//end import()
 
@@ -450,6 +351,73 @@ class CustomDictionaryController extends Controller
         return [$content, $isCsv];
 
     }//end readImportPayload()
+
+    /**
+     * Run one endpoint operation behind the shared guard, mapping the
+     * exceptions every endpoint can raise to their standard responses.
+     *
+     * Centralising this keeps each endpoint a single expression, and keeps
+     * the guard order identical everywhere: unauthenticated (401) is checked
+     * before OpenRegister availability (503), and only then does the
+     * operation run.
+     *
+     * @param callable():array<string, mixed> $operation       The gated operation.
+     * @param string                          $failureMessage  Log/response prefix for an unexpected failure.
+     * @param string                          $notFoundMessage Already-translated 404 message.
+     * @param int                             $status          Success HTTP status.
+     *
+     * @return JSONResponse
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    private function dispatch(
+        callable $operation,
+        string $failureMessage,
+        string $notFoundMessage,
+        int $status=Http::STATUS_OK
+    ): JSONResponse {
+        $blocked = $this->guard();
+        if ($blocked !== null) {
+            return $blocked;
+        }
+
+        try {
+            return new JSONResponse($operation(), $status);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => $notFoundMessage], Http::STATUS_NOT_FOUND);
+        } catch (RuntimeException $e) {
+            return $this->forbidden();
+        } catch (InvalidArgumentException $e) {
+            return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+        } catch (Exception $e) {
+            return $this->error(message: $failureMessage, exception: $e);
+        }//end try
+
+    }//end dispatch()
+
+    /**
+     * The guard every endpoint shares: an authenticated session, and an
+     * installed OpenRegister.
+     *
+     * @return JSONResponse|null The blocking response, or null when the
+     *                           caller may proceed.
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    private function guard(): ?JSONResponse
+    {
+        $unauthenticated = $this->requireAuthenticated();
+        if ($unauthenticated !== null) {
+            return $unauthenticated;
+        }
+
+        if ($this->service->isAvailable() === false) {
+            return $this->unavailable();
+        }
+
+        return null;
+
+    }//end guard()
 
     /**
      * Require an authenticated session.

--- a/lib/Controller/PortalSigningReceiverController.php
+++ b/lib/Controller/PortalSigningReceiverController.php
@@ -42,6 +42,7 @@ declare(strict_types=1);
 namespace OCA\DocuDesk\Controller;
 
 use OCA\DocuDesk\Portal\PortalAssertionVerifier;
+use OCA\DocuDesk\Service\PortalSigningDocumentResolver;
 use OCA\DocuDesk\Service\SettingsService;
 use OCA\DocuDesk\Service\SigningService;
 use OCP\AppFramework\Controller;
@@ -49,8 +50,6 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\Files\File;
-use OCP\Files\IRootFolder;
 use OCP\IAppConfig;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -90,9 +89,9 @@ class PortalSigningReceiverController extends Controller
      * @param PortalAssertionVerifier $verifier        Verifies the X-Portal-Subject assertion.
      * @param SigningService          $signingService  The honest signing primitive.
      * @param SettingsService         $settingsService Settings service (resolves OR's ObjectService).
-     * @param IAppConfig              $config          App config (resolves signerRecord/signingRequest register/schema).
-     * @param IRootFolder             $rootFolder      Root folder (reads the target document for viewDocument).
-     * @param LoggerInterface         $logger          Logger.
+     * @param IAppConfig                     $config           App config (resolves signerRecord/signingRequest register/schema).
+     * @param LoggerInterface                $logger           Logger.
+     * @param PortalSigningDocumentResolver  $documentResolver Resolves the target document for viewDocument.
      *
      * @return void
      */
@@ -103,8 +102,8 @@ class PortalSigningReceiverController extends Controller
         private readonly SigningService $signingService,
         private readonly SettingsService $settingsService,
         private readonly IAppConfig $config,
-        private readonly IRootFolder $rootFolder,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly PortalSigningDocumentResolver $documentResolver
     ) {
         parent::__construct(appName: $appName, request: $request);
 
@@ -243,7 +242,7 @@ class PortalSigningReceiverController extends Controller
             return $this->forbidden();
         }
 
-        $file = $this->resolveDocumentFile(signingRequest: $signingRequest);
+        $file = $this->documentResolver->resolve(signingRequest: $signingRequest);
         if ($file === null) {
             return new JSONResponse(['error' => 'document_unavailable'], Http::STATUS_NOT_FOUND);
         }
@@ -407,40 +406,6 @@ class PortalSigningReceiverController extends Controller
         return null;
 
     }//end resolveInvitedSigner()
-
-    /**
-     * Resolve the target document's File node for viewDocument.
-     *
-     * Resolves through the request's initiator folder — a portal signer has
-     * no Nextcloud session of their own to fall back to.
-     *
-     * @param array<string, mixed> $signingRequest The resolved signing-request array.
-     *
-     * @return File|null The resolved file node, or null when unavailable.
-     */
-    private function resolveDocumentFile(array $signingRequest): ?File
-    {
-        $fileId    = (int) ($signingRequest['documentFileId'] ?? 0);
-        $initiator = (string) ($signingRequest['initiatorUserId'] ?? '');
-        if ($fileId <= 0 || $initiator === '') {
-            return null;
-        }
-
-        try {
-            $nodes = $this->rootFolder->getUserFolder($initiator)->getById($fileId);
-        } catch (Throwable $e) {
-            return null;
-        }
-
-        foreach ($nodes as $node) {
-            if ($node instanceof File) {
-                return $node;
-            }
-        }
-
-        return null;
-
-    }//end resolveDocumentFile()
 
     /**
      * Normalise an OpenRegister result (array or ObjectEntity) to an array.

--- a/lib/Controller/PortalSigningReceiverController.php
+++ b/lib/Controller/PortalSigningReceiverController.php
@@ -84,14 +84,14 @@ class PortalSigningReceiverController extends Controller
     /**
      * Constructor.
      *
-     * @param string                  $appName         App name.
-     * @param IRequest                $request         Request object.
-     * @param PortalAssertionVerifier $verifier        Verifies the X-Portal-Subject assertion.
-     * @param SigningService          $signingService  The honest signing primitive.
-     * @param SettingsService         $settingsService Settings service (resolves OR's ObjectService).
-     * @param IAppConfig                     $config           App config (resolves signerRecord/signingRequest register/schema).
-     * @param LoggerInterface                $logger           Logger.
-     * @param PortalSigningDocumentResolver  $documentResolver Resolves the target document for viewDocument.
+     * @param string                        $appName          App name.
+     * @param IRequest                      $request          Request object.
+     * @param PortalAssertionVerifier       $verifier         Verifies the X-Portal-Subject assertion.
+     * @param SigningService                $signingService   The honest signing primitive.
+     * @param SettingsService               $settingsService  Settings service (resolves OR's ObjectService).
+     * @param IAppConfig                    $config           App config (resolves signerRecord/signingRequest register/schema).
+     * @param LoggerInterface               $logger           Logger.
+     * @param PortalSigningDocumentResolver $documentResolver Resolves the target document for viewDocument.
      *
      * @return void
      */

--- a/lib/Service/AnonymizationService.php
+++ b/lib/Service/AnonymizationService.php
@@ -41,7 +41,6 @@ use OCA\DocuDesk\Exception\ConversionFailedException;
 use OCA\DocuDesk\Exception\ProhibitionGateException;
 use OCA\DocuDesk\Service\EmlPdfAssemblyService;
 use RuntimeException;
-use Symfony\Component\Uid\Uuid;
 use Throwable;
 use OCP\App\IAppManager;
 use OCP\Files\File;
@@ -146,8 +145,6 @@ class AnonymizationService
      *                                                            to construct without OpenRegister
      *                                                            installed — its own methods degrade
      *                                                            internally.
-     * @param CustomDictionaryMatchService $customDictionaryMatch Pure matcher run per active
-     *                                                            dictionary during detection.
      * @param ConfidentialityLabelService  $confidentialityLabel  Reads a file's existing
      *                                                            files_confidential TSCP/BAILS
      *                                                            classification (availability-
@@ -155,6 +152,13 @@ class AnonymizationService
      *                                                            it can be surfaced alongside
      *                                                            detected entities and risk
      *                                                            (files-confidential-labels).
+     * @param CustomDictionaryDetectionRunner $customDictionaryDetection The custom-dictionary
+     *                                                            detection pass
+     *                                                            (custom-dictionary-recognition
+     *                                                            design.md §D3). Best-effort — it
+     *                                                            returns a warning string rather
+     *                                                            than throwing, so OpenRegister's
+     *                                                            own detections always survive.
      *
      * @return void
      */
@@ -171,8 +175,8 @@ class AnonymizationService
         private readonly PdfConversionService $pdfConversion,
         private readonly EmlPdfAssemblyService $emlAssembly,
         private readonly CustomDictionaryService $customDictionary,
-        private readonly CustomDictionaryMatchService $customDictionaryMatch,
-        private readonly ConfidentialityLabelService $confidentialityLabel
+        private readonly ConfidentialityLabelService $confidentialityLabel,
+        private readonly CustomDictionaryDetectionRunner $customDictionaryDetection
     ) {
 
     }//end __construct()
@@ -276,7 +280,7 @@ class AnonymizationService
             // back below, so freshly-written CUSTOM_DICTIONARY relations are
             // included in `$entities`. Best-effort — a failure here is logged
             // and surfaced as a warning but never blocks OR's own detection.
-            $customDictionaryWarning = $this->runCustomDictionaryDetection(
+            $customDictionaryWarning = $this->customDictionaryDetection->run(
                 fileId: $fileId,
                 entityTypeWhitelist: $entityTypes
             );
@@ -345,273 +349,6 @@ class AnonymizationService
         }//end try
 
     }//end extractAndDetectEntities()
-
-    /**
-     * Custom-dictionary detection pass hooked into
-     * `extractAndDetectEntities()` (custom-dictionary-recognition,
-     * design.md §D3).
-     *
-     * For every active dictionary visible to the caller's accessible
-     * organisations, matches its terms against the file's already-extracted
-     * chunks (`CustomDictionaryMatchService::match()`, per-dictionary match
-     * mode) and writes each occurrence into OpenRegister's shared catalogue
-     * as a `CUSTOM_DICTIONARY` entity/relation — entity `type` =
-     * `CUSTOM_DICTIONARY`, `category` = `contextual_data`, relation
-     * `detectionMethod` = `custom_dictionary`, `confidence` = `1.0`, and the
-     * matching dictionary/term label carried on `context` (the only
-     * free-text field `EntityRelation` exposes for this purpose).
-     *
-     * Idempotent: this file's prior `custom_dictionary` relations are
-     * cleared before re-matching so re-running detection never appends
-     * duplicates. Cross-chunk / cross-dictionary overlaps are resolved
-     * longest-match-first by absolute document position (mirrors both
-     * `CustomDictionaryMatchService`'s own per-dictionary overlap rule and
-     * OpenRegister's `ChunkTextMatcher` dedup convention), so a match
-     * straddling two overlapping chunks is written only once.
-     *
-     * Best-effort: any failure is logged and returned as a human-readable
-     * warning string; it never throws, so OpenRegister's own detections are
-     * always returned by the caller regardless.
-     *
-     * @param int                     $fileId              The Nextcloud file ID.
-     * @param array<int, string>|null $entityTypeWhitelist The operator's enabled-type
-     *                                                     selection (null = all types).
-     *                                                     When non-null and it does not
-     *                                                     contain `CUSTOM_DICTIONARY`, the
-     *                                                     pass is skipped entirely.
-     *
-     * @return string|null Null on success (or when skipped), a warning message on failure.
-     *
-     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
-     */
-    private function runCustomDictionaryDetection(int $fileId, ?array $entityTypeWhitelist): ?string
-    {
-        if ($entityTypeWhitelist !== null && in_array('CUSTOM_DICTIONARY', $entityTypeWhitelist, true) === false) {
-            // Operator has disabled automatic custom-dictionary detection.
-            return null;
-        }
-
-        try {
-            $dictionaries = $this->customDictionary->listActiveDictionariesForDetection();
-            if (empty($dictionaries) === true) {
-                return null;
-            }
-
-            $chunkMapper = $this->getOpenRegisterService(className: 'OCA\OpenRegister\Db\ChunkMapper');
-            $chunks      = $chunkMapper->findBySource('file', $fileId);
-            if (empty($chunks) === true) {
-                return null;
-            }
-
-            $entityRelationMapper = $this->getOpenRegisterService(
-                className: 'OCA\OpenRegister\Db\EntityRelationMapper'
-            );
-            $gdprEntityMapper     = $this->getOpenRegisterService(
-                className: 'OCA\OpenRegister\Db\GdprEntityMapper'
-            );
-
-            $this->clearCustomDictionaryRelations(fileId: $fileId, entityRelationMapper: $entityRelationMapper);
-
-            $rowsToInsert = $this->matchDictionariesAgainstChunks(
-                chunks: $chunks,
-                dictionaries: $dictionaries,
-                fileId: $fileId,
-                gdprEntityMapper: $gdprEntityMapper
-            );
-
-            if (empty($rowsToInsert) === false) {
-                $entityRelationMapper->insertBatch(rows: $rowsToInsert);
-            }
-
-            return null;
-        } catch (Throwable $e) {
-            $this->logger->error(
-                '[AnonymizationService] Custom dictionary matching failed; continuing with OpenRegister detection only.',
-                ['file' => __FILE__, 'line' => __LINE__, 'fileId' => $fileId, 'error' => $e->getMessage()]
-            );
-            return 'Custom dictionary matching did not run: '.$e->getMessage();
-        }//end try
-
-    }//end runCustomDictionaryDetection()
-
-    /**
-     * Run every active dictionary's matcher against every chunk and build
-     * the `EntityRelationMapper::insertBatch()` row set.
-     *
-     * @param array<int, mixed> $chunks           OpenRegister `Chunk` entities, chunk-index ascending.
-     * @param array<int, mixed> $dictionaries     Active dictionaries + terms (see
-     *                                            {@see CustomDictionaryService::listActiveDictionariesForDetection()}
-     *                                            for the exact row shape).
-     * @param int               $fileId           The Nextcloud file ID.
-     * @param mixed             $gdprEntityMapper OpenRegister `GdprEntityMapper` instance.
-     *
-     * @return array<int, array<string, mixed>> Rows ready for `EntityRelationMapper::insertBatch()`.
-     */
-    private function matchDictionariesAgainstChunks(
-        array $chunks,
-        array $dictionaries,
-        int $fileId,
-        mixed $gdprEntityMapper
-    ): array {
-        $globalClaimed = [];
-        $entityCache   = [];
-        $rowsToInsert  = [];
-
-        foreach ($chunks as $chunk) {
-            $chunkText = (string) $chunk->getTextContent();
-            if ($chunkText === '') {
-                continue;
-            }
-
-            $chunkOccurrences = [];
-            foreach ($dictionaries as $dictionary) {
-                foreach ($this->customDictionaryMatch->match(
-                        text: $chunkText,
-                        terms: $dictionary['terms'],
-                        mode: $dictionary['matchMode']
-                    ) as $occurrence
-                ) {
-                    $chunkOccurrences[] = $occurrence;
-                }
-            }
-
-            if (empty($chunkOccurrences) === true) {
-                continue;
-            }
-
-            // Longest-match-first so a shorter cross-dictionary match cannot
-            // pre-empt a longer one at an overlapping position — mirrors
-            // CustomDictionaryMatchService's own per-dictionary overlap rule.
-            usort(
-                $chunkOccurrences,
-                static fn (array $a, array $b): int => (
-                    ($b['positionEnd'] - $b['positionStart']) <=> ($a['positionEnd'] - $a['positionStart'])
-                )
-            );
-
-            $startOffset = (int) $chunk->getStartOffset();
-            foreach ($chunkOccurrences as $occurrence) {
-                $absoluteStart = ($startOffset + $occurrence['positionStart']);
-                $absoluteEnd   = ($startOffset + $occurrence['positionEnd']);
-
-                if ($this->rangeOverlapsAny(start: $absoluteStart, end: $absoluteEnd, claimed: $globalClaimed) === true) {
-                    // Already matched at this absolute document position —
-                    // typically the same occurrence seen again in an
-                    // overlap region shared by two adjacent chunks.
-                    continue;
-                }
-
-                $globalClaimed[] = [$absoluteStart, $absoluteEnd];
-
-                $entityKey = ('CUSTOM_DICTIONARY|'.$occurrence['value']);
-                if (isset($entityCache[$entityKey]) === false) {
-                    $entityCache[$entityKey] = $this->lookupOrCreateCustomDictionaryEntity(
-                        value: $occurrence['value'],
-                        gdprEntityMapper: $gdprEntityMapper
-                    );
-                }
-
-                $rowsToInsert[] = [
-                    'entityId'          => $entityCache[$entityKey],
-                    'fileId'            => $fileId,
-                    'chunkId'           => (int) $chunk->getId(),
-                    'positionStart'     => $occurrence['positionStart'],
-                    'positionEnd'       => $occurrence['positionEnd'],
-                    'confidence'        => 1.0,
-                    'detectionMethod'   => 'custom_dictionary',
-                    // The only free-text field EntityRelation exposes; carries
-                    // the matching term/dictionary label for the review UI
-                    // (design.md §D3 — "per-list label carried on the relation").
-                    'context'           => $occurrence['label'],
-                    'anonymized'        => false,
-                    'skipAnonymization' => false,
-                    'createdAt'         => new DateTime(),
-                ];
-            }//end foreach
-        }//end foreach
-
-        return $rowsToInsert;
-
-    }//end matchDictionariesAgainstChunks()
-
-    /**
-     * Look up an existing `CUSTOM_DICTIONARY` catalogue entry for `$value`,
-     * or create one. Mirrors OpenRegister's own manual-entity lookup-or-
-     * create convention (`ManualEntityService::lookupOrCreateEntity`) so
-     * repeated matches of the same literal value share one catalogue row.
-     *
-     * @param string $value            The matched term text.
-     * @param mixed  $gdprEntityMapper OpenRegister `GdprEntityMapper` instance.
-     *
-     * @return int The catalogue entity id.
-     */
-    private function lookupOrCreateCustomDictionaryEntity(string $value, mixed $gdprEntityMapper): int
-    {
-        $existing = $gdprEntityMapper->findOneByValueAndType(value: $value, type: 'CUSTOM_DICTIONARY');
-        if ($existing !== null) {
-            return (int) $existing->getId();
-        }
-
-        // Instantiated by FQCN string (not a hard `use` import) so this class
-        // stays loadable without OpenRegister installed, mirroring
-        // `getOpenRegisterService()`'s own lazy-resolution convention. A
-        // fresh instance is required per call — the container's `get()`
-        // would return a shared, mutable singleton, which is wrong for an
-        // Entity that is set up differently on every insert.
-        $entityClass = 'OCA\OpenRegister\Db\GdprEntity';
-        $now         = new DateTime();
-        $entity      = new $entityClass();
-        $entity->setUuid(Uuid::v4()->toRfc4122());
-        $entity->setValue($value);
-        $entity->setType('CUSTOM_DICTIONARY');
-        $entity->setCategory('contextual_data');
-        $entity->setDetectedAt($now);
-        $entity->setUpdatedAt($now);
-
-        $inserted = $gdprEntityMapper->insert($entity);
-        return (int) $inserted->getId();
-
-    }//end lookupOrCreateCustomDictionaryEntity()
-
-    /**
-     * Clear this file's prior `custom_dictionary` relations so a re-run
-     * never appends duplicates (design.md §D3 idempotency rule).
-     *
-     * @param int   $fileId               The Nextcloud file ID.
-     * @param mixed $entityRelationMapper OpenRegister `EntityRelationMapper` instance.
-     *
-     * @return void
-     */
-    private function clearCustomDictionaryRelations(int $fileId, mixed $entityRelationMapper): void
-    {
-        foreach ($entityRelationMapper->findByFileId($fileId) as $relation) {
-            if ($relation->getDetectionMethod() === 'custom_dictionary') {
-                $entityRelationMapper->delete($relation);
-            }
-        }
-
-    }//end clearCustomDictionaryRelations()
-
-    /**
-     * Whether `[start, end)` overlaps any already-claimed absolute-position range.
-     *
-     * @param int                            $start   Candidate match start.
-     * @param int                            $end     Candidate match end.
-     * @param array<int, array{0:int,1:int}> $claimed Already-claimed `[start, end]` pairs.
-     *
-     * @return bool True when the candidate overlaps a claimed range.
-     */
-    private function rangeOverlapsAny(int $start, int $end, array $claimed): bool
-    {
-        foreach ($claimed as [$claimedStart, $claimedEnd]) {
-            if ($start < $claimedEnd && $end > $claimedStart) {
-                return true;
-            }
-        }
-
-        return false;
-
-    }//end rangeOverlapsAny()
 
     /**
      * Try to get PolicyMatchService from the container without throwing

--- a/lib/Service/AnonymizationService.php
+++ b/lib/Service/AnonymizationService.php
@@ -119,46 +119,49 @@ class AnonymizationService
     /**
      * Constructor for AnonymizationService
      *
-     * @param LoggerInterface              $logger                Logger for error reporting
-     * @param ContainerInterface           $container             Container for dependency injection
-     * @param IAppManager                  $appManager            App manager interface
-     * @param EntityDetectionService       $entityDetection       Entity detection and mapping service
-     * @param IAppConfig                   $appConfig             App configuration for threshold settings
-     * @param ConsentCrudService           $consentCrud           Consent CRUD service for register/schema config
-     * @param ConsentService               $consentService        Consent service for creating publication consents
-     * @param GrondslagenSummaryService    $grondslagenSummary    Renderer for the per-document grondslagen
-     *                                                            summary page (Wave 4a — opt-in via
-     *                                                            `appendBasisSummary: true` on the
-     *                                                            request).
-     * @param FileEntityStatsService       $fileEntityStats       Service for entity statistics and risk levels.
-     * @param PdfConversionService         $pdfConversion         Cascade orchestrator that converts the
-     *                                                            anonymised intermediate to PDF when
-     *                                                            `outputFormat: "pdf"` is in effect.
-     * @param EmlPdfAssemblyService        $emlAssembly           Assembles OR's redacted anonymise-EML
-     *                                                            result into a PDF/A-3b. EML inputs
-     *                                                            are routed here directly because OR's
-     *                                                            `anonymizeDocument()` throws on
-     *                                                            `message/rfc822`.
-     * @param CustomDictionaryService      $customDictionary      Organisation-managed term-list CRUD +
-     *                                                            detection-scoped listing
-     *                                                            (custom-dictionary-recognition). Safe
-     *                                                            to construct without OpenRegister
-     *                                                            installed — its own methods degrade
-     *                                                            internally.
-     * @param ConfidentialityLabelService  $confidentialityLabel  Reads a file's existing
-     *                                                            files_confidential TSCP/BAILS
-     *                                                            classification (availability-
-     *                                                            guarded; null when absent) so
-     *                                                            it can be surfaced alongside
-     *                                                            detected entities and risk
-     *                                                            (files-confidential-labels).
+     * @param LoggerInterface                 $logger                    Logger for error reporting
+     * @param ContainerInterface              $container                 Container for dependency injection
+     * @param IAppManager                     $appManager                App manager interface
+     * @param EntityDetectionService          $entityDetection           Entity detection and mapping service
+     * @param IAppConfig                      $appConfig                 App configuration for threshold settings
+     * @param ConsentCrudService              $consentCrud               Consent CRUD service for register/schema config
+     * @param ConsentService                  $consentService            Consent service for creating publication consents
+     * @param GrondslagenSummaryService       $grondslagenSummary        Renderer for the per-document grondslagen
+     *                                                                   summary page (Wave 4a — opt-in via
+     *                                                                   `appendBasisSummary: true` on the
+     *                                                                   request).
+     * @param FileEntityStatsService          $fileEntityStats           Service for entity statistics and risk levels.
+     * @param PdfConversionService            $pdfConversion             Cascade orchestrator that converts the
+     *                                                                   anonymised intermediate to PDF when
+     *                                                                   `outputFormat: "pdf"` is in effect.
+     * @param EmlPdfAssemblyService           $emlAssembly               Assembles OR's redacted anonymise-EML
+     *                                                                   result into a PDF/A-3b. EML inputs
+     *                                                                   are routed here directly because OR's
+     *                                                                   `anonymizeDocument()` throws on
+     *                                                                   `message/rfc822`.
+     * @param CustomDictionaryService         $customDictionary          Organisation-managed term-list CRUD +
+     *                                                                   detection-scoped listing
+     *                                                                   (custom-dictionary-recognition). Safe
+     *                                                                   to construct without OpenRegister
+     *                                                                   installed — its own methods degrade
+     *                                                                   internally.
+     * @param ConfidentialityLabelService     $confidentialityLabel      Reads a file's existing
+     *                                                                   files_confidential
+     *                                                                   TSCP/BAILS
+     *                                                                   classification
+     *                                                                   (availability- guarded;
+     *                                                                   null when absent) so it
+     *                                                                   can be surfaced
+     *                                                                   alongside detected
+     *                                                                   entities and risk
+     *                                                                   (files-confidential-labels).
      * @param CustomDictionaryDetectionRunner $customDictionaryDetection The custom-dictionary
-     *                                                            detection pass
-     *                                                            (custom-dictionary-recognition
-     *                                                            design.md §D3). Best-effort — it
-     *                                                            returns a warning string rather
-     *                                                            than throwing, so OpenRegister's
-     *                                                            own detections always survive.
+     *                                                                   detection pass
+     *                                                                   (custom-dictionary-recognition
+     *                                                                   design.md §D3). Best-effort — it
+     *                                                                   returns a warning string rather
+     *                                                                   than throwing, so OpenRegister's
+     *                                                                   own detections always survive.
      *
      * @return void
      */

--- a/lib/Service/CustomDictionaryAccessGate.php
+++ b/lib/Service/CustomDictionaryAccessGate.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Custom Dictionary Access Gate
+ *
+ * The fail-closed organisation-membership gate behind
+ * {@see CustomDictionaryService}. A record without an organisation, an
+ * anonymous caller, or any failure resolving OpenRegister's
+ * `OrganisationService` is treated as inaccessible — never as
+ * "everyone may access it". Extracted from CustomDictionaryService so the
+ * authorisation decision lives in one small, separately testable class.
+ *
+ * @category  Service
+ * @package   OCA\DocuDesk\Service
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git_id>
+ * @link      https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service;
+
+use OCP\App\IAppManager;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Fail-closed organisation gate for custom dictionaries and terms.
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+ */
+class CustomDictionaryAccessGate
+{
+
+    /**
+     * OpenRegister's app id, used for the install-presence check.
+     *
+     * @var string
+     */
+    private const OPENREGISTER_APP_ID = 'openregister';
+
+    /**
+     * Constructor.
+     *
+     * @param ContainerInterface $container   DI container for lazy OpenRegister service resolution.
+     * @param IAppManager        $appManager  App manager (OpenRegister availability check).
+     * @param IUserSession       $userSession Current-user lookup for the organisation gate.
+     * @param LoggerInterface    $logger      Structured logger.
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly IAppManager $appManager,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Whether OpenRegister is installed. Callers use this to return an
+     * explanatory unavailable state instead of crashing (REQ-DDCDR-004).
+     *
+     * @return bool
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    public function isAvailable(): bool
+    {
+        return in_array(self::OPENREGISTER_APP_ID, $this->appManager->getInstalledApps(), true);
+
+    }//end isAvailable()
+
+    /**
+     * Fail-closed organisation-membership check for one record.
+     *
+     * A record without an organisation, or any failure resolving
+     * OpenRegister's `OrganisationService`, is treated as inaccessible —
+     * never as "everyone may access it".
+     *
+     * @param array<string, mixed> $record The record to check.
+     *
+     * @return bool True when the current caller may read/write this record.
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    public function callerHasAccess(array $record): bool
+    {
+        $organisationUuid = (string) ($this->selfMeta(record: $record)['organisation'] ?? '');
+        if ($organisationUuid === '') {
+            return false;
+        }
+
+        if ($this->userSession->getUser() === null) {
+            return false;
+        }
+
+        try {
+            $organisationService = $this->getOrganisationService();
+            return $organisationService->hasAccessToOrganisation($organisationUuid);
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                '[CustomDictionaryAccessGate] organisation-access check failed; denying access (fail-closed).',
+                ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
+            );
+            return false;
+        }
+
+    }//end callerHasAccess()
+
+    /**
+     * Extract the `@self` metadata block from a record, defensively.
+     *
+     * @param array<string, mixed> $record The record.
+     *
+     * @return array<string, mixed>
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    public function selfMeta(array $record): array
+    {
+        $self = $record['@self'] ?? [];
+        if (is_array($self) === false) {
+            return [];
+        }
+
+        return $self;
+
+    }//end selfMeta()
+
+    /**
+     * Lazily resolve OpenRegister's `OrganisationService` by FQCN via the
+     * DI container (same cross-app pattern used throughout DocuDesk), so
+     * this class stays loadable without OpenRegister installed.
+     *
+     * @return object OpenRegister's `OrganisationService`.
+     *
+     * @throws RuntimeException When OpenRegister is not installed.
+     */
+    private function getOrganisationService(): object
+    {
+        if ($this->isAvailable() === false) {
+            throw new RuntimeException('OpenRegister is not available.');
+        }
+
+        return $this->container->get('OCA\OpenRegister\Service\OrganisationService');
+
+    }//end getOrganisationService()
+}//end class

--- a/lib/Service/CustomDictionaryDetectionRunner.php
+++ b/lib/Service/CustomDictionaryDetectionRunner.php
@@ -69,11 +69,11 @@ class CustomDictionaryDetectionRunner
     /**
      * Constructor.
      *
-     * @param LoggerInterface              $logger                Logger for error reporting.
-     * @param ContainerInterface           $container             Container for lazy OpenRegister resolution.
-     * @param IAppManager                  $appManager            App manager (OpenRegister availability).
-     * @param CustomDictionaryService      $customDictionary      Detection-scoped dictionary listing.
-     * @param CustomDictionaryMatchService $matcher Pure matcher run per active dictionary.
+     * @param LoggerInterface              $logger           Logger for error reporting.
+     * @param ContainerInterface           $container        Container for lazy OpenRegister resolution.
+     * @param IAppManager                  $appManager       App manager (OpenRegister availability).
+     * @param CustomDictionaryService      $customDictionary Detection-scoped dictionary listing.
+     * @param CustomDictionaryMatchService $matcher          Pure matcher run per active dictionary.
      *
      * @return void
      */

--- a/lib/Service/CustomDictionaryDetectionRunner.php
+++ b/lib/Service/CustomDictionaryDetectionRunner.php
@@ -1,0 +1,371 @@
+<?php
+/**
+ * Custom Dictionary Detection Runner
+ *
+ * The custom-dictionary detection pass extracted from AnonymizationService:
+ * runs every active organisation dictionary's matcher across a file's
+ * OpenRegister chunks, de-duplicates matches by absolute document position
+ * (so an occurrence straddling two overlapping chunks is written once), and
+ * writes the resulting `CUSTOM_DICTIONARY` entity relations.
+ *
+ * Best-effort by contract: any failure is logged and returned as a
+ * human-readable warning string. It never throws, so OpenRegister's own
+ * detections are always returned by the caller regardless.
+ *
+ * @category  Service
+ * @package   OCA\DocuDesk\Service
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git_id>
+ * @link      https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service;
+
+use DateTime;
+use OCP\App\IAppManager;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * Runs the custom-dictionary detection pass over a file's chunks.
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+ */
+class CustomDictionaryDetectionRunner
+{
+
+    /**
+     * The entity type this pass produces.
+     *
+     * @var string
+     */
+    private const ENTITY_TYPE = 'CUSTOM_DICTIONARY';
+
+    /**
+     * The detection method stamped on every relation this pass writes.
+     *
+     * @var string
+     */
+    private const DETECTION_METHOD = 'custom_dictionary';
+
+    /**
+     * Constructor.
+     *
+     * @param LoggerInterface              $logger                Logger for error reporting.
+     * @param ContainerInterface           $container             Container for lazy OpenRegister resolution.
+     * @param IAppManager                  $appManager            App manager (OpenRegister availability).
+     * @param CustomDictionaryService      $customDictionary      Detection-scoped dictionary listing.
+     * @param CustomDictionaryMatchService $matcher Pure matcher run per active dictionary.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly ContainerInterface $container,
+        private readonly IAppManager $appManager,
+        private readonly CustomDictionaryService $customDictionary,
+        private readonly CustomDictionaryMatchService $matcher
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Run the custom-dictionary detection pass for one file.
+     *
+     * @param int                     $fileId              The Nextcloud file ID.
+     * @param array<int, string>|null $entityTypeWhitelist The operator's enabled-type
+     *                                                     selection (null = all types).
+     *                                                     When non-null and it does not
+     *                                                     contain `CUSTOM_DICTIONARY`, the
+     *                                                     pass is skipped entirely.
+     *
+     * @return string|null Null on success (or when skipped), a warning message on failure.
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    public function run(int $fileId, ?array $entityTypeWhitelist): ?string
+    {
+        if ($entityTypeWhitelist !== null && in_array(self::ENTITY_TYPE, $entityTypeWhitelist, true) === false) {
+            // Operator has disabled automatic custom-dictionary detection.
+            return null;
+        }
+
+        try {
+            $dictionaries = $this->customDictionary->listActiveDictionariesForDetection();
+            if (empty($dictionaries) === true) {
+                return null;
+            }
+
+            $chunkMapper = $this->getOpenRegisterService(className: 'OCA\OpenRegister\Db\ChunkMapper');
+            $chunks      = $chunkMapper->findBySource('file', $fileId);
+            if (empty($chunks) === true) {
+                return null;
+            }
+
+            $entityRelationMapper = $this->getOpenRegisterService(
+                className: 'OCA\OpenRegister\Db\EntityRelationMapper'
+            );
+            $gdprEntityMapper     = $this->getOpenRegisterService(
+                className: 'OCA\OpenRegister\Db\GdprEntityMapper'
+            );
+
+            $this->clearRelations(fileId: $fileId, entityRelationMapper: $entityRelationMapper);
+
+            $rowsToInsert = $this->matchDictionariesAgainstChunks(
+                chunks: $chunks,
+                dictionaries: $dictionaries,
+                fileId: $fileId,
+                gdprEntityMapper: $gdprEntityMapper
+            );
+
+            if (empty($rowsToInsert) === false) {
+                $entityRelationMapper->insertBatch(rows: $rowsToInsert);
+            }
+
+            return null;
+        } catch (Throwable $e) {
+            $this->logger->error(
+                '[CustomDictionaryDetectionRunner] Custom dictionary matching failed; continuing with OpenRegister detection only.',
+                ['file' => __FILE__, 'line' => __LINE__, 'fileId' => $fileId, 'error' => $e->getMessage()]
+            );
+            return 'Custom dictionary matching did not run: '.$e->getMessage();
+        }//end try
+
+    }//end run()
+
+    /**
+     * Run every active dictionary's matcher against every chunk and build
+     * the `EntityRelationMapper::insertBatch()` row set.
+     *
+     * @param array<int, mixed> $chunks           OpenRegister `Chunk` entities, chunk-index ascending.
+     * @param array<int, mixed> $dictionaries     Active dictionaries + terms (see
+     *                                            {@see CustomDictionaryService::listActiveDictionariesForDetection()}
+     *                                            for the exact row shape).
+     * @param int               $fileId           The Nextcloud file ID.
+     * @param mixed             $gdprEntityMapper OpenRegister `GdprEntityMapper` instance.
+     *
+     * @return array<int, array<string, mixed>> Rows ready for `EntityRelationMapper::insertBatch()`.
+     */
+    private function matchDictionariesAgainstChunks(
+        array $chunks,
+        array $dictionaries,
+        int $fileId,
+        mixed $gdprEntityMapper
+    ): array {
+        $globalClaimed = [];
+        $entityCache   = [];
+        $rowsToInsert  = [];
+
+        foreach ($chunks as $chunk) {
+            $chunkText = (string) $chunk->getTextContent();
+            if ($chunkText === '') {
+                continue;
+            }
+
+            $chunkOccurrences = $this->collectChunkOccurrences(
+                chunkText: $chunkText,
+                dictionaries: $dictionaries
+            );
+            if (empty($chunkOccurrences) === true) {
+                continue;
+            }
+
+            $startOffset = (int) $chunk->getStartOffset();
+            foreach ($chunkOccurrences as $occurrence) {
+                $absoluteStart = ($startOffset + $occurrence['positionStart']);
+                $absoluteEnd   = ($startOffset + $occurrence['positionEnd']);
+
+                if ($this->rangeOverlapsAny(start: $absoluteStart, end: $absoluteEnd, claimed: $globalClaimed) === true) {
+                    // Already matched at this absolute document position —
+                    // typically the same occurrence seen again in an
+                    // overlap region shared by two adjacent chunks.
+                    continue;
+                }
+
+                $globalClaimed[] = [$absoluteStart, $absoluteEnd];
+
+                $entityKey = (self::ENTITY_TYPE.'|'.$occurrence['value']);
+                if (isset($entityCache[$entityKey]) === false) {
+                    $entityCache[$entityKey] = $this->lookupOrCreateEntity(
+                        value: $occurrence['value'],
+                        gdprEntityMapper: $gdprEntityMapper
+                    );
+                }
+
+                $rowsToInsert[] = [
+                    'entityId'          => $entityCache[$entityKey],
+                    'fileId'            => $fileId,
+                    'chunkId'           => (int) $chunk->getId(),
+                    'positionStart'     => $occurrence['positionStart'],
+                    'positionEnd'       => $occurrence['positionEnd'],
+                    'confidence'        => 1.0,
+                    'detectionMethod'   => self::DETECTION_METHOD,
+                    // The only free-text field EntityRelation exposes; carries
+                    // the matching term/dictionary label for the review UI
+                    // (design.md §D3 — "per-list label carried on the relation").
+                    'context'           => $occurrence['label'],
+                    'anonymized'        => false,
+                    'skipAnonymization' => false,
+                    'createdAt'         => new DateTime(),
+                ];
+            }//end foreach
+        }//end foreach
+
+        return $rowsToInsert;
+
+    }//end matchDictionariesAgainstChunks()
+
+    /**
+     * Collect one chunk's occurrences across every active dictionary,
+     * longest-match-first.
+     *
+     * Sorting longest-first means a shorter cross-dictionary match cannot
+     * pre-empt a longer one at an overlapping position — mirrors
+     * CustomDictionaryMatchService's own per-dictionary overlap rule.
+     *
+     * @param string            $chunkText    The chunk's text content.
+     * @param array<int, mixed> $dictionaries Active dictionaries + terms.
+     *
+     * @return array<int, array<string, mixed>> Occurrences, longest match first.
+     */
+    private function collectChunkOccurrences(string $chunkText, array $dictionaries): array
+    {
+        $chunkOccurrences = [];
+        foreach ($dictionaries as $dictionary) {
+            foreach ($this->matcher->match(
+                    text: $chunkText,
+                    terms: $dictionary['terms'],
+                    mode: $dictionary['matchMode']
+                ) as $occurrence
+            ) {
+                $chunkOccurrences[] = $occurrence;
+            }
+        }
+
+        usort(
+            $chunkOccurrences,
+            static fn (array $a, array $b): int => (
+                ($b['positionEnd'] - $b['positionStart']) <=> ($a['positionEnd'] - $a['positionStart'])
+            )
+        );
+
+        return $chunkOccurrences;
+
+    }//end collectChunkOccurrences()
+
+    /**
+     * Look up an existing `CUSTOM_DICTIONARY` catalogue entry for `$value`,
+     * or create one. Mirrors OpenRegister's own manual-entity lookup-or-
+     * create convention (`ManualEntityService::lookupOrCreateEntity`) so
+     * repeated matches of the same literal value share one catalogue row.
+     *
+     * @param string $value            The matched term text.
+     * @param mixed  $gdprEntityMapper OpenRegister `GdprEntityMapper` instance.
+     *
+     * @return int The catalogue entity id.
+     */
+    private function lookupOrCreateEntity(string $value, mixed $gdprEntityMapper): int
+    {
+        $existing = $gdprEntityMapper->findOneByValueAndType(value: $value, type: self::ENTITY_TYPE);
+        if ($existing !== null) {
+            return (int) $existing->getId();
+        }
+
+        // Instantiated by FQCN string (not a hard `use` import) so this class
+        // stays loadable without OpenRegister installed, mirroring
+        // `getOpenRegisterService()`'s own lazy-resolution convention. A
+        // fresh instance is required per call — the container's `get()`
+        // would return a shared, mutable singleton, which is wrong for an
+        // Entity that is set up differently on every insert.
+        $entityClass = 'OCA\OpenRegister\Db\GdprEntity';
+        $now         = new DateTime();
+        $entity      = new $entityClass();
+        $entity->setUuid(Uuid::v4()->toRfc4122());
+        $entity->setValue($value);
+        $entity->setType(self::ENTITY_TYPE);
+        $entity->setCategory('contextual_data');
+        $entity->setDetectedAt($now);
+        $entity->setUpdatedAt($now);
+
+        $inserted = $gdprEntityMapper->insert($entity);
+        return (int) $inserted->getId();
+
+    }//end lookupOrCreateEntity()
+
+    /**
+     * Clear this file's prior `custom_dictionary` relations so a re-run
+     * never appends duplicates (design.md §D3 idempotency rule).
+     *
+     * @param int   $fileId               The Nextcloud file ID.
+     * @param mixed $entityRelationMapper OpenRegister `EntityRelationMapper` instance.
+     *
+     * @return void
+     */
+    private function clearRelations(int $fileId, mixed $entityRelationMapper): void
+    {
+        foreach ($entityRelationMapper->findByFileId($fileId) as $relation) {
+            if ($relation->getDetectionMethod() === self::DETECTION_METHOD) {
+                $entityRelationMapper->delete($relation);
+            }
+        }
+
+    }//end clearRelations()
+
+    /**
+     * Whether `[start, end)` overlaps any already-claimed absolute-position range.
+     *
+     * @param int                            $start   Candidate match start.
+     * @param int                            $end     Candidate match end.
+     * @param array<int, array{0:int,1:int}> $claimed Already-claimed `[start, end]` pairs.
+     *
+     * @return bool True when the candidate overlaps a claimed range.
+     */
+    private function rangeOverlapsAny(int $start, int $end, array $claimed): bool
+    {
+        foreach ($claimed as [$claimedStart, $claimedEnd]) {
+            if ($start < $claimedEnd && $end > $claimedStart) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end rangeOverlapsAny()
+
+    /**
+     * Get an OpenRegister service or mapper by class name.
+     *
+     * @param string $className The fully qualified class name.
+     *
+     * @return mixed The service instance.
+     *
+     * @throws RuntimeException If OpenRegister is not available.
+     */
+    private function getOpenRegisterService(string $className): mixed
+    {
+        if (in_array('openregister', $this->appManager->getInstalledApps(), true) === true) {
+            return $this->container->get($className);
+        }
+
+        throw new RuntimeException($className.' is not available.');
+
+    }//end getOpenRegisterService()
+}//end class

--- a/lib/Service/CustomDictionaryPayloadNormaliser.php
+++ b/lib/Service/CustomDictionaryPayloadNormaliser.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Custom Dictionary Payload Normaliser
+ *
+ * Pure input-shaping for {@see CustomDictionaryService}: server-side CSV /
+ * newline-list import parsing (design.md §D5 — parsing MUST NOT be delegated
+ * to the browser), `matchMode` sanitisation against the schema enum, and the
+ * small coercions applied before persistence. Extracted from
+ * CustomDictionaryService so that service holds only CRUD orchestration.
+ *
+ * Every method here is a pure function of its arguments — no I/O, no state.
+ *
+ * @category  Service
+ * @package   OCA\DocuDesk\Service
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git_id>
+ * @link      https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service;
+
+/**
+ * Pure input-shaping helpers for custom dictionary payloads.
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+ */
+class CustomDictionaryPayloadNormaliser
+{
+
+    /**
+     * Valid `matchMode` values (mirrors the schema enum).
+     *
+     * @var array<int, string>
+     */
+    public const VALID_MATCH_MODES = ['exact', 'caseInsensitive', 'wordBoundary'];
+
+    /**
+     * Default match mode when unset/invalid.
+     *
+     * @var string
+     */
+    public const DEFAULT_MATCH_MODE = 'caseInsensitive';
+
+    /**
+     * Sanitise a `matchMode` value against the schema enum.
+     *
+     * @param mixed $mode Raw value.
+     *
+     * @return string A value from {@see VALID_MATCH_MODES}.
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    public function sanitizeMatchMode(mixed $mode): string
+    {
+        if (is_string($mode) === true && in_array($mode, self::VALID_MATCH_MODES, true) === true) {
+            return $mode;
+        }
+
+        return self::DEFAULT_MATCH_MODE;
+
+    }//end sanitizeMatchMode()
+
+    /**
+     * Parse CSV import content into `{value, label}` rows.
+     *
+     * @param string $content Raw CSV content.
+     *
+     * @return array<int, array{value: string, label: string|null}>
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    public function parseCsv(string $content): array
+    {
+        $rows = [];
+        foreach ($this->splitLines(content: $content) as $line) {
+            // Explicit $escape (PHP 8.4 deprecates the implicit default) —
+            // no escape character: dictionary term CSVs are simple
+            // value[,label] rows, never quoted-and-escaped fields.
+            $columns = str_getcsv(string: $line, separator: ',', enclosure: '"', escape: '');
+            $rows[]  = [
+                'value' => (string) ($columns[0] ?? ''),
+                'label' => ($columns[1] ?? null),
+            ];
+        }
+
+        return $rows;
+
+    }//end parseCsv()
+
+    /**
+     * Parse newline-separated plain-text import content into
+     * `{value, label}` rows.
+     *
+     * @param string $content Raw plain-text content.
+     *
+     * @return array<int, array{value: string, label: string|null}>
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    public function parseList(string $content): array
+    {
+        $rows = [];
+        foreach ($this->splitLines(content: $content) as $line) {
+            $rows[] = [
+                'value' => $line,
+                'label' => null,
+            ];
+        }
+
+        return $rows;
+
+    }//end parseList()
+
+    /**
+     * Strip framework-injected request params before persistence.
+     *
+     * @param array<string, mixed> $data Raw incoming data.
+     *
+     * @return array<string, mixed>
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    public function stripFrameworkParams(array $data): array
+    {
+        unset($data['_route'], $data['_method'], $data['id'], $data['uuid']);
+        return $data;
+
+    }//end stripFrameworkParams()
+
+    /**
+     * Coerce a value to a trimmed string, or null when blank/absent.
+     *
+     * @param mixed $value Raw value.
+     *
+     * @return string|null
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    public function stringOrNull(mixed $value): ?string
+    {
+        if (is_string($value) === false) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        return $trimmed;
+
+    }//end stringOrNull()
+
+    /**
+     * Split raw import content into lines.
+     *
+     * Normalises line endings so a Windows-authored CSV/list parses the same
+     * as a Unix one, then drops exactly one trailing newline artifact (a
+     * pasted textarea value or an uploaded file almost always ends with one)
+     * so it is not counted as an extra blank line. Every OTHER
+     * blank/whitespace-only line is preserved as a row — importTerms() counts
+     * it toward `skipped` per REQ-DDCDR-005's scenario numbers (blank lines
+     * are part of the reported total, not silently dropped pre-count).
+     *
+     * @param string $content Raw content.
+     *
+     * @return array<int, string>
+     */
+    private function splitLines(string $content): array
+    {
+        $normalized = str_replace(["\r\n", "\r"], "\n", $content);
+
+        if (str_ends_with($normalized, "\n") === true) {
+            $normalized = substr($normalized, 0, -1);
+        }
+
+        return explode("\n", $normalized);
+
+    }//end splitLines()
+}//end class

--- a/lib/Service/CustomDictionaryRepository.php
+++ b/lib/Service/CustomDictionaryRepository.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Custom Dictionary Repository
+ *
+ * The OpenRegister persistence primitives behind {@see CustomDictionaryService}:
+ * slug-aware list, find, save and delete for the `customDictionary` /
+ * `customDictionaryTerm` schemas, plus the serialisation of OpenRegister's
+ * object shapes down to plain arrays. Extracted from CustomDictionaryService
+ * so that service holds only the organisation gate, import parsing and CRUD
+ * orchestration.
+ *
+ * @category  Service
+ * @package   OCA\DocuDesk\Service
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git_id>
+ * @link      https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service;
+
+use Exception;
+use Psr\Log\LoggerInterface;
+
+/**
+ * OpenRegister persistence primitives for custom dictionaries and terms.
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+ */
+class CustomDictionaryRepository
+{
+
+    /**
+     * Register slug both schemas live in.
+     *
+     * @var string
+     */
+    public const REGISTER = 'document';
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Provides OpenRegister's ObjectService.
+     * @param LoggerInterface $logger          Structured logger.
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger
+    ) {
+
+    }//end __construct()
+
+    /**
+     * List records by schema slug (register is always {@see REGISTER}) and
+     * serialise them to plain arrays.
+     *
+     * @param string $schema Schema slug.
+     *
+     * @return array<int, array<string, mixed>>
+     *
+     * @throws Exception On query failure.
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    public function listBySchema(string $schema): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        // Slug-aware variant — OR's standard searchObjects requires numeric
+        // register/schema ids and silently returns nothing otherwise.
+        $results = $objectService->searchObjectsBySlug(
+            registerSlug: self::REGISTER,
+            schemaSlug: $schema,
+            _rbac: false,
+            _multitenancy: false
+        );
+
+        if (is_int($results) === true) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($results as $result) {
+            $row = $this->toArrayOrNull(value: $result);
+            if ($row !== null) {
+                $rows[] = $row;
+            }
+        }
+
+        return $rows;
+
+    }//end listBySchema()
+
+    /**
+     * Look up one record by UUID.
+     *
+     * @param string $schema Schema slug.
+     * @param string $uuid   Record UUID.
+     *
+     * @return array<string, mixed>|null
+     *
+     * @throws Exception On lookup failure.
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    public function findOne(string $schema, string $uuid): ?array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        $object        = $objectService->find(
+            id: $uuid,
+            register: self::REGISTER,
+            schema: $schema,
+            _rbac: false,
+            _multitenancy: false
+        );
+
+        if ($object === null) {
+            return null;
+        }
+
+        return $this->toArrayOrCast(value: $object);
+
+    }//end findOne()
+
+    /**
+     * Persist a record via `ObjectService::saveObject`.
+     *
+     * @param string               $schema Schema slug.
+     * @param array<string, mixed> $data   Record payload.
+     * @param string|null          $uuid   Optional UUID for updates.
+     *
+     * @return array<string, mixed>
+     *
+     * @throws Exception On write failure.
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    public function save(string $schema, array $data, ?string $uuid=null): array
+    {
+        try {
+            $objectService = $this->settingsService->getObjectService();
+            $saved         = $objectService->saveObject(
+                object: $data,
+                register: self::REGISTER,
+                schema: $schema,
+                uuid: $uuid,
+                _rbac: false,
+                _multitenancy: false
+            );
+
+            return $this->toArrayOrCast(value: $saved);
+        } catch (Exception $e) {
+            $this->logger->error(
+                'CustomDictionaryRepository: save failed',
+                ['schema' => $schema, 'uuid' => $uuid, 'error' => $e->getMessage()]
+            );
+            throw $e;
+        }//end try
+
+    }//end save()
+
+    /**
+     * Delete a record via `ObjectService::deleteObject`.
+     *
+     * @param string $schema Schema slug.
+     * @param string $uuid   Record UUID.
+     *
+     * @return void
+     *
+     * @throws Exception On deletion failure.
+     *
+     * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+     */
+    public function delete(string $schema, string $uuid): void
+    {
+        $objectService = $this->settingsService->getObjectService();
+        // NOTE: unlike find()/saveObject() (whose first param is $id / a
+        // $uuid keyword respectively), ObjectService::deleteObject()'s first
+        // parameter is named $uuid — verified against
+        // OCA\OpenRegister\Service\ObjectService::deleteObject() at HEAD.
+        $objectService->deleteObject(
+            uuid: $uuid,
+            register: self::REGISTER,
+            schema: $schema,
+            _rbac: false,
+            _multitenancy: false
+        );
+
+    }//end delete()
+
+    /**
+     * Normalise one OpenRegister result to a plain array, discarding values
+     * that are neither serialisable nor already an array.
+     *
+     * Used on list results, where an unrecognised row is skipped rather than
+     * coerced into a meaningless array.
+     *
+     * @param mixed $value An ObjectEntity, a plain array, or anything else.
+     *
+     * @return array<string, mixed>|null The array form, or null when unrecognised.
+     */
+    private function toArrayOrNull(mixed $value): ?array
+    {
+        if (is_object($value) === true && method_exists($value, 'jsonSerialize') === true) {
+            return $value->jsonSerialize();
+        }
+
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        return null;
+
+    }//end toArrayOrNull()
+
+    /**
+     * Normalise one OpenRegister result to a plain array, casting anything
+     * unrecognised rather than discarding it.
+     *
+     * Used on single-record results, where the caller has already established
+     * that a record exists and expects an array back.
+     *
+     * @param mixed $value An ObjectEntity, a plain array, or anything else.
+     *
+     * @return array<string, mixed> The array form.
+     */
+    private function toArrayOrCast(mixed $value): array
+    {
+        return ($this->toArrayOrNull(value: $value) ?? (array) $value);
+
+    }//end toArrayOrCast()
+}//end class

--- a/lib/Service/CustomDictionaryService.php
+++ b/lib/Service/CustomDictionaryService.php
@@ -89,10 +89,10 @@ class CustomDictionaryService
     /**
      * Constructor.
      *
-     * @param CustomDictionaryRepository         $repository Persistence primitives.
-     * @param CustomDictionaryAccessGate         $accessGate Fail-closed organisation gate.
-     * @param CustomDictionaryPayloadNormaliser  $normaliser Import parsing and payload coercion.
-     * @param LoggerInterface                    $logger     Structured logger.
+     * @param CustomDictionaryRepository        $repository Persistence primitives.
+     * @param CustomDictionaryAccessGate        $accessGate Fail-closed organisation gate.
+     * @param CustomDictionaryPayloadNormaliser $normaliser Import parsing and payload coercion.
+     * @param LoggerInterface                   $logger     Structured logger.
      */
     public function __construct(
         private readonly CustomDictionaryRepository $repository,
@@ -581,5 +581,4 @@ class CustomDictionaryService
         return $dictionary;
 
     }//end enrichWithTermCount()
-
 }//end class

--- a/lib/Service/CustomDictionaryService.php
+++ b/lib/Service/CustomDictionaryService.php
@@ -30,10 +30,7 @@ namespace OCA\DocuDesk\Service;
 
 use Exception;
 use InvalidArgumentException;
-use OCP\App\IAppManager;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
@@ -74,27 +71,6 @@ class CustomDictionaryService
     public const SCHEMA_TERM = 'customDictionaryTerm';
 
     /**
-     * OpenRegister's app id, used for the install-presence check.
-     *
-     * @var string
-     */
-    private const OPENREGISTER_APP_ID = 'openregister';
-
-    /**
-     * Valid `matchMode` values (mirrors the schema enum).
-     *
-     * @var array<int, string>
-     */
-    private const VALID_MATCH_MODES = ['exact', 'caseInsensitive', 'wordBoundary'];
-
-    /**
-     * Default match mode when unset/invalid.
-     *
-     * @var string
-     */
-    private const DEFAULT_MATCH_MODE = 'caseInsensitive';
-
-    /**
      * Maximum number of term rows accepted in a single import call —
      * bounds the request against a denial-of-service via an oversized
      * upload (design.md §Security Considerations).
@@ -113,17 +89,15 @@ class CustomDictionaryService
     /**
      * Constructor.
      *
-     * @param SettingsService    $settingsService Provides OpenRegister's ObjectService.
-     * @param ContainerInterface $container       DI container for lazy OpenRegister service resolution.
-     * @param IAppManager        $appManager      App manager (OpenRegister availability check).
-     * @param IUserSession       $userSession     Current-user lookup for the organisation gate.
-     * @param LoggerInterface    $logger          Structured logger.
+     * @param CustomDictionaryRepository         $repository Persistence primitives.
+     * @param CustomDictionaryAccessGate         $accessGate Fail-closed organisation gate.
+     * @param CustomDictionaryPayloadNormaliser  $normaliser Import parsing and payload coercion.
+     * @param LoggerInterface                    $logger     Structured logger.
      */
     public function __construct(
-        private readonly SettingsService $settingsService,
-        private readonly ContainerInterface $container,
-        private readonly IAppManager $appManager,
-        private readonly IUserSession $userSession,
+        private readonly CustomDictionaryRepository $repository,
+        private readonly CustomDictionaryAccessGate $accessGate,
+        private readonly CustomDictionaryPayloadNormaliser $normaliser,
         private readonly LoggerInterface $logger
     ) {
 
@@ -139,7 +113,7 @@ class CustomDictionaryService
      */
     public function isAvailable(): bool
     {
-        return in_array(self::OPENREGISTER_APP_ID, $this->appManager->getInstalledApps(), true);
+        return $this->accessGate->isAvailable();
 
     }//end isAvailable()
 
@@ -157,11 +131,11 @@ class CustomDictionaryService
             return [];
         }
 
-        $rows       = $this->listByRegisterSchema(schema: self::SCHEMA_DICTIONARY);
+        $rows       = $this->repository->listBySchema(schema: self::SCHEMA_DICTIONARY);
         $accessible = array_values(
             array_filter(
                 $rows,
-                fn (array $record): bool => $this->callerHasAccess(record: $record)
+                fn (array $record): bool => $this->accessGate->callerHasAccess(record: $record)
             )
         );
 
@@ -207,12 +181,12 @@ class CustomDictionaryService
      */
     public function createDictionary(array $data): array
     {
-        $payload = $this->stripFrameworkParams(data: $data);
+        $payload = $this->normaliser->stripFrameworkParams(data: $data);
         unset($payload['termCount']);
         $payload['active']    = ($payload['active'] ?? true);
-        $payload['matchMode'] = $this->sanitizeMatchMode(mode: ($payload['matchMode'] ?? null));
+        $payload['matchMode'] = $this->normaliser->sanitizeMatchMode(mode: ($payload['matchMode'] ?? null));
 
-        $saved = $this->saveObject(schema: self::SCHEMA_DICTIONARY, data: $payload);
+        $saved = $this->repository->save(schema: self::SCHEMA_DICTIONARY, data: $payload);
         return $this->enrichWithTermCount(dictionary: $saved);
 
     }//end createDictionary()
@@ -236,11 +210,11 @@ class CustomDictionaryService
     {
         $existing = $this->findDictionaryOrFail(uuid: $uuid);
 
-        $payload = array_merge($existing, $this->stripFrameworkParams(data: $data));
+        $payload = array_merge($existing, $this->normaliser->stripFrameworkParams(data: $data));
         unset($payload['termCount'], $payload['@self']);
-        $payload['matchMode'] = $this->sanitizeMatchMode(mode: ($payload['matchMode'] ?? null));
+        $payload['matchMode'] = $this->normaliser->sanitizeMatchMode(mode: ($payload['matchMode'] ?? null));
 
-        $saved = $this->saveObject(schema: self::SCHEMA_DICTIONARY, data: $payload, uuid: $uuid);
+        $saved = $this->repository->save(schema: self::SCHEMA_DICTIONARY, data: $payload, uuid: $uuid);
         return $this->enrichWithTermCount(dictionary: $saved);
 
     }//end updateDictionary()
@@ -264,11 +238,11 @@ class CustomDictionaryService
         foreach ($this->listTermsForDictionary(dictionary: $existing) as $term) {
             $termId = (string) ($term['id'] ?? '');
             if ($termId !== '') {
-                $this->deleteObject(schema: self::SCHEMA_TERM, uuid: $termId);
+                $this->repository->delete(schema: self::SCHEMA_TERM, uuid: $termId);
             }
         }
 
-        $this->deleteObject(schema: self::SCHEMA_DICTIONARY, uuid: $uuid);
+        $this->repository->delete(schema: self::SCHEMA_DICTIONARY, uuid: $uuid);
 
     }//end deleteDictionary()
 
@@ -313,11 +287,11 @@ class CustomDictionaryService
             throw new InvalidArgumentException('Term value must not be blank.');
         }
 
-        return $this->saveObject(
+        return $this->repository->save(
             schema: self::SCHEMA_TERM,
             data: [
                 'value'      => $value,
-                'label'      => $this->stringOrNull(value: ($data['label'] ?? null)),
+                'label'      => $this->normaliser->stringOrNull(value: ($data['label'] ?? null)),
                 'dictionary' => (string) ($dictionary['id'] ?? $dictionaryUuid),
             ]
         );
@@ -342,12 +316,12 @@ class CustomDictionaryService
     {
         $dictionary = $this->findDictionaryOrFail(uuid: $dictionaryUuid);
 
-        $term = $this->findOne(schema: self::SCHEMA_TERM, uuid: $termUuid);
+        $term = $this->repository->findOne(schema: self::SCHEMA_TERM, uuid: $termUuid);
         if ($term === null || $this->termBelongsToDictionary(term: $term, dictionary: $dictionary) === false) {
             throw new DoesNotExistException('Term not found for this dictionary.');
         }
 
-        $this->deleteObject(schema: self::SCHEMA_TERM, uuid: $termUuid);
+        $this->repository->delete(schema: self::SCHEMA_TERM, uuid: $termUuid);
 
     }//end deleteTerm()
 
@@ -381,7 +355,11 @@ class CustomDictionaryService
             );
         }
 
-        $rows = $this->parseImportContent(content: $content, isCsv: $isCsv);
+        $rows = $this->normaliser->parseList(content: $content);
+        if ($isCsv === true) {
+            $rows = $this->normaliser->parseCsv(content: $content);
+        }
+
         if (count($rows) > self::MAX_IMPORT_ROWS) {
             throw new InvalidArgumentException(
                 sprintf('Import exceeds the %d row limit.', self::MAX_IMPORT_ROWS)
@@ -399,7 +377,7 @@ class CustomDictionaryService
         $seenThisBatch = [];
 
         foreach ($rows as $row) {
-            // parseImportContent() always emits a string `value` (a missing CSV
+            // The normaliser always emits a string `value` (a missing CSV
             // column is coerced to ''), so no null-coalesce is needed here.
             $value = trim($row['value']);
             if ($value === '') {
@@ -415,11 +393,11 @@ class CustomDictionaryService
 
             $seenThisBatch[$key] = true;
 
-            $this->saveObject(
+            $this->repository->save(
                 schema: self::SCHEMA_TERM,
                 data: [
                     'value'      => $value,
-                    'label'      => $this->stringOrNull(value: ($row['label'] ?? null)),
+                    'label'      => $this->normaliser->stringOrNull(value: ($row['label'] ?? null)),
                     'dictionary' => $dictionaryReference,
                 ]
             );
@@ -470,7 +448,7 @@ class CustomDictionaryService
 
                 $result[] = [
                     'label'     => (string) ($dictionary['label'] ?? ''),
-                    'matchMode' => $this->sanitizeMatchMode(mode: ($dictionary['matchMode'] ?? null)),
+                    'matchMode' => $this->normaliser->sanitizeMatchMode(mode: ($dictionary['matchMode'] ?? null)),
                     'terms'     => $termRows,
                 ];
             }//end foreach
@@ -534,12 +512,12 @@ class CustomDictionaryService
      */
     private function findDictionaryOrFail(string $uuid): array
     {
-        $record = $this->findOne(schema: self::SCHEMA_DICTIONARY, uuid: $uuid);
+        $record = $this->repository->findOne(schema: self::SCHEMA_DICTIONARY, uuid: $uuid);
         if ($record === null) {
             throw new DoesNotExistException(sprintf('Custom dictionary %s not found.', $uuid));
         }
 
-        if ($this->callerHasAccess(record: $record) === false) {
+        if ($this->accessGate->callerHasAccess(record: $record) === false) {
             throw new RuntimeException('You do not have access to this custom dictionary.');
         }
 
@@ -558,7 +536,7 @@ class CustomDictionaryService
      */
     private function listTermsForDictionary(array $dictionary): array
     {
-        $rows = $this->listByRegisterSchema(schema: self::SCHEMA_TERM);
+        $rows = $this->repository->listBySchema(schema: self::SCHEMA_TERM);
         return array_values(
             array_filter(
                 $rows,
@@ -584,7 +562,7 @@ class CustomDictionaryService
         }
 
         $dictionaryId   = (string) ($dictionary['id'] ?? '');
-        $dictionarySlug = (string) ($this->selfMeta(record: $dictionary)['slug'] ?? ($dictionary['slug'] ?? ''));
+        $dictionarySlug = (string) ($this->accessGate->selfMeta(record: $dictionary)['slug'] ?? ($dictionary['slug'] ?? ''));
 
         return $reference === $dictionaryId || ($dictionarySlug !== '' && $reference === $dictionarySlug);
 
@@ -604,319 +582,4 @@ class CustomDictionaryService
 
     }//end enrichWithTermCount()
 
-    /**
-     * Fail-closed organisation-membership check for one record.
-     *
-     * A record without an organisation, or any failure resolving
-     * OpenRegister's `OrganisationService`, is treated as inaccessible —
-     * never as "everyone may access it".
-     *
-     * @param array<string, mixed> $record The record to check.
-     *
-     * @return bool True when the current caller may read/write this record.
-     */
-    private function callerHasAccess(array $record): bool
-    {
-        $organisationUuid = (string) ($this->selfMeta(record: $record)['organisation'] ?? '');
-        if ($organisationUuid === '') {
-            return false;
-        }
-
-        if ($this->userSession->getUser() === null) {
-            return false;
-        }
-
-        try {
-            $organisationService = $this->getOrganisationService();
-            return $organisationService->hasAccessToOrganisation($organisationUuid);
-        } catch (Throwable $e) {
-            $this->logger->warning(
-                '[CustomDictionaryService] organisation-access check failed; denying access (fail-closed).',
-                ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
-            );
-            return false;
-        }
-
-    }//end callerHasAccess()
-
-    /**
-     * Lazily resolve OpenRegister's `OrganisationService` by FQCN via the
-     * DI container (same cross-app pattern used throughout DocuDesk), so
-     * this class stays loadable without OpenRegister installed.
-     *
-     * @return object OpenRegister's `OrganisationService`.
-     *
-     * @throws RuntimeException When OpenRegister is not installed.
-     */
-    private function getOrganisationService(): object
-    {
-        if ($this->isAvailable() === false) {
-            throw new RuntimeException('OpenRegister is not available.');
-        }
-
-        return $this->container->get('OCA\OpenRegister\Service\OrganisationService');
-
-    }//end getOrganisationService()
-
-    /**
-     * Extract the `@self` metadata block from a record, defensively.
-     *
-     * @param array<string, mixed> $record The record.
-     *
-     * @return array<string, mixed>
-     */
-    private function selfMeta(array $record): array
-    {
-        $self = $record['@self'] ?? [];
-        if (is_array($self) === false) {
-            return [];
-        }
-
-        return $self;
-
-    }//end selfMeta()
-
-    /**
-     * Sanitise a `matchMode` value against the schema enum.
-     *
-     * @param mixed $mode Raw value.
-     *
-     * @return string A value from {@see VALID_MATCH_MODES}.
-     */
-    private function sanitizeMatchMode(mixed $mode): string
-    {
-        if (is_string($mode) === true && in_array($mode, self::VALID_MATCH_MODES, true) === true) {
-            return $mode;
-        }
-
-        return self::DEFAULT_MATCH_MODE;
-
-    }//end sanitizeMatchMode()
-
-    /**
-     * Parse import content into `{value, label}` rows.
-     *
-     * @param string $content Raw content.
-     * @param bool   $isCsv   True for CSV parsing, false for newline-list parsing.
-     *
-     * @return array<int, array{value: string, label: string|null}>
-     */
-    private function parseImportContent(string $content, bool $isCsv): array
-    {
-        // Normalise line endings so a Windows-authored CSV/list parses the
-        // same as a Unix one.
-        $normalized = str_replace(["\r\n", "\r"], "\n", $content);
-
-        // Drop exactly one trailing newline artifact (a pasted textarea
-        // value or an uploaded file almost always ends with one) so it is
-        // not counted as an extra blank line. Every OTHER blank/whitespace-
-        // only line is preserved as a row — importTerms() counts it toward
-        // `skipped` per REQ-DDCDR-005's scenario numbers (blank lines are
-        // part of the reported total, not silently dropped pre-count).
-        if (str_ends_with($normalized, "\n") === true) {
-            $normalized = substr($normalized, 0, -1);
-        }
-
-        $lines = explode("\n", $normalized);
-
-        $rows = [];
-        foreach ($lines as $line) {
-            if ($isCsv === true) {
-                // Explicit $escape (PHP 8.4 deprecates the implicit default) —
-                // no escape character: dictionary term CSVs are simple
-                // value[,label] rows, never quoted-and-escaped fields.
-                $columns = str_getcsv(string: $line, separator: ',', enclosure: '"', escape: '');
-                $rows[]  = [
-                    'value' => (string) ($columns[0] ?? ''),
-                    'label' => ($columns[1] ?? null),
-                ];
-                continue;
-            }
-
-            $rows[] = [
-                'value' => $line,
-                'label' => null,
-            ];
-        }//end foreach
-
-        return $rows;
-
-    }//end parseImportContent()
-
-    /**
-     * Strip framework-injected request params before persistence.
-     *
-     * @param array<string, mixed> $data Raw incoming data.
-     *
-     * @return array<string, mixed>
-     */
-    private function stripFrameworkParams(array $data): array
-    {
-        unset($data['_route'], $data['_method'], $data['id'], $data['uuid']);
-        return $data;
-
-    }//end stripFrameworkParams()
-
-    /**
-     * Coerce a value to a trimmed string, or null when blank/absent.
-     *
-     * @param mixed $value Raw value.
-     *
-     * @return string|null
-     */
-    private function stringOrNull(mixed $value): ?string
-    {
-        if (is_string($value) === false) {
-            return null;
-        }
-
-        $trimmed = trim($value);
-        if ($trimmed === '') {
-            return null;
-        }
-
-        return $trimmed;
-
-    }//end stringOrNull()
-
-    /**
-     * List records by schema slug (register is always {@see REGISTER}) and
-     * serialise them to plain arrays.
-     *
-     * @param string $schema Schema slug.
-     *
-     * @return array<int, array<string, mixed>>
-     *
-     * @throws Exception On query failure.
-     */
-    private function listByRegisterSchema(string $schema): array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        // Slug-aware variant — OR's standard searchObjects requires numeric
-        // register/schema ids and silently returns nothing otherwise.
-        $results = $objectService->searchObjectsBySlug(
-            registerSlug: self::REGISTER,
-            schemaSlug: $schema,
-            _rbac: false,
-            _multitenancy: false
-        );
-
-        if (is_int($results) === true) {
-            return [];
-        }
-
-        $rows = [];
-        foreach ($results as $result) {
-            if (is_object($result) === true && method_exists($result, 'jsonSerialize') === true) {
-                $rows[] = $result->jsonSerialize();
-                continue;
-            }
-
-            if (is_array($result) === true) {
-                $rows[] = $result;
-            }
-        }
-
-        return $rows;
-
-    }//end listByRegisterSchema()
-
-    /**
-     * Look up one record by UUID.
-     *
-     * @param string $schema Schema slug.
-     * @param string $uuid   Record UUID.
-     *
-     * @return array<string, mixed>|null
-     *
-     * @throws Exception On lookup failure.
-     */
-    private function findOne(string $schema, string $uuid): ?array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        $object        = $objectService->find(
-            id: $uuid,
-            register: self::REGISTER,
-            schema: $schema,
-            _rbac: false,
-            _multitenancy: false
-        );
-
-        if ($object === null) {
-            return null;
-        }
-
-        if (is_object($object) === true && method_exists($object, 'jsonSerialize') === true) {
-            return $object->jsonSerialize();
-        }
-
-        return (array) $object;
-
-    }//end findOne()
-
-    /**
-     * Persist a record via `ObjectService::saveObject`.
-     *
-     * @param string               $schema Schema slug.
-     * @param array<string, mixed> $data   Record payload.
-     * @param string|null          $uuid   Optional UUID for updates.
-     *
-     * @return array<string, mixed>
-     *
-     * @throws Exception On write failure.
-     */
-    private function saveObject(string $schema, array $data, ?string $uuid=null): array
-    {
-        try {
-            $objectService = $this->settingsService->getObjectService();
-            $saved         = $objectService->saveObject(
-                object: $data,
-                register: self::REGISTER,
-                schema: $schema,
-                uuid: $uuid,
-                _rbac: false,
-                _multitenancy: false
-            );
-
-            if (is_object($saved) === true && method_exists($saved, 'jsonSerialize') === true) {
-                return $saved->jsonSerialize();
-            }
-
-            return (array) $saved;
-        } catch (Exception $e) {
-            $this->logger->error(
-                'CustomDictionaryService: save failed',
-                ['schema' => $schema, 'uuid' => $uuid, 'error' => $e->getMessage()]
-            );
-            throw $e;
-        }//end try
-
-    }//end saveObject()
-
-    /**
-     * Delete a record via `ObjectService::deleteObject`.
-     *
-     * @param string $schema Schema slug.
-     * @param string $uuid   Record UUID.
-     *
-     * @return void
-     *
-     * @throws Exception On deletion failure.
-     */
-    private function deleteObject(string $schema, string $uuid): void
-    {
-        $objectService = $this->settingsService->getObjectService();
-        // NOTE: unlike find()/saveObject() (whose first param is $id / a
-        // $uuid keyword respectively), ObjectService::deleteObject()'s first
-        // parameter is named $uuid — verified against
-        // OCA\OpenRegister\Service\ObjectService::deleteObject() at HEAD.
-        $objectService->deleteObject(
-            uuid: $uuid,
-            register: self::REGISTER,
-            schema: $schema,
-            _rbac: false,
-            _multitenancy: false
-        );
-
-    }//end deleteObject()
 }//end class

--- a/lib/Service/OpenRegisterAvailabilityService.php
+++ b/lib/Service/OpenRegisterAvailabilityService.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Open Register Availability Service
+ *
+ * Owns the "is OpenRegister present and new enough, and how do I get its
+ * ObjectService" concern. Extracted from SettingsService so that settings
+ * handling is not also responsible for app-manager probing, manifest parsing
+ * and DI-container resolution.
+ *
+ * @category  Service
+ * @package   OCA\DocuDesk\Service
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git_id>
+ * @link      https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/admin-settings/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service;
+
+use RuntimeException;
+use OCP\App\IAppManager;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Resolves OpenRegister availability, minimum version and ObjectService
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/admin-settings/spec.md
+ */
+class OpenRegisterAvailabilityService
+{
+
+    /**
+     * The unique identifier for the OpenRegister application
+     *
+     * @var string The ID of the OpenRegister app
+     */
+    public const OPENREGISTER_APP_ID = 'openregister';
+
+    /**
+     * Fallback minimum OpenRegister version if the manifest cannot be read.
+     *
+     * The canonical source of truth is `openspec/manifest.yaml`
+     * (`dependencies.openregister.minVersion`) per
+     * docudesk-adopt-or-abstractions task 1. This constant is only used when
+     * the manifest is missing/unreadable so the runtime still has a defensive
+     * floor; the manifest validator enforces parity.
+     *
+     * @var string Fallback minimum required version of OpenRegister.
+     */
+    public const FALLBACK_MIN_OPENREGISTER_VERSION = '0.2.10';
+
+    /**
+     * Cached minimum OpenRegister version resolved from the manifest.
+     *
+     * @var string|null
+     */
+    private ?string $cachedMinVersion = null;
+
+    /**
+     * OpenRegisterAvailabilityService constructor
+     *
+     * @param IAppManager        $appManager App manager interface
+     * @param ContainerInterface $container  Container for DI
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly IAppManager $appManager,
+        private readonly ContainerInterface $container
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Checks if OpenRegister is installed and meets version requirements
+     *
+     * @return bool True if OpenRegister is installed and meets version requirements
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function isInstalled(): bool
+    {
+        if ($this->appManager->isInstalled(self::OPENREGISTER_APP_ID) === false) {
+            return false;
+        }
+
+        $currentVersion = $this->appManager->getAppVersion(self::OPENREGISTER_APP_ID);
+        return version_compare($currentVersion, $this->getMinVersion(), '>=') === true;
+
+    }//end isInstalled()
+
+    /**
+     * Resolve the minimum supported OpenRegister version.
+     *
+     * Reads `dependencies.openregister.minVersion` from the project's
+     * `openspec/manifest.yaml`. Falls back to FALLBACK_MIN_OPENREGISTER_VERSION
+     * when the manifest is missing, unreadable, or shaped unexpectedly so the
+     * boot path stays defensive. The result is memoised per-instance.
+     *
+     * @return string Semantic version of the minimum supported OpenRegister.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function getMinVersion(): string
+    {
+        if ($this->cachedMinVersion !== null) {
+            return $this->cachedMinVersion;
+        }
+
+        $manifestPath = dirname(__DIR__, 2).'/openspec/manifest.yaml';
+        $minVersion   = self::FALLBACK_MIN_OPENREGISTER_VERSION;
+        if (is_file($manifestPath) === true && is_readable($manifestPath) === true) {
+            $contents = file_get_contents($manifestPath);
+            if (is_string($contents) === true && preg_match(
+                '/dependencies:\s*\n(?:\s+#[^\n]*\n)*\s+openregister:\s*\n(?:\s+#[^\n]*\n)*\s+minVersion:\s*["\']?([0-9][0-9A-Za-z\.\-+]*)["\']?/m',
+                $contents,
+                $matches
+            ) === 1
+            ) {
+                $minVersion = $matches[1];
+            }
+        }
+
+        $this->cachedMinVersion = $minVersion;
+        return $minVersion;
+
+    }//end getMinVersion()
+
+    /**
+     * Attempts to retrieve the OpenRegister service from the container
+     *
+     * @return \OCA\OpenRegister\Service\ObjectService|null The OpenRegister service
+     *
+     * @throws \RuntimeException If the service is not available
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function getObjectService(): ?\OCA\OpenRegister\Service\ObjectService
+    {
+        if (in_array(
+            self::OPENREGISTER_APP_ID,
+            $this->appManager->getInstalledApps(),
+            true
+        ) === true
+        ) {
+            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        }
+
+        throw new RuntimeException('OpenRegister service is not available.');
+
+    }//end getObjectService()
+}//end class

--- a/lib/Service/PortalSigningDocumentResolver.php
+++ b/lib/Service/PortalSigningDocumentResolver.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Portal Signing Document Resolver
+ *
+ * Resolves the target document's `File` node for the portal signing
+ * receiver's `viewDocument` act, reading it from the signing request's
+ * initiator's user folder.
+ *
+ * This class makes NO authorisation decision. The receiver's fail-closed
+ * ordering — verify assertion (401) -> derive scope from claims (403) ->
+ * validate input (403) -> authorise against the domain row (403, uniform) ->
+ * act -> relay — lives entirely in
+ * {@see \OCA\DocuDesk\Controller\PortalSigningReceiverController}, and this
+ * resolver is only ever called once that ordering has already granted the
+ * act. It was extracted from the controller so the trust boundary stays a
+ * small, readable class; the resolution logic itself is unchanged.
+ *
+ * @category  Service
+ * @package   OCA\DocuDesk\Service
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git_id>
+ * @link      https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/specs/portal-signing-actions/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service;
+
+use OCP\Files\File;
+use OCP\Files\IRootFolder;
+use Throwable;
+
+/**
+ * Resolves the signing request's target document node.
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/portal-signing-actions/spec.md
+ */
+class PortalSigningDocumentResolver
+{
+
+    /**
+     * Constructor.
+     *
+     * @param IRootFolder $rootFolder Root folder (reads the target document).
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly IRootFolder $rootFolder
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Resolve the target document's File node for viewDocument.
+     *
+     * Returns null — never throws — when the request carries no usable file
+     * reference or the node cannot be read, so the caller can answer
+     * `document_unavailable` without leaking storage internals.
+     *
+     * @param array<string, mixed> $signingRequest The resolved signing request.
+     *
+     * @return File|null The resolved file node, or null when unavailable.
+     *
+     * @spec openspec/specs/portal-signing-actions/spec.md
+     */
+    public function resolve(array $signingRequest): ?File
+    {
+        $fileId    = (int) ($signingRequest['documentFileId'] ?? 0);
+        $initiator = (string) ($signingRequest['initiatorUserId'] ?? '');
+        if ($fileId <= 0 || $initiator === '') {
+            return null;
+        }
+
+        try {
+            $nodes = $this->rootFolder->getUserFolder($initiator)->getById($fileId);
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        foreach ($nodes as $node) {
+            if ($node instanceof File) {
+                return $node;
+            }
+        }
+
+        return null;
+
+    }//end resolve()
+}//end class

--- a/lib/Service/PortalSigningDocumentResolver.php
+++ b/lib/Service/PortalSigningDocumentResolver.php
@@ -50,7 +50,6 @@ use Throwable;
  */
 class PortalSigningDocumentResolver
 {
-
     /**
      * Constructor.
      *

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -32,8 +32,6 @@ namespace OCA\DocuDesk\Service;
 use Exception;
 use RuntimeException;
 use OCP\IAppConfig;
-use OCP\App\IAppManager;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -59,43 +57,15 @@ class SettingsService
     private readonly string $appName;
 
     /**
-     * The unique identifier for the OpenRegister application
-     *
-     * @var string The ID of the OpenRegister app
-     */
-    private const OPENREGISTER_APP_ID = 'openregister';
-
-    /**
-     * Fallback minimum OpenRegister version if the manifest cannot be read.
-     *
-     * The canonical source of truth is `openspec/manifest.yaml`
-     * (`dependencies.openregister.minVersion`) per
-     * docudesk-adopt-or-abstractions task 1. This constant is only used when
-     * the manifest is missing/unreadable so the runtime still has a defensive
-     * floor; the manifest validator enforces parity.
-     *
-     * @var string Fallback minimum required version of OpenRegister.
-     */
-    private const FALLBACK_MIN_OPENREGISTER_VERSION = '0.2.10';
-
-    /**
-     * Cached minimum OpenRegister version resolved from the manifest.
-     *
-     * @var string|null
-     */
-    private ?string $minOpenRegisterVersion = null;
-
-    /**
      * SettingsService constructor
      *
-     * @param IAppConfig               $config            App configuration interface
-     * @param ContainerInterface       $container         Container for DI
-     * @param IAppManager              $appManager        App manager interface
-     * @param LoggerInterface          $logger            Logger interface
-     * @param RegisterDiscoveryService $discoveryService  Register discovery service
-     * @param SettingsInitializer      $initializer       Settings initializer
-     * @param OcrService               $ocrService        OCR service for Tesseract status
-     * @param GrondslagProposalService $grondslagProposal Grondslag-per-entity-type proposal service
+     * @param IAppConfig                        $config            App configuration interface
+     * @param LoggerInterface                   $logger            Logger interface
+     * @param RegisterDiscoveryService          $discoveryService  Register discovery service
+     * @param SettingsInitializer               $initializer       Settings initializer
+     * @param OcrService                        $ocrService        OCR service for Tesseract status
+     * @param GrondslagProposalService          $grondslagProposal Grondslag-per-entity-type proposal service
+     * @param OpenRegisterAvailabilityService   $openRegister      OpenRegister availability resolver
      *
      * @return void
      *
@@ -103,13 +73,12 @@ class SettingsService
      */
     public function __construct(
         private readonly IAppConfig $config,
-        private readonly ContainerInterface $container,
-        private readonly IAppManager $appManager,
         private readonly LoggerInterface $logger,
         private readonly RegisterDiscoveryService $discoveryService,
         private readonly SettingsInitializer $initializer,
         private readonly OcrService $ocrService,
-        private readonly GrondslagProposalService $grondslagProposal
+        private readonly GrondslagProposalService $grondslagProposal,
+        private readonly OpenRegisterAvailabilityService $openRegister
     ) {
         $this->appName = 'docudesk';
 
@@ -122,49 +91,9 @@ class SettingsService
      */
     private function isOpenRegisterInstalled(): bool
     {
-        if ($this->appManager->isInstalled(self::OPENREGISTER_APP_ID) === false) {
-            return false;
-        }
-
-        $currentVersion = $this->appManager->getAppVersion(self::OPENREGISTER_APP_ID);
-        return version_compare($currentVersion, $this->getMinOpenRegisterVersion(), '>=') === true;
+        return $this->openRegister->isInstalled();
 
     }//end isOpenRegisterInstalled()
-
-    /**
-     * Resolve the minimum supported OpenRegister version.
-     *
-     * Reads `dependencies.openregister.minVersion` from the project's
-     * `openspec/manifest.yaml`. Falls back to FALLBACK_MIN_OPENREGISTER_VERSION
-     * when the manifest is missing, unreadable, or shaped unexpectedly so the
-     * boot path stays defensive. The result is memoised per-instance.
-     *
-     * @return string Semantic version of the minimum supported OpenRegister.
-     */
-    private function getMinOpenRegisterVersion(): string
-    {
-        if ($this->minOpenRegisterVersion !== null) {
-            return $this->minOpenRegisterVersion;
-        }
-
-        $manifestPath = dirname(__DIR__, 2).'/openspec/manifest.yaml';
-        $minVersion   = self::FALLBACK_MIN_OPENREGISTER_VERSION;
-        if (is_file($manifestPath) === true && is_readable($manifestPath) === true) {
-            $contents = file_get_contents($manifestPath);
-            if (is_string($contents) === true && preg_match(
-                '/dependencies:\s*\n(?:\s+#[^\n]*\n)*\s+openregister:\s*\n(?:\s+#[^\n]*\n)*\s+minVersion:\s*["\']?([0-9][0-9A-Za-z\.\-+]*)["\']?/m',
-                $contents,
-                $matches
-            ) === 1
-            ) {
-                $minVersion = $matches[1];
-            }
-        }
-
-        $this->minOpenRegisterVersion = $minVersion;
-        return $minVersion;
-
-    }//end getMinOpenRegisterVersion()
 
     /**
      * Attempts to retrieve the OpenRegister service from the container
@@ -177,16 +106,7 @@ class SettingsService
      */
     public function getObjectService(): ?\OCA\OpenRegister\Service\ObjectService
     {
-        if (in_array(
-            self::OPENREGISTER_APP_ID,
-            $this->appManager->getInstalledApps(),
-            true
-        ) === true
-        ) {
-            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
-        }
-
-        throw new RuntimeException('OpenRegister service is not available.');
+        return $this->openRegister->getObjectService();
 
     }//end getObjectService()
 

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -59,13 +59,13 @@ class SettingsService
     /**
      * SettingsService constructor
      *
-     * @param IAppConfig                        $config            App configuration interface
-     * @param LoggerInterface                   $logger            Logger interface
-     * @param RegisterDiscoveryService          $discoveryService  Register discovery service
-     * @param SettingsInitializer               $initializer       Settings initializer
-     * @param OcrService                        $ocrService        OCR service for Tesseract status
-     * @param GrondslagProposalService          $grondslagProposal Grondslag-per-entity-type proposal service
-     * @param OpenRegisterAvailabilityService   $openRegister      OpenRegister availability resolver
+     * @param IAppConfig                      $config            App configuration interface
+     * @param LoggerInterface                 $logger            Logger interface
+     * @param RegisterDiscoveryService        $discoveryService  Register discovery service
+     * @param SettingsInitializer             $initializer       Settings initializer
+     * @param OcrService                      $ocrService        OCR service for Tesseract status
+     * @param GrondslagProposalService        $grondslagProposal Grondslag-per-entity-type proposal service
+     * @param OpenRegisterAvailabilityService $openRegister      OpenRegister availability resolver
      *
      * @return void
      *

--- a/lib/Service/SignedArtifactProducer.php
+++ b/lib/Service/SignedArtifactProducer.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Signed Artifact Producer
+ *
+ * Produces and stores the verifiable signed artifact for a completing signing
+ * request, and resolves the two inputs it needs: the target document's `File`
+ * node and a human label for the completing signer.
+ *
+ * Extracted verbatim from SigningService, which had grown past the
+ * class-length threshold. The honesty rules it enforces are unchanged:
+ *
+ *  - A request with no document file id, an unreadable document, or a failed
+ *    write throws — a request is never marked COMPLETED without a real signed
+ *    document (signing-trust-rebuild REQ-DDSTR-002).
+ *  - The request's named provider is resolved STRICTLY. An unknown provider
+ *    name fails the completion loudly and is never silently substituted with
+ *    `getActiveProvider()` / the native provider.
+ *  - Portal evidence is sourced ONLY from the already-verified actor, never
+ *    the request body, and is folded into the same MAC as the rest of the
+ *    assertion (portal-signing-surface REQ-DDPSS-004).
+ *
+ * @category  Service
+ * @package   OCA\DocuDesk\Service
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git_id>
+ * @link      https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/specs/document-signing/spec.md
+ * @spec openspec/specs/portal-signing-surface/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use OCA\DocuDesk\Service\Signing\SigningProviderFactory;
+use OCP\Files\File;
+use OCP\Files\IRootFolder;
+use OCP\IRequest;
+use OCP\IUserSession;
+use RuntimeException;
+
+/**
+ * Produces and stores the signed artifact for a completing signing request.
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/document-signing/spec.md
+ */
+class SignedArtifactProducer
+{
+    /**
+     * Constructor.
+     *
+     * @param SigningProviderFactory $providerFactory Provider factory (strict resolution).
+     * @param IUserSession           $userSession     User session (signer label + folder fallback).
+     * @param IRequest               $request         HTTP request (client IP for the evidence context).
+     * @param IRootFolder            $rootFolder      Root folder (reads the document, stores the signed version).
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly SigningProviderFactory $providerFactory,
+        private readonly IUserSession $userSession,
+        private readonly IRequest $request,
+        private readonly IRootFolder $rootFolder
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Produce the signed artifact and store it as a new file version.
+     *
+     * @param array<string, mixed>      $request       The completing signing-request array.
+     * @param array<string, mixed>|null $verifiedActor The verified external actor completing
+     *                                                 this act, when portal-originated —
+     *                                                 folded into the produced artifact's
+     *                                                 evidence binding (portal-signing-surface
+     *                                                 REQ-DDPSS-004).
+     *
+     * @return string The stored signed-artifact reference (file id + version).
+     *
+     * @throws RuntimeException When no verifiable artifact can be produced/stored,
+     *                          or when the request names an unregistered provider.
+     *
+     * @spec openspec/specs/document-signing/spec.md
+     * @spec openspec/specs/portal-signing-surface/spec.md
+     */
+    public function produce(array $request, ?array $verifiedActor=null): string
+    {
+        $fileId = (int) ($request['documentFileId'] ?? 0);
+        if ($fileId <= 0) {
+            throw new RuntimeException('Cannot produce a signed artifact: the request has no document file id');
+        }
+
+        $file = $this->resolveDocumentFile(fileId: $fileId, request: $request);
+
+        try {
+            $originalContent = $file->getContent();
+        } catch (\Throwable $e) {
+            throw new RuntimeException('Cannot read the document to sign: '.$e->getMessage());
+        }
+
+        // Provider/level honesty (REQ-DDSTR-002 point 2): resolve the request's
+        // named provider strictly. An unknown provider name MUST fail the
+        // completion loudly — no fallback to getActiveProvider()/native. This
+        // is the honest-completion gate closing the #304 residual where a
+        // request naming a misconfigured/unregistered provider silently
+        // completed with a substituted (native) artifact.
+        $providerName = (string) ($request['provider'] ?? 'native');
+        $provider     = $this->providerFactory->getProvider(identifier: $providerName);
+
+        $context = $this->buildContext(request: $request, verifiedActor: $verifiedActor);
+
+        $signedBytes = $provider->produceSignedArtifact(documentContent: $originalContent, context: $context);
+
+        // Writing new content to the existing file creates a new Nextcloud file
+        // version of the prior (unsigned) content automatically (files_versions).
+        try {
+            $file->putContent($signedBytes);
+        } catch (\Throwable $e) {
+            throw new RuntimeException('Cannot store the signed artifact as a new file version: '.$e->getMessage());
+        }
+
+        // The signed-artifact reference is the file id plus a content-derived
+        // version tag identifying this specific signed version — never the bare
+        // original file id.
+        return $fileId.':signed:'.substr(hash('sha256', $signedBytes), 0, 16);
+
+    }//end produce()
+
+    /**
+     * Build the provider's evidence context.
+     *
+     * @param array<string, mixed>      $request       The completing signing-request array.
+     * @param array<string, mixed>|null $verifiedActor The verified external actor, when portal-originated.
+     *
+     * @return array<string, mixed> The provider context.
+     */
+    private function buildContext(array $request, ?array $verifiedActor): array
+    {
+        $context = [
+            'signer'    => $this->resolveSignerLabel(verifiedActor: $verifiedActor),
+            'signers'   => ($request['signerIds'] ?? []),
+            'timestamp' => (new DateTimeImmutable())->format(DateTimeInterface::ATOM),
+            'ip'        => $this->request->getRemoteAddress(),
+            'level'     => (string) ($request['signatureLevel'] ?? 'SES'),
+        ];
+
+        if ($verifiedActor === null) {
+            return $context;
+        }
+
+        // Portal-signature evidence binding (portal-signing-surface
+        // REQ-DDPSS-004): fold the verified assertion's portal subject
+        // claims into the provider context so they land inside the SAME
+        // MAC as the rest of the assertion. Sourced ONLY from the
+        // already-verified actor (never the request body).
+        $portalFieldMap = [
+            'subjectRef'  => 'portalSubjectRef',
+            'identityRef' => 'portalIdentityRef',
+            'trust'       => 'portalTrust',
+            'jti'         => 'portalJti',
+        ];
+
+        foreach ($portalFieldMap as $actorKey => $contextKey) {
+            if (empty($verifiedActor[$actorKey]) === false) {
+                $context[$contextKey] = (string) $verifiedActor[$actorKey];
+            }
+        }
+
+        return $context;
+
+    }//end buildContext()
+
+    /**
+     * Resolve the document File node for the signing request.
+     *
+     * Resolves through the initiator's user folder (the request owner), falling
+     * back to the current signer's folder — either way a node that is not a
+     * readable/writeable file throws rather than silently skipping the artifact.
+     *
+     * @param int                  $fileId  The Nextcloud file id.
+     * @param array<string, mixed> $request The signing-request array.
+     *
+     * @return File The resolved file node.
+     *
+     * @throws RuntimeException When the file cannot be resolved.
+     */
+    private function resolveDocumentFile(int $fileId, array $request): File
+    {
+        $candidates = [];
+        $initiator  = (string) ($request['initiatorUserId'] ?? '');
+        if ($initiator !== '') {
+            $candidates[] = $initiator;
+        }
+
+        $current = $this->userSession->getUser();
+        if ($current !== null) {
+            $candidates[] = $current->getUID();
+        }
+
+        foreach (array_unique($candidates) as $uid) {
+            try {
+                $nodes = $this->rootFolder->getUserFolder($uid)->getById($fileId);
+            } catch (\Throwable $e) {
+                continue;
+            }
+
+            foreach ($nodes as $node) {
+                if ($node instanceof File) {
+                    return $node;
+                }
+            }
+        }
+
+        throw new RuntimeException('Cannot resolve the document file to sign: '.$fileId);
+
+    }//end resolveDocumentFile()
+
+    /**
+     * Resolve a human label for the completing signer.
+     *
+     * @param array<string, mixed>|null $verifiedActor The verified external actor completing
+     *                                                 this act, when portal-originated.
+     *
+     * @return string The signer display name, verified portal email, UID, or 'Unknown'.
+     */
+    private function resolveSignerLabel(?array $verifiedActor=null): string
+    {
+        if ($verifiedActor !== null) {
+            $email = (string) ($verifiedActor['email'] ?? '');
+            if ($email !== '') {
+                return $email;
+            }
+
+            return 'External signer';
+        }
+
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return 'Unknown';
+        }
+
+        // IUser::getDisplayName() is guaranteed non-empty by contract — it
+        // falls back to the UID itself when no display name is set.
+        return $user->getDisplayName();
+
+    }//end resolveSignerLabel()
+}//end class

--- a/lib/Service/SigningRequestValidator.php
+++ b/lib/Service/SigningRequestValidator.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Signing Request Validator
+ *
+ * Validates a signing request's data at creation time, before anything is
+ * persisted. Extracted verbatim from SigningService, which had grown past the
+ * class-length threshold.
+ *
+ * Provider/level honesty at request creation (signing-trust-rebuild
+ * REQ-DDSTR-002 point 1): an unknown provider, or a provider that does not
+ * support the requested signature level, is rejected with HTTP 400 before
+ * anything is persisted — so the completion path (REQ-DDSTR-002 point 2)
+ * never has to silently substitute a provider or level, because an invalid
+ * pair can never be created in the first place.
+ *
+ * @category  Service
+ * @package   OCA\DocuDesk\Service
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git_id>
+ * @link      https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/specs/document-signing/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service;
+
+use OCA\DocuDesk\Service\Signing\SigningProviderFactory;
+use RuntimeException;
+
+/**
+ * Validates signing request data and the provider/level pair.
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/document-signing/spec.md
+ */
+class SigningRequestValidator
+{
+    /**
+     * Constructor.
+     *
+     * @param SigningProviderFactory $providerFactory Provider factory (strict resolution).
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly SigningProviderFactory $providerFactory
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Validate signing request data.
+     *
+     * @param array<string, mixed> $data The request data.
+     *
+     * @return void
+     *
+     * @throws RuntimeException If validation fails.
+     *
+     * @spec openspec/specs/document-signing/spec.md
+     */
+    public function validateRequestData(array $data): void
+    {
+        if (empty($data['documentFileId']) === true) {
+            throw new RuntimeException('Document file ID is required', 400);
+        }
+
+        if (empty($data['documentName']) === true) {
+            throw new RuntimeException('Document name is required', 400);
+        }
+
+        if (in_array($data['signatureLevel'] ?? '', ['SES', 'AdES', 'QES'], true) === false) {
+            throw new RuntimeException('Invalid signature level', 400);
+        }
+
+        if (in_array($data['signingMode'] ?? '', ['sequential', 'parallel'], true) === false) {
+            throw new RuntimeException('Invalid signing mode', 400);
+        }
+
+    }//end validateRequestData()
+
+    /**
+     * Validate that the requested provider actually supports the requested level.
+     *
+     * Provider/level honesty at request creation (signing-trust-rebuild
+     * REQ-DDSTR-002 point 1): an unknown provider, or a provider that does not
+     * support the requested signature level (via
+     * `SigningProviderInterface::supportsLevel()`), is rejected with HTTP 400
+     * before anything is persisted — the completion path (REQ-DDSTR-002 point
+     * 2) never has to silently substitute a provider or level because an
+     * invalid pair can never be created in the first place.
+     *
+     * @param string $provider The requested provider identifier.
+     * @param string $level    The requested signature level.
+     *
+     * @return void
+     *
+     * @throws RuntimeException With HTTP code 400 when the provider is unknown
+     *                          or does not support the requested level.
+     *
+     * @spec openspec/specs/document-signing/spec.md
+     */
+    public function validateProviderLevelPair(string $provider, string $level): void
+    {
+        try {
+            $providerInstance = $this->providerFactory->getProvider(identifier: $provider);
+        } catch (\Throwable $e) {
+            throw new RuntimeException('Unknown signing provider: '.$provider, 400);
+        }
+
+        if ($providerInstance->supportsLevel(level: $level) === false) {
+            throw new RuntimeException(
+                'Signing provider "'.$provider.'" does not support signature level "'.$level.'"',
+                400
+            );
+        }
+
+    }//end validateProviderLevelPair()
+}//end class

--- a/lib/Service/SigningService.php
+++ b/lib/Service/SigningService.php
@@ -25,10 +25,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use Exception;
 use OCA\DocuDesk\Event\SigningConcludedEvent;
-use OCA\DocuDesk\Service\Signing\SigningProviderFactory;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Files\File;
-use OCP\Files\IRootFolder;
 use OCP\IAppConfig;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -72,30 +69,30 @@ class SigningService
     /**
      * Constructor
      *
-     * @param SettingsService        $settingsService     Settings service
-     * @param SigningAuditService    $auditService        Audit service
-     * @param SigningProviderFactory $providerFactory     Provider factory
-     * @param IAppConfig             $config              App config
-     * @param IUserSession           $userSession         User session
-     * @param INotificationManager   $notificationManager Notification manager
-     * @param LoggerInterface        $logger              Logger
-     * @param IRequest               $request             HTTP request
-     * @param IEventDispatcher       $eventDispatcher     Dispatches the SigningConcludedEvent cross-app contract
-     * @param IRootFolder            $rootFolder          Root folder (reads the document, stores the signed version)
+     * @param SettingsService         $settingsService     Settings service
+     * @param SigningAuditService     $auditService        Audit service
+     * @param IAppConfig              $config              App config
+     * @param IUserSession            $userSession         User session
+     * @param INotificationManager    $notificationManager Notification manager
+     * @param LoggerInterface         $logger              Logger
+     * @param IRequest                $request             HTTP request
+     * @param IEventDispatcher        $eventDispatcher     Dispatches the SigningConcludedEvent cross-app contract
+     * @param SignedArtifactProducer  $artifactProducer    Produces + stores the verifiable signed artifact
+     * @param SigningRequestValidator $validator           Validates request data + the provider/level pair
      *
      * @return void
      */
     public function __construct(
         private readonly SettingsService $settingsService,
         private readonly SigningAuditService $auditService,
-        private readonly SigningProviderFactory $providerFactory,
         private readonly IAppConfig $config,
         private readonly IUserSession $userSession,
         private readonly INotificationManager $notificationManager,
         private readonly LoggerInterface $logger,
         private readonly IRequest $request,
         private readonly IEventDispatcher $eventDispatcher,
-        private readonly IRootFolder $rootFolder
+        private readonly SignedArtifactProducer $artifactProducer,
+        private readonly SigningRequestValidator $validator
     ) {
 
     }//end __construct()
@@ -153,14 +150,17 @@ class SigningService
             'signerIds'       => [],
         ];
 
-        $this->validateRequestData(data: $request);
+        $this->validator->validateRequestData(data: $request);
 
         // Provider/level honesty at creation time (signing-trust-rebuild
         // REQ-DDSTR-002 point 1): reject an unsupported provider/level pair
         // with 400 BEFORE any object is persisted, so a QES request can never
         // be routed to a provider that will later silently complete it with a
         // lower-assurance (e.g. native SES) artifact.
-        $this->validateProviderLevelPair(provider: (string) $request['provider'], level: (string) $request['signatureLevel']);
+        $this->validator->validateProviderLevelPair(
+            provider: (string) $request['provider'],
+            level: (string) $request['signatureLevel']
+        );
 
         // Cross-app delegated-signing contract (docudesk-signing-events): when a
         // consumer raised this request through DocumentSigningRequestedEvent it
@@ -776,73 +776,6 @@ class SigningService
     }//end isValidTransition()
 
     /**
-     * Validate signing request data
-     *
-     * @param array<string, mixed> $data The request data
-     *
-     * @return void
-     *
-     * @throws RuntimeException If validation fails
-     */
-    private function validateRequestData(array $data): void
-    {
-        if (empty($data['documentFileId']) === true) {
-            throw new RuntimeException('Document file ID is required', 400);
-        }
-
-        if (empty($data['documentName']) === true) {
-            throw new RuntimeException('Document name is required', 400);
-        }
-
-        if (in_array($data['signatureLevel'] ?? '', ['SES', 'AdES', 'QES'], true) === false) {
-            throw new RuntimeException('Invalid signature level', 400);
-        }
-
-        if (in_array($data['signingMode'] ?? '', ['sequential', 'parallel'], true) === false) {
-            throw new RuntimeException('Invalid signing mode', 400);
-        }
-
-    }//end validateRequestData()
-
-    /**
-     * Validate that the requested provider actually supports the requested level.
-     *
-     * Provider/level honesty at request creation (signing-trust-rebuild
-     * REQ-DDSTR-002 point 1): an unknown provider, or a provider that does not
-     * support the requested signature level (via
-     * `SigningProviderInterface::supportsLevel()`), is rejected with HTTP 400
-     * before anything is persisted — the completion path (REQ-DDSTR-002 point
-     * 2) never has to silently substitute a provider or level because an
-     * invalid pair can never be created in the first place.
-     *
-     * @param string $provider The requested provider identifier.
-     * @param string $level    The requested signature level.
-     *
-     * @return void
-     *
-     * @throws RuntimeException With HTTP code 400 when the provider is unknown
-     *                          or does not support the requested level.
-     *
-     * @spec openspec/specs/document-signing/spec.md
-     */
-    private function validateProviderLevelPair(string $provider, string $level): void
-    {
-        try {
-            $providerInstance = $this->providerFactory->getProvider(identifier: $provider);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Unknown signing provider: '.$provider, 400);
-        }
-
-        if ($providerInstance->supportsLevel(level: $level) === false) {
-            throw new RuntimeException(
-                'Signing provider "'.$provider.'" does not support signature level "'.$level.'"',
-                400
-            );
-        }
-
-    }//end validateProviderLevelPair()
-
-    /**
      * Update the signing request status based on signer progress
      *
      * @param string                    $requestId     The signing request ID
@@ -928,7 +861,7 @@ class SigningService
             );
         }
 
-        $signedDocumentRef = $this->produceAndStoreSignedArtifact(request: $freshRequest, verifiedActor: $verifiedActor);
+        $signedDocumentRef = $this->artifactProducer->produce(request: $freshRequest, verifiedActor: $verifiedActor);
 
         $freshRequest['status']            = 'COMPLETED';
         $freshRequest['signedDocumentRef'] = $signedDocumentRef;
@@ -945,182 +878,6 @@ class SigningService
         );
 
     }//end updateRequestStatus()
-
-    /**
-     * Produce the signed artifact and store it as a new Nextcloud file version.
-     *
-     * Resolves the active provider (via SigningProviderFactory), reads the
-     * original document bytes, asks the provider to produce the signed artifact,
-     * and writes the result back to the same Nextcloud file — which creates a
-     * new file version of the prior content via `files_versions`. Returns a
-     * reference to the stored artifact (`<fileId>:<versionMtime>`).
-     *
-     * Honest-completion gate: any failure (no file, unreadable, provider cannot
-     * produce an artifact) throws, so the caller never marks the request
-     * COMPLETED without a real signed document. Provider/level honesty
-     * (signing-trust-rebuild REQ-DDSTR-002 point 2): the request's named
-     * provider is resolved STRICTLY — an unknown provider name fails the
-     * completion loudly and is never silently substituted with
-     * `getActiveProvider()` / the native provider.
-     *
-     * @param array<string, mixed>      $request       The completing signing-request array.
-     * @param array<string, mixed>|null $verifiedActor The verified external actor completing
-     *                                                 this act, when portal-originated —
-     *                                                 folded into the produced artifact's
-     *                                                 evidence binding (portal-signing-surface
-     *                                                 REQ-DDPSS-004).
-     *
-     * @return string The stored signed-artifact reference (file id + version).
-     *
-     * @throws RuntimeException When no verifiable artifact can be produced/stored,
-     *                          or when the request names an unregistered provider.
-     *
-     * @spec openspec/specs/document-signing/spec.md
-     * @spec openspec/specs/portal-signing-surface/spec.md
-     */
-    private function produceAndStoreSignedArtifact(array $request, ?array $verifiedActor=null): string
-    {
-        $fileId = (int) ($request['documentFileId'] ?? 0);
-        if ($fileId <= 0) {
-            throw new RuntimeException('Cannot produce a signed artifact: the request has no document file id');
-        }
-
-        $file = $this->resolveDocumentFile(fileId: $fileId, request: $request);
-
-        try {
-            $originalContent = $file->getContent();
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Cannot read the document to sign: '.$e->getMessage());
-        }
-
-        // Provider/level honesty (REQ-DDSTR-002 point 2): resolve the request's
-        // named provider strictly. An unknown provider name MUST fail the
-        // completion loudly — no fallback to getActiveProvider()/native. This
-        // is the honest-completion gate closing the #304 residual where a
-        // request naming a misconfigured/unregistered provider silently
-        // completed with a substituted (native) artifact.
-        $providerName = (string) ($request['provider'] ?? 'native');
-        $provider     = $this->providerFactory->getProvider(identifier: $providerName);
-
-        $context = [
-            'signer'    => $this->resolveSignerLabel(verifiedActor: $verifiedActor),
-            'signers'   => ($request['signerIds'] ?? []),
-            'timestamp' => (new DateTimeImmutable())->format(DateTimeInterface::ATOM),
-            'ip'        => $this->getClientIp(),
-            'level'     => (string) ($request['signatureLevel'] ?? 'SES'),
-        ];
-
-        if ($verifiedActor !== null) {
-            // Portal-signature evidence binding (portal-signing-surface
-            // REQ-DDPSS-004): fold the verified assertion's portal subject
-            // claims into the provider context so they land inside the SAME
-            // MAC as the rest of the assertion. Sourced ONLY from the
-            // already-verified actor (never the request body).
-            $portalFieldMap = [
-                'subjectRef'  => 'portalSubjectRef',
-                'identityRef' => 'portalIdentityRef',
-                'trust'       => 'portalTrust',
-                'jti'         => 'portalJti',
-            ];
-
-            foreach ($portalFieldMap as $actorKey => $contextKey) {
-                if (empty($verifiedActor[$actorKey]) === false) {
-                    $context[$contextKey] = (string) $verifiedActor[$actorKey];
-                }
-            }
-        }
-
-        $signedBytes = $provider->produceSignedArtifact(documentContent: $originalContent, context: $context);
-
-        // Writing new content to the existing file creates a new Nextcloud file
-        // version of the prior (unsigned) content automatically (files_versions).
-        try {
-            $file->putContent($signedBytes);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('Cannot store the signed artifact as a new file version: '.$e->getMessage());
-        }
-
-        // The signed-artifact reference is the file id plus a content-derived
-        // version tag identifying this specific signed version — never the bare
-        // original file id.
-        return $fileId.':signed:'.substr(hash('sha256', $signedBytes), 0, 16);
-
-    }//end produceAndStoreSignedArtifact()
-
-    /**
-     * Resolve the document File node for the signing request.
-     *
-     * Resolves through the initiator's user folder (the request owner), falling
-     * back to the current signer's folder — either way a node that is not a
-     * readable/writeable file throws rather than silently skipping the artifact.
-     *
-     * @param int                  $fileId  The Nextcloud file id.
-     * @param array<string, mixed> $request The signing-request array.
-     *
-     * @return File The resolved file node.
-     *
-     * @throws RuntimeException When the file cannot be resolved.
-     */
-    private function resolveDocumentFile(int $fileId, array $request): File
-    {
-        $candidates = [];
-        $initiator  = (string) ($request['initiatorUserId'] ?? '');
-        if ($initiator !== '') {
-            $candidates[] = $initiator;
-        }
-
-        $current = $this->userSession->getUser();
-        if ($current !== null) {
-            $candidates[] = $current->getUID();
-        }
-
-        foreach (array_unique($candidates) as $uid) {
-            try {
-                $nodes = $this->rootFolder->getUserFolder($uid)->getById($fileId);
-            } catch (\Throwable $e) {
-                continue;
-            }
-
-            foreach ($nodes as $node) {
-                if ($node instanceof File) {
-                    return $node;
-                }
-            }
-        }
-
-        throw new RuntimeException('Cannot resolve the document file to sign: '.$fileId);
-
-    }//end resolveDocumentFile()
-
-    /**
-     * Resolve a human label for the completing signer.
-     *
-     * @param array<string, mixed>|null $verifiedActor The verified external actor completing
-     *                                                 this act, when portal-originated.
-     *
-     * @return string The signer display name, verified portal email, UID, or 'Unknown'.
-     */
-    private function resolveSignerLabel(?array $verifiedActor=null): string
-    {
-        if ($verifiedActor !== null) {
-            $email = (string) ($verifiedActor['email'] ?? '');
-            if ($email !== '') {
-                return $email;
-            }
-
-            return 'External signer';
-        }
-
-        $user = $this->userSession->getUser();
-        if ($user === null) {
-            return 'Unknown';
-        }
-
-        // IUser::getDisplayName() is guaranteed non-empty by contract — it
-        // falls back to the UID itself when no display name is set.
-        return $user->getDisplayName();
-
-    }//end resolveSignerLabel()
 
     /**
      * Emit a terminal SigningConcludedEvent for an expired request.

--- a/tests/unit/Controller/PortalSigningReceiverControllerTest.php
+++ b/tests/unit/Controller/PortalSigningReceiverControllerTest.php
@@ -37,6 +37,7 @@ namespace OCA\DocuDesk\Tests\Unit\Controller;
 
 use OCA\DocuDesk\Controller\PortalSigningReceiverController;
 use OCA\DocuDesk\Portal\PortalAssertionVerifier;
+use OCA\DocuDesk\Service\PortalSigningDocumentResolver;
 use OCA\DocuDesk\Service\SettingsService;
 use OCA\DocuDesk\Service\SigningService;
 use OCA\OpenRegister\Service\ObjectService;
@@ -152,8 +153,8 @@ class PortalSigningReceiverControllerTest extends TestCase
             signingService: $this->mockSigningService,
             settingsService: $this->mockSettingsService,
             config: $this->mockConfig,
-            rootFolder: $this->mockRootFolder,
-            logger: $this->mockLogger
+            logger: $this->mockLogger,
+            documentResolver: new PortalSigningDocumentResolver(rootFolder: $this->mockRootFolder)
         );
 
     }//end controller()

--- a/tests/unit/Service/AnonymizationLinkServiceTest.php
+++ b/tests/unit/Service/AnonymizationLinkServiceTest.php
@@ -179,8 +179,10 @@ class AnonymizationLinkServiceTest extends TestCase
             pdfConversion: $this->createMock(originalClassName: PdfConversionService::class),
             emlAssembly: $this->createMock(originalClassName: EmlPdfAssemblyService::class),
             customDictionary: $this->createMock(originalClassName: CustomDictionaryService::class),
-            customDictionaryMatch: new CustomDictionaryMatchService(),
-            confidentialityLabel: $this->createMock(originalClassName: \OCA\DocuDesk\Service\ConfidentialityLabelService::class)
+            confidentialityLabel: $this->createMock(originalClassName: \OCA\DocuDesk\Service\ConfidentialityLabelService::class),
+            customDictionaryDetection: $this->createMock(
+                originalClassName: \OCA\DocuDesk\Service\CustomDictionaryDetectionRunner::class
+            )
         );
 
     }//end buildService()

--- a/tests/unit/Service/AnonymizationServiceConfidentialityTest.php
+++ b/tests/unit/Service/AnonymizationServiceConfidentialityTest.php
@@ -152,8 +152,10 @@ class AnonymizationServiceConfidentialityTest extends TestCase
             pdfConversion: $this->createMock(\OCA\DocuDesk\Service\PdfConversionService::class),
             emlAssembly: $this->createMock(\OCA\DocuDesk\Service\EmlPdfAssemblyService::class),
             customDictionary: $customDictionary,
-            customDictionaryMatch: new CustomDictionaryMatchService(),
-            confidentialityLabel: $this->mockConfidentialityLabel
+            confidentialityLabel: $this->mockConfidentialityLabel,
+            customDictionaryDetection: $this->createMock(
+                originalClassName: \OCA\DocuDesk\Service\CustomDictionaryDetectionRunner::class
+            )
         );
 
     }//end makeService()

--- a/tests/unit/Service/AnonymizationServiceCustomDictionaryTest.php
+++ b/tests/unit/Service/AnonymizationServiceCustomDictionaryTest.php
@@ -26,6 +26,7 @@ use OCA\DocuDesk\Service\AnonymizationResultParser;
 use OCA\DocuDesk\Service\AnonymizationService;
 use OCA\DocuDesk\Service\ConsentCrudService;
 use OCA\DocuDesk\Service\ConsentService;
+use OCA\DocuDesk\Service\CustomDictionaryDetectionRunner;
 use OCA\DocuDesk\Service\CustomDictionaryMatchService;
 use OCA\DocuDesk\Service\CustomDictionaryService;
 use OCA\DocuDesk\Service\EntityDetectionService;
@@ -160,8 +161,14 @@ class AnonymizationServiceCustomDictionaryTest extends TestCase
             pdfConversion: $this->createMock(\OCA\DocuDesk\Service\PdfConversionService::class),
             emlAssembly: $this->createMock(\OCA\DocuDesk\Service\EmlPdfAssemblyService::class),
             customDictionary: $customDictionary,
-            customDictionaryMatch: new CustomDictionaryMatchService(),
-            confidentialityLabel: $this->createMock(\OCA\DocuDesk\Service\ConfidentialityLabelService::class)
+            confidentialityLabel: $this->createMock(\OCA\DocuDesk\Service\ConfidentialityLabelService::class),
+            customDictionaryDetection: new CustomDictionaryDetectionRunner(
+                logger: new NullLogger(),
+                container: $this->mockContainer,
+                appManager: $appManager,
+                customDictionary: $customDictionary,
+                matcher: new CustomDictionaryMatchService()
+            )
         );
 
     }//end makeService()

--- a/tests/unit/Service/AnonymizationServiceOutputFormatTest.php
+++ b/tests/unit/Service/AnonymizationServiceOutputFormatTest.php
@@ -279,9 +279,9 @@ class AnonymizationServiceOutputFormatTest extends TestCase
         $fileEntityStats    = $this->createMock(\OCA\DocuDesk\Service\FileEntityStatsService::class);
         $pdfConversion      = $this->createMock(\OCA\DocuDesk\Service\PdfConversionService::class);
         $emlAssembly        = $this->createMock(\OCA\DocuDesk\Service\EmlPdfAssemblyService::class);
-        $customDictionary      = $this->createMock(\OCA\DocuDesk\Service\CustomDictionaryService::class);
-        $customDictionaryMatch = new \OCA\DocuDesk\Service\CustomDictionaryMatchService();
-        $confidentialityLabel  = $this->createMock(\OCA\DocuDesk\Service\ConfidentialityLabelService::class);
+        $customDictionary     = $this->createMock(\OCA\DocuDesk\Service\CustomDictionaryService::class);
+        $confidentialityLabel = $this->createMock(\OCA\DocuDesk\Service\ConfidentialityLabelService::class);
+        $dictionaryDetection  = $this->createMock(\OCA\DocuDesk\Service\CustomDictionaryDetectionRunner::class);
 
         return new AnonymizationService(
             $logger,
@@ -296,8 +296,8 @@ class AnonymizationServiceOutputFormatTest extends TestCase
             $pdfConversion,
             $emlAssembly,
             $customDictionary,
-            $customDictionaryMatch,
-            $confidentialityLabel
+            $confidentialityLabel,
+            $dictionaryDetection
         );
 
     }//end buildServiceWithoutDependencies()

--- a/tests/unit/Service/AnonymizationServiceProhibitionTest.php
+++ b/tests/unit/Service/AnonymizationServiceProhibitionTest.php
@@ -127,8 +127,10 @@ class AnonymizationServiceProhibitionTest extends TestCase
             pdfConversion: $this->createMock(originalClassName: \OCA\DocuDesk\Service\PdfConversionService::class),
             emlAssembly: $this->createMock(originalClassName: \OCA\DocuDesk\Service\EmlPdfAssemblyService::class),
             customDictionary: $this->makeNoOpCustomDictionaryService(),
-            customDictionaryMatch: new CustomDictionaryMatchService(),
-            confidentialityLabel: $this->createMock(originalClassName: \OCA\DocuDesk\Service\ConfidentialityLabelService::class)
+            confidentialityLabel: $this->createMock(originalClassName: \OCA\DocuDesk\Service\ConfidentialityLabelService::class),
+            customDictionaryDetection: $this->createMock(
+                originalClassName: \OCA\DocuDesk\Service\CustomDictionaryDetectionRunner::class
+            )
         );
 
     }//end makeService()

--- a/tests/unit/Service/AnonymizationServicePublicationClearanceTest.php
+++ b/tests/unit/Service/AnonymizationServicePublicationClearanceTest.php
@@ -90,8 +90,10 @@ class AnonymizationServicePublicationClearanceTest extends TestCase
             pdfConversion: $this->createMock(originalClassName: \OCA\DocuDesk\Service\PdfConversionService::class),
             emlAssembly: $this->createMock(originalClassName: \OCA\DocuDesk\Service\EmlPdfAssemblyService::class),
             customDictionary: $this->createMock(originalClassName: CustomDictionaryService::class),
-            customDictionaryMatch: new CustomDictionaryMatchService(),
-            confidentialityLabel: $this->createMock(originalClassName: \OCA\DocuDesk\Service\ConfidentialityLabelService::class)
+            confidentialityLabel: $this->createMock(originalClassName: \OCA\DocuDesk\Service\ConfidentialityLabelService::class),
+            customDictionaryDetection: $this->createMock(
+                originalClassName: \OCA\DocuDesk\Service\CustomDictionaryDetectionRunner::class
+            )
         );
 
     }//end buildService()

--- a/tests/unit/Service/AnonymizationServiceTest.php
+++ b/tests/unit/Service/AnonymizationServiceTest.php
@@ -591,8 +591,10 @@ class AnonymizationServiceTest extends TestCase
             pdfConversion: $pdfConversion,
             emlAssembly: $emlAssembly,
             customDictionary: $this->makeNoOpCustomDictionaryService(),
-            customDictionaryMatch: new \OCA\DocuDesk\Service\CustomDictionaryMatchService(),
-            confidentialityLabel: $this->createMock(\OCA\DocuDesk\Service\ConfidentialityLabelService::class)
+            confidentialityLabel: $this->createMock(\OCA\DocuDesk\Service\ConfidentialityLabelService::class),
+            customDictionaryDetection: $this->createMock(
+                \OCA\DocuDesk\Service\CustomDictionaryDetectionRunner::class
+            )
         );
 
     }//end buildServiceWithoutDependencies()
@@ -675,8 +677,10 @@ class AnonymizationServiceTest extends TestCase
             pdfConversion: $this->createMock(PdfConversionService::class),
             emlAssembly: $this->createMock(EmlPdfAssemblyService::class),
             customDictionary: $this->makeNoOpCustomDictionaryService(),
-            customDictionaryMatch: new \OCA\DocuDesk\Service\CustomDictionaryMatchService(),
-            confidentialityLabel: $this->createMock(\OCA\DocuDesk\Service\ConfidentialityLabelService::class)
+            confidentialityLabel: $this->createMock(\OCA\DocuDesk\Service\ConfidentialityLabelService::class),
+            customDictionaryDetection: $this->createMock(
+                \OCA\DocuDesk\Service\CustomDictionaryDetectionRunner::class
+            )
         );
 
     }//end makeServiceWithMatcher()

--- a/tests/unit/Service/CustomDictionaryServiceTest.php
+++ b/tests/unit/Service/CustomDictionaryServiceTest.php
@@ -22,6 +22,9 @@
 
 namespace OCA\DocuDesk\Tests\Unit\Service;
 
+use OCA\DocuDesk\Service\CustomDictionaryAccessGate;
+use OCA\DocuDesk\Service\CustomDictionaryPayloadNormaliser;
+use OCA\DocuDesk\Service\CustomDictionaryRepository;
 use OCA\DocuDesk\Service\CustomDictionaryService;
 use OCA\DocuDesk\Service\SettingsService;
 use OCA\OpenRegister\Service\ObjectService;
@@ -89,10 +92,17 @@ class CustomDictionaryServiceTest extends TestCase
         }
 
         return new CustomDictionaryService(
-            settingsService: $settingsService,
-            container: $container,
-            appManager: $appManager,
-            userSession: $userSession,
+            repository: new CustomDictionaryRepository(
+                settingsService: $settingsService,
+                logger: new NullLogger()
+            ),
+            accessGate: new CustomDictionaryAccessGate(
+                container: $container,
+                appManager: $appManager,
+                userSession: $userSession,
+                logger: new NullLogger()
+            ),
+            normaliser: new CustomDictionaryPayloadNormaliser(),
             logger: new NullLogger()
         );
 

--- a/tests/unit/Service/OpenRegisterAvailabilityServiceTest.php
+++ b/tests/unit/Service/OpenRegisterAvailabilityServiceTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Unit tests for OpenRegisterAvailabilityService
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2025 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+namespace OCA\DocuDesk\Tests\Unit\Service;
+
+use OCA\DocuDesk\Service\OpenRegisterAvailabilityService;
+use OCP\App\IAppManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+/**
+ * Unit tests for OpenRegisterAvailabilityService
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.nl
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class OpenRegisterAvailabilityServiceTest extends TestCase
+{
+
+    /**
+     * @var OpenRegisterAvailabilityService
+     */
+    private OpenRegisterAvailabilityService $service;
+
+    /**
+     * @var IAppManager|MockObject
+     */
+    private IAppManager|MockObject $mockAppManager;
+
+    /**
+     * @var ContainerInterface|MockObject
+     */
+    private ContainerInterface|MockObject $mockContainer;
+
+
+    /**
+     * Set up test environment
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockAppManager = $this->createMock(IAppManager::class);
+        $this->mockContainer  = $this->createMock(ContainerInterface::class);
+
+        $this->service = new OpenRegisterAvailabilityService(
+            $this->mockAppManager,
+            $this->mockContainer
+        );
+
+    }//end setUp()
+
+
+    /**
+     * Test isInstalled returns false when the app is absent
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testIsInstalledReturnsFalseWhenAppAbsent(): void
+    {
+        $this->mockAppManager->method('isInstalled')
+            ->willReturn(false);
+
+        $this->assertFalse($this->service->isInstalled());
+
+    }//end testIsInstalledReturnsFalseWhenAppAbsent()
+
+
+    /**
+     * Test isInstalled returns false when the installed version is too old
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testIsInstalledReturnsFalseWhenVersionTooOld(): void
+    {
+        $this->mockAppManager->method('isInstalled')
+            ->willReturn(true);
+        $this->mockAppManager->method('getAppVersion')
+            ->willReturn('0.0.1');
+
+        $this->assertFalse($this->service->isInstalled());
+
+    }//end testIsInstalledReturnsFalseWhenVersionTooOld()
+
+
+    /**
+     * Test isInstalled returns true when the installed version is new enough
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testIsInstalledReturnsTrueWhenVersionSatisfied(): void
+    {
+        $this->mockAppManager->method('isInstalled')
+            ->willReturn(true);
+        $this->mockAppManager->method('getAppVersion')
+            ->willReturn('999.0.0');
+
+        $this->assertTrue($this->service->isInstalled());
+
+    }//end testIsInstalledReturnsTrueWhenVersionSatisfied()
+
+
+    /**
+     * Test getMinVersion resolves a non-empty semantic version
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testGetMinVersionResolvesAVersion(): void
+    {
+        $first = $this->service->getMinVersion();
+
+        $this->assertNotSame('', $first);
+        // Memoised: a second call returns the identical value.
+        $this->assertSame($first, $this->service->getMinVersion());
+
+    }//end testGetMinVersionResolvesAVersion()
+
+
+    /**
+     * Test getObjectService throws when OpenRegister is not installed
+     *
+     * @return void
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    public function testGetObjectServiceThrowsWhenNotInstalled(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('OpenRegister service is not available');
+
+        $this->mockAppManager->method('getInstalledApps')
+            ->willReturn([]);
+
+        $this->service->getObjectService();
+
+    }//end testGetObjectServiceThrowsWhenNotInstalled()
+
+
+}//end class

--- a/tests/unit/Service/SettingsServiceTest.php
+++ b/tests/unit/Service/SettingsServiceTest.php
@@ -22,14 +22,13 @@ namespace OCA\DocuDesk\Tests\Unit\Service;
 
 use OCA\DocuDesk\Service\GrondslagProposalService;
 use OCA\DocuDesk\Service\OcrService;
+use OCA\DocuDesk\Service\OpenRegisterAvailabilityService;
 use OCA\DocuDesk\Service\RegisterDiscoveryService;
 use OCA\DocuDesk\Service\SettingsInitializer;
 use OCA\DocuDesk\Service\SettingsService;
-use OCP\App\IAppManager;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
@@ -58,14 +57,9 @@ class SettingsServiceTest extends TestCase
     private IAppConfig|MockObject $mockConfig;
 
     /**
-     * @var ContainerInterface|MockObject
+     * @var OpenRegisterAvailabilityService|MockObject
      */
-    private ContainerInterface|MockObject $mockContainer;
-
-    /**
-     * @var IAppManager|MockObject
-     */
-    private IAppManager|MockObject $mockAppManager;
+    private OpenRegisterAvailabilityService|MockObject $mockOpenRegister;
 
     /**
      * @var LoggerInterface|MockObject
@@ -103,23 +97,21 @@ class SettingsServiceTest extends TestCase
         parent::setUp();
 
         $this->mockConfig            = $this->createMock(IAppConfig::class);
-        $this->mockContainer         = $this->createMock(ContainerInterface::class);
-        $this->mockAppManager        = $this->createMock(IAppManager::class);
         $this->mockLogger            = $this->createMock(LoggerInterface::class);
         $this->mockDiscoveryService  = $this->createMock(RegisterDiscoveryService::class);
         $this->mockInitializer       = $this->createMock(SettingsInitializer::class);
         $this->mockOcrService        = $this->createMock(OcrService::class);
         $this->mockGrondslagProposal = $this->createMock(GrondslagProposalService::class);
+        $this->mockOpenRegister      = $this->createMock(OpenRegisterAvailabilityService::class);
 
         $this->settingsService = new SettingsService(
             $this->mockConfig,
-            $this->mockContainer,
-            $this->mockAppManager,
             $this->mockLogger,
             $this->mockDiscoveryService,
             $this->mockInitializer,
             $this->mockOcrService,
-            $this->mockGrondslagProposal
+            $this->mockGrondslagProposal,
+            $this->mockOpenRegister
         );
 
     }//end setUp()
@@ -135,8 +127,8 @@ class SettingsServiceTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('OpenRegister service is not available');
 
-        $this->mockAppManager->method('getInstalledApps')
-            ->willReturn([]);
+        $this->mockOpenRegister->method('getObjectService')
+            ->willThrowException(new RuntimeException('OpenRegister service is not available.'));
 
         $this->settingsService->getObjectService();
 
@@ -169,7 +161,7 @@ class SettingsServiceTest extends TestCase
      */
     public function testGetAllSettingsReturnsExpectedStructure(): void
     {
-        $this->mockAppManager->method('isInstalled')
+        $this->mockOpenRegister->method('isInstalled')
             ->willReturn(false);
 
         $this->mockDiscoveryService->method('loadObjectTypeConfiguration')

--- a/tests/unit/Service/SigningServiceTest.php
+++ b/tests/unit/Service/SigningServiceTest.php
@@ -25,6 +25,8 @@ namespace OCA\DocuDesk\Tests\Unit\Service;
 
 use OCA\DocuDesk\Service\Signing\SigningProviderFactory;
 use OCA\DocuDesk\Service\SigningAuditService;
+use OCA\DocuDesk\Service\SignedArtifactProducer;
+use OCA\DocuDesk\Service\SigningRequestValidator;
 use OCA\DocuDesk\Service\SigningService;
 use OCA\DocuDesk\Service\SettingsService;
 use OCA\OpenRegister\Service\ObjectService;
@@ -160,14 +162,19 @@ class SigningServiceTest extends TestCase
         $this->service = new SigningService(
             settingsService: $this->settingsService,
             auditService: $this->auditService,
-            providerFactory: $this->providerFactory,
             config: $this->config,
             userSession: $this->userSession,
             notificationManager: $notificationManager,
             logger: $logger,
             request: $this->request,
             eventDispatcher: $eventDispatcher,
-            rootFolder: $this->rootFolder
+            artifactProducer: new SignedArtifactProducer(
+                providerFactory: $this->providerFactory,
+                userSession: $this->userSession,
+                request: $this->request,
+                rootFolder: $this->rootFolder
+            ),
+            validator: new SigningRequestValidator(providerFactory: $this->providerFactory)
         );
 
     }//end setUp()


### PR DESCRIPTION
## Why

The shared workflow gates PHPUnit on `needs.php-quality.result != 'failure'`. While phpmd was red, **PHPUnit was silently `skipped`, not passing** — so clearing phpmd also un-gates a test suite that has been unmaintained for as long as phpmd has been red.

phpmd: **6 findings → 0** (exit 2 → exit 0).

## What was actually refactored

No suppressions, no baseline changes, no widened excludes. Every finding was fixed by extracting a genuinely cohesive collaborator.

| Finding | Fix |
|---|---|
| `SettingsService` CouplingBetweenObjects 13 | Extracted `OpenRegisterAvailabilityService` — app-manager probing, manifest parsing and DI-container resolution left settings handling entirely |
| `CustomDictionaryService` ExcessiveClassComplexity 78 | Split into `CustomDictionaryRepository` (OpenRegister persistence), `CustomDictionaryAccessGate` (the fail-closed organisation gate) and `CustomDictionaryPayloadNormaliser` (pure import parsing / coercion) |
| `CustomDictionaryController` ExcessiveClassComplexity 69 | Nine endpoints each repeated the same auth+availability guard and the same exception ladder. Both now live in one `dispatch()`/`guard()` pair; each endpoint is a single expression |
| `AnonymizationService` TooManyMethods 29 | Extracted `CustomDictionaryDetectionRunner` — the detection pass was five cohesive private methods on an already-oversized service |
| `SigningService` ExcessiveClassLength 1214 | Extracted `SignedArtifactProducer` and `SigningRequestValidator`, both verbatim |
| `PortalSigningReceiverController` ExcessiveClassComplexity 51 | See below |

### The portal signing trust boundary

This controller was previously left alone deliberately: it is 1 point over the threshold but it is the portal signing trust/authorisation boundary.

It is now clear, **without touching any authorisation logic**. `viewDocument`'s file lookup (`resolveDocumentFile`) carries no authorisation decision — it runs only after `authoriseAct()` has already granted the act — but it dragged `IRootFolder` and `File` into the class. Moving it verbatim into `PortalSigningDocumentResolver` cleared *both* `ExcessiveClassComplexity` (51) and `CouplingBetweenObjects` (13, which surfaced the moment anything else was added).

The fail-closed ordering — verify (401) → derive scope from claims (403) → validate input (403) → authorise against the domain row (403, uniform, no existence oracle) → act → relay — is unchanged, as is the call site and its position. All **15** receiver tests, including every negative/forbidden case, still pass.

An earlier attempt injected a pure row-normaliser instead; it cleared complexity but pushed coupling to 13. That approach was reverted in favour of this one.

## Verification

- **Positive control**: the pristine worktree reproduced the CI count exactly — 6 findings, exit 2 — before any edit. (Host PHP is 8.2.22 and vendor needs ≥8.3, so `vendor/bin/phpmd` dies in `platform_check.php` with exit 255 and a naive grep of that output reports "0 findings". Everything here ran in a PHP 8.3/8.4 container with the exit code checked.)
- **Negative control**: with phpmd at 0, a deliberate violation was injected, reported (exit 2), and reverted (exit 0) — the zero is a real zero, not a tool that failed to start.
- Compared **by finding**, not by count. Two findings the baseline had been masking (`LongVariable` in `SettingsService`, `BooleanArgumentFlag` on a parse helper) surfaced once the code moved to new files and were fixed properly rather than re-baselined.
- phpcs **0 errors** (183 pre-existing warnings unchanged), phpstan clean, PHPUnit **1123 tests / 3432 assertions, 0 failures**.

## Expected effect on CI

PHPUnit should now actually run rather than report `skipped`. `Integration Tests (Newman)` was gated off too and may surface its own pre-existing failure — that would be a discovery, not a regression from this PR.
