### PR TITLE
fix(security): guard eml-preview with an explicit file-access check

### DIFF
--- a/lib/Controller/EmlPreviewController.php
+++ b/lib/Controller/EmlPreviewController.php
@@ -23,9 +23,14 @@ namespace OCA\DocuDesk\Controller;
 
 use OCA\DocuDesk\Service\EmlPreviewService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\Files\File;
+use OCP\Files\IRootFolder;
+use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -48,29 +53,90 @@ class EmlPreviewController extends Controller
      * @param IRequest          $request           The current request.
      * @param EmlPreviewService $emlPreviewService Renders the original EML to PDF.
      * @param LoggerInterface   $logger            Logger for diagnostics.
+     * @param IUserSession      $userSession       Session user, for the file-access guard.
+     * @param IRootFolder       $rootFolder        Root folder, for the file-access guard.
+     * @param IL10N             $l10n              Translations for the guard responses.
      */
     public function __construct(
         string $appName,
         IRequest $request,
         private readonly EmlPreviewService $emlPreviewService,
         private readonly LoggerInterface $logger,
+        private readonly IUserSession $userSession,
+        private readonly IRootFolder $rootFolder,
+        private readonly IL10N $l10n,
     ) {
         parent::__construct(appName: $appName, request: $request);
 
     }//end __construct()
 
     /**
+     * Verify the current user has access to the given file id.
+     *
+     * Resolves the file through the caller's OWN file tree — the same guard
+     * `AnonymizationController::verifyFileAccess()` applies to the sibling
+     * `extract` / `anonymize` endpoints under this URL prefix.
+     *
+     * Without this, the only thing separating a caller from another user's
+     * message is Nextcloud's session-scoped id resolution: the render path
+     * hands `$fileId` to OpenRegister's `FileService::getFileById()`, which
+     * calls `IRootFolder::getById()` at ROOT scope. That resolves against the
+     * session's mounts and so denies cross-user reads today, but it is an
+     * incidental protection, not an authorisation check — it disappears the
+     * moment the same code is reached without a session user (a background
+     * job, an `occ` command, any system-context call).
+     *
+     * A shared file still resolves: shares are mounted inside the user folder,
+     * so this denies exactly what is already denied and grants nothing new.
+     * Returns 404 rather than 403 so callers cannot probe for existence.
+     *
+     * @param int $fileId The Nextcloud file id to check.
+     *
+     * @return JSONResponse|null Null when access is granted, an error response otherwise.
+     */
+    private function verifyFileAccess(int $fileId): ?JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(
+                data: ['error' => $this->l10n->t('Not authenticated')],
+                statusCode: Http::STATUS_UNAUTHORIZED
+            );
+        }
+
+        $nodes = $this->rootFolder->getUserFolder($user->getUID())->getById($fileId);
+        if (empty($nodes) === true || ($nodes[0] instanceof File) === false) {
+            return new JSONResponse(
+                data: ['error' => $this->l10n->t('File not found')],
+                statusCode: Http::STATUS_NOT_FOUND
+            );
+        }
+
+        return null;
+
+    }//end verifyFileAccess()
+
+    /**
      * Stream a PDF/A-3b preview of the original (un-redacted) EML.
+     *
+     * The rendered PDF carries the ORIGINAL headers, body and attachments, so
+     * the caller's access to `$fileId` is verified before anything is
+     * rendered.
      *
      * @param int $fileId Nextcloud file id of the source .eml.
      *
-     * @return DataDownloadResponse|JSONResponse PDF bytes, or a JSON error (422).
+     * @return DataDownloadResponse|JSONResponse PDF bytes, or a JSON error (401/404/422).
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      */
     public function preview(int $fileId): DataDownloadResponse | JSONResponse
     {
+        $accessError = $this->verifyFileAccess(fileId: $fileId);
+        if ($accessError !== null) {
+            return $accessError;
+        }
+
         try {
             $pdf = $this->emlPreviewService->renderOriginalPreview(fileId: $fileId);
         } catch (Throwable $e) {

--- a/tests/unit/Controller/EmlPreviewControllerTest.php
+++ b/tests/unit/Controller/EmlPreviewControllerTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * Unit tests for EmlPreviewController
+ *
+ * Covers the file-access guard: the endpoint renders the ORIGINAL,
+ * un-redacted message, so a caller-supplied file id must be resolved
+ * through the caller's own file tree before anything is rendered.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Controller;
+
+use OCA\DocuDesk\Controller\EmlPreviewController;
+use OCA\DocuDesk\Service\EmlPreviewService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataDownloadResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for EmlPreviewController.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://conduction.nl
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class EmlPreviewControllerTest extends TestCase
+{
+
+    /**
+     * @var EmlPreviewService|MockObject
+     */
+    private EmlPreviewService|MockObject $mockService;
+
+    /**
+     * @var IUserSession|MockObject
+     */
+    private IUserSession|MockObject $mockUserSession;
+
+    /**
+     * @var IRootFolder|MockObject
+     */
+    private IRootFolder|MockObject $mockRootFolder;
+
+    /**
+     * @var EmlPreviewController
+     */
+    private EmlPreviewController $controller;
+
+
+    /**
+     * Build the controller with mocked collaborators.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->mockService     = $this->createMock(EmlPreviewService::class);
+        $this->mockUserSession = $this->createMock(IUserSession::class);
+        $this->mockRootFolder  = $this->createMock(IRootFolder::class);
+
+        $mockL10n = $this->createMock(IL10N::class);
+        $mockL10n->method('t')->willReturnArgument(0);
+
+        $this->controller = new EmlPreviewController(
+            'docudesk',
+            $this->createMock(IRequest::class),
+            $this->mockService,
+            $this->createMock(LoggerInterface::class),
+            $this->mockUserSession,
+            $this->mockRootFolder,
+            $mockL10n
+        );
+
+    }//end setUp()
+
+
+    /**
+     * Point the session at a user whose folder resolves $fileId to $nodes.
+     *
+     * @param array $nodes Nodes the caller's own user folder resolves the id to.
+     *
+     * @return void
+     */
+    private function givenUserFolderResolvesTo(array $nodes): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('bob');
+        $this->mockUserSession->method('getUser')->willReturn($user);
+
+        $folder = $this->createMock(Folder::class);
+        $folder->method('getById')->willReturn($nodes);
+        $this->mockRootFolder->method('getUserFolder')->with('bob')->willReturn($folder);
+
+    }//end givenUserFolderResolvesTo()
+
+
+    /**
+     * A file id the caller cannot resolve in their own tree is refused with
+     * 404 — and the render service is never reached, so no un-redacted bytes
+     * are produced.
+     *
+     * @return void
+     */
+    public function testPreviewRefusesFileIdOutsideTheCallersOwnTree(): void
+    {
+        $this->givenUserFolderResolvesTo([]);
+        $this->mockService->expects($this->never())->method('renderOriginalPreview');
+
+        $response = $this->controller->preview(fileId: 21992);
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+    }//end testPreviewRefusesFileIdOutsideTheCallersOwnTree()
+
+
+    /**
+     * An unauthenticated caller is refused with 401 and never reaches the
+     * render service.
+     *
+     * @return void
+     */
+    public function testPreviewRefusesUnauthenticatedCaller(): void
+    {
+        $this->mockUserSession->method('getUser')->willReturn(null);
+        $this->mockService->expects($this->never())->method('renderOriginalPreview');
+
+        $response = $this->controller->preview(fileId: 21992);
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testPreviewRefusesUnauthenticatedCaller()
+
+
+    /**
+     * A file id that resolves to a folder rather than a file is refused with
+     * 404 rather than handed to the renderer.
+     *
+     * @return void
+     */
+    public function testPreviewRefusesNonFileNode(): void
+    {
+        $this->givenUserFolderResolvesTo([$this->createMock(Folder::class)]);
+        $this->mockService->expects($this->never())->method('renderOriginalPreview');
+
+        $response = $this->controller->preview(fileId: 21992);
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+    }//end testPreviewRefusesNonFileNode()
+
+
+    /**
+     * A file the caller CAN resolve in their own tree — including one reached
+     * through a share, which is mounted inside the user folder — still
+     * renders, so the guard grants nothing less than before.
+     *
+     * @return void
+     */
+    public function testPreviewRendersFileReachableByTheCaller(): void
+    {
+        $this->givenUserFolderResolvesTo([$this->createMock(File::class)]);
+        $this->mockService->expects($this->once())
+            ->method('renderOriginalPreview')
+            ->with(fileId: 21991)
+            ->willReturn('%PDF-1.7 bytes');
+
+        $response = $this->controller->preview(fileId: 21991);
+
+        $this->assertInstanceOf(DataDownloadResponse::class, $response);
+
+    }//end testPreviewRendersFileReachableByTheCaller()
+
+
+    /**
+     * A render failure on a file the caller may read still surfaces as 422,
+     * unchanged by the guard.
+     *
+     * @return void
+     */
+    public function testPreviewStillReturns422OnRenderFailure(): void
+    {
+        $this->givenUserFolderResolvesTo([$this->createMock(File::class)]);
+        $this->mockService->method('renderOriginalPreview')
+            ->willThrowException(new \RuntimeException('EML preview requires the OpenRegister anonymise-EML API.'));
+
+        $response = $this->controller->preview(fileId: 21991);
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(422, $response->getStatus());
+
+    }//end testPreviewStillReturns422OnRenderFailure()
+}//end class


### PR DESCRIPTION
Closes #408.

## What this changes

`EmlPreviewController::preview` renders the **original, un-redacted** EML for a caller-supplied `fileId` and had **no ownership or permission check of its own**. This adds `verifyFileAccess()` — the same guard `AnonymizationController` already applies to the sibling `extract` / `anonymize` endpoints under the same `api/anonymization/` URL prefix — plus 5 unit tests.

## Why, given cross-user access is already denied

Two agents disagreed today over whether this was an exploitable IDOR. A live two-user probe settled it: **unguarded, but not currently exploitable.** The denial is real, but it belongs to Nextcloud, not to DocuDesk.

```
preview($fileId)
  -> EmlPreviewService::renderOriginalPreview($fileId)
    -> OpenRegister FileService::getFileById($fileId)
      -> IRootFolder::getById($fileId)     <- ROOT scope, not the user folder
      -> checkOwnership() == $node->isReadable(), whose own docblock says the
         owner-vs-session comparison is deliberately omitted
```

`IRootFolder::getById()` is `Folder::getById()` → `Root::getByIdInPath($id, '')`. With an empty path the `$user` derived from the path is `null`, so the mount cache is queried **across all users**, and the hits are then intersected with the **current session's** mounts. That intersection is the only thing between a caller and another user's message — and it disappears the moment the same code runs without a session user: a background job, an `occ` command, any system-context call.

## Live probe (shared dev instance, NC 34.0.0, two fresh non-admin users, Basic auth, no shared cookie jar, `OCS-APIRequest: true`)

| Caller | fileId | Owner | HTTP | Body |
|---|---|---|---|---|
| *(unauthenticated)* | 21992 | A | **401** | `Current user is not logged in` |
| B | 21991 | **B (own)** | **422** | `... requires the OpenRegister anonymise-EML API.` |
| B | 21992 | **A (cross-user)** | **422** | `... file 21992 is not a readable file node.` |
| B | 99999999 | *(no such file)* | **422** | `... file 99999999 is not a readable file node.` |
| B | 21992 | A, **shared to B** | **422** | `... requires the OpenRegister anonymise-EML API.` |
| B | 21992 | A, **share removed** | **422** | `... file 21992 is not a readable file node.` |

`renderOriginalPreview()` resolves the file **before** it checks for the OpenRegister API, so the two error strings distinguish the two steps exactly. Rows 5 and 6 are the differential control: same user, same id, same request — grant a share and resolution succeeds, remove it and it fails again. The gate is *precisely* mount/share visibility, not authorisation.

## Strict subset

`getUserFolder($uid)->getById()` still resolves shared files (shares are mounted inside the user folder), so the shared-file case above stays a grant. The guard denies exactly what is already denied, only explicitly and early, and keeps denying if resolution ever leaves a session. 404 rather than 403 so callers cannot probe for existence.

## Verification

- `phpunit tests/unit/Controller/EmlPreviewControllerTest.php` → **OK (5 tests, 13 assertions)**
- **Negative control**: with the `verifyFileAccess()` call removed and everything else identical → **3 of 5 fail** (401→422, 404→422 ×2). The tests can fail.
- Wider suite `EmlPreviewControllerTest + EmlPreviewServiceTest + AnonymizationControllerTest` → **OK (32 tests, 78 assertions)**
- `phpcs --standard=phpcs.xml lib/Controller/EmlPreviewController.php` → **exit 0** (2 pre-existing `@spec` warnings, present before this change)
- `phpstan analyse lib/Controller/EmlPreviewController.php` → **[OK] No errors**

## Out of scope, flagged in #408

`anonymizeEmlStructured` **does not exist in OpenRegister** — not in the deployed 0.2.17-unstable.25, not on `origin/development`, not on any `origin/*` branch (verified with a positive control: `getFileById` is found by the same query). Every call to this endpoint therefore 422s at the `method_exists()` check, and `src/services/fileViewerService.js:82` points the file viewer at it. The feature is dead end-to-end; that is a separate fix.