### PR TITLE
chore(license): normalise licence declarations to EUPL-1.2

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 DocuDesk Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Playwright config for DocuDesk.
  *

--- a/tests/e2e/base-url.ts
+++ b/tests/e2e/base-url.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 DocuDesk Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * The ONE place the e2e suite decides which Nextcloud it talks to.
  *

--- a/tests/e2e/docs-screenshots.spec.ts
+++ b/tests/e2e/docs-screenshots.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 DocuDesk Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Documentation screenshot capture suite — docudesk.
  *

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 DocuDesk Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Playwright globalSetup — logs into Nextcloud once and persists the
  * resulting cookie jar / localStorage to `tests/e2e/.auth/admin.json`.

--- a/tests/e2e/visual/_visual-helpers.ts
+++ b/tests/e2e/visual/_visual-helpers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Shared helpers for the visual-regression layer (GAP-5).
  *

--- a/tests/e2e/visual/docudesk.visual.spec.ts
+++ b/tests/e2e/visual/docudesk.visual.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Visual-regression baselines for DocuDesk's key surfaces (GAP-5).
  *


### PR DESCRIPTION
## What

The app is licensed **EUPL-1.2** — `composer.json`, `package.json`, `package-lock.json`, `appinfo/info.xml` and the bundled `LICENSE` all say so — but six test/config files still carried `AGPL-3.0-or-later` SPDX headers left over from the Nextcloud app template. A licence header is a legal claim, so a repo that states two different licences about itself is a real defect, not a lint nit.

### Changed (6 files, all `SPDX-License-Identifier: AGPL-3.0-or-later` → `EUPL-1.2`)
- `playwright.config.ts`
- `tests/e2e/base-url.ts`
- `tests/e2e/docs-screenshots.spec.ts`
- `tests/e2e/global-setup.ts`
- `tests/e2e/visual/_visual-helpers.ts`
- `tests/e2e/visual/docudesk.visual.spec.ts`

No `@copyright` / `SPDX-FileCopyrightText` line was touched — this normalises the **licence** only. The diff is six single-line comment changes and nothing else.

### Nothing was left behind
Every `lib/**/*.php` file already declared `EUPL-1.2`, and after this change a repo-wide grep for `AGPL`/`GPL`/`MIT`/`Apache`/`BSD` SPDX identifiers, `@license AGPL|GPL|https`, and the trailing-period `EUPL-1.2.` form returns **zero hits** across all tracked files. docudesk has no vendored third-party source carrying a foreign licence header, so unlike some sibling repos there is no do-not-touch carve-out here.

## Verification

| check | before | after |
|---|---|---|
| PHPUnit (PHP 8.4) | **1133 tests, 3470 assertions, 2 deprecations, 1 skipped** | **1133 tests, 3470 assertions, 2 deprecations, 1 skipped** |
| vitest | **45 passed (7 files)** | **45 passed (7 files)** |
| hydra gate-28 `license-triangle` | PASS | PASS |

Gate-28 was already passing here — this PR does not flip it, it removes the AGPL claims the gate never looked at (the gate only reads the first `@license` tag of each `lib/**.php` file, so a green gate-28 is not evidence a repo is licence-clean).

PHPUnit was run under PHP 8.4; host PHP is 8.2 and aborts on `platform_check` with exit 255, which is a VOID run rather than a verdict. Gate-28 was run with an isolated findings log because the gate hardcodes `/tmp/hydra-gate-license-triangle.log` and concurrent runs contaminate it.