### PR TITLE
fix(security): declare updateProfiles admin-only — the obvious gate-5 fix would expose PII

### DIFF
--- a/lib/Controller/BatchAnonymizationController.php
+++ b/lib/Controller/BatchAnonymizationController.php
@@ -42,8 +42,10 @@ use OCA\DocuDesk\Service\BatchUploadService;
 use OCA\DocuDesk\Service\EntityConsolidationService;
 use OCA\DocuDesk\Service\FolderBatchService;
 use OCA\DocuDesk\Service\WooProfileService;
+use OCA\DocuDesk\Settings\DocuDeskAdmin;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
@@ -541,10 +543,35 @@ class BatchAnonymizationController extends Controller
     /**
      * Persist a new WOO anonymization profile from the request body.
      *
+     * ADMIN-ONLY, DELIBERATELY. The profile this writes is INSTANCE-WIDE: it
+     * lands in `IAppConfig` under `docudesk_woo_entity_profiles`
+     * ({@see WooProfileService::saveProfile()}), and
+     * {@see EntityConsolidationService} reads it to decide which entity types
+     * are redacted for EVERY user. Moving `PERSON` / `BSN` / `EMAIL` out of the
+     * `anonymize` set therefore leaves other people's PII in place on every
+     * subsequent run.
+     *
+     * ⚠️ The obvious way to satisfy a "missing auth attribute" finding here —
+     * copying the sibling `getProfiles()`'s user-level annotation onto this
+     * method — WOULD INTRODUCE EXACTLY THAT VULNERABILITY. The two are not
+     * symmetric: reading the profile is a user-level concern, writing it is
+     * instance policy. Until this attribute existed the endpoint was admin-only
+     * only by ACCIDENT (Nextcloud defaults an unannotated method to admin), and
+     * the body's lone `getUser() === null` check reads as though user-level
+     * access were intended, which is what makes the wrong fix look right.
+     *
+     * `#[AuthorizedAdminSetting]` matches how every other instance-wide write in
+     * this app declares itself ({@see SettingsController},
+     * {@see AnonymiserWarningController}).
+     *
+     * The null-session check below is retained as defence in depth, not as the
+     * authorization boundary — the attribute is the boundary.
+     *
      * @return JSONResponse Success message, or an error payload when the body is malformed.
      *
      * @spec openspec/specs/batch-anonymization/spec.md#requirement-woo-entity-category-profiles
      */
+    #[AuthorizedAdminSetting(DocuDeskAdmin::class)]
     public function updateProfiles(): JSONResponse
     {
         try {

--- a/tests/unit/Controller/BatchAnonymizationControllerProfileAuthTest.php
+++ b/tests/unit/Controller/BatchAnonymizationControllerProfileAuthTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Authorization-posture tests for BatchAnonymizationController's WOO profile endpoints.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/batch-anonymization/spec.md#requirement-woo-entity-category-profiles
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Controller;
+
+use OCA\DocuDesk\Controller\BatchAnonymizationController;
+use OCA\DocuDesk\Settings\DocuDeskAdmin;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Pins the asymmetry between READING and WRITING the instance-wide WOO profile.
+ *
+ * `WooProfileService` persists the profile through `IAppConfig`, so it is a
+ * SINGLE INSTANCE-WIDE VALUE, and `EntityConsolidationService` reads it to
+ * decide which entity types get redacted for every user. A non-admin who could
+ * write it could move `PERSON` / `BSN` / `EMAIL` out of the `anonymize` set and
+ * leave other people's PII in place.
+ *
+ * These tests exist because the plausible-looking repair is the dangerous one:
+ * `getProfiles()` carries `@NoAdminRequired`, and copying that onto
+ * `updateProfiles()` to silence a "missing auth attribute" finding would hand
+ * instance-wide PII policy to every authenticated user. The write posture is
+ * therefore asserted explicitly rather than left to Nextcloud's default.
+ */
+class BatchAnonymizationControllerProfileAuthTest extends TestCase
+{
+
+    /**
+     * The WRITE endpoint must declare admin-only authorization explicitly.
+     *
+     * @return void
+     */
+    public function testUpdateProfilesIsAdminOnly(): void
+    {
+        $method     = new ReflectionMethod(BatchAnonymizationController::class, 'updateProfiles');
+        $attributes = $method->getAttributes(AuthorizedAdminSetting::class);
+
+        $this->assertCount(
+            1,
+            $attributes,
+            'updateProfiles() writes the instance-wide WOO profile via IAppConfig and MUST declare '
+            .'#[AuthorizedAdminSetting]. Without it the endpoint is admin-only only by Nextcloud default, '
+            .'which is an accident rather than a decision.'
+        );
+
+        $this->assertSame(
+            [DocuDeskAdmin::class],
+            $attributes[0]->getArguments(),
+            'The admin setting must be DocuDesk\'s own, matching SettingsController and AnonymiserWarningController.'
+        );
+
+    }//end testUpdateProfilesIsAdminOnly()
+
+
+    /**
+     * The WRITE endpoint must NOT be reachable by any authenticated user.
+     *
+     * This is the regression this file exists for: `#[NoAdminRequired]` (or the
+     * `@NoAdminRequired` docblock tag) on `updateProfiles()` would satisfy a
+     * naive "declare an auth posture" check while opening instance-wide PII
+     * policy to every logged-in account.
+     *
+     * @return void
+     */
+    public function testUpdateProfilesIsNotUserAccessible(): void
+    {
+        $method = new ReflectionMethod(BatchAnonymizationController::class, 'updateProfiles');
+
+        $this->assertCount(
+            0,
+            $method->getAttributes(NoAdminRequired::class),
+            'updateProfiles() must NOT carry #[NoAdminRequired] — it writes instance-wide anonymisation policy.'
+        );
+
+        // Match the tag only where a tag can actually live — at the start of a
+        // docblock line. A bare substring search would also hit the prose in
+        // this method's own docblock, which NAMES the annotation in order to
+        // warn against it: a checker that greps a string literal matches
+        // comments as readily as code, and fails in both directions at once.
+        $this->assertDoesNotMatchRegularExpression(
+            '/^\s*\*\s*@NoAdminRequired\b/m',
+            (string) $method->getDocComment(),
+            'updateProfiles() must NOT carry the @NoAdminRequired docblock tag either; Nextcloud honours both '
+            .'spellings, so pinning only the attribute would leave the docblock route open.'
+        );
+
+    }//end testUpdateProfilesIsNotUserAccessible()
+
+
+    /**
+     * Reading the profile stays user-level — the asymmetry is deliberate.
+     *
+     * Without this arm the pair above could be "satisfied" by locking the read
+     * endpoint down too, which would break the UI while still looking green.
+     *
+     * @return void
+     */
+    public function testGetProfilesRemainsUserAccessible(): void
+    {
+        $method = new ReflectionMethod(BatchAnonymizationController::class, 'getProfiles');
+        $doc    = (string) $method->getDocComment();
+
+        $declaresUserAccess = ($method->getAttributes(NoAdminRequired::class) !== []
+            || preg_match('/^\s*\*\s*@NoAdminRequired\b/m', $doc) === 1);
+
+        $this->assertTrue(
+            $declaresUserAccess,
+            'getProfiles() is a read of policy the UI needs and must stay user-accessible.'
+        );
+
+        $this->assertCount(
+            0,
+            $method->getAttributes(AuthorizedAdminSetting::class),
+            'getProfiles() must not be admin-gated; only the WRITE side is.'
+        );
+
+    }//end testGetProfilesRemainsUserAccessible()
+
+
+}//end class


### PR DESCRIPTION
## The finding, and why the obvious fix is the dangerous one

`BatchAnonymizationController::updateProfiles` is routed (`PUT api/anonymization/profiles`) but carried **no authorization attribute at all** — gate-5 `missing-auth-attribute`, measured full-tree on `development`.

Its sibling on the **same URL**, `getProfiles()` (`GET`), carries `@NoAdminRequired`. So the natural repair is to copy that annotation across. **That would open a real PII hole:**

| hop | location |
|---|---|
| write endpoint | `lib/Controller/BatchAnonymizationController.php` `updateProfiles()` |
| → | `lib/Service/WooProfileService.php:94` `saveProfile()` → `IAppConfig::setValueString('docudesk', 'docudesk_woo_entity_profiles', …)` |
| read side | `lib/Service/WooProfileService.php:63` `getProfile()`, consumed by `lib/Service/EntityConsolidationService.php` |

`IAppConfig` is a **single instance-wide value**, and `EntityConsolidationService` reads it to decide which entity types get redacted **for every user**. With `@NoAdminRequired`, any authenticated account could move `PERSON` / `BSN` / `EMAIL` out of `anonymize` into `keep` and leave everyone else's PII in place on every subsequent anonymisation run.

Reading the profile is a user-level concern. Writing it is instance policy. That asymmetry is now **declared** instead of inherited: until this PR the endpoint was admin-only only **by accident**, because Nextcloud defaults an unannotated method to admin. The body's lone `getUser() === null` check reads as though user-level access were intended — which is exactly what makes the wrong fix look right. It stays as defence in depth, not as the boundary.

`#[AuthorizedAdminSetting(DocuDeskAdmin::class)]` is how every other instance-wide write in this app already declares itself (`SettingsController`, `AnonymiserWarningController`).

## Proof the tests can fail

| arm | result |
|---|---|
| fix as submitted | 3 tests, 6 assertions, **exit 0** |
| `#[AuthorizedAdminSetting]` removed | `testUpdateProfilesIsAdminOnly` **FAILS** with its own message |
| `@NoAdminRequired` tag added (the dangerous fix) | `testUpdateProfilesIsNotUserAccessible` **FAILS** with its own message |
| restored | 3 tests, 6 assertions, **exit 0** |

A third test asserts `getProfiles()` **stays** user-accessible, so the pair above cannot be satisfied by locking the read side down too — which would have been green and broken.

The class was confirmed to resolve to this worktree's own `lib/Controller/BatchAnonymizationController.php`, not a deployed copy, so Nextcloud's `OCA\<App>\*` autoloader hijack is excluded as an explanation for the green.

One incidental finding worth recording: the docblock assertion originally used a plain substring search for `@NoAdminRequired` and **failed against this method's own prose**, which names the annotation in order to warn against it. It now matches only at docblock **tag position** (`/^\s*\*\s*@NoAdminRequired\b/m`). A checker that greps a string literal matches comments as readily as code.

## Gate measurement

Full tree, hydra-gates @ `main` (756fe89) — not diff-scoped, because no CI job in this fleet gives a full-tree verdict:

```
gate-5  route-auth                 FAIL (1)  ->  PASS
gate-47 security-change-has-tests            PASS
```

Failing-gate set is a **strict subset of `development`'s by name**; this PR adds none.

## Deliberately NOT fixed here

`gate-9 semantic-auth` still reports `SigningController::cancelRequest`. It is a **false positive** and its advice would break the endpoint.

`@NoAdminRequired` is correct there — the method is how an initiator cancels their **own** signing request. The `groupManager->isAdmin($uid)` call in the body **widens** access (admins skip the initiator check); it is not an admin gate. gate-9 matches "`@NoAdminRequired` + `isAdmin(` in body" and cannot tell escalation from restriction. Following its advice (*remove `@NoAdminRequired`*) would make the endpoint admin-only and stop initiators cancelling their own requests — undoing the WF1 fix (docudesk#100) that the surrounding comment documents.