### PR TITLE
chore(quality): make check:strict pass — one phpcs error, six phpmd findings

### DIFF
--- a/lib/Controller/CustomDictionaryController.php
+++ b/lib/Controller/CustomDictionaryController.php
@@ -49,6 +49,14 @@ use RuntimeException;
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.app
  *
+ * Exceeds PHPMD's class-complexity threshold (69 vs 50). The figure is the sum
+ * of roughly a dozen thin CRUD/import/export endpoints, each individually
+ * simple; no single method is near the per-method thresholds. Splitting the
+ * class would fragment one REST resource across several controllers without
+ * reducing any method's complexity.
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ *
  * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
  */
 class CustomDictionaryController extends Controller

--- a/lib/Controller/PortalSigningReceiverController.php
+++ b/lib/Controller/PortalSigningReceiverController.php
@@ -59,6 +59,13 @@ use Throwable;
 /**
  * Receives portaliq's forwarded signing actions on the `signer` audience.
  *
+ * Exceeds PHPMD's class-complexity threshold by one (51 vs 50). This is a
+ * single inbound webhook surface, and its branches are the payload-validation
+ * guards the spec requires. Extracting them would move the guards away from
+ * the endpoint they protect, which is the wrong trade for one point.
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ *
  * @spec openspec/specs/portal-signing-actions/spec.md
  */
 class PortalSigningReceiverController extends Controller

--- a/lib/Service/AnonymizationService.php
+++ b/lib/Service/AnonymizationService.php
@@ -58,6 +58,13 @@ use Psr\Log\LoggerInterface;
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.app
  *
+ * Exceeds PHPMD's 25-method threshold (29 non-accessor methods). The extra
+ * four are private per-entity-kind helpers that exist to keep each entity's
+ * anonymisation rule next to the pipeline that applies it; moving them to a
+ * sibling class would separate the rule from its only caller.
+ *
+ * @SuppressWarnings(PHPMD.TooManyMethods)
+ *
  * @spec openspec/specs/anonymization/spec.md
  * @spec openspec/changes/anonymisation-prohibition-gate/tasks.md#task-3
  * @spec openspec/changes/files-confidential-labels/specs/files-confidential-labels/spec.md

--- a/lib/Service/CustomDictionaryService.php
+++ b/lib/Service/CustomDictionaryService.php
@@ -47,6 +47,14 @@ use Throwable;
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.app
  *
+ * Exceeds PHPMD's class-complexity threshold (78 vs 50). Dictionary CRUD, term
+ * CRUD, and CSV/plain-text import and export live in one service because they
+ * share the same organisation-permission and de-duplication rules; splitting
+ * them would duplicate those rules across classes, which is the failure mode
+ * the threshold is meant to prevent.
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ *
  * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
  */
 class CustomDictionaryService
@@ -399,8 +407,8 @@ class CustomDictionaryService
         $seenThisBatch = [];
 
         foreach ($rows as $row) {
-            // parseImportContent() always emits a string `value` (a missing CSV
-            // column is coerced to ''), so no null-coalesce is needed here.
+            // The parseImportContent() helper always emits a string `value` (a
+            // missing CSV column is coerced to ''), so no null-coalesce here.
             $value = trim($row['value']);
             if ($value === '') {
                 $skipped++;

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -45,6 +45,14 @@ use Psr\Log\LoggerInterface;
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.app
  *
+ * Sits on PHPMD's object-coupling threshold (13 vs 13). This service is the
+ * single read/write point for every DocuDesk app setting, so it necessarily
+ * touches one type per settings domain it serves. The coupling is a
+ * consequence of centralising settings access rather than scattering it, which
+ * is the property we want to keep.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ *
  * @spec openspec/changes/ocr-document-scanning/tasks.md#task-4.1
  * @spec openspec/changes/files-confidential-labels/specs/files-confidential-labels/spec.md#requirement-optionally-suggest-batchfolder-analysis-priority-req-ddfcl-003
  */

--- a/lib/Service/SigningService.php
+++ b/lib/Service/SigningService.php
@@ -45,9 +45,17 @@ use RuntimeException;
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.app
  *
+ * Exceeds PHPMD's class-length threshold (1214 lines vs 1000). The class is the
+ * whole signing-request lifecycle, and the bulk of those lines are the
+ * documented per-state transition rules rather than logic density. This is
+ * flagged as a candidate for a genuine split (extracting the provider-dispatch
+ * and verification halves), which is a behavioural refactor and deliberately
+ * not folded into a quality-gate change.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength)
  *
  * @spec openspec/specs/document-signing/spec.md
  */


### PR DESCRIPTION
Replays the intent of Codeberg `Conduction/docudesk` #191 onto GitHub, which is canonical. Codeberg's `development` is a **stale mirror — 54 commits behind, and diverged** (it carries 1 commit GitHub does not). The fixes were re-measured on this base and ported; the diff was **not** cherry-picked.

## What was already fixed here

Most of #191's debt does not exist on the GitHub base:
- **psalm: clean** (148 files scanned, 91.8% type inference)
- **phpstan: clean** (`[OK] No errors`)
- **composer.json `check:strict` scripts are already un-masked** — see the note below on why that mattered

## What actually remained

**phpcs — one ERROR:** `Squiz.Commenting.InlineComment.NotCapital` in `CustomDictionaryService.php:402`. The other **183 findings are `@spec`-tag WARNINGS** and do not fail the run.

**phpmd — six class-level findings**, each suppressed with its reason recorded next to the suppression:

| class | rule | measured |
|---|---|---|
| CustomDictionaryController | ExcessiveClassComplexity | 69 vs 50 |
| PortalSigningReceiverController | ExcessiveClassComplexity | 51 vs 50 |
| AnonymizationService | TooManyMethods | 29 vs 25 |
| CustomDictionaryService | ExcessiveClassComplexity | **78** vs 50 |
| SettingsService | CouplingBetweenObjects | 13 vs 13 |
| SigningService | ExcessiveClassLength | 1214 vs 1000 |

The figures are **this base's**. CustomDictionaryService reads **78 here against 77 on Codeberg** — a small but concrete demonstration of why the diff could not be replayed blind.

`SigningService`'s length is flagged in its docblock as a genuine split candidate (provider-dispatch and verification halves). That is a behavioural refactor and is deliberately **not** folded into a quality-gate change.

## Why this class of PR is worth having at all

The pattern these PRs originally targeted was `"psalm": "./vendor/bin/psalm ... || echo 'Psalm not installed, skipping...'"`. `cmd || echo` **exits 0 whatever the tool returns** — the gate reported success and its absence was indistinguishable from it. On this base that un-masking has already landed, which is precisely why the remaining findings above are visible at all.

## Proof

- `composer check:strict` exits **0** on **PHP 8.3**, fresh `composer install` (no copied `vendor/`) — **1118 tests, 3425 assertions**
- **Positive control:** removing the `ExcessiveClassLength` suppression makes phpmd exit **2**, naming `lib/Service/SigningService.php` and the rule; restoring it returns phpmd to **0**. The suppressions are load-bearing, not decorative.