### PR TITLE
fix(apphost): register OpenRegister's autoloader before touching AppHost

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -69,6 +69,23 @@ class Application extends App implements IBootstrap
      */
     public function register(IRegistrationContext $context): void
     {
+        // LOAD-ORDER HAZARD: OC_App::getEnabledApps() sort()s the app list and
+        // Coordinator::registerApps() calls registerAutoloading() then register()
+        // one app at a time, so this method runs BEFORE OCA\OpenRegister\ is
+        // autoloadable (this app sorts before `openregister`). Any AppHost
+        // reference here — including a class_exists() probe — therefore answers
+        // FALSE on a perfectly healthy instance. Put OpenRegister's prefix on the
+        // autoloader ourselves; registerAutoloading() touches only the autoloader
+        // and is idempotent ($alreadyRegistered key guard). Deliberately NOT
+        // IAppManager::loadApp(), which would mark OpenRegister loaded and boot it
+        // before its own register() had run.
+        try {
+            $openRegisterPath = \OCP\Server::get(\OCP\App\IAppManager::class)->getAppPath('openregister');
+            \OC_App::registerAutoloading('openregister', $openRegisterPath);
+        } catch (\Throwable) {
+            // OpenRegister absent/disabled — fall through to the degraded path.
+        }
+
         $bootstrap = new RegistrationBootstrap();
         $bootstrap->register(context: $context);
 


### PR DESCRIPTION
## The defect

`OC_App::getEnabledApps()` ends with `sort($apps)` (`lib/private/legacy/OC_App.php:193`). `Coordinator::registerApps()` (`lib/private/AppFramework/Bootstrap/Coordinator.php:71-112`) walks that **sorted** list one app at a time, calling `OC_App::registerAutoloading($appId, $path)` and then immediately `$application->register()` for that same app before moving on.

So each app's `register()` runs **before** the PSR-4 prefix of every alphabetically-later app has been put on the autoloader. `docudesk` < `openregister`, therefore `OCA\OpenRegister\` is **not autoloadable inside `Application::register()`** — on a completely healthy instance with OpenRegister installed and enabled.

Consequences:

- `class_exists('OCA\OpenRegister\AppHost\...')` answers **FALSE** at register() time. A `class_exists()` guard is not a probe of "is OpenRegister installed?", it is a probe of "have we reached OpenRegister in the sorted loop yet?" — and the answer is always no.
- An *unguarded* reference throws an `\Error`, which aborts the **entire** `register()`. The Coordinator catches it, logs an `emergency`, and continues — so the app stays enabled and looks perfectly fine while half its wiring silently never registered. This is a fail-silent mode, not a crash.

`docudesk` reaches AppHost from `lib/AppInfo/ObservabilityRegistrar.php` and `lib/AppInfo/MetricsEngineFactory.php`, both driven off `RegistrationBootstrap` which this `register()` invokes. Most of those references sit inside lazy service closures which resolve long after boot and are fine today. This prelude is cheap insurance that makes the whole registration path order-independent regardless of how those references move in future.

## The fix

Put OpenRegister's prefix on the autoloader ourselves, as the very first thing in `register()` — before `RegistrationBootstrap` runs:

```php
try {
    $openRegisterPath = \OCP\Server::get(\OCP\App\IAppManager::class)->getAppPath('openregister');
    \OC_App::registerAutoloading('openregister', $openRegisterPath);
} catch (\Throwable) {
    // OpenRegister absent/disabled — fall through to the degraded path.
}
```

### Why `registerAutoloading()` and not `IAppManager::loadApp()`

`loadApp()` would mark OpenRegister as loaded **and boot it** — running its `register()`/`boot()` out of order, from inside our own `register()`. That is a far worse ordering violation than the one being fixed, and it would make OpenRegister's own Coordinator entry a no-op later.

`OC_App::registerAutoloading()` touches **only** the autoloader. It is idempotent: `lib/private/legacy/OC_App.php:104-110` guards on a `self::$alreadyRegistered[$key]` map, so OpenRegister's own turn in the Coordinator loop is a cheap no-op rather than a double registration.

The `catch (\Throwable)` keeps the existing degraded path intact when OpenRegister is genuinely absent or disabled — `IAppManager::getAppPath()` throws `AppPathNotFoundException` in that case.

## Verified

- Core mechanism read directly from the running instance, not from memory:
  - `OC_App::registerAutoloading(string $app, string $path, bool $force = false): void` at `lib/private/legacy/OC_App.php:104`, with the `self::$alreadyRegistered` guard at lines 43/106/110 — the idempotence claim in the comment is real.
  - `IAppManager::getAppPath(string $appId, bool $ignoreCache = false): string` at `lib/public/App/IAppManager.php:177`, `@throws AppPathNotFoundException` — so the `catch` is the right shape.
- `php -l` clean, both locally (PHP 8.2) and inside the Nextcloud container (PHP 8.4.22).
- **PHPCS: 0 errors.** Run with this repo's own `vendor/bin/phpcs` (3.13.5) and its own `phpcs.xml` + `phpcs-custom-sniffs/`, including the error-level `NamedParametersSniff`.
  - Baseline on the **unmodified** file: 0 errors, 3 `@spec` warnings (class, `register()`, `boot()`).
  - After this change: 0 errors, the **same** 3 pre-existing `@spec` warnings. This change introduces nothing new.

## Not verified

Runtime behaviour was not exercised — the fix was not booted on a live instance, and no test asserts the ordering. The reasoning rests on the core source read above.

## Scope

One file, one hunk. No reformatting, no removed guards, no touched comments, no route-file changes (`appinfo/routes.php` is loaded by the router long after every app has registered and is safe by timing).
