### PR TITLE
chore(license): openapi.json still declared 'agpl'

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "DocuDesk",
         "license": {
-            "name": "agpl"
+            "name": "EUPL-1.2"
         }
     },
     "components": {


### PR DESCRIPTION
Follow-up to #388.

`openapi.json`'s `info.license.name` said `"agpl"` while `composer.json`, `package.json`, `appinfo/info.xml`, the bundled `LICENSE` and every source header say **EUPL-1.2**.

```diff
         "license": {
-            "name": "agpl"
+            "name": "EUPL-1.2"
         }
```

Every generated client, API portal and spec viewer reads `info.license.name`, so this is a licence claim actively shipped to consumers of the API.

#388 missed it, and it is worth saying why: that sweep grepped for `SPDX-License-Identifier:` and `@license` tags. This one is a lowercase JSON value in a completely different shape, so a header-shaped grep could never have found it. Same miss existed in openconnector and zaakafhandelapp and is being fixed there too.

`openapi.json` re-validated as JSON after the edit. No behaviour change.