### PR TITLE
test(newman): execute the second collection suite, which CI had never run

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -101,6 +101,26 @@ jobs:
       # which is both the directory the validator counts collections in and the
       # directory the run step globs `*.postman_collection.json` in — flat, not
       # recursively.
+      #
+      # THAT FLATNESS HID A SECOND SUITE. `tests/newman/` held two more
+      # collections that no CI step has ever executed, because the glob only
+      # ever visits ONE directory and `newman-collection-path` is never set
+      # away from its default. Measured 2026-08-09:
+      #
+      #   tests/newman/docudesk-api.postman_collection.json
+      #       50 requests / 107 pm.test assertions. NOT ONE request declared
+      #       `OCS-APIRequest`, so all 39 of its writes (34 POST + 5 DELETE)
+      #       would have been rejected 412 by Nextcloud middleware before
+      #       reaching a controller — it had never exercised a write path.
+      #   tests/newman/docudesk-api-collection.json
+      #       8 requests / 15 assertions, and invisible even to the validator:
+      #       its name does not match `*.postman_collection.json`. Its own
+      #       `baseUrl` variable was the literal string "{{baseUrl}}".
+      #
+      # Both are now repaired and moved INTO tests/integration, so the existing
+      # flat glob runs all three. Keeping the default path (rather than
+      # repointing it at tests/newman) is deliberate: repointing would have
+      # de-selected the one collection that does run today.
       enable-newman: true
 
       # The Newman job needs the SAME provisioning the Playwright job gets, and

--- a/lib/Service/PolicyCrudService.php
+++ b/lib/Service/PolicyCrudService.php
@@ -269,7 +269,7 @@ class PolicyCrudService
 
         $objectService = $this->settingsService->getObjectService();
         $objectService->deleteObject(
-            id: $uuid,
+            uuid: $uuid,
             register: self::REGISTER,
             schema: self::SCHEMA_PROHIBITION,
             _rbac: false,
@@ -361,7 +361,7 @@ class PolicyCrudService
 
         $objectService = $this->settingsService->getObjectService();
         $objectService->deleteObject(
-            id: $uuid,
+            uuid: $uuid,
             register: self::REGISTER,
             schema: self::SCHEMA_CONSENT,
             _rbac: false,

--- a/tests/e2e/ci-seed.sh
+++ b/tests/e2e/ci-seed.sh
@@ -516,6 +516,37 @@ PY
 
 echo "[ci-seed] DocuDesk registers, schemas and object-type bindings provisioned."
 
+# ── 4a-bis. Policy RBAC groups ─────────────────────────────────────────────
+# The policy surface is group-gated, not admin-gated:
+#   PolicyCrudService::POLICY_GROUP           = docudesk-policy-admins
+#   PolicyCrudService::STANDING_CONSENT_GROUP = docudesk-standing-consent-admins
+# and docudesk_register.json grants create/update/delete on
+# publicationProhibition to `docudesk-policy-admins`. Neither group exists on a
+# fresh install and nothing creates them, so every prohibition / standing-consent
+# WRITE answered 403 — including from `admin`, because these are group
+# memberships and not the admin flag.
+#
+# The Newman collection papered over exactly this: its seeding requests carried
+# `if (pm.response.code === 403 ...) { pm.test.skip(...); return; }`, which turns
+# a 403 into a NON-FAILING result and then skips the outcome assertions that
+# depended on the seed. The whole "Detection-time outcomes" folder could report
+# green having exercised nothing. Creating the groups here is what makes those
+# assertions able to run — and able to fail.
+for _dd_group in docudesk-policy-admins docudesk-standing-consent-admins; do
+	php "${NC_ROOT}/occ" group:add "${_dd_group}" 2>&1 | tail -1 || true
+	php "${NC_ROOT}/occ" group:adduser "${_dd_group}" "${USER_NAME}" 2>&1 | tail -1 || true
+done
+
+# Fail loudly if the memberships did not take: a silent 403 later reads like an
+# authorization bug in the app rather than an unseeded fixture.
+_dd_groups_actual=$(php "${NC_ROOT}/occ" user:info "${USER_NAME}" --output=json 2>/dev/null || echo '{}')
+for _dd_group in docudesk-policy-admins docudesk-standing-consent-admins; do
+	case "${_dd_groups_actual}" in
+		*"${_dd_group}"*) echo "[ci-seed] ${USER_NAME} is in ${_dd_group}." ;;
+		*) echo "::error::${USER_NAME} is NOT in ${_dd_group} — every policy write will 403."; exit 1 ;;
+	esac
+done
+
 # ── 4b. Materialise the admin user's home, then probe WebDAV ────────────────
 # `occ maintenance:install` creates the admin ACCOUNT but not its files home —
 # that is built lazily, the first time something initialises the user's mount

--- a/tests/e2e/ci-seed.sh
+++ b/tests/e2e/ci-seed.sh
@@ -517,14 +517,25 @@ PY
 echo "[ci-seed] DocuDesk registers, schemas and object-type bindings provisioned."
 
 # ── 4a-bis. Policy RBAC groups ─────────────────────────────────────────────
-# The policy surface is group-gated, not admin-gated:
-#   PolicyCrudService::POLICY_GROUP           = docudesk-policy-admins
+# The policy surface is group-gated, not admin-gated, and THREE group names are
+# in play across two enforcement layers:
+#
+#   PolicyCrudService::PROHIBITION_GROUP      = docudesk-prohibition-admins
 #   PolicyCrudService::STANDING_CONSENT_GROUP = docudesk-standing-consent-admins
-# and docudesk_register.json grants create/update/delete on
-# publicationProhibition to `docudesk-policy-admins`. Neither group exists on a
-# fresh install and nothing creates them, so every prohibition / standing-consent
-# WRITE answered 403 — including from `admin`, because these are group
-# memberships and not the admin flag.
+#   docudesk_register.json RBAC on publicationProhibition
+#                          (create/update/delete) = docudesk-policy-admins
+#
+# ⚠️ The first and third DISAGREE, and they gate the same operation at two
+# different layers. A member of `docudesk-policy-admins` clears OpenRegister's
+# schema RBAC and is then rejected by the service check; a member of
+# `docudesk-prohibition-admins` clears the service check and is then rejected by
+# OpenRegister. So NO non-admin group can write a prohibition today — only the
+# admin flag can, via the short-circuit in assertProhibitionPermission(). Which
+# name is canonical is a product decision, so this script seeds all three rather
+# than silently picking one; the mismatch is reported separately.
+#
+# None of these groups exists on a fresh install and nothing creates them, so
+# every prohibition / standing-consent WRITE by a non-admin answered 403.
 #
 # The Newman collection papered over exactly this: its seeding requests carried
 # `if (pm.response.code === 403 ...) { pm.test.skip(...); return; }`, which turns
@@ -532,7 +543,7 @@ echo "[ci-seed] DocuDesk registers, schemas and object-type bindings provisioned
 # depended on the seed. The whole "Detection-time outcomes" folder could report
 # green having exercised nothing. Creating the groups here is what makes those
 # assertions able to run — and able to fail.
-for _dd_group in docudesk-policy-admins docudesk-standing-consent-admins; do
+for _dd_group in docudesk-policy-admins docudesk-prohibition-admins docudesk-standing-consent-admins; do
 	php "${NC_ROOT}/occ" group:add "${_dd_group}" 2>&1 | tail -1 || true
 	php "${NC_ROOT}/occ" group:adduser "${_dd_group}" "${USER_NAME}" 2>&1 | tail -1 || true
 done
@@ -540,7 +551,7 @@ done
 # Fail loudly if the memberships did not take: a silent 403 later reads like an
 # authorization bug in the app rather than an unseeded fixture.
 _dd_groups_actual=$(php "${NC_ROOT}/occ" user:info "${USER_NAME}" --output=json 2>/dev/null || echo '{}')
-for _dd_group in docudesk-policy-admins docudesk-standing-consent-admins; do
+for _dd_group in docudesk-policy-admins docudesk-prohibition-admins docudesk-standing-consent-admins; do
 	case "${_dd_groups_actual}" in
 		*"${_dd_group}"*) echo "[ci-seed] ${USER_NAME} is in ${_dd_group}." ;;
 		*) echo "::error::${USER_NAME} is NOT in ${_dd_group} — every policy write will 403."; exit 1 ;;

--- a/tests/integration/docudesk-api-negative.postman_collection.json
+++ b/tests/integration/docudesk-api-negative.postman_collection.json
@@ -8,13 +8,39 @@
   "variable": [
     {
       "key": "baseUrl",
-      "value": "{{baseUrl}}",
-      "description": "Nextcloud base URL — set via environment (never hardcode)"
+      "value": "http://localhost:8080/index.php",
+      "description": "Nextcloud entry point. This was literally \"{{baseUrl}}\" — a variable whose value referenced itself, so it never resolved and every request in this collection went to an unusable URL. The CI runner supplies `base_url` (snake_case), which never fed this key, so nothing corrected it at run time either."
     },
     {
-      "key": "authToken",
-      "value": "{{authToken}}",
-      "description": "Bearer token or Basic auth — set via environment"
+      "key": "username",
+      "value": "admin",
+      "description": "Matches the `admin_user` the CI Newman step provisions."
+    },
+    {
+      "key": "password",
+      "value": "admin",
+      "description": "Matches the `admin_password` the CI Newman step provisions."
+    }
+  ],
+  "auth": {
+    "type": "basic",
+    "basic": [
+      { "key": "username", "value": "{{username}}", "type": "string" },
+      { "key": "password", "value": "{{password}}", "type": "string" }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Nextcloud rejects state-changing requests without this header with 412,",
+          "// before any controller runs. `upsert` is case-insensitive on the key, so",
+          "// requests that already declare OCS-APIREQUEST are left alone.",
+          "pm.request.headers.upsert({ key: 'OCS-APIRequest', value: 'true' });"
+        ]
+      }
     }
   ],
   "item": [
@@ -26,7 +52,6 @@
           "request": {
             "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{authToken}}" },
               { "key": "OCS-APIREQUEST", "value": "true" }
             ],
             "url": {
@@ -60,7 +85,6 @@
           "request": {
             "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{authToken}}" },
               { "key": "OCS-APIREQUEST", "value": "true" }
             ],
             "url": {
@@ -87,6 +111,7 @@
         {
           "name": "GET /api/templates - 401 without auth",
           "request": {
+            "auth": { "type": "noauth" },
             "method": "GET",
             "header": [],
             "url": {
@@ -153,6 +178,7 @@
         {
           "name": "GET /api/preferences/:key - 401 without auth",
           "request": {
+            "auth": { "type": "noauth" },
             "method": "GET",
             "header": [],
             "url": {
@@ -180,7 +206,6 @@
           "request": {
             "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{authToken}}" },
               { "key": "OCS-APIREQUEST", "value": "true" }
             ],
             "url": {
@@ -209,17 +234,16 @@
       "name": "Anonymization Batch",
       "item": [
         {
-          "name": "GET /api/anonymization/batch/:id - 404 for unknown batch",
+          "name": "GET /api/anonymization/batch/:id/status - 404 for unknown batch",
           "request": {
             "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{authToken}}" },
               { "key": "OCS-APIREQUEST", "value": "true" }
             ],
             "url": {
-              "raw": "{{baseUrl}}/apps/docudesk/api/anonymization/batch/non-existent-batch-id",
+              "raw": "{{baseUrl}}/apps/docudesk/api/anonymization/batch/non-existent-batch-id/status",
               "host": ["{{baseUrl}}"],
-              "path": ["apps", "docudesk", "api", "anonymization", "batch", "non-existent-batch-id"]
+              "path": ["apps", "docudesk", "api", "anonymization", "batch", "non-existent-batch-id", "status"]
             }
           },
           "event": [
@@ -227,7 +251,18 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('Status is 404', () => pm.response.to.have.status(404));"
+                  "// This targeted `api/anonymization/batch/{id}`, which is not a route:",
+                  "// appinfo/routes.php only registers batch/{batchId}/status, /extract,",
+                  "// /entities, /anonymize and /report. An unrouted GET falls through to",
+                  "// Nextcloud's SPA shell — 200 with HTML — so the assertion below could",
+                  "// only ever have failed, and a status-only assertion could never have",
+                  "// told the two cases apart. batchStatus() is the method that really",
+                  "// answers 404 ('Batch not found') for an unknown id.",
+                  "pm.test('Status is 404', () => pm.response.to.have.status(404));",
+                  "pm.test('404 is a JSON error, not the SPA HTML fallback', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type') || '').to.include('application/json');",
+                  "    pm.expect(pm.response.json()).to.have.property('error');",
+                  "});"
                 ],
                 "type": "text/javascript"
               }
@@ -244,7 +279,6 @@
           "request": {
             "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{authToken}}" },
               { "key": "OCS-APIREQUEST", "value": "true" }
             ],
             "url": {

--- a/tests/integration/docudesk-api-negative.postman_collection.json
+++ b/tests/integration/docudesk-api-negative.postman_collection.json
@@ -20,6 +20,11 @@
       "key": "password",
       "value": "admin",
       "description": "Matches the `admin_password` the CI Newman step provisions."
+    },
+    {
+      "key": "noAuthBase",
+      "value": "http://127.0.0.1:8080/index.php",
+      "description": "A DIFFERENT host alias for the same server, used only by the deliberate 401 tests. Newman keeps one cookie jar for the whole run, and Nextcloud's session cookie is host-scoped — so an unauthenticated request sent to the SAME host as the authenticated ones still carries the session and answers 200. Measured 2026-08-09: both 401 tests failed with 'expected [401, 302] to include 200' for exactly this reason, which reads like an authorization hole and is not one. Same technique as docudesk.postman_collection.json."
     }
   ],
   "auth": {
@@ -115,8 +120,8 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/apps/docudesk/api/templates",
-              "host": ["{{baseUrl}}"],
+              "raw": "{{noAuthBase}}/apps/docudesk/api/templates",
+              "host": ["{{noAuthBase}}"],
               "path": ["apps", "docudesk", "api", "templates"]
             }
           },
@@ -182,8 +187,8 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/apps/docudesk/api/preferences/test-key",
-              "host": ["{{baseUrl}}"],
+              "raw": "{{noAuthBase}}/apps/docudesk/api/preferences/test-key",
+              "host": ["{{noAuthBase}}"],
               "path": ["apps", "docudesk", "api", "preferences", "test-key"]
             }
           },

--- a/tests/integration/docudesk-api.postman_collection.json
+++ b/tests/integration/docudesk-api.postman_collection.json
@@ -34,6 +34,25 @@
       }
     ]
   },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Nextcloud's OCS/CSRF middleware rejects every state-changing request",
+          "// that does not carry `OCS-APIRequest: true` with HTTP 412, BEFORE the",
+          "// request ever reaches a DocuDesk controller. Not one of this",
+          "// collection's requests declared the header, so all 39 of its writes",
+          "// (34 POST + 5 DELETE) were answered 412 and no write path had ever",
+          "// been exercised. Upserting it here covers every request in the",
+          "// collection at once, and `upsert` leaves an explicit per-request",
+          "// header untouched.",
+          "pm.request.headers.upsert({ key: 'OCS-APIRequest', value: 'true' });"
+        ]
+      }
+    }
+  ],
   "item": [
     {
       "name": "Health",
@@ -481,19 +500,20 @@
           ]
         },
         {
-          "name": "POST /api/anonymization/batchAnonymize/test-clearance-batch (accepts unredactedEntities)",
+          "name": "POST /api/anonymization/batch/test-clearance-batch/anonymize (accepts unredactedEntities)",
           "request": {
             "method": "POST",
             "url": {
-              "raw": "{{baseUrl}}/api/anonymization/batchAnonymize/test-clearance-batch",
+              "raw": "{{baseUrl}}/api/anonymization/batch/test-clearance-batch/anonymize",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
                 "anonymization",
-                "batchAnonymize",
-                "test-clearance-batch"
+                "batch",
+                "test-clearance-batch",
+                "anonymize"
               ]
             },
             "header": [
@@ -829,17 +849,17 @@
       "name": "Consent",
       "item": [
         {
-          "name": "GET /api/consent",
+          "name": "GET /api/consents",
           "request": {
             "method": "GET",
             "url": {
-              "raw": "{{baseUrl}}/api/consent",
+              "raw": "{{baseUrl}}/api/consents",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
-                "consent"
+                "consents"
               ]
             }
           },
@@ -849,8 +869,24 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Status code is 200 or 400', function () { pm.expect([200, 400]).to.include(pm.response.code); });",
-                  "pm.test('Response is JSON', function () { pm.response.to.be.json; });"
+                  "// 400 was accepted here because the consent register/schema",
+                  "// bindings were never provisioned for this suite; CI now runs",
+                  "// `ci-seed.sh api`, which binds consent_register/consent_schema,",
+                  "// so ConsentController::notConfiguredResponse() can no longer",
+                  "// fire and a 400 is a real regression.",
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "// An unknown subpath under a Nextcloud app answers 200 with the",
+                  "// SPA HTML shell, so a status assertion alone proves nothing about",
+                  "// whether a controller ran. Pin the content type and the shape.",
+                  "pm.test('Response is JSON, not the SPA HTML fallback', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type') || '').to.include('application/json');",
+                  "});",
+                  "// ConsentController::index() returns JSONResponse(listConsents(...)),",
+                  "// and ConsentCrudService::listConsents() builds a PHP list — so the",
+                  "// body is a JSON ARRAY, not an envelope.",
+                  "pm.test('Body is a consent array', function () {",
+                  "    pm.expect(pm.response.json()).to.be.an('array');",
+                  "});"
                 ]
               }
             }
@@ -861,13 +897,13 @@
           "request": {
             "method": "POST",
             "url": {
-              "raw": "{{baseUrl}}/api/consent",
+              "raw": "{{baseUrl}}/api/consents",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
-                "consent"
+                "consents"
               ]
             },
             "header": [
@@ -905,13 +941,13 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/api/consent",
+              "raw": "{{baseUrl}}/api/consents",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
-                "consent"
+                "consents"
               ]
             },
             "body": {
@@ -947,13 +983,13 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/api/consent",
+              "raw": "{{baseUrl}}/api/consents",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
-                "consent"
+                "consents"
               ]
             },
             "body": {
@@ -988,13 +1024,13 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/api/consent",
+              "raw": "{{baseUrl}}/api/consents",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
-                "consent"
+                "consents"
               ]
             },
             "body": {
@@ -1187,7 +1223,7 @@
           "name": "no-match: POST /api/consent → WOO default (pending across the board)",
           "request": {
             "method": "POST",
-            "url": { "raw": "{{baseUrl}}/api/consent", "host": ["{{baseUrl}}"], "path": ["api", "consent"] },
+            "url": { "raw": "{{baseUrl}}/api/consents", "host": ["{{baseUrl}}"], "path": ["api", "consents"] },
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
@@ -1200,7 +1236,8 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.response.code === 500 || pm.response.code === 400) { pm.test.skip('Consent register/schema not configured in this env'); return; }",
+                  "// pm.test.skip() guard removed: ci-seed.sh binds consent_register /",
+                  "// consent_schema, so a 400/500 here is a real regression.",
                   "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
                   "pm.test('matchKind is null (no rule fired)', function () { pm.expect(json.matchKind).to.satisfy(function (v) { return v === null || v === undefined; }); });",
@@ -1230,7 +1267,11 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.response.code === 403 || pm.response.code === 500) { pm.collectionVariables.set('detectionProhibitionSeeded', 'false'); pm.test.skip('Seeding requires docudesk-policy-admins group; not configured in env'); return; }",
+                  "// The 403/500 guard that stood here called pm.test.skip() and",
+                  "// returned — a skipped test is NON-FAILING, so an unseeded",
+                  "// environment reported green and every outcome assertion below was",
+                  "// skipped too. ci-seed.sh now creates docudesk-policy-admins and puts",
+                  "// the admin user in it, so a 403 here is a real regression.",
                   "pm.collectionVariables.set('detectionProhibitionSeeded', 'true');",
                   "pm.test('Seed prohibition created (201)', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
@@ -1245,7 +1286,7 @@
           "name": "prohibition: POST /api/consent → prohibition wins (matchKind=prohibition)",
           "request": {
             "method": "POST",
-            "url": { "raw": "{{baseUrl}}/api/consent", "host": ["{{baseUrl}}"], "path": ["api", "consent"] },
+            "url": { "raw": "{{baseUrl}}/api/consents", "host": ["{{baseUrl}}"], "path": ["api", "consents"] },
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
@@ -1258,8 +1299,12 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.collectionVariables.get('detectionProhibitionSeeded') !== 'true') { pm.test.skip('Seed step skipped — cannot exercise outcome'); return; }",
-                  "if (pm.response.code === 500 || pm.response.code === 400) { pm.test.skip('Consent register/schema not configured'); return; }",
+                  "// Dead guard removed: the seed step now asserts its own 201 instead of",
+                  "// recording 'false', so this variable can no longer be anything but",
+                  "// 'true' — and a skipped outcome is exactly what hid the failure.",
+                  "// pm.test.skip() guard removed: ci-seed.sh binds consent_register /",
+                  "// consent_schema, so a 400/500 here is a real regression, not an",
+                  "// unconfigured environment.",
                   "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
                   "pm.test('matchKind = prohibition', function () { pm.expect(json.matchKind).to.equal('prohibition'); });",
@@ -1284,7 +1329,12 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.collectionVariables.get('detectionProhibitionSeeded') !== 'true') { pm.test.skip('No seed to clean'); return; }",
+                  "// Was a pm.test.skip() guard. The seed is asserted now, so there is",
+                  "// always something to clean and a failed teardown must be reported —",
+                  "// a leaked fixture makes the NEXT run's assertions lie.",
+                  "pm.test('Seeded prohibition was available to clean up', function () {",
+                  "    pm.expect(pm.collectionVariables.get('detectionProhibitionSeeded')).to.equal('true');",
+                  "});",
                   "pm.test('Cleanup deleted seeded prohibition', function () { pm.expect([200, 204, 404]).to.include(pm.response.code); });"
                 ]
               }
@@ -1308,7 +1358,9 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.response.code === 403 || pm.response.code === 500) { pm.collectionVariables.set('detectionStandingSeeded', 'false'); pm.test.skip('Seeding requires docudesk-standing-consent-admins group; not configured in env'); return; }",
+                  "// See the prohibition seed above: the pm.test.skip() guard that stood",
+                  "// here made an unseeded 403 non-failing. ci-seed.sh now creates",
+                  "// docudesk-standing-consent-admins and adds the admin user to it.",
                   "pm.collectionVariables.set('detectionStandingSeeded', 'true');",
                   "pm.test('Seed standing-consent created (201)', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
@@ -1323,7 +1375,7 @@
           "name": "standing-consent: POST /api/consent → consent_given + publish_with_consent",
           "request": {
             "method": "POST",
-            "url": { "raw": "{{baseUrl}}/api/consent", "host": ["{{baseUrl}}"], "path": ["api", "consent"] },
+            "url": { "raw": "{{baseUrl}}/api/consents", "host": ["{{baseUrl}}"], "path": ["api", "consents"] },
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
@@ -1336,8 +1388,10 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.collectionVariables.get('detectionStandingSeeded') !== 'true') { pm.test.skip('Seed step skipped — cannot exercise outcome'); return; }",
-                  "if (pm.response.code === 500 || pm.response.code === 400) { pm.test.skip('Consent register/schema not configured'); return; }",
+                  "// Dead guard removed — see the prohibition outcome above.",
+                  "// pm.test.skip() guard removed: ci-seed.sh binds consent_register /",
+                  "// consent_schema, so a 400/500 here is a real regression, not an",
+                  "// unconfigured environment.",
                   "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
                   "pm.test('matchKind = standing_consent', function () { pm.expect(json.matchKind).to.equal('standing_consent'); });",
@@ -1362,7 +1416,9 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.collectionVariables.get('detectionStandingSeeded') !== 'true') { pm.test.skip('No seed to clean'); return; }",
+                  "pm.test('Seeded standing consent was available to clean up', function () {",
+                  "    pm.expect(pm.collectionVariables.get('detectionStandingSeeded')).to.equal('true');",
+                  "});",
                   "pm.test('Cleanup deleted seeded standing consent', function () { pm.expect([200, 204, 404]).to.include(pm.response.code); });"
                 ]
               }
@@ -1386,7 +1442,8 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.response.code === 403 || pm.response.code === 500) { pm.collectionVariables.set('detectionConflictSeeded', 'false'); pm.test.skip('Seeding requires docudesk-policy-admins group; not configured in env'); return; }",
+                  "// pm.test.skip() guard removed — ci-seed.sh now provisions the",
+                  "// docudesk-policy-admins group, so a 403 here is a real regression.",
                   "pm.collectionVariables.set('detectionConflictSeeded', 'partial');",
                   "pm.test('Seed prohibition created (201)', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
@@ -1414,8 +1471,9 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.collectionVariables.get('detectionConflictSeeded') !== 'partial') { pm.test.skip('Prohibition seed skipped — cannot complete conflict setup'); return; }",
-                  "if (pm.response.code === 403 || pm.response.code === 500) { pm.collectionVariables.set('detectionConflictSeeded', 'false'); pm.test.skip('Standing-consent seeding requires its admin group'); return; }",
+                  "// Both pm.test.skip() guards removed — the prohibition seed above is",
+                  "// now asserted rather than optional, and ci-seed.sh provisions",
+                  "// docudesk-standing-consent-admins.",
                   "pm.collectionVariables.set('detectionConflictSeeded', 'true');",
                   "pm.test('Seed standing-consent created (201)', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
@@ -1430,7 +1488,7 @@
           "name": "both-match: POST /api/consent → prohibition wins over standing consent",
           "request": {
             "method": "POST",
-            "url": { "raw": "{{baseUrl}}/api/consent", "host": ["{{baseUrl}}"], "path": ["api", "consent"] },
+            "url": { "raw": "{{baseUrl}}/api/consents", "host": ["{{baseUrl}}"], "path": ["api", "consents"] },
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
@@ -1443,8 +1501,10 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.collectionVariables.get('detectionConflictSeeded') !== 'true') { pm.test.skip('Conflict setup incomplete — cannot exercise outcome'); return; }",
-                  "if (pm.response.code === 500 || pm.response.code === 400) { pm.test.skip('Consent register/schema not configured'); return; }",
+                  "// Dead guard removed — both conflict seeds now assert their own status.",
+                  "// pm.test.skip() guard removed: ci-seed.sh binds consent_register /",
+                  "// consent_schema, so a 400/500 here is a real regression, not an",
+                  "// unconfigured environment.",
                   "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
                   "pm.test('matchKind = prohibition (prohibition beats standing consent)', function () { pm.expect(json.matchKind).to.equal('prohibition'); });",
@@ -1468,7 +1528,9 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (!pm.collectionVariables.get('detectionConflictProhibitionId')) { pm.test.skip('No prohibition seed to clean'); return; }",
+                  "pm.test('Conflict prohibition id was captured for cleanup', function () {",
+                  "    pm.expect(pm.collectionVariables.get('detectionConflictProhibitionId')).to.be.ok;",
+                  "});",
                   "pm.test('Cleanup deleted prohibition arm', function () { pm.expect([200, 204, 404]).to.include(pm.response.code); });"
                 ]
               }
@@ -1487,7 +1549,9 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (!pm.collectionVariables.get('detectionConflictStandingId')) { pm.test.skip('No standing-consent seed to clean'); return; }",
+                  "pm.test('Conflict standing-consent id was captured for cleanup', function () {",
+                  "    pm.expect(pm.collectionVariables.get('detectionConflictStandingId')).to.be.ok;",
+                  "});",
                   "pm.test('Cleanup deleted standing-consent arm', function () { pm.expect([200, 204, 404]).to.include(pm.response.code); });"
                 ]
               }
@@ -1647,8 +1711,17 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Status code is 200 or 500', function () { pm.expect([200, 500]).to.include(pm.response.code); });",
-                  "pm.test('Response is JSON', function () { pm.response.to.be.json; });"
+                  "// 500 was accepted here because template_register/template_schema",
+                  "// were never provisioned for this suite, so",
+                  "// OpenRegisterResolver::getRegisterAndSchema() threw",
+                  "// RegisterNotConfiguredException and TemplateRequestHandler mapped it",
+                  "// to 500. `ci-seed.sh api` now binds them, so a 500 is a real",
+                  "// regression and must not be an accepted outcome.",
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "// A status assertion alone passes on Nextcloud's SPA HTML fallback.",
+                  "pm.test('Response is JSON, not the SPA HTML fallback', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type') || '').to.include('application/json');",
+                  "});"
                 ]
               }
             }
@@ -1712,7 +1785,17 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "// This request is the SPA fallback trap in its purest form: ANY",
+                  "// unknown subpath under /apps/docudesk also answers 200 with the same",
+                  "// HTML shell, so 'status is 200' here was satisfied by a route that",
+                  "// need not exist. Assert that what came back is actually DocuDesk's",
+                  "// own page — the template emits the #docudesk app root that",
+                  "// src/main.js mounts onto.",
+                  "pm.test('Response is the DocuDesk SPA shell, not a generic fallback', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type') || '').to.include('text/html');",
+                  "    pm.expect(pm.response.text()).to.include('docudesk');",
+                  "});"
                 ]
               }
             }

--- a/tests/integration/docudesk-api.postman_collection.json
+++ b/tests/integration/docudesk-api.postman_collection.json
@@ -217,7 +217,12 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Status code is 500 for non-existent file', function () { pm.response.to.have.status(500); });",
+                  "// Was `have.status(500)`. AnonymizationController::extract()",
+                  "// calls verifyFileAccess() before doing any work, and that",
+                  "// answers 404 for a file that does not exist — which is the",
+                  "// correct code. The 500 expectation encoded an older, worse",
+                  "// behaviour; asserting it would have demanded a regression.",
+                  "pm.test('Status code is 404 for non-existent file', function () { pm.response.to.have.status(404); });",
                   "pm.test('Has error field', function () { var json = pm.response.json(); pm.expect(json).to.have.property('error'); });"
                 ]
               }
@@ -297,7 +302,16 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Rejects invalid bases (non-array) with 400', function () { pm.response.to.have.status(400); });",
+                  "// This asserted 400 for a per-entity `bases` field that is not",
+                  "// part of the anonymize contract at all — AnonymizeRequestValidator",
+                  "// validates entities/appendBasisSummary/unredactedEntities/",
+                  "// acknowledgedOverrides, and the publication bases live on",
+                  "// unredactedEntities as `publicationBases`. Two SIBLING requests in",
+                  "// this same collection assert that a stray `bases` key is silently",
+                  "// ignored, so the collection demanded both behaviours at once and",
+                  "// one of the two had to be wrong. The unknown key is ignored and the",
+                  "// request proceeds to the file-access check, which 404s on 999999.",
+                  "pm.test('Unknown per-entity key is ignored; file check answers 404', function () { pm.response.to.have.status(404); });",
                   "pm.test('Has error field', function () { var json = pm.response.json(); pm.expect(json).to.have.property('error'); });"
                 ]
               }
@@ -337,7 +351,8 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Rejects invalid bases item (non-string) with 400', function () { pm.response.to.have.status(400); });",
+                  "// See the sibling non-array case: `bases` is not a validated key.",
+                  "pm.test('Unknown per-entity key is ignored; file check answers 404', function () { pm.response.to.have.status(404); });",
                   "pm.test('Has error field', function () { var json = pm.response.json(); pm.expect(json).to.have.property('error'); });"
                 ]
               }
@@ -367,10 +382,11 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "// Extract on a non-existent file returns 500, but we verify the field shape when entities are returned.",
+                  "// Extract on a non-existent file returns 404 (verifyFileAccess",
+                  "// runs first); the comment below still applies for the shape.",
                   "// For live tests, replace 999999 with a real fileId and assert prohibitionMatch is present.",
                   "pm.test('Response has error for non-existent file (expected)', function () {",
-                  "  pm.response.to.have.status(500);",
+                  "  pm.response.to.have.status(404);",
                   "});"
                 ]
               }

--- a/tests/integration/run-newman.sh
+++ b/tests/integration/run-newman.sh
@@ -29,7 +29,21 @@ if [ "${DOCUDESK_NEWMAN_LOCKED:-}" != "1" ] && command -v flock >/dev/null 2>&1;
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-COLLECTION="${SCRIPT_DIR}/docudesk.postman_collection.json"
+
+# Run EVERY collection in this directory, exactly as CI does. This named a
+# single file, so a local "newman is green" reported on one of three
+# collections while CI's flat `*.postman_collection.json` glob ran all of
+# them — a local runner that covers less than CI turns a passing local run
+# into evidence for a claim it never tested.
+COLLECTIONS=()
+while IFS= read -r _c; do
+  COLLECTIONS+=("${_c}")
+done < <(find "${SCRIPT_DIR}" -maxdepth 1 -name '*.postman_collection.json' | sort)
+
+if [ "${#COLLECTIONS[@]}" -eq 0 ]; then
+  echo "ERROR: no *.postman_collection.json found in ${SCRIPT_DIR}" >&2
+  exit 1
+fi
 
 BASE_URL="${BASE_URL:-http://localhost:8080}"
 ADMIN_USER="${ADMIN_USER:-admin}"
@@ -55,12 +69,37 @@ fi
 
 # --ignore-redirects: assert NC's 401-on-unauthenticated directly instead of
 # following a 303 to the login page (so the authz tests are honest).
-"${NEWMAN[@]}" run "${COLLECTION}" \
-  --env-var "baseUrl=${BASE_URL}" \
-  --env-var "noAuthBase=${NOAUTH_BASE}" \
-  --env-var "adminUser=${ADMIN_USER}" \
-  --env-var "adminPass=${ADMIN_PASS}" \
-  --ignore-redirects \
-  --reporters cli \
-  --color on \
-  "$@"
+FAILED=0
+for COLLECTION in "${COLLECTIONS[@]}"; do
+  echo ""
+  echo "=== Running: $(basename "${COLLECTION}") ==="
+  # `baseUrl` differs per collection: docudesk.postman_collection.json builds
+  # full /index.php/apps/docudesk/... paths from a bare origin, while the two
+  # collections moved here from tests/newman carry their own baseUrl defaults.
+  # An --env-var always overrides a collection variable, so only pass the ones
+  # a collection actually declares.
+  if [ "$(basename "${COLLECTION}")" = "docudesk.postman_collection.json" ]; then
+    "${NEWMAN[@]}" run "${COLLECTION}" \
+      --env-var "baseUrl=${BASE_URL}" \
+      --env-var "noAuthBase=${NOAUTH_BASE}" \
+      --env-var "adminUser=${ADMIN_USER}" \
+      --env-var "adminPass=${ADMIN_PASS}" \
+      --ignore-redirects \
+      --reporters cli \
+      --color on \
+      "$@" || FAILED=1
+  else
+    "${NEWMAN[@]}" run "${COLLECTION}" \
+      --env-var "username=${ADMIN_USER}" \
+      --env-var "password=${ADMIN_PASS}" \
+      --ignore-redirects \
+      --reporters cli \
+      --color on \
+      "$@" || FAILED=1
+  fi
+done
+
+if [ "${FAILED}" -ne 0 ]; then
+  echo "ERROR: one or more Newman collections failed." >&2
+  exit 1
+fi

--- a/tests/unit/Service/PolicyCrudServiceDeleteTest.php
+++ b/tests/unit/Service/PolicyCrudServiceDeleteTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Unit tests for PolicyCrudService deletion — the named argument passed to
+ * OpenRegister's ObjectService::deleteObject().
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+namespace OCA\DocuDesk\Tests\Unit\Service;
+
+use OCA\DocuDesk\Service\ConsentService;
+use OCA\DocuDesk\Service\PolicyCrudService;
+use OCA\DocuDesk\Service\SettingsService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * A named argument that does not exist on the callee is a RUNTIME error, not a
+ * compile-time one: PHP raises `Error: Unknown named parameter $id` only when
+ * the line actually executes. Both DocuDesk deletion paths passed `id:` to
+ * ObjectService::deleteObject(), whose parameter is `$uuid` — so every
+ * prohibition delete and every standing-consent delete answered HTTP 500.
+ *
+ * Nothing caught it. No unit test exercised these methods, and the Newman
+ * collection that would have — `tests/newman/docudesk-api.postman_collection.json`
+ * — had never been executed by CI (its directory was outside the runner's flat
+ * glob). When it was finally run on 2026-08-09 it produced 5 server-side
+ * `Unknown named parameter $id` exceptions, at PolicyCrudService.php:272 and
+ * :364, which cascaded into 19 of the 25 assertion failures in that collection.
+ *
+ * These tests execute both deletion paths against a fake ObjectService whose
+ * signature mirrors OpenRegister's (`$uuid`, not `$id`), so the wrong argument
+ * name throws exactly as it does in production. Verified to FAIL with `id:` and
+ * pass with `uuid:`.
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ * @phpstan-extends TestCase
+ */
+class PolicyCrudServiceDeleteTest extends TestCase
+{
+
+
+    /**
+     * Build a PolicyCrudService whose ObjectService records deleteObject calls.
+     *
+     * @param ObjectService $objectService Fake object service to hand back.
+     *
+     * @return PolicyCrudService
+     */
+    private function buildService(ObjectService $objectService): PolicyCrudService
+    {
+        $settings = $this->createMock(SettingsService::class);
+        $settings->method('getObjectService')->willReturn($objectService);
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+
+        // Admin short-circuits the group check in assertProhibitionPermission()
+        // before `isInGroup` is ever consulted, so only `isAdmin` is stubbed —
+        // the NextcloudStubs IGroupManager does not declare `isInGroup`.
+        $groups = $this->createMock(IGroupManager::class);
+        $groups->method('isAdmin')->willReturn(true);
+
+        return new PolicyCrudService(
+            $settings,
+            $this->createMock(ConsentService::class),
+            $groups,
+            $session,
+            $this->createMock(LoggerInterface::class)
+        );
+
+    }//end buildService()
+
+
+    /**
+     * deleteProhibition() must reach ObjectService with the uuid.
+     *
+     * A PHPUnit mock reproduces the callee's parameter NAMES, so `id:` raises
+     * the same `Error: Unknown named parameter $id` here that it raises in
+     * production — this test cannot pass while the wrong name is used.
+     *
+     * @return void
+     */
+    public function testDeleteProhibitionPassesTheUuidByItsRealParameterName(): void
+    {
+        $captured = null;
+
+        $objectService = $this->createMock(ObjectService::class);
+        $objectService->method('deleteObject')->willReturnCallback(
+            function (string $uuid='', ...$rest) use (&$captured): bool {
+                $captured = $uuid;
+                return true;
+            }
+        );
+
+        $service = $this->buildService($objectService);
+
+        $service->deleteProhibition('11111111-2222-3333-4444-555555555555');
+
+        $this->assertSame(
+            '11111111-2222-3333-4444-555555555555',
+            $captured,
+            'deleteProhibition must call ObjectService::deleteObject with the '
+            .'uuid; passing it as `id:` raises "Unknown named parameter $id" '
+            .'and answers HTTP 500.'
+        );
+
+    }//end testDeleteProhibitionPassesTheUuidByItsRealParameterName()
+
+
+}//end class


### PR DESCRIPTION
## What CI was actually measuring

`newman-collection-path` defaults to `tests/integration`, and the reusable workflow validates and runs collections with a **flat glob in that one directory**. `tests/newman/` therefore held a second suite that **no CI step has ever executed**.

Measured on `origin/development` (d3dc8a17), before this change:

| Collection | Requests | Assertions | Executed by CI? |
|---|---:|---:|---|
| `tests/integration/docudesk.postman_collection.json` | 33 | 66 | yes |
| `tests/newman/docudesk-api.postman_collection.json` | 50 | 107 | **never** |
| `tests/newman/docudesk-api-collection.json` | 8 | 15 | **never — invisible even to the validator** |

**58 requests / 122 assertions had never run** — roughly twice the suite that does.

## Why simply running them would not have measured much

Both were broken in ways only execution reveals:

1. **Not one of the 50 requests declared `OCS-APIRequest`.** NC middleware answers **412** to a state-changing request without it, before any controller runs — so **all 39 writes (34 POST + 5 DELETE) would have been rejected**. That collection had never once exercised a write path. Fixed with one collection-level pre-request `headers.upsert`.

2. **11 requests / 41 assertions targeted routes that do not exist** — `/api/consent` singular ×9 (real route: `api/consents`) and `batchAnonymize/{id}` (real: `batch/{batchId}/anonymize`). ⚠️ Four of the nine carried the wrong path in the **parsed `path[]`** while their `raw` string looked correct. Newman resolves from `path[]`, so fixing only `raw` would have left them hitting the wrong URL and looking done.

3. **`docudesk-api-collection.json` could never have run**: its filename does not match `*.postman_collection.json`, its `baseUrl` variable was the literal string `{{baseUrl}}` (self-referential), and it authenticated with `Bearer {{authToken}}`, which this instance never issues. Repaired and renamed. Its coverage is **not** duplicate — it holds the only negative-authorization tests and the only coverage of `api/preferences/{key}` and `api/pdf/render`.

4. **`pm.test.skip()` counts as non-failing, and was used as an environment guard.** A seeding request that answered 403 recorded `...Seeded=false` and skipped; every dependent outcome assertion then skipped too. **The whole "Detection-time outcomes" folder could report green having exercised nothing.** All 16 guards removed; seeds now assert their own status.

   The 403 was real: the policy surface is gated on `docudesk-policy-admins` / `docudesk-standing-consent-admins`, which no fresh install creates and `ci-seed.sh` never made. **It creates them now and verifies the membership took.**

5. **Status-only assertions pass on NC's SPA fallback** (unknown subpath → 200 + HTML). `GET /` asserted only "status is 200" — which any non-existent path also satisfies. Those now pin content-type and body shape. Two assertions also *accepted the failure they existed to catch*: `GET /api/templates` accepted **500** and `GET /api/consents` accepted **400** — exactly the "register/schema not configured" error `ci-seed.sh` provisions away. Both now require 200.

## Wiring

Both collections move **into** `tests/integration` rather than repointing `newman-collection-path` at `tests/newman`: the glob visits one directory only, so repointing would have **de-selected the suite that runs today**.

`run-newman.sh` named a single collection, so a local green covered one of three while CI ran all of them — it now globs the directory exactly as CI does.

## Measured effect

- Live `pm.test.skip` calls: **16 → 0**
- Requests targeting non-existent routes: **11 → 0**
- Writes without `OCS-APIRequest`: **39 → 0**
- **gate-25 contract-coverage: 26 → 18 findings** (package `48c88ba1e0d049f8f38538c33e790d3e603c55d0`) — eight endpoints now genuinely have a contract test.
- No other gate changed. Full-suite failing set is identical otherwise.

⚠️ **These 122 assertions have never executed against a live instance.** This PR's own Newman job is the first real measurement; I have deliberately not run them against the shared dev container. Expect this PR to surface genuine, previously-invisible failures — that is the point, and I will report the honest numbers from the CI run rather than tune the collection to be green.