### PR TITLE
test(e2e): replace all 18 networkidle waits with deterministic readiness waits (gate-58)

### DIFF
--- a/tests/e2e/docs-screenshots.spec.ts
+++ b/tests/e2e/docs-screenshots.spec.ts
@@ -85,8 +85,24 @@ async function go(page: Page, route: string): Promise<void> {
 	const url = route.startsWith('/apps/') || route.startsWith('/settings/')
 		? route
 		: cleaned === '' ? APP : `${APP}/${cleaned}`
-	await page.goto(url).catch(() => { /* tolerate a 404 — caller decides */ })
-	await page.waitForLoadState('networkidle').catch(() => { /* idle never fires on some pages */ })
+	const response = await page.goto(url, { waitUntil: 'domcontentloaded' })
+		.catch(() => null) /* tolerate a 404 — caller decides */
+	// This used to be `waitForLoadState('networkidle').catch(() => {})`, which
+	// ADR-074 rule 4 / gate-58 forbids: Nextcloud holds long-lived connections
+	// open (notifications polling, user-status heartbeat), so the network never
+	// goes idle. The wait always ran to its own timeout and the `.catch`
+	// swallowed it — every screenshot route paid ~30s and still shot a page
+	// that had no guarantee of having painted.
+	//
+	// The 404 tolerance above is deliberate (this spec walks routes that may
+	// legitimately not exist), so the readiness wait is scoped to the success
+	// path — where it is NOT swallowed: if Nextcloud served the page, its
+	// content region must appear, and a screenshot of a page that never
+	// rendered is worthless rather than merely late.
+	if (response?.ok()) {
+		await page.locator('#content, #app-content, .app-content, main').first()
+			.waitFor({ state: 'visible', timeout: 20_000 })
+	}
 	await dismissOverlays(page)
 	await page.waitForTimeout(900)
 }

--- a/tests/e2e/spec-coverage/_helpers.ts
+++ b/tests/e2e/spec-coverage/_helpers.ts
@@ -127,16 +127,73 @@ export async function dismissOverlays(page: Page): Promise<void> {
  */
 export const APP = '/index.php/apps/docudesk'
 
+/**
+ * Wait until the DocuDesk SPA has actually mounted and painted its content
+ * region.
+ *
+ * ⚠️ This replaces the `await page.waitForLoadState('networkidle').catch(() => {})`
+ * that used to follow every navigation in this suite (ADR-074 rule 4 /
+ * gate-58 e2e-networkidle). That call could never do what it looked like it
+ * did: Nextcloud holds long-lived connections open — notifications polling,
+ * the user-status heartbeat — so the network NEVER goes idle. The wait
+ * therefore always ran to its own timeout and was then swallowed by
+ * `.catch(() => {})`. It did not "let the app settle"; it burned ~30s per
+ * navigation and then continued at exactly the moment it would have anyway,
+ * leaving the assertions to race a possibly-unmounted app. Worse, the swallow
+ * turned that timeout into a pass, so nothing ever reported it.
+ *
+ * The deterministic form of the same intent is two explicit waits:
+ *  1. `#docudesk-app` — the mount point `templates/index.php` server-renders.
+ *     Its presence also separates a real Nextcloud response from PHP's
+ *     built-in-server 404 page (see the `APP` docblock above), which has a
+ *     `<body>` and a non-`/login` URL and so satisfied several assertions.
+ *  2. the content region the manifest shell renders inside it — present only
+ *     once Vue has mounted and the active route has painted.
+ *
+ * Neither wait is swallowed. A page that never mounts must fail here, loudly
+ * and at the navigation, instead of failing later at an assertion where it
+ * reads like an application defect.
+ *
+ * @param page    The Playwright page.
+ * @param timeout Budget for each of the two waits, in ms.
+ * @return Resolves once the SPA has mounted and painted.
+ */
+export async function waitForAppReady(page: Page, timeout = 30_000): Promise<void> {
+	await page.locator('#docudesk-app').waitFor({ state: 'attached', timeout })
+	await page.locator('main, #app-content, .app-content, #content-vue').first()
+		.waitFor({ state: 'visible', timeout })
+}
+
+/**
+ * Wait until a *Nextcloud core* page (admin settings, Dashboard, Files) has
+ * painted its authenticated content region.
+ *
+ * Same rationale as `waitForAppReady` — `networkidle` never fires on
+ * Nextcloud — but these routes are not the DocuDesk SPA, so there is no
+ * `#docudesk-app` to key on. `#content` is rendered by NC's *authenticated*
+ * layout only; the guest/login layout does not have it, so this wait also
+ * fails fast on a session that silently expired instead of letting a
+ * `not.toHaveURL(/\/login/)` assertion decide it much later.
+ *
+ * @param page    The Playwright page.
+ * @param timeout Wait budget in ms.
+ * @return Resolves once the NC content region is visible.
+ */
+export async function waitForNcContentReady(page: Page, timeout = 30_000): Promise<void> {
+	await page.locator('#content, #app-content, .app-content, main').first()
+		.waitFor({ state: 'visible', timeout })
+}
+
 export async function go(page: Page, route: string): Promise<void> {
 	const url = route ? `${APP}/${route}` : APP
 	// Wait for `domcontentloaded`, not the default `load`. Nextcloud keeps
 	// long-lived connections open (notifications polling, user-status
 	// heartbeat), so on a busy instance the `load` event can be minutes late
 	// or never fire at all — every navigation then failed with a 60s timeout
-	// even though the page was interactive. `networkidle` below still gives
-	// the Vue app time to settle, and is already failure-tolerant.
+	// even though the page was interactive. `waitForAppReady` below then waits
+	// on the app itself rather than on the network going quiet.
 	await page.goto(url, { waitUntil: 'domcontentloaded' })
-	await page.waitForLoadState('networkidle').catch(() => {})
+	await waitForAppReady(page)
 	await dismissOverlays(page)
 	await page.waitForTimeout(800)
 }
@@ -148,6 +205,11 @@ export async function navClick(page: Page, label: string): Promise<void> {
 	// collide with longer labels and "Dashboard" stays unambiguous.
 	const link = page.locator(`#app-navigation a[title="${label}"], .app-navigation a[title="${label}"]`).first()
 	await link.click()
-	await page.waitForLoadState('networkidle').catch(() => {})
+	// The click routes in-app. Re-assert the shell rather than waiting for
+	// network silence (which never arrives): a manifest route that throws
+	// during render unmounts the content region, so requiring it back is a
+	// real check that the destination painted. Callers' `toHaveURL` /
+	// `toBeVisible` expectations then retry over the route-specific markup.
+	await waitForAppReady(page)
 	await page.waitForTimeout(800)
 }

--- a/tests/e2e/spec-coverage/admin-settings.spec.ts
+++ b/tests/e2e/spec-coverage/admin-settings.spec.ts
@@ -24,6 +24,7 @@
 // @e2e openspec/specs/processing-activity-export/spec.md#unconfigured-identity-prompts-not-blocks
 
 import { test, expect, type Page } from '@playwright/test'
+import { waitForNcContentReady } from './_helpers'
 
 async function dismissOverlays(page: Page): Promise<void> {
 	const wizard = page.locator('#firstrunwizard')
@@ -40,8 +41,16 @@ async function dismissOverlays(page: Page): Promise<void> {
 // non-`/login` URL, both of which PHP's 404 page satisfies — so these specs
 // passed against it.
 async function goSettings(page: Page): Promise<void> {
-	await page.goto('/index.php/settings/admin/docudesk')
-	await page.waitForLoadState('networkidle').catch(() => {})
+	// `domcontentloaded`, not the default `load` — NC's long-lived polling
+	// connections can delay `load` past any sane timeout. See _helpers.ts.
+	await page.goto('/index.php/settings/admin/docudesk', { waitUntil: 'domcontentloaded' })
+	// Wait for exactly what these specs read next: the settings content region
+	// (`#app-content, .app-content, #content` — asserted verbatim below). The
+	// old `waitForLoadState('networkidle').catch(() => {})` could not settle
+	// anything: Nextcloud never goes network-idle, so it always ran to its own
+	// timeout and the `.catch` silently turned that into a pass. ADR-074
+	// rule 4 / gate-58.
+	await waitForNcContentReady(page)
 	await dismissOverlays(page)
 	await page.waitForTimeout(800)
 }
@@ -71,8 +80,12 @@ test.describe('admin-settings — admin panel integration', () => {
 
 	test('DocuDesk appears in admin settings navigation', async ({ page }) => {
 		// @e2e openspec/specs/admin-settings/spec.md#admin-opens-docudesk-settings-section
-		await page.goto('/index.php/settings/admin')
-		await page.waitForLoadState('networkidle').catch(() => {})
+		await page.goto('/index.php/settings/admin', { waitUntil: 'domcontentloaded' })
+		// The admin settings overview must have painted its content region
+		// before the assertions below mean anything. Not `networkidle`: it
+		// never settles on Nextcloud (ADR-074 rule 4 / gate-58), and the
+		// `.catch` it needed converted its own timeout into a pass.
+		await waitForNcContentReady(page)
 		await dismissOverlays(page)
 		await page.waitForTimeout(600)
 		// Admin settings sidebar should be visible

--- a/tests/e2e/spec-coverage/anonymization.spec.ts
+++ b/tests/e2e/spec-coverage/anonymization.spec.ts
@@ -15,6 +15,7 @@
 // @e2e openspec/specs/anonymization/spec.md#anonymize-another-document
 
 import { test, expect, type Page } from '@playwright/test'
+import { waitForAppReady } from './_helpers'
 
 // `index.php`-prefixed — see the APP constant in ./_helpers.ts for why the
 // prefix is required on CI (`php -S` does not rewrite, so `/apps/...` hits
@@ -34,7 +35,10 @@ async function go(page: Page, route: string): Promise<void> {
 	// `domcontentloaded`, not the default `load` — NC's long-lived polling
 	// connections can delay `load` past any sane timeout. See _helpers.ts.
 	await page.goto(url, { waitUntil: 'domcontentloaded' })
-	await page.waitForLoadState('networkidle').catch(() => {})
+	// Not `networkidle` — Nextcloud's long-lived polling means it never fires,
+	// so the old swallowed wait burned its timeout and then proceeded anyway.
+	// See waitForAppReady in ./_helpers (ADR-074 rule 4 / gate-58).
+	await waitForAppReady(page)
 	await dismissOverlays(page)
 	await page.waitForTimeout(800)
 }

--- a/tests/e2e/spec-coverage/consent-management.spec.ts
+++ b/tests/e2e/spec-coverage/consent-management.spec.ts
@@ -14,6 +14,7 @@
 // @e2e openspec/specs/consent-management/spec.md#empty-consent-list
 
 import { test, expect, type Page } from '@playwright/test'
+import { waitForAppReady } from './_helpers'
 
 // `index.php`-prefixed — see the APP constant in ./_helpers.ts for why the
 // prefix is required on CI (`php -S` does not rewrite, so `/apps/...` hits
@@ -33,7 +34,11 @@ async function go(page: Page, route: string): Promise<void> {
 	// `domcontentloaded`, not the default `load` — NC's long-lived polling
 	// connections can delay `load` past any sane timeout. See _helpers.ts.
 	await page.goto(url, { waitUntil: 'domcontentloaded' })
-	await page.waitForLoadState('networkidle').catch(() => {})
+	// Not `networkidle` — it never fires on Nextcloud (long-lived notification
+	// polling / user-status heartbeat), so the old swallowed wait burned its
+	// full timeout and then proceeded anyway. See waitForAppReady in
+	// ./_helpers for the full reasoning (ADR-074 rule 4 / gate-58).
+	await waitForAppReady(page)
 	await dismissOverlays(page)
 	await page.waitForTimeout(800)
 }
@@ -76,9 +81,14 @@ test.describe('consent-management — consent list UI', () => {
 		const rows = page.locator('tr[data-id], .consent-row, .list-item').first()
 		const rowVisible = await rows.isVisible().catch(() => false)
 		if (rowVisible) {
-			// Click the first consent row to navigate to detail
+			// Click the first consent row to navigate to detail.
 			await rows.click()
-			await page.waitForLoadState('networkidle').catch(() => {})
+			// Wait for the SPA to have painted whatever the click routed to,
+			// rather than for network silence — `networkidle` never fires on
+			// Nextcloud, so the previous swallowed wait only spent its timeout.
+			// A route that throws during render unmounts the content region, so
+			// requiring it back is a real check that something rendered.
+			await waitForAppReady(page)
 			await page.waitForTimeout(500)
 			// Should still be on docudesk (either detail route or unchanged)
 			await expect(page).toHaveURL(/\/apps\/docudesk/)

--- a/tests/e2e/spec-coverage/custom-dictionary-recognition.spec.ts
+++ b/tests/e2e/spec-coverage/custom-dictionary-recognition.spec.ts
@@ -23,6 +23,7 @@
 // @e2e openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md#the-dictionaries-page-lists-dictionaries-with-their-term-counts
 
 import { test, expect, type Page } from '@playwright/test'
+import { waitForAppReady } from './_helpers'
 
 // `index.php`-prefixed — see the APP constant in ./_helpers.ts for why the
 // prefix is required on CI (`php -S` does not rewrite, so `/apps/...` hits
@@ -42,7 +43,10 @@ async function go(page: Page, route: string): Promise<void> {
 	// `domcontentloaded`, not the default `load` — NC's long-lived polling
 	// connections can delay `load` past any sane timeout. See _helpers.ts.
 	await page.goto(url, { waitUntil: 'domcontentloaded' })
-	await page.waitForLoadState('networkidle').catch(() => {})
+	// Not `networkidle` — Nextcloud's long-lived polling means it never fires,
+	// so the old swallowed wait burned its timeout and then proceeded anyway.
+	// See waitForAppReady in ./_helpers (ADR-074 rule 4 / gate-58).
+	await waitForAppReady(page)
 	await dismissOverlays(page)
 	await page.waitForTimeout(800)
 }
@@ -98,7 +102,15 @@ test.describe('custom-dictionary-recognition — dictionary detail UI', () => {
 		const rowVisible = await row.isVisible().catch(() => false)
 		if (rowVisible) {
 			await row.click()
-			await page.waitForLoadState('networkidle').catch(() => {})
+			// Wait for exactly the transition this test then asserts: the
+			// in-app route moving from the index (`/custom-dictionaries`) to a
+			// detail (`/custom-dictionaries/<id>`). The previous
+			// `waitForLoadState('networkidle').catch(() => {})` waited for a
+			// state Nextcloud never reaches, then swallowed its own timeout —
+			// so the assertions ran against a page that might not have routed
+			// at all (ADR-074 rule 4 / gate-58).
+			await page.waitForURL(/\/custom-dictionaries\/.+/, { timeout: 15_000 })
+			await waitForAppReady(page)
 			await page.waitForTimeout(500)
 			await expect(page).toHaveURL(/\/custom-dictionaries\//)
 			await expect(page.getByText(/terms/i).first()).toBeVisible()

--- a/tests/e2e/spec-coverage/dashboard.spec.ts
+++ b/tests/e2e/spec-coverage/dashboard.spec.ts
@@ -25,6 +25,7 @@
 // @e2e openspec/specs/dashboard/spec.md#admin-settings-section-icon
 
 import { test, expect, type Page } from '@playwright/test'
+import { waitForAppReady, waitForNcContentReady } from './_helpers'
 
 // `index.php`-prefixed — see the APP constant in ./_helpers.ts for why the
 // prefix is required on CI (`php -S` does not rewrite, so `/apps/...` hits
@@ -44,7 +45,11 @@ async function go(page: Page, route = ''): Promise<void> {
 	// `domcontentloaded`, not the default `load` — NC's long-lived polling
 	// connections can delay `load` past any sane timeout. See _helpers.ts.
 	await page.goto(url, { waitUntil: 'domcontentloaded' })
-	await page.waitForLoadState('networkidle').catch(() => {})
+	// Not `networkidle` — it never fires on Nextcloud (long-lived notification
+	// polling / user-status heartbeat), so the old swallowed wait spent its
+	// whole timeout and then continued regardless. See waitForAppReady in
+	// ./_helpers (ADR-074 rule 4 / gate-58).
+	await waitForAppReady(page)
 	await dismissOverlays(page)
 	await page.waitForTimeout(800)
 }
@@ -92,8 +97,12 @@ test.describe('dashboard — main view', () => {
 test.describe('dashboard — NC dashboard widgets', () => {
 	test('Nextcloud Dashboard page is accessible and DocuDesk widgets can be added', async ({ page }) => {
 		// @e2e openspec/specs/dashboard/spec.md#widgets-available-on-nextcloud-dashboard
-		await page.goto('/index.php/apps/dashboard')
-		await page.waitForLoadState('networkidle').catch(() => {})
+		await page.goto('/index.php/apps/dashboard', { waitUntil: 'domcontentloaded' })
+		// Nextcloud's own Dashboard app, not the DocuDesk SPA — wait for NC's
+		// authenticated content region. Not `networkidle`: it never settles on
+		// Nextcloud, and the `.catch(() => {})` this line used to carry turned
+		// its own timeout into a pass (ADR-074 rule 4 / gate-58).
+		await waitForNcContentReady(page)
 		await dismissOverlays(page)
 		await page.waitForTimeout(800)
 		// Dashboard page should load
@@ -104,12 +113,16 @@ test.describe('dashboard — NC dashboard widgets', () => {
 	test('DocuDesk navigation entry icon is app.svg', async ({ page }) => {
 		// @e2e openspec/specs/dashboard/spec.md#navigation-icon
 		// Navigate to NC and check DocuDesk nav entry
-		await page.goto('/index.php/apps/files')
-		await page.waitForLoadState('networkidle').catch(() => {})
-		await dismissOverlays(page)
-		await page.waitForTimeout(600)
+		await page.goto('/index.php/apps/files', { waitUntil: 'domcontentloaded' })
 		// NC app list / navigation — DocuDesk should appear with app icon
 		const navMenu = page.locator('#appmenu, nav.app-menu, #navigation').first()
+		// Wait for exactly the element this test then asserts on. The previous
+		// `waitForLoadState('networkidle').catch(() => {})` waited for a state
+		// Nextcloud never reaches (long-lived polling), so it only burned its
+		// timeout and then swallowed the failure. ADR-074 rule 4 / gate-58.
+		await navMenu.waitFor({ state: 'visible', timeout: 30_000 })
+		await dismissOverlays(page)
+		await page.waitForTimeout(600)
 		await expect(navMenu).toBeVisible()
 	})
 
@@ -169,8 +182,11 @@ test.describe('dashboard — icon files', () => {
 	test('DocuDesk admin settings page loads (settings icon uses app-dark.svg)', async ({ page }) => {
 		// @e2e openspec/specs/dashboard/spec.md#dashboard-widget-icon
 		// @e2e openspec/specs/dashboard/spec.md#admin-settings-section-icon
-		await page.goto('/index.php/settings/admin/docudesk')
-		await page.waitForLoadState('networkidle').catch(() => {})
+		await page.goto('/index.php/settings/admin/docudesk', { waitUntil: 'domcontentloaded' })
+		// NC admin settings, not the DocuDesk SPA — wait for NC's authenticated
+		// content region instead of `networkidle`, which never fires here
+		// (ADR-074 rule 4 / gate-58) and was swallowed when it timed out.
+		await waitForNcContentReady(page)
 		await dismissOverlays(page)
 		await page.waitForTimeout(600)
 		// Settings page should load for admin

--- a/tests/e2e/spec-coverage/templates.spec.ts
+++ b/tests/e2e/spec-coverage/templates.spec.ts
@@ -90,13 +90,21 @@ test.describe('template-management — templates list UI', () => {
 		await go(page, 'templates')
 		await dismissOverlays(page)
 		await page.getByRole('button', { name: 'New template' }).click()
-		await page.waitForLoadState('networkidle').catch(() => {})
-		await page.waitForTimeout(800)
 		// The create surface is a dialog. Asserting it directly, rather than
 		// `dialog.or(content)`: `.or()` on two locators that BOTH resolve is a
 		// strict-mode violation, and "the content area is visible" is true on
 		// every page anyway, so it could never have failed.
 		const dialog = page.locator('[role="dialog"]').first()
+		// Wait for exactly that dialog. This replaces a
+		// `waitForLoadState('networkidle').catch(() => {})` which never settled
+		// — Nextcloud keeps long-lived connections open, so it always ran to
+		// its own timeout and the `.catch` swallowed the failure (ADR-074
+		// rule 4 / gate-58). Waiting on the dialog is the deterministic form of
+		// the same intent, and its absence now fails here rather than silently.
+		await dialog.waitFor({ state: 'visible', timeout: 15_000 })
+		// Brief settle so the dialog's open animation has finished before the
+		// content assertion reads it.
+		await page.waitForTimeout(400)
 		await expect(dialog).toBeVisible()
 		await expect(dialog).toContainText(/Template/i)
 		expect(guard.server5xx, `5xx: ${guard.server5xx.join(' | ')}`).toEqual([])

--- a/tests/e2e/workflows/_fixtures.ts
+++ b/tests/e2e/workflows/_fixtures.ts
@@ -56,14 +56,22 @@ export const API = '/index.php/apps/docudesk/api'
 export async function harvestToken(page: Page): Promise<string> {
 	// `index.php`-prefixed for the same reason `API` above is: nothing rewrites
 	// `/apps/...` on a `php -S` runner, so the unprefixed form returns PHP's own
-	// 404 page — which has no `requesttoken` meta and no `window.OC`, making
-	// this helper fail with "CSRF request-token must be harvestable" and
-	// accusing the session instead of the URL.
+	// 404 page — which carries neither the head `data-requesttoken` attribute
+	// nor `window.OC`, making this helper fail with "CSRF request-token must be
+	// harvestable" and accusing the session instead of the URL.
 	await page.goto('/index.php/apps/docudesk', { waitUntil: 'domcontentloaded' })
-	// Wait for exactly what the evaluate below reads: the CSRF request-token.
-	// `window.OC.requestToken` is set by NC core's bundle and the
-	// `meta[name="requesttoken"]` is server-rendered into the head, so the head
-	// tag is the earliest deterministic signal that the token is readable.
+	// Wait for exactly what the evaluate below reads: a non-empty CSRF
+	// request-token.
+	//
+	// Nextcloud does NOT publish the token as `<meta name="requesttoken">` —
+	// that element does not exist on any authenticated page. `layout.user.php`
+	// renders it as an attribute on the head element
+	// (`<head … data-requesttoken="…">`), and NC core's own accessor
+	// `getRequestToken()` (core/src/OC/requesttoken.ts) reads exactly
+	// `document.head.dataset.requesttoken`; `window.OC.requestToken` is that
+	// same value re-exported once the core bundle has evaluated. So the two
+	// readable sources are `window.OC.requestToken` and the head attribute,
+	// and this waits for whichever appears first.
 	//
 	// This replaces `await page.waitForLoadState('networkidle').catch(() => {})`
 	// (ADR-074 rule 4 / gate-58). Nextcloud holds long-lived connections open,
@@ -71,11 +79,21 @@ export async function harvestToken(page: Page): Promise<string> {
 	// the `.catch` turned the timeout into a pass — meaning it gave the token
 	// no guarantee whatsoever, and the "CSRF request-token must be harvestable"
 	// expectation below was left to race the page.
-	await page.locator('meta[name="requesttoken"]').waitFor({ state: 'attached', timeout: 30_000 })
+	//
+	// The wait is not swallowed: on PHP's built-in-server 404 page (see the
+	// `page.goto` note above) neither source ever appears, and this fails here
+	// naming the token, instead of failing later as a mysterious 412 on the
+	// first write request.
+	await page.waitForFunction(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		() => Boolean((window as any).OC?.requestToken || document.head.dataset.requesttoken),
+		undefined,
+		{ timeout: 30_000 },
+	)
 	const token = await page.evaluate(
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		() => (window as any).OC?.requestToken
-			|| document.head.querySelector('meta[name="requesttoken"]')?.getAttribute('content')
+			|| document.head.dataset.requesttoken
 			|| '',
 	)
 	expect(token, 'CSRF request-token must be harvestable from the running app').not.toEqual('')

--- a/tests/e2e/workflows/_fixtures.ts
+++ b/tests/e2e/workflows/_fixtures.ts
@@ -59,8 +59,19 @@ export async function harvestToken(page: Page): Promise<string> {
 	// 404 page — which has no `requesttoken` meta and no `window.OC`, making
 	// this helper fail with "CSRF request-token must be harvestable" and
 	// accusing the session instead of the URL.
-	await page.goto('/index.php/apps/docudesk')
-	await page.waitForLoadState('networkidle').catch(() => {})
+	await page.goto('/index.php/apps/docudesk', { waitUntil: 'domcontentloaded' })
+	// Wait for exactly what the evaluate below reads: the CSRF request-token.
+	// `window.OC.requestToken` is set by NC core's bundle and the
+	// `meta[name="requesttoken"]` is server-rendered into the head, so the head
+	// tag is the earliest deterministic signal that the token is readable.
+	//
+	// This replaces `await page.waitForLoadState('networkidle').catch(() => {})`
+	// (ADR-074 rule 4 / gate-58). Nextcloud holds long-lived connections open,
+	// so networkidle never fires: that wait always ran to its own timeout and
+	// the `.catch` turned the timeout into a pass — meaning it gave the token
+	// no guarantee whatsoever, and the "CSRF request-token must be harvestable"
+	// expectation below was left to race the page.
+	await page.locator('meta[name="requesttoken"]').waitFor({ state: 'attached', timeout: 30_000 })
 	const token = await page.evaluate(
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		() => (window as any).OC?.requestToken

--- a/tests/e2e/workflows/anonymization-workflow.spec.ts
+++ b/tests/e2e/workflows/anonymization-workflow.spec.ts
@@ -37,7 +37,7 @@
  */
 
 import { test, expect } from '@playwright/test'
-import { APP, dismissOverlays } from '../spec-coverage/_helpers'
+import { APP, dismissOverlays, waitForAppReady } from '../spec-coverage/_helpers'
 import {
 	harvestToken, jsonHeaders, API, TEST_PREFIX, TEST_FAMILY,
 	createDavFolder, createDavFile,
@@ -71,11 +71,19 @@ test.afterAll(async ({ request }) => {
  */
 async function goRoute(page, route: string): Promise<void> {
 	// `index.php`-prefixed — see the APP constant in ../spec-coverage/_helpers.ts.
-	await page.goto(APP)
-	await page.waitForLoadState('networkidle').catch(() => {})
+	// `domcontentloaded` + an explicit app-mounted wait, not `networkidle`:
+	// Nextcloud keeps long-lived connections open (notifications polling,
+	// user-status heartbeat) so networkidle never fires. Both calls here used
+	// to be `waitForLoadState('networkidle').catch(() => {})`, i.e. two full
+	// timeouts burned per navigation, each swallowed into a pass, after which
+	// the specs asserted against a possibly-unmounted app. `waitForAppReady`
+	// waits for the DocuDesk mount point and its painted content region
+	// instead, and throws if they never arrive. ADR-074 rule 4 / gate-58.
+	await page.goto(APP, { waitUntil: 'domcontentloaded' })
+	await waitForAppReady(page)
 	await dismissOverlays(page)
-	await page.goto(`${APP}/${route}`)
-	await page.waitForLoadState('networkidle').catch(() => {})
+	await page.goto(`${APP}/${route}`, { waitUntil: 'domcontentloaded' })
+	await waitForAppReady(page)
 	await dismissOverlays(page)
 	await page.waitForTimeout(1200)
 }


### PR DESCRIPTION
## What

Closes hydra **gate-58 `e2e-networkidle`** for docudesk: **18 findings → 0**.

## Why

`page.waitForLoadState('networkidle')` can never settle on Nextcloud. The instance holds long-lived connections open (notifications polling, the user-status heartbeat), so the network is never quiet.

Every one of these 18 waits therefore:

1. ran to its **full timeout** (~30s per navigation), then
2. was **swallowed by `.catch(() => {})`**, which converted that timeout into a pass, then
3. let the test assert against a page with **no guarantee of having rendered**.

It never settled anything. It burned the budget and then continued at exactly the moment it would have anyway — and because of the swallow, nothing ever reported it. ADR-074 rule 4.

## How

Not deleted — deleting turns a 30s implicit settle into *no* wait and makes these specs flaky. Each site now waits for **exactly what the test does next**, and **no `.catch(() => {})` is carried forward onto any replacement**:

Two shared helpers in `tests/e2e/spec-coverage/_helpers.ts`:

- **`waitForAppReady()`** — the `#docudesk-app` mount point that `templates/index.php` server-renders, then the content region the manifest shell paints inside it. The mount-point check additionally separates a real Nextcloud response from PHP's built-in-server 404 page, which has a `<body>` and a non-`/login` URL and so satisfied several assertions in this suite.
- **`waitForNcContentReady()`** — for Nextcloud *core* routes (admin settings, Dashboard, Files), which have no `#docudesk-app`. `#content` belongs to NC's authenticated layout only, so this also fails fast on an expired session.

Per-site:

| Site | Now waits for |
|---|---|
| `_helpers.ts` `go()` / `navClick()` | `waitForAppReady()` |
| `consent-management` `go()`, `anonymization` `go()`, `custom-dictionary-recognition` `go()`, `dashboard` `go()` | `waitForAppReady()` |
| `admin-settings` `goSettings()` + `/settings/admin` | `waitForNcContentReady()` — the very `#app-content, .app-content, #content` locator those specs assert two lines later; both `goto`s also move to `waitUntil: 'domcontentloaded'` |
| `dashboard` → NC Dashboard, admin settings | `waitForNcContentReady()` |
| `dashboard` → Files | `#appmenu, nav.app-menu, #navigation` — exactly the locator that test then asserts is visible |
| `templates` after "New template" click | the `[role="dialog"]` the next assertion reads |
| `custom-dictionary-recognition` after row click | `waitForURL` on the index → detail transition the test then asserts |
| `consent-management` after row click | the shell — a route that throws during render unmounts the content region |
| `workflows/_fixtures` `harvestToken()` | a non-empty `window.OC.requestToken` **or** head `data-requesttoken` — precisely what the next `evaluate` reads |
| `workflows/anonymization-workflow` `goRoute()` | `waitForAppReady()` after each of its two `goto`s |
| `docs-screenshots` `go()` | content region, **scoped to the success path** — this helper deliberately tolerates a 404, so the wait is skipped on a failed navigation but is *not* swallowed when the page did load |

## Verification

Gate runner `run-hydra-gates.sh`, package sha `48c88ba1e0d049f8f38538c33e790d3e603c55d0`, full-repo scope. STDOUT read directly — never the exit byte.

**Before**
```
[gate-58] e2e-networkidle: FAIL — 18 networkidle wait(s) in changed e2e file(s)
```

**After**
```
[gate-58] e2e-networkidle: PASS
```

**Proof the gate can still fail** — one `networkidle` call temporarily reintroduced into `anonymization.spec.ts`:
```
[gate-58] e2e-networkidle: FAIL — 1 networkidle wait(s) in changed e2e file(s)
tests/e2e/spec-coverage/anonymization.spec.ts:41:await page.waitForLoadState('networkidle').catch(() => {})
```
Exactly one finding, naming the reintroduced line — which also confirms the explanatory comments added by this PR are **not** counted (the gate masks comment regions, per .github#230). The probe was then removed.

### Correction — the first push regressed the Playwright job

The static checks below were the **only** verification of the first two commits, and static checks cannot see a locator that does not exist. `harvestToken()` was changed to wait for `meta[name="requesttoken"]`. **Nextcloud has no such element.** `core/templates/layout.user.php` renders the token as an attribute on the head element (`<head … data-requesttoken="…">`, unchanged at v32.0.0, the major CI runs), and NC core's own accessor `getRequestToken()` reads exactly `document.head.dataset.requesttoken`.

So that wait could never resolve on any page and ran to its full 30s timeout every time — the same defect gate-58 exists to catch, just louder: the old `networkidle` wait was swallowed by `.catch(() => {})` and therefore *passed*, while this one *failed*. Three workflow tests died in it and took eight more with them (serial files):

```
✘ workflows/anonymization-workflow.spec.ts:98
✘ workflows/signing-workflow.spec.ts:86
✘ workflows/templates-crud.spec.ts:54
  TimeoutError: locator.waitFor: Timeout 30000ms exceeded.
  - waiting for locator('meta[name="requesttoken"]')
3 failed, 67 passed
```

Fixed in `f2112485`: wait for a non-empty `window.OC.requestToken` **or** head `data-requesttoken`, and read those same two sources. The wait is still not swallowed — on PHP's built-in-server 404 page neither source appears and it fails there naming the token, instead of surfacing later as a mysterious 412 on the first write.

**CI result after the fix** — `quality / E2E Tests (Playwright)`: **78 passed, 0 failed**, identical to the `development` baseline (78 passed). All 29 checks pass.

**Static checks** (run before the CI measurement above; on their own they were *not* sufficient — never run against the shared dev instance):
- `npm ci` → exit 0
- `npx tsc --noEmit` → exit 0
- `npx playwright test --list` → exit 0, **94 tests in 20 files** (`--list` type-checks and enumerates without executing; pointed at a dead port, never the shared container)

**No regressions.** The failing-gate set is identical before and after, minus 58:
`1, 7, 19, 25, 26, 32, 34, 39, 43, 45, 50, 54` — all pre-existing and out of scope here. No non-empty `*.err` in either run, so no checker crashed.

## Scope

`tests/` only. No production code, no waivers, no `.skip` / `test.fixme` / `@e2e exclude` / threshold changes.
