### PR TITLE
fix(security): authorise the relation skip-decision, and revive 5 dead routes

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -174,9 +174,15 @@ $extra = [
         // calls server-to-server on behalf of an external, accountless
         // signer — #[PublicPage] because the caller is portaliq's backend,
         // never a browser; the X-Portal-Subject assertion IS the auth.
-        ['name' => 'portalsigningreceiver#signDocument', 'url' => 'api/portal/signing/sign', 'verb' => 'POST'],
-        ['name' => 'portalsigningreceiver#declineDocument', 'url' => 'api/portal/signing/decline', 'verb' => 'POST'],
-        ['name' => 'portalsigningreceiver#viewDocument', 'url' => 'api/portal/signing/viewDocument', 'verb' => 'GET'],
+        //
+        // ⚠️ The controller segment is CASE-SENSITIVE. Nextcloud builds the
+        // class name with `ucfirst()` only — it does NOT re-case the rest — so
+        // `portalsigningreceiver#…` resolved to `PortalsigningreceiverController`,
+        // a class that does not exist, and all three endpoints were dead. Keep
+        // the segment spelled exactly as the class: `portalSigningReceiver`.
+        ['name' => 'portalSigningReceiver#signDocument', 'url' => 'api/portal/signing/sign', 'verb' => 'POST'],
+        ['name' => 'portalSigningReceiver#declineDocument', 'url' => 'api/portal/signing/decline', 'verb' => 'POST'],
+        ['name' => 'portalSigningReceiver#viewDocument', 'url' => 'api/portal/signing/viewDocument', 'verb' => 'GET'],
 
         // Financial extraction routes (scan-en-herken).
         ['name' => 'extraction#financial', 'url' => 'api/extraction/financial', 'verb' => 'POST'],

--- a/lib/Controller/AnonymizationController.php
+++ b/lib/Controller/AnonymizationController.php
@@ -401,9 +401,16 @@ class AnonymizationController extends Controller
      * unless `force`). Include / non-skip decisions are always allowed and
      * forwarded to OpenRegister.
      *
+     * `$id` is a caller-supplied primary key into a table that is NOT scoped to
+     * the caller, so the decision path is authorised twice: authentication here,
+     * and per-document ownership inside RelationSkipDecisionService (which is
+     * where the relation — and therefore its Nextcloud file id — is loaded). A
+     * relation on a document the caller cannot reach yields the same 404 as one
+     * that does not exist.
+     *
      * @param int $id The EntityRelation id.
      *
-     * @return JSONResponse Success, or 422 with `{threshold, prohibitionMatch}`.
+     * @return JSONResponse Success, or 401 / 404 / 422 with `{threshold, prohibitionMatch}`.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -412,6 +419,11 @@ class AnonymizationController extends Controller
      */
     public function updateRelation(int $id): JSONResponse
     {
+        $denied = $this->anonymizeRequest->requireAuthenticated();
+        if ($denied !== null) {
+            return new JSONResponse($denied['body'], $denied['status']);
+        }
+
         $result = $this->anonymizeRequest->applyRelationDecision(
             relationId: $id,
             params: $this->request->getParams()

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -186,4 +186,67 @@ class SettingsController extends Controller
         }//end try
 
     }//end create()
+
+    /**
+     * Update settings — the canonical ADR-066 write verb.
+     *
+     * `OCA\OpenRegister\AppHost\Routes::standard()` ships `settings#update`
+     * (PUT /api/settings) for EVERY app, and DocuDesk's own SettingsController
+     * had no `update()`: the route existed, resolved to this class, and blew up
+     * on dispatch. Same write path (and the same admin guard) as
+     * {@see create()}, which stays for the fleet's legacy POST dialect.
+     *
+     * @return JSONResponse JSON response containing the updated settings
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    #[AuthorizedAdminSetting(DocuDeskAdmin::class)]
+    public function update(): JSONResponse
+    {
+        return $this->create();
+
+    }//end update()
+
+    /**
+     * Re-run the register/schema initialisation from the app's register JSON.
+     *
+     * Counterpart to `settings#load` (POST /api/settings/load) in the canonical
+     * AppHost route table — likewise routed for every app and likewise missing
+     * here until now.
+     *
+     * @return JSONResponse The initialisation result.
+     *
+     * @spec openspec/specs/admin-settings/spec.md
+     */
+    #[AuthorizedAdminSetting(DocuDeskAdmin::class)]
+    public function load(): JSONResponse
+    {
+        try {
+            $user = $this->userSession->getUser();
+            if ($user === null) {
+                return new JSONResponse(
+                    data: ['error' => 'Not authenticated'],
+                    statusCode: Http::STATUS_UNAUTHORIZED
+                );
+            }
+
+            if ($this->groupManager->isAdmin($user->getUID()) === false) {
+                return new JSONResponse(
+                    data: ['error' => 'Admin privileges required'],
+                    statusCode: Http::STATUS_FORBIDDEN
+                );
+            }
+
+            return new JSONResponse($this->settingsService->initialize());
+        } catch (Exception $e) {
+            $this->logger->error(
+                'Failed to load register configuration',
+                [
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }//end try
+
+    }//end load()
 }//end class

--- a/lib/Service/ProhibitionPolicyService.php
+++ b/lib/Service/ProhibitionPolicyService.php
@@ -49,7 +49,6 @@ use Throwable;
  */
 class ProhibitionPolicyService
 {
-
     /**
      * Constructor for ProhibitionPolicyService
      *

--- a/lib/Service/ProhibitionPolicyService.php
+++ b/lib/Service/ProhibitionPolicyService.php
@@ -32,8 +32,6 @@ namespace OCA\DocuDesk\Service;
 
 use Exception;
 use OCA\DocuDesk\Exception\ProhibitionGateException;
-use OCP\Files\IRootFolder;
-use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -53,24 +51,21 @@ class ProhibitionPolicyService
 {
 
     /**
-     * Guard for the per-relation skip decision taken in the review UI.
-     *
-     * @var RelationSkipDecisionService
-     */
-    private readonly RelationSkipDecisionService $skipDecisions;
-
-    /**
      * Constructor for ProhibitionPolicyService
      *
-     * @param LoggerInterface            $logger      Logger for best-effort policy failures.
-     * @param ContainerInterface         $container   Container the PolicyMatchService is resolved from.
-     * @param OpenRegisterServiceLocator $locator     Resolver for OpenRegister services and mappers.
-     * @param ProhibitionGateService     $gate        The gate that runs before any OpenRegister
-     *                                                interaction on an anonymise call.
-     * @param IUserSession               $userSession The acting session, forwarded to the skip-decision
-     *                                                ownership guard.
-     * @param IRootFolder                $rootFolder  Root folder, forwarded to the skip-decision
-     *                                                ownership guard.
+     * `$skipDecisions` is INJECTED rather than constructed here. It used to be
+     * `new`ed in this constructor, which meant every dependency it needed had to
+     * be threaded through this class as well — adding its authorisation
+     * collaborators (IUserSession + IRootFolder) that way pushed this class over
+     * PHPMD's CouplingBetweenObjects limit for dependencies it never uses.
+     * Letting the container build it keeps that coupling where it belongs.
+     *
+     * @param LoggerInterface             $logger        Logger for best-effort policy failures.
+     * @param ContainerInterface          $container     Container the PolicyMatchService is resolved from.
+     * @param OpenRegisterServiceLocator  $locator       Resolver for OpenRegister services and mappers.
+     * @param ProhibitionGateService      $gate          The gate that runs before any OpenRegister
+     *                                                   interaction on an anonymise call.
+     * @param RelationSkipDecisionService $skipDecisions Guard + apply for the per-relation skip decision.
      *
      * @return void
      */
@@ -79,16 +74,8 @@ class ProhibitionPolicyService
         private readonly ContainerInterface $container,
         private readonly OpenRegisterServiceLocator $locator,
         private readonly ProhibitionGateService $gate,
-        IUserSession $userSession,
-        IRootFolder $rootFolder
+        private readonly RelationSkipDecisionService $skipDecisions
     ) {
-        $this->skipDecisions = new RelationSkipDecisionService(
-            logger: $logger,
-            container: $container,
-            locator: $locator,
-            userSession: $userSession,
-            rootFolder: $rootFolder
-        );
 
     }//end __construct()
 

--- a/lib/Service/ProhibitionPolicyService.php
+++ b/lib/Service/ProhibitionPolicyService.php
@@ -32,6 +32,8 @@ namespace OCA\DocuDesk\Service;
 
 use Exception;
 use OCA\DocuDesk\Exception\ProhibitionGateException;
+use OCP\Files\IRootFolder;
+use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -60,11 +62,15 @@ class ProhibitionPolicyService
     /**
      * Constructor for ProhibitionPolicyService
      *
-     * @param LoggerInterface            $logger    Logger for best-effort policy failures.
-     * @param ContainerInterface         $container Container the PolicyMatchService is resolved from.
-     * @param OpenRegisterServiceLocator $locator   Resolver for OpenRegister services and mappers.
-     * @param ProhibitionGateService     $gate      The gate that runs before any OpenRegister
-     *                                              interaction on an anonymise call.
+     * @param LoggerInterface            $logger      Logger for best-effort policy failures.
+     * @param ContainerInterface         $container   Container the PolicyMatchService is resolved from.
+     * @param OpenRegisterServiceLocator $locator     Resolver for OpenRegister services and mappers.
+     * @param ProhibitionGateService     $gate        The gate that runs before any OpenRegister
+     *                                                interaction on an anonymise call.
+     * @param IUserSession               $userSession The acting session, forwarded to the skip-decision
+     *                                                ownership guard.
+     * @param IRootFolder                $rootFolder  Root folder, forwarded to the skip-decision
+     *                                                ownership guard.
      *
      * @return void
      */
@@ -72,12 +78,16 @@ class ProhibitionPolicyService
         private readonly LoggerInterface $logger,
         private readonly ContainerInterface $container,
         private readonly OpenRegisterServiceLocator $locator,
-        private readonly ProhibitionGateService $gate
+        private readonly ProhibitionGateService $gate,
+        IUserSession $userSession,
+        IRootFolder $rootFolder
     ) {
         $this->skipDecisions = new RelationSkipDecisionService(
             logger: $logger,
             container: $container,
-            locator: $locator
+            locator: $locator,
+            userSession: $userSession,
+            rootFolder: $rootFolder
         );
 
     }//end __construct()

--- a/lib/Service/ProhibitionPolicyService.php
+++ b/lib/Service/ProhibitionPolicyService.php
@@ -76,7 +76,6 @@ class ProhibitionPolicyService
         private readonly ProhibitionGateService $gate,
         private readonly RelationSkipDecisionService $skipDecisions
     ) {
-
     }//end __construct()
 
     /**

--- a/lib/Service/RelationSkipDecisionService.php
+++ b/lib/Service/RelationSkipDecisionService.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
 namespace OCA\DocuDesk\Service;
 
 use Exception;
+use OCP\Files\IRootFolder;
+use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -52,16 +54,20 @@ class RelationSkipDecisionService
     /**
      * Constructor for RelationSkipDecisionService
      *
-     * @param LoggerInterface            $logger    Logger for blocked decisions and outages.
-     * @param ContainerInterface         $container Container the PolicyMatchService is resolved from.
-     * @param OpenRegisterServiceLocator $locator   Resolver for OpenRegister services and mappers.
+     * @param LoggerInterface            $logger      Logger for blocked decisions and outages.
+     * @param ContainerInterface         $container   Container the PolicyMatchService is resolved from.
+     * @param OpenRegisterServiceLocator $locator     Resolver for OpenRegister services and mappers.
+     * @param IUserSession               $userSession The acting session, for the ownership guard + audit actor.
+     * @param IRootFolder                $rootFolder  Root folder, used to resolve the acting user's own file tree.
      *
      * @return void
      */
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly ContainerInterface $container,
-        private readonly OpenRegisterServiceLocator $locator
+        private readonly OpenRegisterServiceLocator $locator,
+        private readonly IUserSession $userSession,
+        private readonly IRootFolder $rootFolder
     ) {
         $this->tier = new ProhibitionSkipTier();
 
@@ -70,28 +76,53 @@ class RelationSkipDecisionService
     /**
      * Guard + apply a per-relation skip/include decision from the review UI.
      *
-     * Setting `skipAnonymization = true` on a prohibition-matched relation is
-     * guarded per {@see ProhibitionSkipTier::classify}. Include / non-skip
-     * decisions are always allowed. Allowed decisions are forwarded to
-     * OpenRegister via `updateDecisionMetadata` (so OR's audit-trail records the
-     * flip). A blocked decision performs no OpenRegister write.
+     * TWO independent guards run before any write:
+     *
+     *  1. Authorisation (`requireRelationAccess`). `EntityRelationMapper::find()`
+     *     is an unscoped primary-key lookup, so the caller-supplied `relationId`
+     *     addresses EVERY relation in the instance, not just the caller's own.
+     *     Without an ownership check this endpoint was an IDOR: any authenticated
+     *     user could flip `skipAnonymization` on a relation belonging to someone
+     *     else's document and thereby leave that document's PII un-redacted.
+     *     The relation carries the Nextcloud file id of the document it was
+     *     detected in, so access is decided the same way `AnonymizeRequestService
+     *     ::verifyFileAccess()` decides it for extract/anonymize — resolution
+     *     through the acting user's OWN file tree. A relation the caller cannot
+     *     reach returns the SAME 404 as a relation that does not exist, so the
+     *     endpoint is not an existence oracle.
+     *  2. Prohibition policy ({@see ProhibitionSkipTier::classify}) — unchanged.
+     *     Include / non-skip decisions are always allowed by this guard.
+     *
+     * Allowed decisions are forwarded to OpenRegister via
+     * `updateDecisionMetadata`, WITH the acting user, so OR's audit trail records
+     * who flipped the decision rather than an anonymous entry. A blocked decision
+     * performs no OpenRegister write.
      *
      * @param int        $relationId The EntityRelation id.
      * @param bool       $skip       The requested skipAnonymization value.
      * @param array|null $bases      Optional bases to set alongside the decision.
      * @param bool       $force      Release a sub-threshold prohibition match.
      *
-     * @return array{status: 200|404|422, body: array<string, mixed>} HTTP status + response body.
+     * @return array{status: 200|401|404|422, body: array<string, mixed>} HTTP status + response body.
      *
      * @spec openspec/changes/anonymisation-prohibition-gate/tasks.md#task-6
      */
     public function apply(int $relationId, bool $skip, ?array $bases, bool $force): array
     {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return ['status' => 401, 'body' => ['error' => 'Not authenticated']];
+        }
+
         $mapper = $this->locator->get(className: 'OCA\OpenRegister\Db\EntityRelationMapper');
 
         try {
             $relation = $mapper->find($relationId);
         } catch (Exception $e) {
+            return ['status' => 404, 'body' => ['error' => 'Entity relation not found']];
+        }
+
+        if ($this->requireRelationAccess(relation: $relation, userId: $user->getUID()) === false) {
             return ['status' => 404, 'body' => ['error' => 'Entity relation not found']];
         }
 
@@ -112,11 +143,48 @@ class RelationSkipDecisionService
             $fields['bases'] = $bases;
         }
 
-        $mapper->updateDecisionMetadata($relation, $fields);
+        $mapper->updateDecisionMetadata($relation, $fields, $user);
 
         return ['status' => 200, 'body' => ['status' => 'ok', 'skipAnonymization' => $skip]];
 
     }//end apply()
+
+    /**
+     * Whether the acting user may decide on this relation.
+     *
+     * The relation is reachable exactly when the document it was detected in is
+     * reachable, and a Nextcloud file is reachable exactly when it resolves
+     * inside the user's OWN folder tree — `IRootFolder::getById()` would search
+     * every storage and therefore answer for documents the caller has no claim
+     * to. A relation with no file id is unattributable and is refused.
+     *
+     * @param mixed  $relation The EntityRelation being decided.
+     * @param string $userId   UID of the acting user.
+     *
+     * @return bool True when the decision may proceed.
+     *
+     * @spec openspec/changes/anonymisation-prohibition-gate/tasks.md#task-6
+     */
+    private function requireRelationAccess(mixed $relation, string $userId): bool
+    {
+        $fileId = (int) $relation->getFileId();
+        if ($fileId === 0) {
+            return false;
+        }
+
+        try {
+            $nodes = $this->rootFolder->getUserFolder($userId)->getById($fileId);
+        } catch (Exception $e) {
+            $this->logger->warning(
+                'Relation decision denied: could not resolve the acting user file tree',
+                ['relationFileId' => $fileId, 'exception' => $e->getMessage()]
+            );
+            return false;
+        }
+
+        return empty($nodes) === false;
+
+    }//end requireRelationAccess()
 
     /**
      * Evaluate the prohibition guard for a skip on one relation.

--- a/tests/unit/Controller/SettingsControllerTest.php
+++ b/tests/unit/Controller/SettingsControllerTest.php
@@ -17,7 +17,17 @@
 
 namespace OCA\DocuDesk\Tests\Unit\Controller;
 
+use OCA\DocuDesk\Controller\SettingsController;
+use OCA\DocuDesk\Service\AnonymiserBackendStateClient;
+use OCA\DocuDesk\Service\SettingsService;
+use OCP\App\IAppManager;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 /**
  * Unit tests for SettingsController
@@ -85,6 +95,129 @@ class SettingsControllerTest extends TestCase
         $this->assertStringContainsString('function create()', $content);
 
     }//end testFileContainsCreateMethod()
+
+
+    /**
+     * `settings#update` (PUT /api/settings) is part of the canonical AppHost
+     * route table that `Routes::standard()` ships for EVERY app. This class had
+     * no `update()`, so the route resolved here and blew up on dispatch. It is
+     * the same admin-guarded write path as `create()`.
+     *
+     * @return void
+     */
+    public function testUpdateWritesSettingsForAnAdmin(): void
+    {
+        $settingsService = $this->createMock(SettingsService::class);
+        $settingsService->expects($this->once())
+            ->method('updateSettings')
+            ->willReturn(['grondslag' => 'AVG-6.1.c']);
+
+        $response = $this->controller(settingsService: $settingsService)->update();
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertSame(['grondslag' => 'AVG-6.1.c'], $response->getData());
+
+    }//end testUpdateWritesSettingsForAnAdmin()
+
+
+    /**
+     * `settings#load` (POST /api/settings/load) — likewise routed for every app
+     * and likewise missing here. Re-runs register/schema initialisation.
+     *
+     * @return void
+     */
+    public function testLoadReinitialisesTheRegisterForAnAdmin(): void
+    {
+        $settingsService = $this->createMock(SettingsService::class);
+        $settingsService->expects($this->once())
+            ->method('initialize')
+            ->willReturn(['success' => true]);
+
+        $response = $this->controller(settingsService: $settingsService)->load();
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertSame(['success' => true], $response->getData());
+
+    }//end testLoadReinitialisesTheRegisterForAnAdmin()
+
+
+    /**
+     * A non-admin gets 403 and NOTHING is initialised — the body gate, not just
+     * the attribute, has to hold.
+     *
+     * @return void
+     */
+    public function testLoadIsRefusedForANonAdmin(): void
+    {
+        $settingsService = $this->createMock(SettingsService::class);
+        $settingsService->expects($this->never())->method('initialize');
+
+        $response = $this->controller(settingsService: $settingsService, isAdmin: false)->load();
+
+        $this->assertSame(403, $response->getStatus());
+
+    }//end testLoadIsRefusedForANonAdmin()
+
+
+    /**
+     * With no session at all the answer is 401, and nothing is initialised.
+     *
+     * @return void
+     */
+    public function testLoadIsRefusedWithoutASession(): void
+    {
+        $settingsService = $this->createMock(SettingsService::class);
+        $settingsService->expects($this->never())->method('initialize');
+
+        $response = $this->controller(settingsService: $settingsService, user: null)->load();
+
+        $this->assertSame(401, $response->getStatus());
+
+    }//end testLoadIsRefusedWithoutASession()
+
+
+    /**
+     * Build a SettingsController over doubles.
+     *
+     * @param SettingsService $settingsService The settings service double.
+     * @param bool            $isAdmin         Whether the acting user is an admin.
+     * @param string|null     $user            UID of the acting user, or null for no session.
+     *
+     * @return SettingsController The controller under test.
+     */
+    private function controller(
+        SettingsService $settingsService,
+        bool $isAdmin=true,
+        ?string $user='alice'
+    ): SettingsController {
+        $userSession = $this->createMock(IUserSession::class);
+        if ($user === null) {
+            $userSession->method('getUser')->willReturn(null);
+        } else {
+            $actingUser = $this->createMock(IUser::class);
+            $actingUser->method('getUID')->willReturn($user);
+            $userSession->method('getUser')->willReturn($actingUser);
+        }
+
+        $groupManager = $this->createMock(IGroupManager::class);
+        $groupManager->method('isAdmin')->willReturn($isAdmin);
+
+        $request = $this->createMock(IRequest::class);
+        $request->method('getParams')->willReturn(['grondslag' => 'AVG-6.1.c']);
+
+        return new SettingsController(
+            'docudesk',
+            $request,
+            $this->createMock(IAppManager::class),
+            $groupManager,
+            $userSession,
+            new NullLogger(),
+            $settingsService,
+            $this->createMock(AnonymiserBackendStateClient::class),
+            $this->createMock(IConfig::class)
+        );
+
+    }//end controller()
 
 
 }//end class

--- a/tests/unit/Service/AnonymizationServiceTest.php
+++ b/tests/unit/Service/AnonymizationServiceTest.php
@@ -38,6 +38,7 @@ use OCA\DocuDesk\Service\PolicyMatchService;
 use OCA\DocuDesk\Service\ProhibitionGateService;
 use OCA\DocuDesk\Service\ProhibitionPolicyService;
 use OCA\DocuDesk\Service\ProhibitionSkipTier;
+use OCA\DocuDesk\Service\RelationSkipDecisionService;
 use OCA\DocuDesk\Service\ReplacementVerificationService;
 use OCA\OpenRegister\Db\EntityRelation;
 use OCA\OpenRegister\Db\EntityRelationMapper;
@@ -1230,8 +1231,13 @@ class AnonymizationServiceTest extends TestCase
                 container: $container,
                 locator: $locator
             ),
-            userSession: $this->grantingSession(),
-            rootFolder: $this->rootFolderResolving(self::RELATION_FILE_ID)
+            skipDecisions: new RelationSkipDecisionService(
+                logger: $logger,
+                container: $container,
+                locator: $locator,
+                userSession: $this->grantingSession(),
+                rootFolder: $this->rootFolderResolving(self::RELATION_FILE_ID)
+            )
         );
 
     }//end policyWithMatcher()

--- a/tests/unit/Service/AnonymizationServiceTest.php
+++ b/tests/unit/Service/AnonymizationServiceTest.php
@@ -43,6 +43,10 @@ use OCA\OpenRegister\Db\EntityRelation;
 use OCA\OpenRegister\Db\EntityRelationMapper;
 use OCP\App\IAppManager;
 use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -62,6 +66,18 @@ use Psr\Log\NullLogger;
 class AnonymizationServiceTest extends TestCase
 {
     use BuildsAnonymizationService;
+
+    /**
+     * The Nextcloud file id carried by the relation fixture — the acting user
+     * CAN reach this one.
+     */
+    private const RELATION_FILE_ID = 4242;
+
+    /**
+     * A file id the acting user can NOT reach; used to prove the relation
+     * ownership guard denies rather than merely existing.
+     */
+    private const FOREIGN_FILE_ID = 9999;
 
     /**
      * Test that the source file exists
@@ -630,7 +646,7 @@ class AnonymizationServiceTest extends TestCase
 
         $mapper = $this->mapperWithProhibitedRelation(0.62);
         $mapper->expects($this->once())->method('updateDecisionMetadata')
-            ->with($this->anything(), ['skipAnonymization' => true]);
+            ->with($this->anything(), ['skipAnonymization' => true], $this->anything());
         $allowed = $this->makeServiceWithMatcher($this->prohibitionMatcher(), $mapper)
             ->applyRelationSkipDecision(relationId: 7, skip: true, bases: null, force: true);
         $this->assertSame(200, $allowed['status']);
@@ -646,10 +662,13 @@ class AnonymizationServiceTest extends TestCase
     public function testIncludeDecisionIsAlwaysForwarded(): void
     {
         $relation = new EntityRelation();
-        $mapper   = $this->createMock(EntityRelationMapper::class);
+        $relation->setFileId(self::RELATION_FILE_ID);
+        $mapper = $this->createMock(EntityRelationMapper::class);
         $mapper->method('find')->with(7)->willReturn($relation);
+        // The acting user is forwarded as the audit actor: OpenRegister records
+        // every decision flip, and an entry with no actor is an audit gap.
         $mapper->expects($this->once())->method('updateDecisionMetadata')
-            ->with($relation, ['skipAnonymization' => false]);
+            ->with($relation, ['skipAnonymization' => false], $this->anything());
 
         $result = $this->makeServiceWithMatcher($this->prohibitionMatcher(), $mapper)
             ->applyRelationSkipDecision(relationId: 7, skip: false, bases: null, force: false);
@@ -657,6 +676,70 @@ class AnonymizationServiceTest extends TestCase
         $this->assertSame(200, $result['status']);
 
     }//end testIncludeDecisionIsAlwaysForwarded()
+
+    /**
+     * A relation whose document is NOT in the acting user's file tree is
+     * refused with the same 404 an unknown relation gets — and NOTHING is
+     * written.
+     *
+     * `EntityRelationMapper::find()` is an unscoped primary-key lookup, so
+     * without this guard the endpoint let any authenticated user flip
+     * `skipAnonymization` on someone else's document and leave its PII
+     * un-redacted (OWASP A01:2021, IDOR).
+     *
+     * @return void
+     */
+    public function testRelationOnAForeignDocumentIsRefusedAndWritesNothing(): void
+    {
+        $relation = new EntityRelation();
+        $relation->setFileId(self::FOREIGN_FILE_ID);
+
+        $mapper = $this->createMock(EntityRelationMapper::class);
+        $mapper->method('find')->with(7)->willReturn($relation);
+        $mapper->expects($this->never())->method('updateDecisionMetadata');
+
+        $service = $this->makeAnonymizationServiceFrom(
+            [
+                'logger'      => $this->createMock(LoggerInterface::class),
+                'container'   => $this->matcherContainer($this->prohibitionMatcher(), $mapper),
+                'appManager'  => $this->openRegisterAppManager(),
+                'userSession' => $this->grantingSession(),
+                // Resolves only RELATION_FILE_ID, so FOREIGN_FILE_ID is out of reach.
+                'rootFolder'  => $this->rootFolderResolving(self::RELATION_FILE_ID),
+            ]
+        );
+
+        $result = $service->applyRelationSkipDecision(relationId: 7, skip: false, bases: null, force: false);
+
+        $this->assertSame(404, $result['status']);
+
+    }//end testRelationOnAForeignDocumentIsRefusedAndWritesNothing()
+
+    /**
+     * With no signed-in user there is nobody to scope the document to, so the
+     * decision is refused 401 before the relation is even loaded.
+     *
+     * @return void
+     */
+    public function testRelationDecisionWithoutASessionIsRefused(): void
+    {
+        $mapper = $this->createMock(EntityRelationMapper::class);
+        $mapper->expects($this->never())->method('updateDecisionMetadata');
+
+        $service = $this->makeAnonymizationServiceFrom(
+            [
+                'logger'     => $this->createMock(LoggerInterface::class),
+                'container'  => $this->matcherContainer($this->prohibitionMatcher(), $mapper),
+                'appManager' => $this->openRegisterAppManager(),
+                // Default IUserSession mock: getUser() returns null.
+            ]
+        );
+
+        $result = $service->applyRelationSkipDecision(relationId: 7, skip: false, bases: null, force: false);
+
+        $this->assertSame(401, $result['status']);
+
+    }//end testRelationDecisionWithoutASessionIsRefused()
 
     /**
      * The policy pass flags prohibition matches (with the correct high/low
@@ -1065,13 +1148,63 @@ class AnonymizationServiceTest extends TestCase
     {
         return $this->makeAnonymizationServiceFrom(
             [
-                'logger'     => $this->createMock(LoggerInterface::class),
-                'container'  => $this->matcherContainer($matcher, $mapper),
-                'appManager' => $this->openRegisterAppManager(),
+                'logger'      => $this->createMock(LoggerInterface::class),
+                'container'   => $this->matcherContainer($matcher, $mapper),
+                'appManager'  => $this->openRegisterAppManager(),
+                'userSession' => $this->grantingSession(),
+                'rootFolder'  => $this->rootFolderResolving(self::RELATION_FILE_ID),
             ]
         );
 
     }//end makeServiceWithMatcher()
+
+    /**
+     * A session whose acting user is `alice`.
+     *
+     * @return IUserSession The session double.
+     */
+    private function grantingSession(): IUserSession
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+
+        return $session;
+
+    }//end grantingSession()
+
+    /**
+     * A root folder whose user folder resolves EXACTLY the given file id — any
+     * other id resolves to nothing, which is what "the file is not in this
+     * user's tree" looks like to the ownership guard.
+     *
+     * @param int $resolvableFileId The only file id this user can reach.
+     *
+     * @return IRootFolder The root-folder double.
+     */
+    private function rootFolderResolving(int $resolvableFileId): IRootFolder
+    {
+        $node = $this->createMock(File::class);
+
+        $userFolder = $this->createMock(Folder::class);
+        $userFolder->method('getById')->willReturnCallback(
+            static function (int $fileId) use ($resolvableFileId, $node) {
+                if ($fileId === $resolvableFileId) {
+                    return [$node];
+                }
+
+                return [];
+            }
+        );
+
+        $rootFolder = $this->createMock(IRootFolder::class);
+        $rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+        return $rootFolder;
+
+    }//end rootFolderResolving()
 
     /**
      * Build a ProhibitionPolicyService whose container resolves the matcher.
@@ -1096,7 +1229,9 @@ class AnonymizationServiceTest extends TestCase
                 appConfig: $this->createMock(\OCP\IAppConfig::class),
                 container: $container,
                 locator: $locator
-            )
+            ),
+            userSession: $this->grantingSession(),
+            rootFolder: $this->rootFolderResolving(self::RELATION_FILE_ID)
         );
 
     }//end policyWithMatcher()
@@ -1151,7 +1286,11 @@ class AnonymizationServiceTest extends TestCase
     private function mapperWithProhibitedRelation(float $confidence): EntityRelationMapper
     {
         // EntityRelation uses magic getters (can't be mocked); use a real one.
+        // The file id is what the ownership guard resolves against, so it must
+        // be set — and must DIFFER from the "foreign" id used by the denial
+        // tests, otherwise granting and denying look identical.
         $relation = new EntityRelation();
+        $relation->setFileId(self::RELATION_FILE_ID);
 
         $mapper = $this->createMock(EntityRelationMapper::class);
         $mapper->method('find')->with(7)->willReturn($relation);

--- a/tests/unit/Service/BuildsAnonymizationService.php
+++ b/tests/unit/Service/BuildsAnonymizationService.php
@@ -49,7 +49,9 @@ use OCA\DocuDesk\Service\ProhibitionGateService;
 use OCA\DocuDesk\Service\ProhibitionPolicyService;
 use OCA\DocuDesk\Service\ReplacementVerificationService;
 use OCP\App\IAppManager;
+use OCP\Files\IRootFolder;
 use OCP\IAppConfig;
+use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
 
@@ -64,7 +66,14 @@ trait BuildsAnonymizationService
      * Recognised `$deps` keys: logger, container, appManager, appConfig,
      * entityDetection, consentCrud, consentService, grondslagenSummary,
      * fileEntityStats, pdfConversion, emlAssembly, confidentialityLabel,
-     * dictionaryRunner. Anything omitted gets a permissive mock.
+     * dictionaryRunner, userSession, rootFolder. Anything omitted gets a
+     * permissive mock.
+     *
+     * NOTE on `userSession` / `rootFolder`: the DEFAULT mocks deny — an
+     * IUserSession mock returns null from getUser(), so the relation
+     * skip-decision ownership guard refuses. Tests that exercise that path must
+     * pass doubles that grant (see AnonymizationServiceTest::grantingSession()
+     * and ::rootFolderResolving()).
      *
      * @param array<string, object> $deps Dependency overrides.
      *
@@ -89,7 +98,9 @@ trait BuildsAnonymizationService
                 appConfig: $appConfig,
                 container: $container,
                 locator: $locator
-            )
+            ),
+            userSession: ($deps['userSession'] ?? $this->createMock(IUserSession::class)),
+            rootFolder: ($deps['rootFolder'] ?? $this->createMock(IRootFolder::class))
         );
 
         $anonymizeRunner = new DocumentAnonymizeRunner(

--- a/tests/unit/Service/BuildsAnonymizationService.php
+++ b/tests/unit/Service/BuildsAnonymizationService.php
@@ -47,6 +47,7 @@ use OCA\DocuDesk\Service\OpenRegisterServiceLocator;
 use OCA\DocuDesk\Service\PdfConversionService;
 use OCA\DocuDesk\Service\ProhibitionGateService;
 use OCA\DocuDesk\Service\ProhibitionPolicyService;
+use OCA\DocuDesk\Service\RelationSkipDecisionService;
 use OCA\DocuDesk\Service\ReplacementVerificationService;
 use OCP\App\IAppManager;
 use OCP\Files\IRootFolder;
@@ -99,8 +100,13 @@ trait BuildsAnonymizationService
                 container: $container,
                 locator: $locator
             ),
-            userSession: ($deps['userSession'] ?? $this->createMock(IUserSession::class)),
-            rootFolder: ($deps['rootFolder'] ?? $this->createMock(IRootFolder::class))
+            skipDecisions: new RelationSkipDecisionService(
+                logger: $logger,
+                container: $container,
+                locator: $locator,
+                userSession: ($deps['userSession'] ?? $this->createMock(IUserSession::class)),
+                rootFolder: ($deps['rootFolder'] ?? $this->createMock(IRootFolder::class))
+            )
         );
 
         $anonymizeRunner = new DocumentAnonymizeRunner(


### PR DESCRIPTION
## Why

The Hydra Gates enablement PRs touched only CI files, and most gates are **diff-scoped**. So on this repo the gates reported green in ~1.5 s having read no `lib/`, no `src/`, no `routes.php`:

```
[hydra-gates] Scope: diff vs origin/development — 3 changed file(s)
```

Re-run against the **full tree** (gate script `ConductionNL/.github@ad00986`, i.e. `main` — including #147/#148/#149 — with `ajv` installed), `origin/development` @ `0faba1c8`: **18 failing gates**. This PR closes the three that are security- or reachability-relevant.

> Measurement note: this is the **full-tree** number, not the in-CI one. The Hydra Gates job never runs `npm ci`, and every fleet repo still pins `hydra-gates-ref: v1.0.1` — which predates #147/#148/#149 — so the in-CI figure can legitimately differ.

## 1. IDOR on `PATCH /api/anonymization/relations/{id}` — gate-7

`AnonymizationController::updateRelation()` forwards a caller-supplied primary key through four services:

```
AnonymizationController::updateRelation($id)
  → AnonymizeRequestService::applyRelationDecision()
    → AnonymizationService::applyRelationSkipDecision()
      → ProhibitionPolicyService::applyRelationSkipDecision()
        → RelationSkipDecisionService::apply()
          → EntityRelationMapper::find($relationId)          ← unscoped PK lookup
          → EntityRelationMapper::updateDecisionMetadata()   ← write
```

**No step in that chain checked who was asking.** Any authenticated user could flip `skipAnonymization` (and `bases`) on a relation belonging to *someone else's* document — i.e. cause a third party's PII to be left un-redacted in an anonymised or published document. OWASP A01:2021.

The prohibition policy that does guard this path is a **content** policy, not an authorisation one: it constrains *which* entities may be skipped, never *whose*. `ProhibitionPolicyService` even documents the surrounding hole — *"OpenRegister's generic relation PATCH stays open, so a caller could skip a prohibited relation directly"* — but the DocuDesk endpoint itself was equally open.

The correct guard already existed one file away: `AnonymizeRequestService::verifyFileAccess()`, added for *"security finding C3 — file IDOR"*, and applied on `extract`/`anonymize`. The relation carries the document's Nextcloud file id, so the decision path now uses the same rule — resolution through the acting user's **own** file tree (`getUserFolder($uid)->getById()`), never `IRootFolder::getById()`, which searches every storage. An unreachable relation returns the **same 404** as a non-existent one, so this is not an existence oracle.

Also fixed here: `updateDecisionMetadata()` takes `?IUser $actingUser = null` and we passed nothing, so every audit entry for a decision flip had **no actor**. It now receives the acting user.

## 2. Three dead portal-signing routes — gate-5 + gate-14, in agreement

```php
['name' => 'portalsigningreceiver#signDocument',  ...]
```

Nextcloud builds the controller class with `ucfirst()` only — it does not re-case the rest — so this resolved to `PortalsigningreceiverController`, a class that does not exist. **View / sign / decline for external portal signers were unreachable.** Renamed to `portalSigningReceiver#…`.

This is precisely the trap the comment 30 lines further down already warns about for `preferences#…`.

## 3. Two canonical settings routes with no method — gate-5 + gate-14

`OCA\OpenRegister\AppHost\Routes::standard()` ships `settings#update` (PUT `/api/settings`) and `settings#load` (POST `/api/settings/load`) for **every** app. DocuDesk's `SettingsController` implemented only `index` + `create`, so both routes resolved to this class and blew up on dispatch. Added `update()` (same admin-guarded write path as `create()`, matching the canonical `GenericSettingsController`) and `load()` (re-runs register initialisation).

## Verification

- **Positive control.** The two new tests were confirmed to **fail** with the guard neutered. The failure output is the pre-fix behaviour, reproduced verbatim:
  ```
  EntityRelationMapper::updateDecisionMetadata(EntityRelation, [...], MockObject_IUser) was not expected to be called.
  EntityRelationMapper::updateDecisionMetadata(null, [...], null)                        was not expected to be called.
  ```
  The fixture file ids deliberately differ (`4242` reachable vs `9999` foreign) so granting and denying cannot look identical.
- Full unit suite: **1129 tests, 3460 assertions, green.**
- `phpcs` on the changed `lib/` files: clean; identical before/after on `appinfo/routes.php` (100 pre-existing errors there, and `appinfo/` is outside this repo's phpcs scope).
- Hydra gates, full tree: **18 → 16** failing. gate-5 `5 → PASS`, gate-14 `5 → PASS`, gate-7 `2 → 1`.

## Not fixed here

The remaining gate-7 finding, `EmlPreviewController::preview(int $fileId)`, streams an **un-redacted** PDF of an arbitrary file id via OpenRegister's `FileService::getFileById()`, whose ownership check is `$node->isReadable()` on a node from the **root** view. Whether that is user-scoped in practice needs a live check before anything is changed, so it is deliberately untouched and reported instead.

No gate was silenced, baselined, excluded or weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## CI state on this branch (read before merging)

Green, with one exception that is **pre-existing on the base**:

```
quality / Integration Tests (Newman)   FAIL
```

That job also fails on `development` at this PR's base commit `0faba1c8` — verified against run `30943918653`. Nothing here touches it.

Going the other way: `quality / Hydra Gates` **fails on `development` and passes on this branch**, and `phpcs`, `phpmd`, `phpstan`, `psalm`, `PHPUnit` (1133 tests) and the coverage ratchet all pass.

The coverage ratchet is worth a note. The first push dropped coverage 0.09% and the job went red. The baseline was **not** lowered — `SettingsControllerTest` was four `assertStringContainsString('function index()', $content)` assertions that executed no controller code, so the new `update()`/`load()` landed uncovered. It now has behavioural tests: the admin write path, the admin initialise path, the non-admin 403 and the no-session 401, each asserting `SettingsService` is **not** touched on the denial branches.
