### PR TITLE
hotfix: raise Nextcloud floor to 32 and PHP floor to 8.3 on main

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -55,7 +55,15 @@ Create a [feature request](https://github.com/docudesk/.github/issues/new/choose
         <database min-version="10">pgsql</database>
         <database>sqlite</database>
         <database min-version="8.0">mysql</database>
-        <nextcloud min-version="30" max-version="34"/>
+        <!--
+            Nextcloud minimum is 32 so this app can require PHP 8.3, which is the
+            fleet-wide standard. It also may not sit below the minimum of an app it
+            depends on: OpenRegister declares a Nextcloud minimum of 32 on its
+            development branch, and advertising a lower minimum here would offer a
+            version range in which that dependency refuses to install and this app
+            is non-functional. See openconnector issues 1172 and 1173.
+        -->
+        <nextcloud min-version="32" max-version="34"/>
     </dependencies>
     <navigations>
         <navigation>


### PR DESCRIPTION
Raises the Nextcloud floor on `main` from **30 to 32**. The PHP floor was **already 8.3** and is unchanged. `max-version` preserved unchanged at **34**. `min-int-size="64"` preserved on the php element.

## Why

Product directive from the PO (Ruben): the fleet standardises on Nextcloud 32 so it can require PHP 8.3 — *"we want php 8.3 so going for min version nc 32 fleet wide is a good thing."*

The governing rule (openconnector#1172 / #1173): an app's `min-version` must be **>= the max of every app dependency's floor**, or the App Store advertises a range the app cannot deliver — the dependency refuses to install and the app is non-functional there.

`openregister@development` declares a Nextcloud floor of **32** (re-measured live with an XML parser immediately before this PR was written; also php floor 8.3).

## Shape

**Floor-only PR, opened directly against `main`.** Reason: `main` trails `development` by 188–5206 commits across this fleet (openregister alone is 5206 ahead), so a `development → main` merge would be a full release, not a floor fix. This PR changes `appinfo/info.xml` only.

## Method note

All floors were measured by parsing `appinfo/info.xml` with `xml.etree.ElementTree`, **not** grep. These files contain literal nextcloud-element examples *inside XML comments*, and grepping them has already produced false floor readings. The added comment is deliberately written in **prose with no angle-bracket XML syntax**: floor guards in this fleet count raw regex matches of the nextcloud element across the whole file including comments, and a quoted example would read as a second, contradictory declaration. Validated before push: the file parses as XML, and `<nextcloud\b[^>]*>` matches **exactly once**.

## Measured before / after (`main`)

| | before | after |
|---|---|---|
| nextcloud min-version | 30 | **32** |
| nextcloud max-version | 34 | 34 (unchanged) |
| php min-version | 8.3 | 8.3 (already at target) |

## CI

Verified, not assumed: `.github/workflows/code-quality.yml` on `main` already sets `nextcloud-test-refs: '["stable32"]'` and `php-version: "8.3"`. **No CI leg installs Nextcloud < 32, so no CI change is needed and no leg was dropped.**

## Branch naming

Opened from `hotfix/nc-floor-32-main`. The fleet `branch-protection` gate (`ConductionNL/.github` → `branch-protection.yml`) requires PRs to `main` to come from `beta` or `hotfix/*`. Since this intentionally lands directly on the released line without a full `beta` promotion, `hotfix/*` is the sanctioned pattern — used so the policy gate passes on its merits rather than being admin-overridden.