### PR TITLE
ci(newman): seed the OpenRegister bindings the collection writes through

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -103,6 +103,34 @@ jobs:
       # recursively.
       enable-newman: true
 
+      # The Newman job needs the SAME provisioning the Playwright job gets, and
+      # for the same reason: DocuDesk resolves every template / consent /
+      # signing write through app-config bindings
+      # (`<schemaSlug>_register` / `_schema`) that an ADMINISTRATOR sets in the
+      # admin settings UI. Nothing auto-provisions them on a fresh install
+      # except `templateVersion_*`. `newman-seed-command` was never set, so the
+      # collection ran against an instance where they were all empty.
+      #
+      # Measured on run 31074205317 (job 92528887929, branch development):
+      # 19 of 66 assertions failed, and every one of them traced to that.
+      # `OpenRegisterResolver::getRegisterAndSchema()` throws
+      # RegisterNotConfiguredException with code 0, so
+      # `TemplateRequestHandler::buildErrorResponse()` maps it to 500 — hence
+      # the 500s on template create/show/update/delete and on signing
+      # create/show/cancel. Consent has its own shape:
+      # `ConsentController::notConfiguredResponse()` answers 400, which is the
+      # two `/api/consents` failures. The two endpoints that DID pass
+      # (`GET /api/templates`, `GET /api/signing/requests`) are precisely the
+      # two that catch RegisterNotConfiguredException and return an empty
+      # `notConfigured: true` list — a green assertion over a store the
+      # collection could never write to.
+      #
+      # `ci-seed.sh` already documents and performs exactly this provisioning
+      # for Playwright; the `api` argument reuses it verbatim and only skips
+      # the closing SPA-bundle gate, which would `exit 1` here because the
+      # Newman job has no frontend build step.
+      newman-seed-command: 'bash apps/docudesk/tests/e2e/ci-seed.sh api'
+
       # ── Coverage ratchet ─────────────────────────────────────────────────
       # `enable-coverage-guard` defaults to FALSE, which is why both
       # "Coverage Baseline Protection" and "Coverage Baseline Check" have only

--- a/tests/e2e/ci-seed.sh
+++ b/tests/e2e/ci-seed.sh
@@ -5,13 +5,19 @@
 #
 # Provision DocuDesk's OpenRegister registers + schemas, and the app-config
 # object-type bindings that depend on them, on a freshly installed Nextcloud
-# for the shared `E2E Tests (Playwright)` CI job.
+# for the shared `E2E Tests (Playwright)` and `Integration Tests (Newman)` CI
+# jobs.
 #
-# Wired up as the workflow's `playwright-seed-command`. That step runs AFTER
-# `php -S` is up and with cwd set to the Nextcloud server root, so this is
-# invoked as:
+# Wired up as the workflow's `playwright-seed-command` / `newman-seed-command`.
+# Both steps run AFTER `php -S` is up and with cwd set to the Nextcloud server
+# root, so this is invoked as:
 #
 #     playwright-seed-command: 'bash apps/docudesk/tests/e2e/ci-seed.sh'
+#     newman-seed-command:     'bash apps/docudesk/tests/e2e/ci-seed.sh api'
+#
+# The optional first argument selects the MODE — see "Mode" below. Everything
+# that provisions state is shared; the only difference is the SPA bundle gate,
+# which is meaningless for an API-only suite that never renders a page.
 #
 # WHY THIS IS NEEDED — TWO SEPARATE GAPS
 # --------------------------------------
@@ -62,6 +68,31 @@
 # re-verifies.
 
 set -euo pipefail
+
+# ── Mode ─────────────────────────────────────────────────────────────────────
+# `e2e` (default) — the Playwright job. Everything below runs, including the
+#                   final GATE that the DocuDesk frontend bundle serves as
+#                   JavaScript.
+# `api`           — the Newman job. Identical provisioning, but the SPA bundle
+#                   warm-up and its gate are skipped.
+#
+# The gate exists because a MISSING bundle does not 404 in Nextcloud: it serves
+# the HTML error page with HTTP 200, so a UI suite would fail later on selector
+# timeouts with a misleading cause. That reasoning is specific to a suite that
+# mounts the SPA. The Newman job never does — and, decisively, it never runs
+# `npm run build` either (the shared workflow's `newman` job has no frontend
+# build step at all, unlike `playwright`). Running the gate there would abort
+# the seed with `exit 1` on a bundle that was never meant to exist, turning a
+# fix for 19 failing assertions into a hard job failure. Skipping it removes no
+# coverage: no Newman assertion loads a page.
+SEED_MODE="${1:-e2e}"
+case "$SEED_MODE" in
+	e2e | api) ;;
+	*)
+		echo "::error::unknown seed mode '${SEED_MODE}' — expected 'e2e' or 'api'."
+		exit 1
+		;;
+esac
 
 # ── Locations ────────────────────────────────────────────────────────────────
 # Resolve from the script's own path so the script does not depend on the
@@ -572,6 +603,13 @@ do
 		-H 'OCS-APIRequest: true' "${BASE}${path}" || echo 000)"
 	echo "[ci-seed] warm ${path} -> ${code}"
 done
+
+if [ "$SEED_MODE" = "api" ]; then
+	echo "[ci-seed] api mode: skipping the SPA bundle warm-up and gate — the Newman"
+	echo "[ci-seed] suite is HTTP-only and its job never builds the frontend."
+	echo "[ci-seed] done."
+	exit 0
+fi
 
 # Pull the main webpack bundle once so it is in the page cache.
 #


### PR DESCRIPTION
## Baseline (measured, not assumed)

Newest completed Newman job on `development`: run **31074205317**, job **92528887929**.

| collections | requests | assertions | passed | failed |
|---|---|---|---|---|
| 1 | 33 | 66 | 47 | **19** |

## One root cause, three response shapes

All 19 failures trace to a single fact: **DocuDesk's OpenRegister object-type bindings are never provisioned in the Newman job.**

DocuDesk resolves every template / consent / signing write through app-config keys `<schemaSlug>_register` / `<schemaSlug>_schema`. Those are set by an **administrator** in the admin settings UI. Nothing auto-provisions them on a fresh install except `templateVersion_*` (`SettingsInitializer::provisionTemplateVersionConfig()` — which is why "template versions" was one of the few green requests).

With them empty:

| shape | mechanism | failures |
|---|---|---|
| **HTTP 500** | `OpenRegisterResolver::getRegisterAndSchema()` throws `RegisterNotConfiguredException`; its code is `0`, so `TemplateRequestHandler::buildErrorResponse()` clamps to 500 | 01–03, 08–12, 19 |
| **HTTP 500** | `SigningService` passes an empty register/schema straight into `ObjectService::saveObject()` / `find()` | 04–07, 13–15, 18 |
| **HTTP 400** | `ConsentController::notConfiguredResponse()` | 16–17 |

Note the two requests that *passed*: `GET /api/templates` and `GET /api/signing/requests` are precisely the two handlers that **catch** `RegisterNotConfiguredException` and answer `200 {results: [], notConfigured: true}`. Two green assertions over a store the collection could never write to.

**Classification: (d) the environment lacks a dependency.** The app is not broken and the collection is not stale — the seed step was never wired.

## Fix

`tests/e2e/ci-seed.sh` already performs exactly this provisioning for the Playwright job, and its header already names this failure mode verbatim (*"answers 500 `Template register/schema not configured`"*). `newman-seed-command` was simply never set.

Reusing it as-is would have made things **worse**: its closing step is a hard gate that the DocuDesk frontend bundle serves as JavaScript, and the shared workflow's `newman` job has **no frontend build step at all** — the seed would `exit 1` and fail the job outright. So the script now takes an optional mode argument:

* `e2e` (default, byte-identical behaviour) — Playwright, gate kept;
* `api` — Newman, skips the SPA warm-up + gate only. No provisioning differs, and no Newman assertion loads a page.

No test was skipped, disabled, relaxed or deleted.

## Result

Measured on a disposable `nextcloud:32-apache` + postgres replica of the CI job (this branch bind-mounted, `openregister@development` alongside):

| | collections | requests | assertions | passed | failed |
|---|---|---|---|---|---|
| before seeding | 1 | 33 | 66 | 47 | **19** (identical failure numbers 01–19 to CI) |
| after seeding | 1 | 33 | 66 | **66** | **0** |

## Failure proofs

Every mutation was reverted and green re-confirmed afterwards.

| mutation | result |
|---|---|
| `occ config:app:set docudesk template_register --value=''` | 9 failed — 01,02,03,08,09,10,11,12,19 |
| `occ config:app:set docudesk signingRequest_register --value=''` | 8 failed — 04,05,06,07,13,14,15,18 |
| `occ config:app:set docudesk publicationConsent_register --value=''` | 2 failed — 16,17 |
| `ci-seed.sh` with `CI=true`, **no** mode argument | **exit 1** at the bundle gate — proves the `api` flag is load-bearing |
| `ci-seed.sh api` with `CI=true` | exit 0 |
| `ci-seed.sh bogus` | exit 1, `unknown seed mode` |

9 + 8 + 2 = the 19 originally failing assertions, disjointly.

## Not changed, reported instead

`tests/newman/docudesk-api.postman_collection.json` (50 requests) and `tests/newman/docudesk-api-collection.json` (8 requests) are **not** run by CI — the shared workflow globs `*.postman_collection.json` non-recursively in `newman-collection-path`, which is `tests/integration`. They are **not duplicates**: they cover a wider surface (`/api/policy/prohibitions`, `/api/policy/standing-consents`, `/api/metadata/enrich`, `/api/pdf/render`, `/api/metrics`) and are referenced by several openspec change tasks. Their `{{baseUrl}}/api/...` URL shape also differs from the executed suite's `{{baseUrl}}/index.php/apps/docudesk/api/...`. Whether to promote them into `tests/integration` (they would then gate every PR, with an unmeasured failure surface) is a product decision, left for a human. Nothing deleted.