### PR TITLE
fix(apphost): stop one cross-app `extends` from 500ing every docudesk route

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -17,12 +17,21 @@
 
 // The mechanical boilerplate routes — `dashboard#page` (`/`) and the SPA
 // catch-all (`/{path}`, `dashboard#catchAll`) — are supplied by
-// `Routes::standard()`; both resolve to docudesk's `DashboardController`
-// (which extends the AppHost `GenericDashboardController`), so the route name
-// `docudesk.dashboard.page` that the navigation (info.xml) and the dashboard
-// widgets link to is defined. The app-specific API routes below are passed
-// through as `$extra` and inserted before the catch-all.
-return \OCA\OpenRegister\AppHost\Routes::standard([
+// `Routes::standard()`; both resolve to docudesk's `DashboardController`, so
+// the route name `docudesk.dashboard.page` that the navigation (info.xml) and
+// the dashboard widgets link to is defined. The app-specific API routes below
+// are passed through as `$extra` and inserted before the catch-all.
+//
+// ⚠️ The AppHost builder is invoked through a `class_exists()` guard. Nextcloud
+// `include`s this file for EVERY docudesk request, so an unguarded static call
+// to a class in another app makes every route in the app fatal with HTTP 500
+// when openregister is absent — not just the AppHost ones. DocuDesk does not
+// declare `<app>openregister</app>`, so an admin can create exactly that
+// configuration. Fixing only the controllers MOVES the fatal here rather than
+// removing it. The `$fallback` branch below reproduces `Routes::standard()`'s
+// output locally so docudesk still routes (and degrades per-endpoint) without
+// openregister. See decidesk#377 / #388.
+$extra = [
         // Metrics and health.
         ['name' => 'metrics#index', 'url' => 'api/metrics', 'verb' => 'GET'],
         ['name' => 'health#index', 'url' => 'api/health', 'verb' => 'GET'],
@@ -183,11 +192,61 @@ return \OCA\OpenRegister\AppHost\Routes::standard([
         // Generic per-user preferences (used by shared nextcloud-vue widgets, e.g.
         // CnSupportDialog) — served by OpenRegister's AppHost
         // GenericPreferencesController (aliased in Application::register).
-        // Served by lib/Controller/PreferencesController (a thin subclass of
-        // OpenRegister's GenericPreferencesController). The route name MUST
-        // stay `preferences#…`: Nextcloud resolves `foo#bar` to
+        // Served by lib/Controller/PreferencesController (a local OCP-only
+        // implementation of OpenRegister's GenericPreferencesController). The
+        // route name MUST stay `preferences#…`: Nextcloud resolves `foo#bar` to
         // OCA\DocuDesk\Controller\FooController, so a namespaced name here
         // resolves to a class that does not exist and 500s.
         ['name' => 'preferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
         ['name' => 'preferences#setPreference', 'url' => '/api/preferences/{key}', 'verb' => 'PUT'],
-]);
+];
+
+// Preferred path: the OpenRegister AppHost owns the canonical route table.
+// `class_exists()` autoloads without fatalling when the class is unavailable.
+if (class_exists('OCA\OpenRegister\AppHost\Routes') === true) {
+    return \OCA\OpenRegister\AppHost\Routes::standard($extra);
+}
+
+// Fallback: openregister is not installed. Reproduce `Routes::standard()`
+// locally — canonical routes first (minus any name `$extra` overrides), then
+// `$extra`, then the SPA catch-all LAST so it never shadows a real route.
+$canonicalRoutes = [
+    ['name' => 'dashboard#page', 'url' => '/', 'verb' => 'GET'],
+    ['name' => 'settings#index', 'url' => '/api/settings', 'verb' => 'GET'],
+    ['name' => 'settings#create', 'url' => '/api/settings', 'verb' => 'POST'],
+    ['name' => 'settings#update', 'url' => '/api/settings', 'verb' => 'PUT'],
+    ['name' => 'settings#load', 'url' => '/api/settings/load', 'verb' => 'POST'],
+    ['name' => 'preferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
+    ['name' => 'preferences#setPreference', 'url' => '/api/preferences/{key}', 'verb' => 'PUT'],
+    ['name' => 'metrics#index', 'url' => '/api/metrics', 'verb' => 'GET'],
+    ['name' => 'health#index', 'url' => '/api/health', 'verb' => 'GET'],
+];
+
+$catchAllRoute = [
+    'name'         => 'dashboard#catchAll',
+    'url'          => '/{path}',
+    'verb'         => 'GET',
+    'requirements' => ['path' => '.+'],
+    'defaults'     => ['path' => ''],
+];
+
+$extraNames = [];
+foreach ($extra as $extraRoute) {
+    if (isset($extraRoute['name']) === true) {
+        $extraNames[(string) $extraRoute['name']] = true;
+    }
+}
+
+$mergedRoutes = [];
+foreach ($canonicalRoutes as $canonicalRoute) {
+    if (isset($extraNames[$canonicalRoute['name']]) === true) {
+        continue;
+    }
+
+    $mergedRoutes[] = $canonicalRoute;
+}
+
+$mergedRoutes   = array_merge($mergedRoutes, $extra);
+$mergedRoutes[] = $catchAllRoute;
+
+return ['routes' => $mergedRoutes];

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -45,10 +45,6 @@ use OCA\OpenRegister\Event\ApprovalStepRejectedEvent;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCA\OpenRegister\Event\ObjectDeletedEvent;
-use OCA\DocuDesk\Controller\HealthController;
-use OCA\DocuDesk\Controller\MetricsController;
-use OCA\OpenRegister\AppHost\Controller\GenericDashboardController;
-use OCA\OpenRegister\AppHost\Controller\GenericPreferencesController;
 use OCP\Files\Conversion\IConversionManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -179,25 +175,32 @@ class Application extends App implements IBootstrap
         // objects to the right variant.
         $context->registerMiddleware(LanguageNegotiationMiddleware::class);
 
-        // AppHost observability adoption (ADR-006 / ADR-040). The thin
-        // HealthController / MetricsController subclasses of OpenRegister's
-        // engine-owned generic controllers serve /api/health and /api/metrics
-        // (URLs unchanged in appinfo/routes.php) — driven by the declarative
-        // `observability` block in src/manifest.json. The bespoke checks /
-        // metric lines / MetricsCollector are gone. Auth posture is owned by
-        // the controllers (health public, metrics admin-only). These factories
-        // supply the engine dependencies the subclasses inherit from the
-        // generic controllers' constructors.
+        // AppHost observability adoption (ADR-006 / ADR-040). DocuDesk's
+        // HealthController / MetricsController serve /api/health and
+        // /api/metrics (URLs unchanged in appinfo/routes.php) — driven by the
+        // declarative `observability` block in src/manifest.json. The bespoke
+        // checks / metric lines / MetricsCollector are gone. Auth posture is
+        // owned by the controllers (health public, metrics admin-only).
+        //
+        // Both controllers now auto-wire from OCP alone and resolve the engine
+        // by FQCN string at dispatch time, so the only thing left to bind is
+        // the MetricsEngine itself (see below for why it needs a factory).
         $this->registerAppHostObservability(context: $context);
 
-        // AppHost boilerplate adoption (ADR-040). The bespoke DashboardController
+        // AppHost boilerplate adoption (ADR-040). The DashboardController
         // (SPA page + catch-all) and PreferencesController (per-user key/value
-        // UI flags) were byte-for-byte copies of OpenRegister's shared AppHost
-        // generics, so bind docudesk's conventional AppHost controller class
-        // names to the engine generics with docudesk's app id injected as
-        // $appName. URLs, route names' targets and JSON contracts are unchanged;
-        // the engine owns the (identical) auth posture so the leaf cannot drift
-        // it. The bespoke classes were deleted.
+        // UI flags) implement the AppHost boilerplate LOCALLY against OCP.
+        // URLs, route names' targets, auth posture and JSON contracts are
+        // unchanged from the engine generics they used to subclass.
+        //
+        // ⚠️ Do NOT re-introduce container aliases that bind leaf AppHost class
+        // names to the OpenRegister generics, and do NOT turn those controllers
+        // back into subclasses. Nextcloud's router `ReflectionClass()`es every
+        // file in lib/Controller/ while MATCHING a route, so one unresolvable
+        // parent returns HTTP 500 for EVERY docudesk route — and DocuDesk does
+        // not declare `<app>openregister</app>`, so an admin can create exactly
+        // that configuration. `extends` is resolved by the AUTOLOADER, not this
+        // container, so lazy registration cannot rescue it. See decidesk#377.
         //
         // NOT adopted (kept bespoke — domain-entangled): SettingsController
         // (its index() merges the openregister-installed flag + isAdmin +
@@ -208,46 +211,14 @@ class Application extends App implements IBootstrap
         // none of that), the DocuDeskAdmin AdminSettings, and the GDPR/consent,
         // anonymisation, PDF/print, signing and dossier domain controllers.
         //
-        // The /api/preferences/{key} and / + /{path} routes resolve to
-        // leaf-namespaced AppHost controller class names
-        // (OCA\DocuDesk\AppHost\Controller\Generic{Dashboard,Preferences}Controller)
-        // that do not physically exist in this app — same pattern as the
-        // Health/Metrics adoption above. Register them as services that
-        // construct the OpenRegister generics with docudesk's id injected as
-        // $appName, so templates/index.php and the `pref_` user-value namespace
-        // are scoped to docudesk, never OpenRegister.
-        $context->registerService(
-            'OCA\\DocuDesk\\AppHost\\Controller\\GenericDashboardController',
-            static function (ContainerInterface $container): GenericDashboardController {
-                return new GenericDashboardController(
-                    appName: self::APP_ID,
-                    request: $container->get(\OCP\IRequest::class)
-                );
-            }
-        );
-        // The conventional `dashboard#page` route resolves to this real
-        // DashboardController subclass; register it explicitly (mirroring
-        // procest) so NC's DI constructs it from IRequest — the AppHost engine
-        // base otherwise expects an injected `string $appName`.
-        $context->registerService(
-            \OCA\DocuDesk\Controller\DashboardController::class,
-            static function (ContainerInterface $container): \OCA\DocuDesk\Controller\DashboardController {
-                return new \OCA\DocuDesk\Controller\DashboardController(
-                    request: $container->get(\OCP\IRequest::class)
-                );
-            }
-        );
-        $context->registerService(
-            'OCA\\DocuDesk\\AppHost\\Controller\\GenericPreferencesController',
-            static function (ContainerInterface $container): GenericPreferencesController {
-                return new GenericPreferencesController(
-                    appName: self::APP_ID,
-                    request: $container->get(\OCP\IRequest::class),
-                    config: $container->get(\OCP\IConfig::class),
-                    userSession: $container->get(\OCP\IUserSession::class)
-                );
-            }
-        );
+        // The `/` + `/{path}` and `/api/preferences/{key}` routes are named
+        // `dashboard#…` / `preferences#…`, which Nextcloud resolves to
+        // OCA\DocuDesk\Controller\{Dashboard,Preferences}Controller. Both are
+        // real classes in this app that extend OCP\AppFramework\Controller and
+        // take only auto-wirable OCP dependencies, so neither needs an explicit
+        // registration and neither can drag OpenRegister into the router's
+        // reflection pass. templates/index.php and the `pref_` user-value
+        // namespace stay scoped to docudesk via Application::APP_ID.
     }//end register()
 
     /**
@@ -311,48 +282,40 @@ class Application extends App implements IBootstrap
     }//end registerFilteredObjectListener()
 
     /**
-     * Wire the AppHost-backed health + metrics controllers.
+     * Wire the AppHost metrics engine into DocuDesk's container.
      *
-     * Registers DocuDesk's HealthController / MetricsController (thin subclasses
-     * of OpenRegister's GenericHealthController / GenericMetricsController) with
-     * `appName = docudesk`, so the engine loads docudesk's src/manifest.json
-     * `observability` block. ManifestLoader + HealthCheckExecutor resolve
-     * through the server container; MetricsEngine is built explicitly because
-     * OpenRegister's own MetricsEngine factory is registered under the
-     * `openregister` app container and is not visible here (auto-wiring it
-     * fresh would fail on the multi-arg constructor).
+     * DocuDesk's HealthController / MetricsController no longer subclass the
+     * OpenRegister generics, and no longer take engine collaborators as
+     * constructor parameters — they resolve them out of the container BY FQCN
+     * STRING at dispatch time and degrade (health `degraded` / metrics 503)
+     * when the lookup fails. Both auto-wire from OCP alone, so neither needs a
+     * factory here any more.
+     *
+     * MetricsEngine still does: OpenRegister's own MetricsEngine factory is
+     * registered under the `openregister` app container and is not visible
+     * here, and auto-wiring it fresh would fail on the multi-arg constructor.
+     * Registering it under its own FQCN string keeps that explicit construction
+     * while letting MetricsController find it with a plain `$container->get()`.
+     *
+     * ⚠️ The closure body is the ONLY place these OpenRegister class names are
+     * resolved, and a closure body runs on `get()`, never at registration. The
+     * closure therefore must NOT declare an OpenRegister return type — that
+     * would be resolved on invocation too, but more importantly it keeps this
+     * file free of any import that a static analyser or a future refactor could
+     * promote into a class-declaration-time reference. See decidesk#377.
      *
      * @param IRegistrationContext $context The registration context.
      *
      * @return void
      *
      * @spec openspec/specs/adopt-apphost/spec.md
-     *
-     * Health/MetricsController extend OpenRegister AppHost base classes that
-     * are absent during static analysis, so Psalm sees no constructor on them
-     * (TooManyArguments) and cannot see $container used inside the flagged
-     * construction (UnusedClosureParam). Both resolve at runtime.
-     *
-     * @psalm-suppress TooManyArguments, UnusedClosureParam
      */
     private function registerAppHostObservability(IRegistrationContext $context): void
     {
         $context->registerService(
-            HealthController::class,
-            static function (ContainerInterface $container): HealthController {
-                return new HealthController(
-                    appName: self::APP_ID,
-                    request: $container->get(\OCP\IRequest::class),
-                    manifestLoader: $container->get(\OCA\OpenRegister\AppHost\Observability\ManifestLoader::class),
-                    executor: $container->get(\OCA\OpenRegister\AppHost\Observability\HealthCheckExecutor::class)
-                );
-            }
-        );
-
-        $context->registerService(
-            MetricsController::class,
-            static function (ContainerInterface $container): MetricsController {
-                $engine = new \OCA\OpenRegister\AppHost\Observability\MetricsEngine(
+            'OCA\\OpenRegister\\AppHost\\Observability\\MetricsEngine',
+            static function (ContainerInterface $container): object {
+                return new \OCA\OpenRegister\AppHost\Observability\MetricsEngine(
                     objectSource: $container->get(\OCA\OpenRegister\AppHost\Observability\Source\ObjectMetricSource::class),
                     tableSource: $container->get(\OCA\OpenRegister\AppHost\Observability\Source\TableMetricSource::class),
                     appConfigSource: $container->get(\OCA\OpenRegister\AppHost\Observability\Source\AppConfigMetricSource::class),
@@ -362,13 +325,6 @@ class Application extends App implements IBootstrap
                     cacheFactory: $container->get(\OCP\ICacheFactory::class),
                     config: $container->get(\OCP\IConfig::class),
                     logger: $container->get(\Psr\Log\LoggerInterface::class)
-                );
-
-                return new MetricsController(
-                    appName: self::APP_ID,
-                    request: $container->get(\OCP\IRequest::class),
-                    manifestLoader: $container->get(\OCA\OpenRegister\AppHost\Observability\ManifestLoader::class),
-                    engine: $engine
                 );
             }
         );

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -3,12 +3,23 @@
 /**
  * DocuDesk Dashboard Controller.
  *
- * Thin subclass of the OpenRegister AppHost GenericDashboardController. The SPA
- * shell (`page()` / `catchAll()`) is inherited unchanged from the engine; this
- * subclass exists so the conventional `dashboard#page` route resolves to a real
- * `OCA\DocuDesk\Controller\DashboardController` class (auto-wired by Nextcloud
- * DI from `IRequest` alone), making the route name `docudesk.dashboard.page`
- * that the navigation (info.xml) and dashboard widgets link to resolvable.
+ * SPA host: renders the SPA from `templates/index.php` and serves the Vue
+ * history-mode catch-all. Behaviourally identical to the OpenRegister AppHost
+ * `GenericDashboardController` it used to subclass, but implemented locally and
+ * depending on nothing outside DocuDesk and OCP. The conventional
+ * `dashboard#page` route resolves to this concrete
+ * `OCA\DocuDesk\Controller\DashboardController`, making the route name
+ * `docudesk.dashboard.page` that the navigation (info.xml) and dashboard widgets
+ * link to resolvable.
+ *
+ * ⚠️ DO NOT "simplify" this back into a subclass of the AppHost generic.
+ * Nextcloud's router `ReflectionClass()`es every file in `lib/Controller/` while
+ * MATCHING a route, so an unresolvable parent makes EVERY route in DocuDesk
+ * return HTTP 500 — including routes with no OpenRegister involvement at all.
+ * DocuDesk does not declare `<app>openregister</app>`, so an admin can create
+ * exactly that configuration. `extends` is resolved by the AUTOLOADER, not the
+ * DI container, so no amount of lazy registration can rescue it, and the few
+ * lines below are cheaper than a whole-app outage. See decidesk#377 / #388.
  *
  * @category Controller
  * @package  OCA\DocuDesk\Controller
@@ -28,7 +39,10 @@ declare(strict_types=1);
 namespace OCA\DocuDesk\Controller;
 
 use OCA\DocuDesk\AppInfo\Application;
-use OCA\OpenRegister\AppHost\Controller\GenericDashboardController;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
 
 /**
@@ -36,13 +50,13 @@ use OCP\IRequest;
  *
  * @psalm-suppress UnusedClass
  */
-class DashboardController extends GenericDashboardController
+class DashboardController extends Controller
 {
     /**
      * Constructor.
      *
-     * Supplies the docudesk app id to the engine base controller so Nextcloud's
-     * DI can auto-wire this subclass from `IRequest` alone.
+     * Supplies the docudesk app id so Nextcloud's DI can auto-wire this
+     * controller from `IRequest` alone.
      *
      * @param IRequest $request HTTP request.
      */
@@ -51,4 +65,49 @@ class DashboardController extends GenericDashboardController
         parent::__construct(appName: Application::APP_ID, request: $request);
 
     }//end __construct()
+
+    /**
+     * Render the main SPA page from `templates/index.php`.
+     *
+     * `#[NoAdminRequired]` / `#[NoCSRFRequired]` were previously INHERITED from
+     * the AppHost generic; they are declared explicitly here so the auth posture
+     * is byte-for-byte unchanged by dropping the inheritance.
+     *
+     * @return TemplateResponse The rendered DocuDesk index template.
+     *
+     * @spec openspec/specs/adopt-apphost/spec.md
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function page(): TemplateResponse
+    {
+        return $this->renderIndex();
+
+    }//end page()
+
+    /**
+     * Serve the SPA for deep links (Vue history mode). Delegates to {@see page()}.
+     *
+     * @return TemplateResponse The rendered DocuDesk index template.
+     *
+     * @spec openspec/specs/adopt-apphost/spec.md
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function catchAll(): TemplateResponse
+    {
+        return $this->page();
+
+    }//end catchAll()
+
+    /**
+     * Build the `index` TemplateResponse.
+     *
+     * @return TemplateResponse The rendered DocuDesk index template.
+     */
+    protected function renderIndex(): TemplateResponse
+    {
+        return new TemplateResponse($this->appName, 'index');
+
+    }//end renderIndex()
 }//end class

--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -1,15 +1,25 @@
 <?php
 
 /**
- * Health Controller — AppHost delegator.
+ * Health Controller — AppHost adopter by COMPOSITION, not inheritance.
  *
- * Thin subclass of OpenRegister's engine-owned GenericHealthController. It
- * exists only so the `health#index` route resolves to a concrete DocuDesk
- * class carrying the ADR-006 auth posture (#[PublicPage]); all behaviour —
- * running the declarative `observability.health` checks from src/manifest.json
- * and rendering `{status, app, version, checks}` — lives in the engine. The
- * previous hand-written database + openregister checks are gone (declared in
- * the manifest instead).
+ * The `health#index` route resolves to this concrete DocuDesk class carrying
+ * the ADR-006 auth posture (#[PublicPage]). The declarative
+ * `observability.health` checks from src/manifest.json are still executed by
+ * OpenRegister's AppHost engine — but the engine collaborators are pulled out
+ * of the DI container BY FQCN STRING at dispatch time rather than inherited,
+ * and the published `{status, app, version, checks}` body shape is rendered
+ * here. The hand-written database + openregister checks remain gone (declared
+ * in the manifest instead).
+ *
+ * ⚠️ DO NOT "simplify" this back into a subclass of the AppHost generic, and do
+ * not `use`-import an OpenRegister class here. Nextcloud's router
+ * `ReflectionClass()`es every file in `lib/Controller/` while MATCHING a route,
+ * so an unresolvable parent makes EVERY route in DocuDesk return HTTP 500, not
+ * just this one. DocuDesk does not declare `<app>openregister</app>`, so an
+ * admin can create exactly that configuration. `extends` is resolved by the
+ * AUTOLOADER, not the container, so lazy DI cannot rescue it.
+ * See decidesk#377 / #388.
  *
  * @category  Controller
  * @package   OCA\DocuDesk\Controller
@@ -29,10 +39,15 @@ declare(strict_types=1);
 
 namespace OCA\DocuDesk\Controller;
 
-use OCA\OpenRegister\AppHost\Controller\GenericHealthController;
+use OCA\DocuDesk\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use Psr\Container\ContainerInterface;
 
 /**
  * Public, declarative health endpoint backed by the AppHost engine.
@@ -43,13 +58,57 @@ use OCP\AppFramework\Http\JSONResponse;
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.app
  */
-class HealthController extends GenericHealthController
+class HealthController extends Controller
 {
+
+    /**
+     * FQCN of the AppHost observability manifest loader.
+     *
+     * Referenced as a string, never imported: the class only exists when
+     * openregister is installed, and an import in a resolved position would
+     * 500 every DocuDesk route when it is not.
+     *
+     * @var string
+     */
+    private const MANIFEST_LOADER = 'OCA\\OpenRegister\\AppHost\\Observability\\ManifestLoader';
+
+    /**
+     * FQCN of the AppHost declarative health-check executor.
+     *
+     * Referenced as a string, never imported: see {@see self::MANIFEST_LOADER}.
+     *
+     * @var string
+     */
+    private const HEALTH_EXECUTOR = 'OCA\\OpenRegister\\AppHost\\Observability\\HealthCheckExecutor';
+
+    /**
+     * Constructor.
+     *
+     * @param IRequest           $request   The request object.
+     * @param IConfig            $config    The Nextcloud config service (app version fallback).
+     * @param ContainerInterface $container DI container — resolves the AppHost engine lazily.
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private readonly IConfig $config,
+        private readonly ContainerInterface $container,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+
+    }//end __construct()
+
     /**
      * GET /api/health — declarative health check (ADR-006).
      *
      * Public per ADR-006: an anonymous probe (load balancer, uptime monitor)
-     * must reach this without a session. Delegates entirely to the engine.
+     * must reach this without a session. Drives the AppHost engine, which runs
+     * the `observability.health` checks declared in src/manifest.json.
+     *
+     * When the engine cannot be resolved — openregister absent or disabled —
+     * the endpoint still ANSWERS (the entire point of a health probe):
+     * `status: degraded`, `checks: {openregister: unavailable}`, HTTP 200.
      *
      * @return JSONResponse `{status, app, version, checks}`.
      *
@@ -59,7 +118,62 @@ class HealthController extends GenericHealthController
     #[NoCSRFRequired]
     public function index(): JSONResponse
     {
-        return parent::index();
+        $body = $this->engineBody();
+        if ($body === null) {
+            $body = [
+                'status'     => 'degraded',
+                'version'    => $this->config->getAppValue(Application::APP_ID, 'installed_version', ''),
+                'checks'     => ['openregister' => 'unavailable'],
+                'cors'       => false,
+                'httpStatus' => Http::STATUS_OK,
+            ];
+        }
+
+        $response = new JSONResponse(
+            [
+                'status'  => $body['status'],
+                'app'     => $this->appName,
+                'version' => $body['version'],
+                'checks'  => $body['checks'],
+            ],
+            (int) $body['httpStatus']
+        );
+
+        if ($body['cors'] === true) {
+            $response->addHeader('Access-Control-Allow-Origin', '*');
+            $response->addHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+        }
+
+        return $response;
 
     }//end index()
+
+    /**
+     * Run the AppHost observability engine and collect its result.
+     *
+     * @return array{status: string, version: string, checks: array<string, mixed>, cors: bool, httpStatus: int}|null
+     *         Null when the engine is unavailable (openregister absent/disabled).
+     */
+    private function engineBody(): ?array
+    {
+        try {
+            $manifestLoader = $this->container->get(self::MANIFEST_LOADER);
+            $executor       = $this->container->get(self::HEALTH_EXECUTOR);
+
+            $appId    = $this->appName;
+            $manifest = $manifestLoader->load(appId: $appId);
+            $result   = $executor->execute(manifest: $manifest);
+
+            return [
+                'status'     => (string) $result->status,
+                'version'    => (string) $manifestLoader->appVersion(appId: $appId),
+                'checks'     => (array) $result->checks,
+                'cors'       => ($manifest->cors === true),
+                'httpStatus' => (int) $result->httpStatusCode,
+            ];
+        } catch (\Throwable $e) {
+            return null;
+        }//end try
+
+    }//end engineBody()
 }//end class

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -1,14 +1,22 @@
 <?php
 
 /**
- * Metrics Controller — AppHost delegator.
+ * Metrics Controller — AppHost adopter by COMPOSITION, not inheritance.
  *
- * Thin subclass of OpenRegister's engine-owned GenericMetricsController. It
- * exists only so the `metrics#index` route resolves to a concrete DocuDesk
- * class; the admin-only auth posture (no #[NoAdminRequired]) and the Prometheus
- * 0.0.4 exposition are owned by the engine. The declarative
- * `observability.metrics` block in src/manifest.json drives the output —
- * the previous hand-written metric lines and MetricsCollector are gone.
+ * The `metrics#index` route resolves to this concrete DocuDesk class, which
+ * owns the admin-only auth posture (no #[NoAdminRequired]) and drives the
+ * OpenRegister AppHost metrics engine — pulled out of the DI container BY FQCN
+ * STRING at dispatch time rather than inherited. The declarative
+ * `observability.metrics` block in src/manifest.json still drives the
+ * Prometheus 0.0.4 exposition; the previous hand-written metric lines and
+ * MetricsCollector remain gone.
+ *
+ * ⚠️ DO NOT "simplify" this back into a subclass of the AppHost generic, and do
+ * not `use`-import an OpenRegister class here. Nextcloud's router
+ * `ReflectionClass()`es every file in `lib/Controller/` while MATCHING a route,
+ * so an unresolvable parent makes EVERY route in DocuDesk return HTTP 500, not
+ * just this one. `extends` is resolved by the AUTOLOADER, not the container, so
+ * lazy DI cannot rescue it. See decidesk#377 / #388.
  *
  * @category  Controller
  * @package   OCA\DocuDesk\Controller
@@ -28,9 +36,13 @@ declare(strict_types=1);
 
 namespace OCA\DocuDesk\Controller;
 
-use OCA\OpenRegister\AppHost\Controller\GenericMetricsController;
+use OCA\DocuDesk\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\TextPlainResponse;
+use OCP\IRequest;
+use Psr\Container\ContainerInterface;
 
 /**
  * Admin-only declarative Prometheus metrics endpoint backed by the AppHost engine.
@@ -44,12 +56,61 @@ use OCP\AppFramework\Http\TextPlainResponse;
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.app
  */
-class MetricsController extends GenericMetricsController
+class MetricsController extends Controller
 {
+
+    /**
+     * FQCN of the AppHost observability manifest loader.
+     *
+     * Referenced as a string, never imported: the class only exists when
+     * openregister is installed, and an import in a resolved position would
+     * 500 every DocuDesk route when it is not.
+     *
+     * @var string
+     */
+    private const MANIFEST_LOADER = 'OCA\\OpenRegister\\AppHost\\Observability\\ManifestLoader';
+
+    /**
+     * FQCN of the AppHost Prometheus metrics engine.
+     *
+     * Referenced as a string, never imported: see {@see self::MANIFEST_LOADER}.
+     *
+     * @var string
+     */
+    private const METRICS_ENGINE = 'OCA\\OpenRegister\\AppHost\\Observability\\MetricsEngine';
+
+    /**
+     * Prometheus text exposition content type.
+     *
+     * Mirrors the engine's `PrometheusRenderer::CONTENT_TYPE`, copied as a
+     * literal because a foreign class CONSTANT is also a class reference.
+     *
+     * @var string
+     */
+    private const CONTENT_TYPE = 'text/plain; version=0.0.4; charset=utf-8';
+
+    /**
+     * Constructor.
+     *
+     * @param IRequest           $request   The request object.
+     * @param ContainerInterface $container DI container — resolves the AppHost engine lazily.
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private readonly ContainerInterface $container,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+
+    }//end __construct()
+
     /**
      * GET /api/metrics — declarative Prometheus metrics (admin-only, ADR-006).
      *
-     * Delegates entirely to the engine.
+     * Drives the AppHost metrics engine. Returns HTTP 503 with a Prometheus
+     * comment line when the engine is unavailable (openregister absent or
+     * disabled) — never a 500.
      *
      * @return TextPlainResponse Prometheus text exposition 0.0.4.
      *
@@ -58,7 +119,22 @@ class MetricsController extends GenericMetricsController
     #[NoCSRFRequired]
     public function index(): TextPlainResponse
     {
-        return parent::index();
+        try {
+            $manifestLoader = $this->container->get(self::MANIFEST_LOADER);
+            $engine         = $this->container->get(self::METRICS_ENGINE);
+
+            $manifest = $manifestLoader->load(appId: $this->appName);
+            $body     = (string) $engine->render(manifest: $manifest);
+            $status   = Http::STATUS_OK;
+        } catch (\Throwable $e) {
+            $body   = '# metrics unavailable: the OpenRegister AppHost observability engine is not installed'."\n";
+            $status = Http::STATUS_SERVICE_UNAVAILABLE;
+        }//end try
+
+        $response = new TextPlainResponse($body, $status);
+        $response->addHeader('Content-Type', self::CONTENT_TYPE);
+
+        return $response;
 
     }//end index()
 }//end class

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -3,8 +3,21 @@
 /**
  * Per-user preferences controller.
  *
- * Thin subclass of OpenRegister's AppHost `GenericPreferencesController`,
- * mirroring the existing `HealthController` / `MetricsController` pattern.
+ * Local implementation of the per-user key/value preference API, mirroring the
+ * existing `HealthController` / `MetricsController` pattern. Behaviourally
+ * identical to OpenRegister's AppHost `GenericPreferencesController` it used to
+ * subclass — same auth posture, same key sanitisation, same per-user scoping,
+ * same JSON shapes — but it needs NOTHING from OpenRegister: the whole
+ * implementation is OCP (`IConfig` + `IUserSession`), so there is no engine to
+ * delegate to and no container lookup to make.
+ *
+ * ⚠️ DO NOT "simplify" this back into a subclass of the AppHost generic.
+ * Nextcloud's router `ReflectionClass()`es every file in `lib/Controller/` while
+ * MATCHING a route, so an unresolvable parent makes EVERY route in DocuDesk
+ * return HTTP 500, not just this one. DocuDesk does not declare
+ * `<app>openregister</app>`, so an admin can create exactly that configuration.
+ * `extends` is resolved by the AUTOLOADER, not the DI container, so lazy DI
+ * cannot rescue it. See decidesk#377 / #388.
  *
  * WHY THIS CLASS EXISTS: Nextcloud resolves a route `name` of the form
  * `foo#bar` to the class `OCA\<App>\Controller\FooController` — it always
@@ -39,15 +52,143 @@ declare(strict_types=1);
 
 namespace OCA\DocuDesk\Controller;
 
-use OCA\OpenRegister\AppHost\Controller\GenericPreferencesController;
+use OCA\DocuDesk\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Serves `GET|PUT /api/preferences/{key}` for DocuDesk.
  *
- * Behaviour (auth posture, key sanitisation, per-user scoping) is inherited
- * unchanged from OpenRegister's generic implementation.
+ * Behaviour (auth posture, key sanitisation, per-user scoping) is a
+ * byte-for-byte reimplementation of OpenRegister's generic. `#[NoAdminRequired]`
+ * was previously INHERITED from the generic; it is declared explicitly on both
+ * methods here so the auth posture is unchanged by dropping the inheritance —
+ * any logged-in user may read and write their OWN preferences, and the
+ * `$user === null` guard still rejects anonymous callers with 401.
  */
-class PreferencesController extends GenericPreferencesController
+class PreferencesController extends Controller
 {
+    /**
+     * Constructor.
+     *
+     * @param IRequest     $request     The request object.
+     * @param IConfig      $config      Nextcloud config service (per-user values).
+     * @param IUserSession $userSession The current user session.
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private readonly IConfig $config,
+        private readonly IUserSession $userSession,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
 
+    }//end __construct()
+
+    /**
+     * GET /api/preferences/{key} — read one preference for the current user.
+     *
+     * @param string $key The preference key (sanitised before use).
+     *
+     * @return JSONResponse `{value: string|null}`, or 401/400 on a bad caller/key.
+     *
+     * @spec openspec/specs/preferences-api/spec.md
+     */
+    #[NoAdminRequired]
+    public function getPreference(string $key): JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(data: ['message' => 'Not logged in'], statusCode: Http::STATUS_UNAUTHORIZED);
+        }
+
+        $safeKey = $this->sanitizeKey(key: $key);
+        if ($safeKey === '') {
+            return new JSONResponse(data: ['message' => 'Invalid key'], statusCode: Http::STATUS_BAD_REQUEST);
+        }
+
+        $value = $this->config->getUserValue(
+            userId: $user->getUID(),
+            appName: $this->appName,
+            key: 'pref_'.$safeKey,
+            default: ''
+        );
+
+        $stored = null;
+        if ($value !== '') {
+            $stored = $value;
+        }
+
+        return new JSONResponse(data: ['value' => $stored]);
+
+    }//end getPreference()
+
+    /**
+     * PUT /api/preferences/{key} — write (or clear) one preference.
+     *
+     * An empty `$value` deletes the stored preference, matching the generic.
+     *
+     * @param string $key   The preference key (sanitised before use).
+     * @param string $value The value to store; empty string clears it.
+     *
+     * @return JSONResponse `{value: string|null}`, or 401/400 on a bad caller/key.
+     *
+     * @spec openspec/specs/preferences-api/spec.md
+     */
+    #[NoAdminRequired]
+    public function setPreference(string $key, string $value=''): JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(data: ['message' => 'Not logged in'], statusCode: Http::STATUS_UNAUTHORIZED);
+        }
+
+        $safeKey = $this->sanitizeKey(key: $key);
+        if ($safeKey === '') {
+            return new JSONResponse(data: ['message' => 'Invalid key'], statusCode: Http::STATUS_BAD_REQUEST);
+        }
+
+        if ($value === '') {
+            $this->config->deleteUserValue(
+                userId: $user->getUID(),
+                appName: $this->appName,
+                key: 'pref_'.$safeKey
+            );
+
+            return new JSONResponse(data: ['value' => null]);
+        }
+
+        $this->config->setUserValue(
+            userId: $user->getUID(),
+            appName: $this->appName,
+            key: 'pref_'.$safeKey,
+            value: $value
+        );
+
+        return new JSONResponse(data: ['value' => $value]);
+
+    }//end setPreference()
+
+    /**
+     * Reduce a caller-supplied key to a safe, bounded storage key.
+     *
+     * Lowercased, restricted to `[a-z0-9-]`, capped at 64 characters.
+     *
+     * @param string $key The raw key from the URL.
+     *
+     * @return string The sanitised key, or '' when nothing survives.
+     */
+    private function sanitizeKey(string $key): string
+    {
+        $safe = preg_replace(pattern: '/[^a-z0-9-]/', replacement: '', subject: strtolower($key));
+
+        return substr((string) $safe, offset: 0, length: 64);
+
+    }//end sanitizeKey()
 }//end class


### PR DESCRIPTION
## The defect

Nextcloud's router `ReflectionClass()`es **every file in `lib/Controller/`** while *matching* a route, and `include`s `appinfo/routes.php` on every request. DocuDesk bound OpenRegister classes in **both** positions:

| Position | Binding |
|---|---|
| `lib/Controller/DashboardController.php` | `extends GenericDashboardController` |
| `lib/Controller/HealthController.php` | `extends GenericHealthController` |
| `lib/Controller/MetricsController.php` | `extends GenericMetricsController` |
| `lib/Controller/PreferencesController.php` | `extends GenericPreferencesController` |
| `appinfo/routes.php:25` | `\OCA\OpenRegister\AppHost\Routes::standard(...)` |

With openregister absent, **every** docudesk route returns HTTP 500 — including routes with no OpenRegister involvement at all. DocuDesk does **not** declare `<app>openregister</app>`, so an admin can create exactly that configuration.

**Lazy DI cannot fix this.** `extends` is resolved by the **autoloader**, not the container. And fixing only the controllers would have **moved** the fatal into `routes.php` rather than removing it.

⚠️ Deliberately **not** fixed by adding `<app>openregister</app>`: that makes `occ app:enable` fail rather than making the app work (rejected in decidesk#388).

## The fix — composition, not inheritance

- **Dashboard / Health / Metrics / Preferences** now extend `OCP\AppFramework\Controller` and implement their methods locally. Every attribute previously **inherited** — `#[NoAdminRequired]`, `#[NoCSRFRequired]`, `#[PublicPage]` — is now **declared explicitly**, so the auth posture is byte-for-byte unchanged. Metrics keeps *no* `#[NoAdminRequired]` (admin-only, ADR-006).
- **Health / Metrics** pull `ManifestLoader` / `HealthCheckExecutor` / `MetricsEngine` from the container **by FQCN string** and **degrade instead of 500ing**: health answers `status: degraded`, `checks: {openregister: unavailable}` at HTTP 200 (the entire point of a health probe); metrics answers **503** with a Prometheus comment line. `PrometheusRenderer::CONTENT_TYPE` is copied as a literal — a foreign class *constant* is also a class reference.
- **Preferences** needs nothing outside OCP (`IConfig` + `IUserSession`), so it has no container lookup at all.
- **`appinfo/routes.php`** calls the AppHost builder behind `class_exists()` with a local fallback table.
- **`Application.php`** drops the now-dead leaf-AppHost container aliases and registers `MetricsEngine` under its FQCN string, preserving the explicit multi-arg construction the auto-wirer cannot do.
- Each broken inheritance carries a "do not simplify this back" note.

No route names, URLs, verbs, auth attributes or response shapes change when openregister **is** installed.

## Evidence

Probe mirroring `Router::getAttributeRoutes()` — scan `lib/Controller/*.php`, `new ReflectionClass()` each — with **openregister absent**:

| | controllers | reflected ok | fail | `routes.php` |
|---|---|---|---|---|
| `origin/development` | 29 | 25 | **4** | **fatal** |
| this branch | 29 | **29** | **0** | **103 routes** |

The 4 pre-fix failures are exactly Dashboard / Health / Metrics / Preferences Controller.

**Positive control:** a throwaway class extending the absent generic still fatals under the same probe, so it is not blind. **Negative control:** an OCP-only controller reflects fine, so the probe is not failing everything for an unrelated reason. Both controls pass on every run reported here.

⚠️ The probe deliberately does **not** load the app's `vendor/autoload.php`. procest's `autoload-dev` (and pipelinq's stale vendor dump) map `OCA\OpenRegister\` onto `tests/Stubs/` — a mapping that does **not** exist in a `composer install --no-dev` release build, and which silently **masks** this defect in CI.

**Route-table equivalence:** real `Routes::standard()` vs. the fallback branch is `===` identical — **103 routes, same order, same `$extra`-overrides-canonical semantics** (docudesk overrides `metrics#index` / `health#index` / the settings + preferences routes), catch-all last. **Negative control:** a one-field mutation of that array is correctly reported as different.

## Local gates (PHP 8.4, container)

`lint` ✅ · `phpcs` ✅ **0 errors** (identical to baseline: 7 pre-existing `@spec` warnings, unchanged) · `phpmd` ✅ · `psalm` ✅ 0 · `phpstan` ✅ 0 · `phpunit` ✅ **1123 tests, 3432 assertions, 0 failures**

Fleet context: same shape fixed in decidesk#388 (merged); procest, pipelinq and nldesign carry it too.