### PR TITLE
fix(a11y): give every unlabelled form control a programmatic label (gate-40)

### DIFF
--- a/l10n/en.json
+++ b/l10n/en.json
@@ -855,7 +855,15 @@
         "Valid from": "Valid from",
         "Version number": "Version number",
         "Warnings": "Warnings",
-        "Branding Configuration": "Branding Configuration"
+        "Branding Configuration": "Branding Configuration",
+        "File ID to verify": "File ID to verify",
+        "Folder path to analyse": "Folder path to analyse",
+        "Include {entity} in anonymisation": "Include {entity} in anonymisation",
+        "Search entities": "Search entities",
+        "Select {document}": "Select {document}",
+        "Select {row}": "Select {row}",
+        "Select files to anonymise": "Select files to anonymise",
+        "Skip {entity}": "Skip {entity}"
     },
     "pluralForm": "nplurals=2; plural=(n != 1);"
 }

--- a/src/components/DdDataTable.vue
+++ b/src/components/DdDataTable.vue
@@ -40,6 +40,7 @@
 					@click="$emit('row-click', row)">
 					<td v-if="selectable" class="dd-data-table__td dd-data-table__td--select" @click.stop>
 						<NcCheckboxRadioSwitch
+							:aria-label="rowSelectLabel(row)"
 							:model-value="isSelected(row)"
 							@update:modelValue="$emit('toggle-select', row)" />
 					</td>
@@ -64,6 +65,7 @@
 </template>
 
 <script>
+import { translate as t } from '@nextcloud/l10n'
 import { NcLoadingIcon, NcCheckboxRadioSwitch } from '@nextcloud/vue'
 
 /**
@@ -170,6 +172,28 @@ export default {
 				return key.split('.').reduce((obj, k) => obj?.[k], row)
 			}
 			return row[key]
+		},
+		/**
+		 * Accessible name for a row's select checkbox.
+		 *
+		 * Without one, every row's checkbox announces as an unnamed
+		 * "checkbox, not checked" — on a twenty-row table that is twenty
+		 * indistinguishable controls (WCAG 2.2 AA SC 4.1.2). The first
+		 * column's rendered value is used because it is what identifies the
+		 * row on screen, so what is announced matches what is read; the row
+		 * key is the fallback when that cell is empty.
+		 *
+		 * @param {object} row Row object.
+		 * @return {string} Label such as `Select invoice-2026-01`.
+		 *
+		 * @spec exclude Generic presentational label derivation for a table row checkbox; no domain semantics.
+		 */
+		rowSelectLabel(row) {
+			const first = this.columns.length ? this.getCellValue(row, this.columns[0].key) : undefined
+			const name = (first === undefined || first === null || first === '')
+				? row[this.rowKey]
+				: first
+			return t('docudesk', 'Select {row}', { row: String(name ?? '') })
 		},
 	},
 }

--- a/src/views/anonymization/AnonymizationWidget.vue
+++ b/src/views/anonymization/AnonymizationWidget.vue
@@ -30,6 +30,7 @@ import { anonymizationStore, fileViewerStore, myDocumentsStore } from '../../sto
 					ref="fileInput"
 					type="file"
 					multiple
+					:aria-label="t('docudesk', 'Select files to anonymise')"
 					accept=".docx,.odt,.txt,.pdf,.eml,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text,text/plain,application/pdf,message/rfc822"
 					class="file-input"
 					@change="handleFileSelect">

--- a/src/views/anonymization/EntityReviewTable.vue
+++ b/src/views/anonymization/EntityReviewTable.vue
@@ -4,7 +4,10 @@
 			{{ t('docudesk', '{selected} of {total} entities selected across {files} files', { selected: selectedCount, total: entities.length, files: fileCount }) }}
 		</div>
 		<div class="filter-bar">
-			<input v-model="searchQuery" type="text" :placeholder="t('docudesk', 'Search entities...')">
+			<input v-model="searchQuery"
+				type="text"
+				:aria-label="t('docudesk', 'Search entities')"
+				:placeholder="t('docudesk', 'Search entities...')">
 			<select v-model="typeFilter">
 				<option value="">
 					{{ t('docudesk', 'All types') }}
@@ -44,7 +47,12 @@
 			</thead>
 			<tbody>
 				<tr v-for="item in filteredEntities" :key="item.idx">
-					<td><input type="checkbox" :checked="item.e.included" @change="$emit('toggle', item.idx)"></td>
+					<td>
+						<input type="checkbox"
+							:aria-label="t('docudesk', 'Include {entity} in anonymisation', { entity: item.e.value })"
+							:checked="item.e.included"
+							@change="$emit('toggle', item.idx)">
+					</td>
 					<td><span class="badge">{{ entityTypeLabel(item.e.type) }}</span></td><td>{{ item.e.value }}</td>
 					<td>{{ ((item.e.highestConfidence||0)*100).toFixed(1) }}%</td><td>{{ item.e.fileCount }}</td>
 					<td class="bases-cell">
@@ -67,6 +75,7 @@
 					</td>
 					<td>
 						<NcCheckboxRadioSwitch
+							:aria-label="t('docudesk', 'Skip {entity}', { entity: item.e.value })"
 							:model-value="!!item.e._decisionSkip"
 							:disabled="!Array.isArray(item.e.relationIds) || item.e.relationIds.length === 0 || !!(item.e.prohibitionMatch && item.e.prohibitionMatch.highConfidence)"
 							@update:modelValue="onSkipChange(item.idx, $event)" />

--- a/src/views/anonymization/FolderAnonymizationView.vue
+++ b/src/views/anonymization/FolderAnonymizationView.vue
@@ -9,6 +9,7 @@
 				<input
 					v-model="folderPath"
 					type="text"
+					:aria-label="t('docudesk', 'Folder path to analyse')"
 					:placeholder="t('docudesk', 'e.g. Documents/contracts')"
 					class="folder-path-input"
 					@keyup.enter="startAnalysis">

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -39,6 +39,7 @@
 					{{ t('docudesk', 'Show anonymiser backend warning') }}
 				</div>
 				<NcCheckboxRadioSwitch
+					:aria-label="t('docudesk', 'Show anonymiser backend warning')"
 					:model-value="false"
 					type="switch"
 					@update:modelValue="resetAnonymiserWarning" />
@@ -125,6 +126,7 @@
 					{{ t('docudesk', 'Language Detection') }}
 				</div>
 				<NcCheckboxRadioSwitch
+					:aria-label="t('docudesk', 'Language Detection')"
 					:model-value="settings.enable_language_detection"
 					type="switch"
 					@update:modelValue="settings.enable_language_detection = $event" />
@@ -138,6 +140,7 @@
 					{{ t('docudesk', 'Keyword Extraction') }}
 				</div>
 				<NcCheckboxRadioSwitch
+					:aria-label="t('docudesk', 'Keyword Extraction')"
 					:model-value="settings.enable_keyword_extraction"
 					type="switch"
 					@update:modelValue="settings.enable_keyword_extraction = $event" />
@@ -151,6 +154,7 @@
 					{{ t('docudesk', 'Topic Classification') }}
 				</div>
 				<NcCheckboxRadioSwitch
+					:aria-label="t('docudesk', 'Topic Classification')"
 					:model-value="settings.enable_topic_classification"
 					type="switch"
 					@update:modelValue="settings.enable_topic_classification = $event" />
@@ -181,6 +185,7 @@
 					{{ t('docudesk', 'Enable OCR') }}
 				</div>
 				<NcCheckboxRadioSwitch
+					:aria-label="t('docudesk', 'Enable OCR')"
 					:model-value="settings.ocr_enabled"
 					type="switch"
 					@update:modelValue="settings.ocr_enabled = $event" />
@@ -252,6 +257,7 @@
 					{{ t('docudesk', 'Prioritise higher-confidentiality files in batch/folder analysis') }}
 				</div>
 				<NcCheckboxRadioSwitch
+					:aria-label="t('docudesk', 'Prioritise higher-confidentiality files in batch/folder analysis')"
 					:model-value="settings['docudesk.confidentiality.prioritise_analysis']"
 					type="switch"
 					@update:modelValue="settings['docudesk.confidentiality.prioritise_analysis'] = $event" />
@@ -346,6 +352,7 @@
 					{{ t('docudesk', 'Enable Digital Signing') }}
 				</div>
 				<NcCheckboxRadioSwitch
+					:aria-label="t('docudesk', 'Enable Digital Signing')"
 					:model-value="settings.signing_enabled"
 					type="switch"
 					@update:modelValue="settings.signing_enabled = $event" />

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -902,7 +902,7 @@ export default {
 		 * by `saveAll`). Invalid JSON shows an inline error and leaves the
 		 * previously-saved vocabulary untouched (files-confidential-labels).
 		 *
-		 * @spec openspec/changes/files-confidential-labels/specs/files-confidential-labels/spec.md#requirement-read-a-files-confidentiality-label-availability-guarded-req-ddfcl-001
+		 * @spec openspec/specs/files-confidential-labels/spec.md#requirement-read-a-files-confidentiality-label-availability-guarded-req-ddfcl-001
 		 */
 		onConfidentialityVocabularyBlur() {
 			let parsed

--- a/src/views/signing/BulkSigningPanel.vue
+++ b/src/views/signing/BulkSigningPanel.vue
@@ -18,7 +18,11 @@
 				</thead>
 				<tbody>
 					<tr v-for="req in pending" :key="req.id || req.uuid" @click="toggle(req.id || req.uuid)">
-						<td><input type="checkbox" :checked="selected.includes(req.id || req.uuid)"></td>
+						<td>
+							<input type="checkbox"
+								:aria-label="t('docudesk', 'Select {document}', { document: req.documentName })"
+								:checked="selected.includes(req.id || req.uuid)">
+						</td>
 						<td>{{ req.documentName }}</td>
 						<td>{{ req.signatureLevel }}</td>
 					</tr>

--- a/src/views/signing/SignatureVerification.vue
+++ b/src/views/signing/SignatureVerification.vue
@@ -2,7 +2,10 @@
 	<div class="signature-verification">
 		<h2>{{ t('docudesk', 'Signature Verification') }}</h2>
 		<div class="verify-form">
-			<input v-model="verifyFileId" type="text" :placeholder="t('docudesk', 'Enter file ID')">
+			<input v-model="verifyFileId"
+				type="text"
+				:aria-label="t('docudesk', 'File ID to verify')"
+				:placeholder="t('docudesk', 'Enter file ID')">
 			<NcButton variant="primary" :disabled="!verifyFileId" @click="verify">
 				{{ t('docudesk', 'Verify') }}
 			</NcButton>

--- a/src/views/signing/SigningRequestForm.vue
+++ b/src/views/signing/SigningRequestForm.vue
@@ -5,12 +5,12 @@
 			{{ t('docudesk', 'This composes a draft signing request only. Sending for signature, provider binding and signer-identity assertion are not available yet — the signature level below records your intent but is not yet cryptographically enforced.') }}
 		</NcNoteCard>
 		<div class="form-group">
-			<label>{{ t('docudesk', 'Document File ID') }}</label>
-			<input v-model="form.documentFileId" type="text">
+			<label for="signing-request-document-file-id">{{ t('docudesk', 'Document File ID') }}</label>
+			<input id="signing-request-document-file-id" v-model="form.documentFileId" type="text">
 		</div>
 		<div class="form-group">
-			<label>{{ t('docudesk', 'Document Name') }}</label>
-			<input v-model="form.documentName" type="text">
+			<label for="signing-request-document-name">{{ t('docudesk', 'Document Name') }}</label>
+			<input id="signing-request-document-name" v-model="form.documentName" type="text">
 		</div>
 		<div class="form-group">
 			<label>{{ t('docudesk', 'Signature Level') }}</label>

--- a/src/views/widgets/AnonymizationDashboardWidget.vue
+++ b/src/views/widgets/AnonymizationDashboardWidget.vue
@@ -110,6 +110,7 @@ import { anonymizationStore } from '../../store/store.js'
 					ref="fileInput"
 					type="file"
 					multiple
+					:aria-label="t('docudesk', 'Select files to anonymise')"
 					accept=".docx,.txt,.pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain,application/pdf"
 					class="file-input"
 					@change="handleFileSelect">


### PR DESCRIPTION

Eighteen form controls in the DocuDesk UI reached a screen reader with no
accessible name. Seven are admin settings switches, four are per-row
selection checkboxes, four are free-text fields carrying only a placeholder,
two are file pickers, and one is a generic table's row-select control.

A control with no programmatic label is announced as bare "checkbox, not
checked" or "edit text, blank". On the Settings page that means seven
consecutive unnamed switches; on a signing or entity-review table it means
one indistinguishable checkbox per row. WCAG 2.2 AA SC 1.3.1 (Info and
Relationships), 3.3.2 (Labels or Instructions) and 4.1.2 (Name, Role,
Value) — the fleet states AA as a requirement.

## What changed

`NcCheckboxRadioSwitch` has no `label` prop: it takes its accessible name
from its default slot and wires `aria-labelledby` to it internally. All the
switches fixed here are self-closing, so that wiring had nothing to point
at. Each now carries an `:aria-label`.

- **Settings.vue** — 7 switches. Each sits under a `<div class="setting-label">`
  which, being a `div` and not a `label`, creates no association at all. The
  aria-label reuses that div's exact text, so the announced name and the
  visible name are the same string (and an existing l10n key).
- **DdDataTable.vue** — the header select-all already had `selectAllLabel`;
  the per-row checkbox had nothing. Adds a `rowSelectLabel(row)` method that
  derives the name from the FIRST COLUMN's rendered value — what identifies
  the row on screen — falling back to `row[rowKey]`. Needed a
  `translate as t` import, which the file did not have.
- **EntityReviewTable.vue** — the include checkbox and the skip switch are
  now named after the entity they act on (`item.e.value`); the search field
  gets a label beside its placeholder.
- **BulkSigningPanel.vue** — per-row checkbox named after `req.documentName`.
- **SigningRequestForm.vue** — two fields had adjacent `<label>` elements
  with no `for`, so the association was visual only. Paired via `for`/`id`
  rather than aria-label: a real `<label>` was already there.
- **SignatureVerification.vue**, **FolderAnonymizationView.vue** — fields
  that had only a placeholder. The placeholder is kept and a label added: a
  placeholder is not a label, it is not reliably exposed as an accessible
  name, and it vanishes as soon as the user types — so the field goes
  anonymous exactly when it holds data.
- **AnonymizationWidget.vue**, **AnonymizationDashboardWidget.vue** — the
  visually-hidden `<input type="file">` behind the drop zone.

Eight new source strings registered in `l10n/en.json` via the repo's own
`node tests/l10n/check-l10n.js --write`.

## Not changed, and why

Gate-40 reports 38 findings on this tree. Eighteen were real and are fixed;
the remaining 20 are gate false positives, left alone rather than papered
over:

- **13 × `NcCheckboxRadioSwitch` with a non-empty default slot** — already
  labelled the way the component's API intends; the gate looks for a `label=`
  prop that does not exist on it.
- **5 × implicit `<label>` wrapping** — `<label><span>Name</span><input></label>`
  in FolderAnonymizationView. Conformant HTML; the gate only implements the
  explicit `for`/`id` form.
- **2 × non-markup text** — `DdToggle.vue`'s JSDoc documents its own markup
  as `` `<input type="checkbox">` `` in a prose paragraph, and the gate scans
  raw file text. That component's real input IS inside its `<label>` and is
  correctly labelled.

Evidence for all three filed on ConductionNL/.github#158. No gate was
suppressed, baselined, excluded or weakened.

## Verification

Identically conditioned before and after, same worktree, one `npm ci`:

| check | before (origin/development @ d8136f80) | after |
|---|---|---|
| `vitest run` | 7 files, 45 tests, all pass | 7 files, 45 tests, all pass |
| `jest` | 7 suites, 77 tests, all pass | 7 suites, 77 tests, all pass |
| `eslint src` | 0 errors, 160 warnings | 0 errors, 160 warnings |
| `test:l10n` | OK | OK (8 keys added) |
| `check:manifest` | Ajv PASS (0 errors) | Ajv PASS (0 errors) |
| gate-40 | 38 | 20, all 20 confirmed false positives |

