### PR TITLE
fix(a11y): close gates 32, 34, 39, 43 and 45 in src/

### DIFF
--- a/l10n/en.json
+++ b/l10n/en.json
@@ -863,7 +863,19 @@
         "Select {document}": "Select {document}",
         "Select {row}": "Select {row}",
         "Select files to anonymise": "Select files to anonymise",
-        "Skip {entity}": "Skip {entity}"
+        "Skip {entity}": "Skip {entity}",
+        "Approved consents — open the consent overview": "Approved consents — open the consent overview",
+        "Delete dictionary": "Delete dictionary",
+        "Delete document": "Delete document",
+        "Delete prohibition": "Delete prohibition",
+        "Delete selected items": "Delete selected items",
+        "Delete standing consent": "Delete standing consent",
+        "Objected consents — open the consent overview": "Objected consents — open the consent overview",
+        "Pending consents — open the consent overview": "Pending consents — open the consent overview",
+        "Remove match rule {number}": "Remove match rule {number}",
+        "Remove term": "Remove term",
+        "Revoke standing consent": "Revoke standing consent",
+        "Total Consents — open the consent overview": "Total Consents — open the consent overview"
     },
     "pluralForm": "nplurals=2; plural=(n != 1);"
 }

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -916,7 +916,19 @@
         "— high accuracy, requires a GPU": "— hoge nauwkeurigheid, vereist een GPU",
         "— lightweight, no GPU required": "— lichtgewicht, geen GPU vereist",
         "— via OpenRegister settings": "— via OpenRegister-instellingen",
-        "“{name}” matches the prohibition rule “{rule}” and must be anonymised.": "“{name}” komt overeen met de verbodsregel “{rule}” en moet worden geanonimiseerd."
+        "“{name}” matches the prohibition rule “{rule}” and must be anonymised.": "“{name}” komt overeen met de verbodsregel “{rule}” en moet worden geanonimiseerd.",
+        "Approved consents — open the consent overview": "Goedgekeurde toestemmingen — open het toestemmingsoverzicht",
+        "Delete dictionary": "Woordenlijst verwijderen",
+        "Delete document": "Document verwijderen",
+        "Delete prohibition": "Verbod verwijderen",
+        "Delete selected items": "Geselecteerde items verwijderen",
+        "Delete standing consent": "Doorlopende toestemming verwijderen",
+        "Objected consents — open the consent overview": "Toestemmingen met bezwaar — open het toestemmingsoverzicht",
+        "Pending consents — open the consent overview": "Toestemmingen in afwachting — open het toestemmingsoverzicht",
+        "Remove match rule {number}": "Matchregel {number} verwijderen",
+        "Remove term": "Term verwijderen",
+        "Revoke standing consent": "Doorlopende toestemming intrekken",
+        "Total Consents — open the consent overview": "Totaal toestemmingen — open het toestemmingsoverzicht"
     },
     "pluralForm": "nplurals=2; plural=(n != 1);"
 }

--- a/src/components/DdButton.vue
+++ b/src/components/DdButton.vue
@@ -202,4 +202,12 @@ export default {
 .dd-button__label {
 	white-space: nowrap;
 }
+
+/* WCAG 2.2 SC 2.3.3 — users who ask the OS for reduced motion get the state
+   change without the tween. */
+@media (prefers-reduced-motion: reduce) {
+	.dd-button {
+		transition: none;
+	}
+}
 </style>

--- a/src/components/DdCardGrid.vue
+++ b/src/components/DdCardGrid.vue
@@ -9,11 +9,18 @@
 		</div>
 
 		<div v-else class="dd-card-grid__grid">
+			<!--
+				The cell is LAYOUT ONLY. It used to carry `@click` with no role,
+				no tabindex and no key handler, so in tile view the card was
+				reachable by mouse alone (WCAG 2.1.1) — and where the slotted card
+				was itself activatable (DdDocumentCard is role="button"), the click
+				fired the handler TWICE, once on the card and once on this wrapper
+				as the event bubbled. Activation belongs to the card in the slot.
+			-->
 			<div
 				v-for="object in objects"
 				:key="object[rowKey]"
-				class="dd-card-grid__cell"
-				@click="$emit('row-click', object)">
+				class="dd-card-grid__cell">
 				<slot name="card" :object="object">
 					{{ object[rowKey] }}
 				</slot>
@@ -29,7 +36,11 @@ import { NcLoadingIcon } from '@nextcloud/vue'
  * Responsive grid for tile/card view in DocuDesk index pages.
  *
  * The card content is fully consumer-defined via the `card` scoped slot.
- * Whole-cell click triggers `row-click` with the object.
+ *
+ * The grid is a layout only — it does not make its cells activatable. A card
+ * that should respond to activation must be an interactive element itself
+ * (see DdDocumentCard, which is role="button" with Enter/Space handling), so
+ * that keyboard users reach it and the handler fires exactly once.
  */
 export default {
 	name: 'DdCardGrid',
@@ -68,7 +79,6 @@ export default {
 }
 
 .dd-card-grid__cell {
-	cursor: pointer;
 	display: flex;
 }
 

--- a/src/components/DdDataTable.vue
+++ b/src/components/DdDataTable.vue
@@ -14,9 +14,17 @@
 							:aria-label="selectAllLabel"
 							@update:modelValue="$emit('toggle-select-all')" />
 					</th>
+					<!--
+						Column headers name every cell beneath them, so they carry
+						scope="col" (WCAG 1.3.1). The select and row-actions
+						headers above/below have no accessible name of their own —
+						they are control columns — so scope on them would
+						associate nothing and is deliberately absent.
+					-->
 					<th
 						v-for="col in columns"
 						:key="col.key"
+						scope="col"
 						class="dd-data-table__th"
 						:style="col.width ? { width: col.width } : null">
 						{{ col.label }}
@@ -279,5 +287,13 @@ export default {
 	text-align: center;
 	padding: calc(12 * var(--default-grid-baseline)) calc(6 * var(--default-grid-baseline));
 	color: var(--dd-data-table-empty-color, var(--color-text-maxcontrast));
+}
+
+/* WCAG 2.2 SC 2.3.3 — the row hover tint still applies, it just arrives
+   instantly for users who ask the OS for reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+	.dd-data-table__row {
+		transition: none;
+	}
 }
 </style>

--- a/src/components/DdDocumentCard.vue
+++ b/src/components/DdDocumentCard.vue
@@ -243,4 +243,12 @@ export default {
 	font-size: 0.8rem;
 	color: var(--color-text-maxcontrast, #6b7280);
 }
+
+/* WCAG 2.2 SC 2.3.3 — the hover lift is decorative; drop it entirely for
+   users who ask the OS for reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+	.dd-document-card {
+		transition: none;
+	}
+}
 </style>

--- a/src/components/DdEntityCard.vue
+++ b/src/components/DdEntityCard.vue
@@ -272,4 +272,12 @@ export default {
 	align-items: center;
 	margin-top: 8px;
 }
+
+/* WCAG 2.2 SC 2.3.3 — users who ask the OS for reduced motion get the state
+   change without the tween. */
+@media (prefers-reduced-motion: reduce) {
+	.dd-entity-card {
+		transition: none;
+	}
+}
 </style>

--- a/src/components/DdIndexPage.vue
+++ b/src/components/DdIndexPage.vue
@@ -42,13 +42,18 @@
 			</template>
 		</DdDataTable>
 
+		<!--
+			No `@row-click` here: DdCardGrid is layout only and the slotted card
+			owns its own activation. The table path above still forwards
+			`row-click`, because a table row is not an interactive element by
+			itself.
+		-->
 		<DdCardGrid
 			v-else
 			:objects="objects"
 			:loading="loading"
 			:row-key="rowKey"
-			:empty-text="emptyText"
-			@row-click="$emit('row-click', $event)">
+			:empty-text="emptyText">
 			<template v-if="$slots.card" #card="{ object }">
 				<slot name="card" :object="object" />
 			</template>

--- a/src/components/DdSearchBar.vue
+++ b/src/components/DdSearchBar.vue
@@ -206,4 +206,13 @@ export default {
 	outline: 2px solid var(--color-primary-element);
 	outline-offset: 1px;
 }
+
+/* WCAG 2.2 SC 2.3.3 — users who ask the OS for reduced motion get the state
+   change without the tween. */
+@media (prefers-reduced-motion: reduce) {
+	.dd-search-bar__input,
+	.dd-search-bar__clear {
+		transition: none;
+	}
+}
 </style>

--- a/src/components/DdToggle.vue
+++ b/src/components/DdToggle.vue
@@ -129,4 +129,13 @@ export default {
 	line-height: 140%;
 	color: var(--color-main-text, #02162e);
 }
+
+/* WCAG 2.2 SC 2.3.3 — the knob still moves and the track still recolours, it
+   just arrives instantly for users who ask the OS for reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+	.dd-toggle__track,
+	.dd-toggle__knob {
+		transition: none;
+	}
+}
 </style>

--- a/src/components/DdViewToggle.vue
+++ b/src/components/DdViewToggle.vue
@@ -170,4 +170,13 @@ export default {
 .dd-view-toggle__label {
 	white-space: nowrap;
 }
+
+/* WCAG 2.2 SC 2.3.3 — the thumb still lands under the selected option, it
+   just jumps there for users who ask the OS for reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+	.dd-view-toggle__thumb,
+	.dd-view-toggle__btn {
+		transition: none;
+	}
+}
 </style>

--- a/src/dialogs/ConfirmActionDialog.vue
+++ b/src/dialogs/ConfirmActionDialog.vue
@@ -1,0 +1,82 @@
+<template>
+	<NcDialog :name="name"
+		:can-close="!busy"
+		@closing="$emit('cancel')">
+		<template #default>
+			<p class="confirm-action-dialog__message">
+				{{ message }}
+			</p>
+		</template>
+		<template #actions>
+			<NcButton :disabled="busy" @click="$emit('cancel')">
+				{{ cancelLabel || t('docudesk', 'Cancel') }}
+			</NcButton>
+			<NcButton :variant="variant" :disabled="busy" @click="$emit('confirm')">
+				{{ confirmLabel || t('docudesk', 'Delete') }}
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script>
+import { translate as t } from '@nextcloud/l10n'
+import { NcButton, NcDialog } from '@conduction/nextcloud-vue'
+
+/**
+ * Generic "are you sure?" dialog.
+ *
+ * Replaces `window.confirm()`, which is unstyled, untranslatable, not
+ * theme-aware and — on a browser where the user has ticked "prevent this page
+ * from creating additional dialogs" — silently returns false, so the action it
+ * guards can never be taken. The dialog is a real focus-trapped NcDialog, and
+ * the caller performs the destructive action only on `@confirm`.
+ *
+ * Lives in src/dialogs/ per ADR-004: NcDialog markup is never written inline
+ * in a parent component.
+ */
+export default {
+	name: 'ConfirmActionDialog',
+	components: { NcButton, NcDialog },
+	props: {
+		/** Dialog title. */
+		name: {
+			type: String,
+			required: true,
+		},
+		/** Body text explaining what is about to happen. */
+		message: {
+			type: String,
+			default: '',
+		},
+		/** Label of the confirming button. Defaults to "Delete". */
+		confirmLabel: {
+			type: String,
+			default: '',
+		},
+		/** Label of the dismissing button. Defaults to "Cancel". */
+		cancelLabel: {
+			type: String,
+			default: '',
+		},
+		/** NcButton variant for the confirming button. */
+		variant: {
+			type: String,
+			default: 'error',
+		},
+		/** Disable both buttons while the confirmed action is in flight. */
+		busy: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	emits: ['confirm', 'cancel'],
+	methods: { t },
+}
+</script>
+
+<style scoped>
+.confirm-action-dialog__message {
+	padding: 8px 0;
+	white-space: pre-line;
+}
+</style>

--- a/src/views/anonymization/AnonymizationWidget.vue
+++ b/src/views/anonymization/AnonymizationWidget.vue
@@ -7,13 +7,19 @@ import { anonymizationStore, fileViewerStore, myDocumentsStore } from '../../sto
 	<div class="anonymization-widget">
 		<!-- Drop zone -->
 		<div class="upload-area">
+			<!--
+				Drag-and-drop is a pointer-only affordance by nature, so the file
+				picker is opened by a REAL <button> rather than by a click handler
+				on this wrapper. The wrapper used to carry `@click` while the
+				<input type="file"> was `display: none`, which left keyboard users
+				with no way at all to reach the picker (WCAG 2.1.1).
+			-->
 			<div
 				class="drop-zone"
 				:class="{ dragging: isDragging }"
 				@dragover.prevent="isDragging = true"
 				@dragleave.prevent="isDragging = false"
-				@drop.prevent="handleDrop"
-				@click="$refs.fileInput.click()">
+				@drop.prevent="handleDrop">
 				<img :src="uploadIcon" alt="" class="upload-icon">
 				<div class="drop-content">
 					<p class="drop-title">
@@ -22,9 +28,9 @@ import { anonymizationStore, fileViewerStore, myDocumentsStore } from '../../sto
 					<p class="drop-subtitle">
 						{{ t('docudesk', 'Only Word (.docx), ODT, PDF or TXT files are supported. Maximum file size 500 MB.') }}
 					</p>
-					<span class="fake-button">
+					<button type="button" class="fake-button" @click="$refs.fileInput.click()">
 						{{ t('docudesk', '+ Select files') }}
-					</span>
+					</button>
 				</div>
 				<input
 					ref="fileInput"
@@ -463,7 +469,7 @@ export default {
 	padding: 32px;
 	background-color: var(--dd-surface, #fff);
 	box-shadow: var(--dd-shadow-panel);
-	cursor: pointer;
+	/* Not a click target any more — the picker is opened by .fake-button. */
 	transition: border-color 0.2s, background-color 0.2s;
 }
 
@@ -506,15 +512,25 @@ export default {
 	color: var(--color-text-maxcontrast);
 }
 
+/* A real <button> now, so the browser's own border/font defaults are reset
+   here to keep the previous appearance byte-for-byte. */
 .fake-button {
 	margin-top: 4px;
 	padding: 8px 16px;
+	border: none;
 	border-radius: var(--border-radius);
 	background-color: var(--color-primary-element);
 	color: var(--color-primary-element-text);
+	font-family: inherit;
 	font-size: 0.9rem;
 	font-weight: 500;
 	white-space: nowrap;
+	cursor: pointer;
+}
+
+.fake-button:focus-visible {
+	outline: 2px solid var(--color-primary-element);
+	outline-offset: 2px;
 }
 
 .file-input {
@@ -571,6 +587,14 @@ export default {
 	grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 	grid-auto-rows: 1fr;
 	gap: 16px;
+}
+
+/* WCAG 2.2 SC 2.3.3 — users who ask the OS for reduced motion get the state
+   change without the tween. */
+@media (prefers-reduced-motion: reduce) {
+	.drop-zone {
+		transition: none;
+	}
 }
 
 </style>

--- a/src/views/anonymization/EntityReviewTable.vue
+++ b/src/views/anonymization/EntityReviewTable.vue
@@ -30,17 +30,17 @@
 		<table class="entity-table">
 			<thead>
 				<tr>
-					<th /><th @click="sortBy('type')">
+					<th /><th scope="col" @click="sortBy('type')">
 						{{ t('docudesk', 'Type') }}
-					</th><th @click="sortBy('value')">
+					</th><th scope="col" @click="sortBy('value')">
 						{{ t('docudesk', 'Value') }}
-					</th><th @click="sortBy('highestConfidence')">
+					</th><th scope="col" @click="sortBy('highestConfidence')">
 						{{ t('docudesk', 'Confidence') }}
-					</th><th @click="sortBy('fileCount')">
+					</th><th scope="col" @click="sortBy('fileCount')">
 						{{ t('docudesk', 'Files') }}
-					</th><th class="bases-col">
+					</th><th scope="col" class="bases-col">
 						{{ t('docudesk', 'Grondslag (bases)') }}
-					</th><th>
+					</th><th scope="col">
 						{{ t('docudesk', 'Skip') }}
 					</th>
 				</tr>

--- a/src/views/consent/ConsentDetail.vue
+++ b/src/views/consent/ConsentDetail.vue
@@ -86,11 +86,18 @@ import { consentStore } from '../../store/store.js'
 		<!-- Consent status section -->
 		<div v-if="consentStore.consentItem" class="detail-section">
 			<h3>{{ t('docudesk', 'Consent Status') }}</h3>
+			<!--
+				This is a name/value grid: every row's first cell IS the name of
+				that row, so it is a row header, not data. It shipped as a table
+				of nothing but <td>, which left the values with no header to be
+				announced against at all (WCAG 1.3.1). <th scope="row"> states
+				what was already true of the markup.
+			-->
 			<table class="detail-table">
 				<tr>
-					<td class="label">
+					<th scope="row" class="label">
 						{{ t('docudesk', 'Consent Status') }}
-					</td>
+					</th>
 					<td>
 						<NcSelect
 							v-model="editData.consentStatus"
@@ -99,9 +106,9 @@ import { consentStore } from '../../store/store.js'
 					</td>
 				</tr>
 				<tr>
-					<td class="label">
+					<th scope="row" class="label">
 						{{ t('docudesk', 'Notification Status') }}
-					</td>
+					</th>
 					<td>
 						<NcSelect
 							v-model="editData.notificationStatus"
@@ -110,9 +117,9 @@ import { consentStore } from '../../store/store.js'
 					</td>
 				</tr>
 				<tr>
-					<td class="label">
+					<th scope="row" class="label">
 						{{ t('docudesk', 'Publication Decision') }}
-					</td>
+					</th>
 					<td>
 						<NcSelect
 							v-model="editData.publicationDecision"
@@ -121,21 +128,21 @@ import { consentStore } from '../../store/store.js'
 					</td>
 				</tr>
 				<tr>
-					<td class="label">
+					<th scope="row" class="label">
 						{{ t('docudesk', 'Objection Deadline') }}
-					</td>
+					</th>
 					<td>{{ formatDate(consentStore.consentItem.objectionDeadline) }}</td>
 				</tr>
 				<tr v-if="consentStore.consentItem.objectionReceivedAt">
-					<td class="label">
+					<th scope="row" class="label">
 						{{ t('docudesk', 'Objection Received') }}
-					</td>
+					</th>
 					<td>{{ formatDate(consentStore.consentItem.objectionReceivedAt) }}</td>
 				</tr>
 				<tr v-if="consentStore.consentItem.legalBasis">
-					<td class="label">
+					<th scope="row" class="label">
 						{{ t('docudesk', 'Legal Basis') }}
-					</td>
+					</th>
 					<td>{{ consentStore.consentItem.legalBasis }}</td>
 				</tr>
 			</table>
@@ -405,12 +412,16 @@ export default {
 	width: 100%;
 }
 
-.detail-table td {
+.detail-table td,
+.detail-table th {
 	padding: 8px 4px;
 	vertical-align: middle;
 }
 
+/* The row headers are <th> now; neutralise the UA's centred default so the
+   rendering is unchanged. */
 .detail-table .label {
+	text-align: start;
 	font-weight: bold;
 	color: var(--color-text-maxcontrast);
 	width: 200px;

--- a/src/views/consent/StandingConsentIndex.vue
+++ b/src/views/consent/StandingConsentIndex.vue
@@ -128,6 +128,20 @@ import { consentStore } from '../../store/store.js'
 			:show="showCreateModal"
 			@close="closeCreateModal"
 			@created="handleCreate" />
+
+		<!--
+			Revoke confirmation. Replaces window.confirm(): revokeConsent below
+			runs only from @confirm, so the withdrawal still requires an
+			explicit confirmation.
+		-->
+		<ConfirmActionDialog
+			v-if="revokeTarget"
+			:name="t('docudesk', 'Revoke standing consent')"
+			:message="t('docudesk', 'Revoke this standing consent? This withdraws permission for any in-flight publications and cannot be undone.')"
+			:confirm-label="t('docudesk', 'Revoke')"
+			:busy="revoking"
+			@confirm="executeRevoke"
+			@cancel="cancelRevoke" />
 	</div>
 </template>
 
@@ -139,6 +153,7 @@ import ClockRemove from 'vue-material-design-icons/ClockRemove.vue'
 import Cancel from 'vue-material-design-icons/Cancel.vue'
 
 import CreateStandingConsentModal from '../../modals/CreateStandingConsentModal.vue'
+import ConfirmActionDialog from '../../dialogs/ConfirmActionDialog.vue'
 
 export default {
 	name: 'StandingConsentIndex',
@@ -152,6 +167,7 @@ export default {
 		ClockRemove,
 		Cancel,
 		CreateStandingConsentModal,
+		ConfirmActionDialog,
 	},
 	data() {
 		return {
@@ -159,6 +175,8 @@ export default {
 			currentPage: 1,
 			pageSize: 20,
 			showCreateModal: false,
+			revokeTarget: null, // consent awaiting revoke confirmation, or null
+			revoking: false,
 			entityTypeColorMap: {
 				person: 'warning',
 				organization: 'primary',
@@ -291,27 +309,50 @@ export default {
 			await consentStore.updateConsent(id, { ...consent, active: false })
 		},
 		/**
-		 * Set the consent status to anonymized (revoke it).
+		 * Ask for confirmation before revoking a standing consent.
 		 *
 		 * Revoke is destructive — Art. 7(3) consent withdrawal flips
 		 * `consentStatus` to `anonymized` and `active` to false; the
-		 * record cannot be re-activated. Confirm before submitting so
-		 * a single mis-click in the row-action menu can't silently
-		 * destroy a standing consent.
+		 * record cannot be re-activated. So this only opens
+		 * ConfirmActionDialog; executeRevoke() does the write.
 		 *
 		 * @param consent
 		 * @spec openspec/changes/publication-consent-policy-fields/tasks.md#task-11
 		 */
-		async revokeConsent(consent) {
-			const id = consent.id || consent.uuid
-			const ok = window.confirm(t(
-				'docudesk',
-				'Revoke this standing consent? This withdraws permission for any in-flight publications and cannot be undone.',
-			))
-			if (!ok) {
+		revokeConsent(consent) {
+			this.revokeTarget = consent
+		},
+		/**
+		 * Dismiss the revoke confirmation without changing anything.
+		 *
+		 * @spec openspec/changes/publication-consent-policy-fields/tasks.md#task-11
+		 */
+		cancelRevoke() {
+			this.revokeTarget = null
+		},
+		/**
+		 * Apply the confirmed revocation.
+		 *
+		 * Reachable only from ConfirmActionDialog's @confirm, so a single
+		 * mis-click in the row-action menu still cannot destroy a standing
+		 * consent.
+		 *
+		 * @return {Promise<void>}
+		 * @spec openspec/changes/publication-consent-policy-fields/tasks.md#task-11
+		 */
+		async executeRevoke() {
+			const consent = this.revokeTarget
+			if (!consent) {
 				return
 			}
-			await consentStore.updateConsent(id, { ...consent, consentStatus: 'anonymized', active: false })
+			const id = consent.id || consent.uuid
+			this.revoking = true
+			try {
+				await consentStore.updateConsent(id, { ...consent, consentStatus: 'anonymized', active: false })
+				this.revokeTarget = null
+			} finally {
+				this.revoking = false
+			}
 		},
 		/**
 		 * Reload the consent list from the backend.

--- a/src/views/customDictionary/CustomDictionaryDetail.vue
+++ b/src/views/customDictionary/CustomDictionaryDetail.vue
@@ -74,9 +74,9 @@
 				<table v-else class="custom-dictionary-detail__terms-table">
 					<thead>
 						<tr>
-							<th>{{ t('docudesk', 'Value') }}</th>
-							<th>{{ t('docudesk', 'Label') }}</th>
-							<th>{{ t('docudesk', 'Actions') }}</th>
+							<th scope="col">{{ t('docudesk', 'Value') }}</th>
+							<th scope="col">{{ t('docudesk', 'Label') }}</th>
+							<th scope="col">{{ t('docudesk', 'Actions') }}</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -112,6 +112,20 @@
 			:result="importResult"
 			@submit="onImportSubmit"
 			@cancel="closeImportDialog" />
+
+		<!--
+			Removal confirmation. Replaces window.confirm(): the removal below
+			runs only from @confirm, so an explicit confirmation is still
+			required before a term disappears.
+		-->
+		<ConfirmActionDialog
+			v-if="removeTarget"
+			:name="t('docudesk', 'Remove term')"
+			:message="removeMessage"
+			:confirm-label="t('docudesk', 'Remove')"
+			:busy="removing"
+			@confirm="executeRemoveTerm"
+			@cancel="cancelRemoveTerm" />
 	</div>
 </template>
 
@@ -123,6 +137,7 @@ import { customDictionaryStore } from '../../store/store.js'
 import { resolveI18nValue } from '../../utils/registerI18n.js'
 import CustomDictionaryFormDialog from '../../dialogs/CustomDictionaryFormDialog.vue'
 import CustomDictionaryImportDialog from '../../dialogs/CustomDictionaryImportDialog.vue'
+import ConfirmActionDialog from '../../dialogs/ConfirmActionDialog.vue'
 
 export default {
 	name: 'CustomDictionaryDetail',
@@ -135,6 +150,7 @@ export default {
 		Delete,
 		CustomDictionaryFormDialog,
 		CustomDictionaryImportDialog,
+		ConfirmActionDialog,
 	},
 	data() {
 		return {
@@ -148,6 +164,8 @@ export default {
 			importDialogOpen: false,
 			importing: false,
 			importError: '',
+			removeTarget: null, // term awaiting removal confirmation, or null
+			removing: false,
 			matchModeColorMap: {
 				exact: 'error',
 				caseInsensitive: 'primary',
@@ -168,6 +186,14 @@ export default {
 		},
 		terms() {
 			return customDictionaryStore.terms
+		},
+		/**
+		 * Body text of the term-removal confirmation dialog.
+		 *
+		 * @spec openspec/specs/custom-dictionary-recognition/spec.md
+		 */
+		removeMessage() {
+			return t('docudesk', 'Remove "{value}"?', { value: this.removeTarget?.value || '' })
 		},
 		importResult() {
 			return customDictionaryStore.importResult
@@ -237,16 +263,47 @@ export default {
 				this.addingTerm = false
 			}
 		},
-		async removeTerm(term) {
-			const id = term['@self']?.id || term.id
-			// eslint-disable-next-line no-alert
-			if (!window.confirm(t('docudesk', 'Remove "{value}"?', { value: term.value }))) {
+		/**
+		 * Ask for confirmation before removing a term.
+		 *
+		 * Opens ConfirmActionDialog; nothing is removed here.
+		 *
+		 * @param {object} term - The term to remove.
+		 * @spec openspec/specs/custom-dictionary-recognition/spec.md
+		 */
+		removeTerm(term) {
+			this.removeTarget = term
+		},
+		/**
+		 * Dismiss the removal confirmation without removing anything.
+		 *
+		 * @spec openspec/specs/custom-dictionary-recognition/spec.md
+		 */
+		cancelRemoveTerm() {
+			this.removeTarget = null
+		},
+		/**
+		 * Remove the confirmed term. Reachable only from the dialog's
+		 * @confirm, so a term is never removed without an explicit
+		 * confirmation.
+		 *
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/custom-dictionary-recognition/spec.md
+		 */
+		async executeRemoveTerm() {
+			const term = this.removeTarget
+			if (!term) {
 				return
 			}
+			const id = term['@self']?.id || term.id
+			this.removing = true
 			try {
 				await customDictionaryStore.deleteTerm(this.dictionaryId, id)
+				this.removeTarget = null
 			} catch (err) {
 				console.error('Failed to remove term:', err)
+			} finally {
+				this.removing = false
 			}
 		},
 		closeImportDialog() {

--- a/src/views/customDictionary/CustomDictionaryIndex.vue
+++ b/src/views/customDictionary/CustomDictionaryIndex.vue
@@ -93,6 +93,19 @@ import { resolveI18nValue } from '../../utils/registerI18n.js'
 			:form-error="formError"
 			@submit="onCreateSubmit"
 			@cancel="dialogOpen = false" />
+
+		<!--
+			Delete confirmation. Replaces window.confirm(): the deletion below
+			runs only from @confirm, so an explicit confirmation is still
+			required before anything is removed.
+		-->
+		<ConfirmActionDialog
+			v-if="deleteTarget"
+			:name="t('docudesk', 'Delete dictionary')"
+			:message="deleteMessage"
+			:busy="deleting"
+			@confirm="executeDelete"
+			@cancel="cancelDelete" />
 	</div>
 </template>
 
@@ -107,6 +120,7 @@ import Delete from 'vue-material-design-icons/Delete.vue'
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 import CustomDictionaryFormDialog from '../../dialogs/CustomDictionaryFormDialog.vue'
+import ConfirmActionDialog from '../../dialogs/ConfirmActionDialog.vue'
 
 export default {
 	name: 'CustomDictionaryIndex',
@@ -116,6 +130,7 @@ export default {
 		NcActions,
 		NcActionButton,
 		CustomDictionaryFormDialog,
+		ConfirmActionDialog,
 		Delete,
 		DotsHorizontal,
 		Pencil,
@@ -128,6 +143,8 @@ export default {
 			dialogOpen: false,
 			saving: false,
 			formError: '',
+			deleteTarget: null, // row awaiting delete confirmation, or null
+			deleting: false,
 			matchModeColorMap: {
 				exact: 'error',
 				caseInsensitive: 'primary',
@@ -158,6 +175,15 @@ export default {
 				return customDictionaryStore.error
 			}
 			return t('docudesk', 'No custom dictionaries defined yet.')
+		},
+		/**
+		 * Body text of the delete confirmation dialog.
+		 *
+		 * @spec openspec/specs/custom-dictionary-recognition/spec.md
+		 */
+		deleteMessage() {
+			const name = this.deleteTarget?.label || t('docudesk', 'this dictionary')
+			return t('docudesk', 'Delete "{name}" and all its terms? This cannot be undone.', { name })
 		},
 	},
 	mounted() {
@@ -219,17 +245,47 @@ export default {
 				this.saving = false
 			}
 		},
-		async confirmDelete(row) {
-			const id = row['@self']?.id || row.id || row.uuid
-			const name = row.label || t('docudesk', 'this dictionary')
-			// eslint-disable-next-line no-alert
-			if (!window.confirm(t('docudesk', 'Delete "{name}" and all its terms? This cannot be undone.', { name }))) {
+		/**
+		 * Ask for confirmation before deleting a dictionary.
+		 *
+		 * Opens ConfirmActionDialog; nothing is removed here.
+		 *
+		 * @param {object} row - The dictionary row to delete.
+		 * @spec openspec/specs/custom-dictionary-recognition/spec.md
+		 */
+		confirmDelete(row) {
+			this.deleteTarget = row
+		},
+		/**
+		 * Dismiss the delete confirmation without deleting anything.
+		 *
+		 * @spec openspec/specs/custom-dictionary-recognition/spec.md
+		 */
+		cancelDelete() {
+			this.deleteTarget = null
+		},
+		/**
+		 * Delete the confirmed dictionary and all its terms. Reachable only
+		 * from the dialog's @confirm, so the record is never removed without
+		 * an explicit confirmation.
+		 *
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/custom-dictionary-recognition/spec.md
+		 */
+		async executeDelete() {
+			const row = this.deleteTarget
+			if (!row) {
 				return
 			}
+			const id = row['@self']?.id || row.id || row.uuid
+			this.deleting = true
 			try {
 				await customDictionaryStore.deleteDictionary(id)
+				this.deleteTarget = null
 			} catch (err) {
 				console.error('Failed to delete custom dictionary:', err)
+			} finally {
+				this.deleting = false
 			}
 		},
 	},

--- a/src/views/dashboard/DashboardIndex.vue
+++ b/src/views/dashboard/DashboardIndex.vue
@@ -17,52 +17,73 @@ import { consentStore } from '../../store/store.js'
 			:widgets="widgetDefs"
 			:layout="dashboardLayout"
 			:loading="consentStore.loading">
+			<!--
+				Each KPI tile navigates to the consent overview. That is a
+				navigation, so it ships as a real link: <RouterLink> renders an
+				<a href>, which is focusable, activates on Enter, and supports
+				middle-click / open-in-new-tab. The previous `<div @click>`
+				wrapper was unreachable by keyboard entirely (WCAG 2.1.1).
+				The explicit aria-label names the link, because its visible text
+				lives inside CnStatsBlock.
+			-->
 			<!-- KPI: Total Consents -->
 			<template #widget-total-consents>
-				<div style="cursor: pointer" @click="$router.push({ name: 'Consent' })">
+				<RouterLink
+					class="dashboard-kpi-link"
+					:to="{ name: 'Consent' }"
+					:aria-label="t('docudesk', 'Total Consents — open the consent overview')">
 					<CnStatsBlock
 						:title="t('docudesk', 'Total Consents')"
 						:count="consentStore.consentStats.total"
 						:count-label="t('docudesk', 'records')"
 						variant="default"
 						show-zero-count />
-				</div>
+				</RouterLink>
 			</template>
 
 			<!-- KPI: Pending -->
 			<template #widget-pending>
-				<div style="cursor: pointer" @click="$router.push({ name: 'Consent' })">
+				<RouterLink
+					class="dashboard-kpi-link"
+					:to="{ name: 'Consent' }"
+					:aria-label="t('docudesk', 'Pending consents — open the consent overview')">
 					<CnStatsBlock
 						:title="t('docudesk', 'Pending')"
 						:count="consentStore.consentStats.pending"
 						:count-label="t('docudesk', 'pending')"
 						variant="warning"
 						show-zero-count />
-				</div>
+				</RouterLink>
 			</template>
 
 			<!-- KPI: Approved -->
 			<template #widget-approved>
-				<div style="cursor: pointer" @click="$router.push({ name: 'Consent' })">
+				<RouterLink
+					class="dashboard-kpi-link"
+					:to="{ name: 'Consent' }"
+					:aria-label="t('docudesk', 'Approved consents — open the consent overview')">
 					<CnStatsBlock
 						:title="t('docudesk', 'Approved')"
 						:count="consentStore.consentStats.approved"
 						:count-label="t('docudesk', 'approved')"
 						variant="success"
 						show-zero-count />
-				</div>
+				</RouterLink>
 			</template>
 
 			<!-- KPI: Objected -->
 			<template #widget-objected>
-				<div style="cursor: pointer" @click="$router.push({ name: 'Consent' })">
+				<RouterLink
+					class="dashboard-kpi-link"
+					:to="{ name: 'Consent' }"
+					:aria-label="t('docudesk', 'Objected consents — open the consent overview')">
 					<CnStatsBlock
 						:title="t('docudesk', 'Objected')"
 						:count="consentStore.consentStats.objected"
 						:count-label="t('docudesk', 'objected')"
 						variant="error"
 						show-zero-count />
-				</div>
+				</RouterLink>
 			</template>
 
 			<!-- Pending Consents table -->
@@ -216,3 +237,20 @@ export default {
 	},
 }
 </script>
+
+<style scoped>
+/* The KPI tiles are links, but they must keep the tile look — no underline,
+   no link colour — while retaining a visible keyboard focus ring. */
+.dashboard-kpi-link {
+	display: block;
+	height: 100%;
+	color: inherit;
+	text-decoration: none;
+}
+
+.dashboard-kpi-link:focus-visible {
+	outline: 2px solid var(--color-primary-element);
+	outline-offset: 2px;
+	border-radius: var(--border-radius-large);
+}
+</style>

--- a/src/views/gallery/ComponentGallery.vue
+++ b/src/views/gallery/ComponentGallery.vue
@@ -178,10 +178,12 @@
 				</h2>
 				<p class="dd-section__desc">
 					Responsive tile grid; card content via the <code>card</code> scoped slot.
+					The grid is layout only — a card that should be activatable is
+					an interactive element in the slot, so keyboard users reach it.
 				</p>
 			</div>
 			<div class="dd-demo">
-				<DdCardGrid :objects="documents" row-key="id" @row-click="noop">
+				<DdCardGrid :objects="documents" row-key="id">
 					<template #card="{ object }">
 						<div class="dd-mini-card">
 							<DdIcon :name="object.isFolder ? 'folder' : 'article'" :size="24" />

--- a/src/views/myDocuments/MyDocumentsIndex.vue
+++ b/src/views/myDocuments/MyDocumentsIndex.vue
@@ -170,6 +170,27 @@ import { myDocumentsStore, fileViewerStore } from '../../store/store.js'
 			:findings="validation.findings"
 			@close="validation.show = false"
 			@ocr="onOcrRequested" />
+
+		<!--
+			Delete confirmation, single row and bulk. Replaces window.confirm():
+			executeDelete()/executeBulkDelete() run only from @confirm, so
+			nothing is removed without an explicit confirmation.
+		-->
+		<ConfirmActionDialog
+			v-if="deleteTarget"
+			:name="t('docudesk', 'Delete document')"
+			:message="deleteMessage"
+			:busy="deleting"
+			@confirm="executeDelete"
+			@cancel="cancelDelete" />
+
+		<ConfirmActionDialog
+			v-if="bulkDeleteNames.length > 0"
+			:name="t('docudesk', 'Delete selected items')"
+			:message="bulkDeleteMessage"
+			:busy="deleting"
+			@confirm="executeBulkDelete"
+			@cancel="cancelBulkDelete" />
 	</div>
 </template>
 
@@ -185,6 +206,7 @@ import DdDocumentCard from '../../components/DdDocumentCard.vue'
 import DdIcon from '../../components/DdIcon.vue'
 import FileViewerPage from '../fileViewer/FileViewerPage.vue'
 import ValidationResultModal from '../../modals/ValidationResultModal.vue'
+import ConfirmActionDialog from '../../dialogs/ConfirmActionDialog.vue'
 import { validateFile } from '../../services/validationService.js'
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 import Eye from 'vue-material-design-icons/Eye.vue'
@@ -234,6 +256,7 @@ export default {
 		DdIcon,
 		FileViewerPage,
 		ValidationResultModal,
+		ConfirmActionDialog,
 		DotsHorizontal,
 		Eye,
 		// TODO: re-enable with the Status column (see import above).
@@ -267,6 +290,9 @@ export default {
 				[t('docudesk', 'Concept')]: 'warning',
 				[t('docudesk', 'Anonymized')]: 'success',
 			},
+			deleteTarget: null, // row awaiting delete confirmation, or null
+			bulkDeleteNames: [], // file names awaiting bulk-delete confirmation
+			deleting: false,
 		}
 	},
 	computed: {
@@ -302,6 +328,28 @@ export default {
 				return myDocumentsStore.error
 			}
 			return t('docudesk', 'No documents found')
+		},
+		/**
+		 * Body text of the single-item delete confirmation dialog.
+		 *
+		 * @spec exclude Presentational string for the delete confirmation dialog.
+		 */
+		deleteMessage() {
+			const row = this.deleteTarget
+			if (!row) {
+				return ''
+			}
+			return row.isFolder
+				? t('docudesk', 'Delete dossier "{name}" and all documents inside it? This cannot be undone.', { name: row.fileName })
+				: t('docudesk', 'Delete "{name}"? This cannot be undone.', { name: this.displayName(row) })
+		},
+		/**
+		 * Body text of the bulk delete confirmation dialog.
+		 *
+		 * @spec exclude Presentational string for the delete confirmation dialog.
+		 */
+		bulkDeleteMessage() {
+			return t('docudesk', 'Delete {count} selected item(s)? Dossiers and the documents inside them will be removed. This cannot be undone.', { count: this.bulkDeleteNames.length })
 		},
 	},
 	/**
@@ -390,15 +438,33 @@ export default {
 		 *
 		 * @spec exclude UI confirmation wrapper around WebDAV passthrough; auth + ACL enforced by Nextcloud core (no DocuDesk domain semantics).
 		 */
-		async bulkDelete() {
+		bulkDelete() {
 			const names = myDocumentsStore.documents
 				.filter((d) => this.selectedIds.includes(d.fileId))
 				.map((d) => d.fileName)
 			if (names.length === 0) return
-			// eslint-disable-next-line no-alert
-			if (!window.confirm(t('docudesk', 'Delete {count} selected item(s)? Dossiers and the documents inside them will be removed. This cannot be undone.', { count: names.length }))) {
-				return
-			}
+			this.bulkDeleteNames = names
+		},
+		/**
+		 * Dismiss the bulk-delete confirmation without deleting anything.
+		 *
+		 * @spec exclude UI confirmation wrapper around WebDAV passthrough; auth + ACL enforced by Nextcloud core (no DocuDesk domain semantics).
+		 */
+		cancelBulkDelete() {
+			this.bulkDeleteNames = []
+		},
+		/**
+		 * Delete the confirmed selection. Reachable only from the dialog's
+		 * @confirm, so nothing is removed without an explicit confirmation.
+		 *
+		 * @return {Promise<void>}
+		 *
+		 * @spec exclude UI confirmation wrapper around WebDAV passthrough; auth + ACL enforced by Nextcloud core (no DocuDesk domain semantics).
+		 */
+		async executeBulkDelete() {
+			const names = this.bulkDeleteNames
+			if (names.length === 0) return
+			this.deleting = true
 			try {
 				const failed = await myDocumentsStore.deleteDocuments(names)
 				if (failed.length > 0) {
@@ -411,6 +477,8 @@ export default {
 				showError(t('docudesk', 'Failed to delete the selected items'))
 			} finally {
 				this.selectedIds = []
+				this.bulkDeleteNames = []
+				this.deleting = false
 			}
 		},
 		/**
@@ -477,21 +545,40 @@ export default {
 		 *
 		 * @spec exclude UI confirmation wrapper around WebDAV passthrough; auth + ACL enforced by Nextcloud core (no DocuDesk domain semantics).
 		 */
-		async confirmDelete(row) {
+		confirmDelete(row) {
 			if (!row || !row.fileName) return
-			const message = row.isFolder
-				? t('docudesk', 'Delete dossier "{name}" and all documents inside it? This cannot be undone.', { name: row.fileName })
-				: t('docudesk', 'Delete "{name}"? This cannot be undone.', { name: this.displayName(row) })
-			// eslint-disable-next-line no-alert
-			if (!window.confirm(message)) {
-				return
-			}
+			this.deleteTarget = row
+		},
+		/**
+		 * Dismiss the delete confirmation without deleting anything.
+		 *
+		 * @spec exclude UI confirmation wrapper around WebDAV passthrough; auth + ACL enforced by Nextcloud core (no DocuDesk domain semantics).
+		 */
+		cancelDelete() {
+			this.deleteTarget = null
+		},
+		/**
+		 * Delete the confirmed file or dossier. Reachable only from the
+		 * dialog's @confirm, so nothing is removed without an explicit
+		 * confirmation.
+		 *
+		 * @return {Promise<void>}
+		 *
+		 * @spec exclude UI confirmation wrapper around WebDAV passthrough; auth + ACL enforced by Nextcloud core (no DocuDesk domain semantics).
+		 */
+		async executeDelete() {
+			const row = this.deleteTarget
+			if (!row) return
+			this.deleting = true
 			try {
 				await myDocumentsStore.deleteDocument(row.fileName)
 				showSuccess(t('docudesk', 'Deleted "{name}"', { name: this.displayName(row) }))
 			} catch (err) {
 				console.error('Failed to delete document:', err)
 				showError(t('docudesk', 'Failed to delete "{name}"', { name: this.displayName(row) }))
+			} finally {
+				this.deleteTarget = null
+				this.deleting = false
 			}
 		},
 		/**
@@ -731,6 +818,14 @@ export default {
    NcActions sizes itself off Nextcloud's `--default-clickable-area` token. */
 .my-documents-row-actions {
 	--default-clickable-area: 32px;
+}
+
+/* WCAG 2.2 SC 2.3.3 — users who ask the OS for reduced motion get the state
+   change without the tween. */
+@media (prefers-reduced-motion: reduce) {
+	.my-documents-name__icon {
+		transition: none;
+	}
 }
 
 </style>

--- a/src/views/policy/ProhibitionFormModal.vue
+++ b/src/views/policy/ProhibitionFormModal.vue
@@ -172,7 +172,16 @@ export default {
 				<NcTextField
 					v-model="rule.value"
 					:label="t('docudesk', 'Match value')" />
-				<NcButton variant="tertiary" @click="removeRule(idx)">
+				<!--
+					Icon-only, so it needs its own name. The row index is part of
+					it: every row renders the same icon, and "Remove match rule"
+					repeated N times tells a screen-reader user nothing about
+					which row focus is on (WCAG 4.1.2).
+				-->
+				<NcButton
+					variant="tertiary"
+					:aria-label="t('docudesk', 'Remove match rule {number}', { number: idx + 1 })"
+					@click="removeRule(idx)">
 					<template #icon>
 						<Delete :size="20" />
 					</template>

--- a/src/views/policy/ProhibitionIndex.vue
+++ b/src/views/policy/ProhibitionIndex.vue
@@ -113,6 +113,19 @@ import { prohibitionStore } from '../../store/store.js'
 			@update:open="dialogOpen = $event"
 			@submit="onModalSubmit"
 			@cancel="dialogOpen = false" />
+
+		<!--
+			Delete confirmation. Replaces window.confirm(): the deletion below
+			runs only from @confirm, so an explicit confirmation is still
+			required before anything is removed.
+		-->
+		<ConfirmActionDialog
+			v-if="deleteTarget"
+			:name="t('docudesk', 'Delete prohibition')"
+			:message="deleteMessage"
+			:busy="deleting"
+			@confirm="executeDelete"
+			@cancel="cancelDelete" />
 	</div>
 </template>
 
@@ -126,6 +139,7 @@ import Delete from 'vue-material-design-icons/Delete.vue'
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 import ProhibitionFormModal from './ProhibitionFormModal.vue'
+import ConfirmActionDialog from '../../dialogs/ConfirmActionDialog.vue'
 
 export default {
 	name: 'ProhibitionIndex',
@@ -136,6 +150,7 @@ export default {
 		NcActions,
 		NcActionButton,
 		ProhibitionFormModal,
+		ConfirmActionDialog,
 		Delete,
 		DotsHorizontal,
 		Pencil,
@@ -150,6 +165,8 @@ export default {
 			editing: null, // UUID of the record being edited, or null for create
 			editingRecord: null, // full record passed to the modal so it can hydrate its form
 			formError: '',
+			deleteTarget: null, // row awaiting delete confirmation, or null
+			deleting: false,
 			entityTypeColorMap: {
 				PERSON: 'warning',
 				ORGANIZATION: 'primary',
@@ -189,6 +206,15 @@ export default {
 				return prohibitionStore.error
 			}
 			return t('docudesk', 'No publication prohibitions defined.')
+		},
+		/**
+		 * Body text of the delete confirmation dialog.
+		 *
+		 * @spec openspec/specs/orphaned-surface-restoration/spec.md#requirement-policy-surfaces-are-reachable-menu-ownership-deferred-req-ddosr-005
+		 */
+		deleteMessage() {
+			const name = this.deleteTarget?.primaryName || t('docudesk', 'this prohibition')
+			return t('docudesk', 'Delete "{name}"? This cannot be undone.', { name })
 		},
 	},
 	mounted() {
@@ -257,17 +283,47 @@ export default {
 				this.saving = false
 			}
 		},
-		async confirmDelete(row) {
-			const id = row['@self']?.id || row.id || row.uuid
-			const name = row.primaryName || t('docudesk', 'this prohibition')
-			// eslint-disable-next-line no-alert
-			if (!window.confirm(t('docudesk', 'Delete "{name}"? This cannot be undone.', { name }))) {
+		/**
+		 * Ask for confirmation before deleting a prohibition.
+		 *
+		 * Opens ConfirmActionDialog; nothing is removed here.
+		 *
+		 * @param {object} row - The prohibition row to delete.
+		 * @spec openspec/specs/orphaned-surface-restoration/spec.md#requirement-policy-surfaces-are-reachable-menu-ownership-deferred-req-ddosr-005
+		 */
+		confirmDelete(row) {
+			this.deleteTarget = row
+		},
+		/**
+		 * Dismiss the delete confirmation without deleting anything.
+		 *
+		 * @spec openspec/specs/orphaned-surface-restoration/spec.md#requirement-policy-surfaces-are-reachable-menu-ownership-deferred-req-ddosr-005
+		 */
+		cancelDelete() {
+			this.deleteTarget = null
+		},
+		/**
+		 * Delete the confirmed prohibition. Reachable only from the dialog's
+		 * @confirm, so the record is never removed without an explicit
+		 * confirmation.
+		 *
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/orphaned-surface-restoration/spec.md#requirement-policy-surfaces-are-reachable-menu-ownership-deferred-req-ddosr-005
+		 */
+		async executeDelete() {
+			const row = this.deleteTarget
+			if (!row) {
 				return
 			}
+			const id = row['@self']?.id || row.id || row.uuid
+			this.deleting = true
 			try {
 				await prohibitionStore.deleteProhibition(id)
+				this.deleteTarget = null
 			} catch (err) {
 				console.error('Failed to delete prohibition:', err)
+			} finally {
+				this.deleting = false
 			}
 		},
 	},

--- a/src/views/policy/StandingConsentFormModal.vue
+++ b/src/views/policy/StandingConsentFormModal.vue
@@ -169,7 +169,16 @@ export default {
 				<NcTextField
 					v-model="rule.value"
 					:label="t('docudesk', 'Match value')" />
-				<NcButton variant="tertiary" @click="removeRule(idx)">
+				<!--
+					Icon-only, so it needs its own name. The row index is part of
+					it: every row renders the same icon, and "Remove match rule"
+					repeated N times tells a screen-reader user nothing about
+					which row focus is on (WCAG 4.1.2).
+				-->
+				<NcButton
+					variant="tertiary"
+					:aria-label="t('docudesk', 'Remove match rule {number}', { number: idx + 1 })"
+					@click="removeRule(idx)">
 					<template #icon>
 						<Delete :size="20" />
 					</template>

--- a/src/views/policy/StandingConsentIndex.vue
+++ b/src/views/policy/StandingConsentIndex.vue
@@ -115,6 +115,19 @@ import { standingConsentStore } from '../../store/store.js'
 			@update:open="dialogOpen = $event"
 			@submit="onModalSubmit"
 			@cancel="dialogOpen = false" />
+
+		<!--
+			Delete confirmation. Replaces window.confirm(): the deletion below
+			runs only from @confirm, so an explicit confirmation is still
+			required before anything is removed.
+		-->
+		<ConfirmActionDialog
+			v-if="deleteTarget"
+			:name="t('docudesk', 'Delete standing consent')"
+			:message="deleteMessage"
+			:busy="deleting"
+			@confirm="executeDelete"
+			@cancel="cancelDelete" />
 	</div>
 </template>
 
@@ -128,6 +141,7 @@ import Delete from 'vue-material-design-icons/Delete.vue'
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 import StandingConsentFormModal from './StandingConsentFormModal.vue'
+import ConfirmActionDialog from '../../dialogs/ConfirmActionDialog.vue'
 
 export default {
 	name: 'StandingConsentIndex',
@@ -138,6 +152,7 @@ export default {
 		NcActions,
 		NcActionButton,
 		StandingConsentFormModal,
+		ConfirmActionDialog,
 		Delete,
 		DotsHorizontal,
 		Pencil,
@@ -152,6 +167,8 @@ export default {
 			editing: null, // UUID of the record being edited, or null for create
 			editingRecord: null, // full record passed to the modal so it can hydrate its form
 			formError: '',
+			deleteTarget: null, // row awaiting delete confirmation, or null
+			deleting: false,
 			entityTypeColorMap: {
 				PERSON: 'warning',
 				ORGANIZATION: 'primary',
@@ -190,6 +207,15 @@ export default {
 				return standingConsentStore.error
 			}
 			return t('docudesk', 'No standing publication consents defined.')
+		},
+		/**
+		 * Body text of the delete confirmation dialog.
+		 *
+		 * @spec openspec/specs/orphaned-surface-restoration/spec.md#requirement-policy-surfaces-are-reachable-menu-ownership-deferred-req-ddosr-005
+		 */
+		deleteMessage() {
+			const name = this.deleteTarget?.entityText || t('docudesk', 'this standing consent')
+			return t('docudesk', 'Delete "{name}"? This cannot be undone.', { name })
 		},
 	},
 	mounted() {
@@ -278,17 +304,47 @@ export default {
 				this.saving = false
 			}
 		},
-		async confirmDelete(row) {
-			const id = row['@self']?.id || row.id || row.uuid
-			const name = row.entityText || t('docudesk', 'this standing consent')
-			// eslint-disable-next-line no-alert
-			if (!window.confirm(t('docudesk', 'Delete "{name}"? This cannot be undone.', { name }))) {
+		/**
+		 * Ask for confirmation before deleting a standing consent.
+		 *
+		 * Opens ConfirmActionDialog; nothing is removed here.
+		 *
+		 * @param {object} row - The standing consent row to delete.
+		 * @spec openspec/specs/orphaned-surface-restoration/spec.md#requirement-policy-surfaces-are-reachable-menu-ownership-deferred-req-ddosr-005
+		 */
+		confirmDelete(row) {
+			this.deleteTarget = row
+		},
+		/**
+		 * Dismiss the delete confirmation without deleting anything.
+		 *
+		 * @spec openspec/specs/orphaned-surface-restoration/spec.md#requirement-policy-surfaces-are-reachable-menu-ownership-deferred-req-ddosr-005
+		 */
+		cancelDelete() {
+			this.deleteTarget = null
+		},
+		/**
+		 * Delete the confirmed standing consent. Reachable only from the
+		 * dialog's @confirm, so the record is never removed without an
+		 * explicit confirmation.
+		 *
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/orphaned-surface-restoration/spec.md#requirement-policy-surfaces-are-reachable-menu-ownership-deferred-req-ddosr-005
+		 */
+		async executeDelete() {
+			const row = this.deleteTarget
+			if (!row) {
 				return
 			}
+			const id = row['@self']?.id || row.id || row.uuid
+			this.deleting = true
 			try {
 				await standingConsentStore.deleteStandingConsent(id)
+				this.deleteTarget = null
 			} catch (err) {
 				console.error('Failed to delete standing consent:', err)
+			} finally {
+				this.deleting = false
 			}
 		},
 	},

--- a/src/views/signing/BulkSigningPanel.vue
+++ b/src/views/signing/BulkSigningPanel.vue
@@ -11,9 +11,11 @@
 			<table class="bulk-table">
 				<thead>
 					<tr>
+						<!-- Selection column: a control header with no name of its
+						     own, so scope= would associate nothing. -->
 						<th />
-						<th>{{ t('docudesk', 'Document') }}</th>
-						<th>{{ t('docudesk', 'Level') }}</th>
+						<th scope="col">{{ t('docudesk', 'Document') }}</th>
+						<th scope="col">{{ t('docudesk', 'Level') }}</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/views/signing/SigningRequestDetail.vue
+++ b/src/views/signing/SigningRequestDetail.vue
@@ -18,9 +18,9 @@
 			<table v-if="signingStore.auditTrail.length > 0" class="audit-table">
 				<thead>
 					<tr>
-						<th>{{ t('docudesk', 'Action') }}</th>
-						<th>{{ t('docudesk', 'Actor') }}</th>
-						<th>{{ t('docudesk', 'Timestamp') }}</th>
+						<th scope="col">{{ t('docudesk', 'Action') }}</th>
+						<th scope="col">{{ t('docudesk', 'Actor') }}</th>
+						<th scope="col">{{ t('docudesk', 'Timestamp') }}</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/views/signing/SigningRequestList.vue
+++ b/src/views/signing/SigningRequestList.vue
@@ -9,11 +9,11 @@
 		<table v-else class="signing-table">
 			<thead>
 				<tr>
-					<th>{{ t('docudesk', 'Document') }}</th>
-					<th>{{ t('docudesk', 'Status') }}</th>
-					<th>{{ t('docudesk', 'Level') }}</th>
-					<th>{{ t('docudesk', 'Mode') }}</th>
-					<th>{{ t('docudesk', 'Deadline') }}</th>
+					<th scope="col">{{ t('docudesk', 'Document') }}</th>
+					<th scope="col">{{ t('docudesk', 'Status') }}</th>
+					<th scope="col">{{ t('docudesk', 'Level') }}</th>
+					<th scope="col">{{ t('docudesk', 'Mode') }}</th>
+					<th scope="col">{{ t('docudesk', 'Deadline') }}</th>
 				</tr>
 			</thead>
 			<tbody>

--- a/src/views/templates/TemplateDetail.vue
+++ b/src/views/templates/TemplateDetail.vue
@@ -189,10 +189,10 @@
 			<table v-else class="template-detail__versions-table">
 				<thead>
 					<tr>
-						<th>{{ t('docudesk', 'Version') }}</th>
-						<th>{{ t('docudesk', 'Editor') }}</th>
-						<th>{{ t('docudesk', 'Change note') }}</th>
-						<th>{{ t('docudesk', 'Actions') }}</th>
+						<th scope="col">{{ t('docudesk', 'Version') }}</th>
+						<th scope="col">{{ t('docudesk', 'Editor') }}</th>
+						<th scope="col">{{ t('docudesk', 'Change note') }}</th>
+						<th scope="col">{{ t('docudesk', 'Actions') }}</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/views/templates/TemplateIndex.vue
+++ b/src/views/templates/TemplateIndex.vue
@@ -26,12 +26,12 @@
 		<table v-else-if="templateStore.templates.length > 0" class="template-index__table">
 			<thead>
 				<tr>
-					<th>{{ t('docudesk', 'Name') }}</th>
-					<th>{{ t('docudesk', 'Category') }}</th>
-					<th>{{ t('docudesk', 'Namespace') }}</th>
-					<th>{{ t('docudesk', 'Tags') }}</th>
-					<th>{{ t('docudesk', 'Status') }}</th>
-					<th>{{ t('docudesk', 'Actions') }}</th>
+					<th scope="col">{{ t('docudesk', 'Name') }}</th>
+					<th scope="col">{{ t('docudesk', 'Category') }}</th>
+					<th scope="col">{{ t('docudesk', 'Namespace') }}</th>
+					<th scope="col">{{ t('docudesk', 'Tags') }}</th>
+					<th scope="col">{{ t('docudesk', 'Status') }}</th>
+					<th scope="col">{{ t('docudesk', 'Actions') }}</th>
 				</tr>
 			</thead>
 			<tbody>

--- a/src/views/widgets/AnonymizationDashboardWidget.vue
+++ b/src/views/widgets/AnonymizationDashboardWidget.vue
@@ -10,14 +10,14 @@ import { anonymizationStore } from '../../store/store.js'
 			<table class="results-table">
 				<thead>
 					<tr>
-						<th>{{ t('docudesk', 'File') }}</th>
-						<th class="col-number">
+						<th scope="col">{{ t('docudesk', 'File') }}</th>
+						<th scope="col" class="col-number">
 							{{ t('docudesk', 'Entities') }}
 						</th>
-						<th class="col-number">
+						<th scope="col" class="col-number">
 							{{ t('docudesk', 'Removed') }}
 						</th>
-						<th class="col-action">
+						<th scope="col" class="col-action">
 							{{ t('docudesk', 'Result') }}
 						</th>
 					</tr>
@@ -81,13 +81,19 @@ import { anonymizationStore } from '../../store/store.js'
 
 		<!-- Drop zone -->
 		<div class="upload-area" :class="{ compact: anonymizationStore.hasFiles }">
+			<!--
+				Drag-and-drop is a pointer-only affordance by nature, so the file
+				picker is opened by a REAL <button> rather than by a click handler
+				on this wrapper. The wrapper used to carry `@click` while the
+				<input type="file"> was `display: none`, which left keyboard users
+				with no way at all to reach the picker (WCAG 2.1.1).
+			-->
 			<div
 				class="drop-zone"
 				:class="{ dragging: isDragging }"
 				@dragover.prevent="isDragging = true"
 				@dragleave.prevent="isDragging = false"
-				@drop.prevent="handleDrop"
-				@click="$refs.fileInput.click()">
+				@drop.prevent="handleDrop">
 				<img v-if="!anonymizationStore.hasFiles"
 					:src="uploadIcon"
 					alt=""
@@ -102,9 +108,9 @@ import { anonymizationStore } from '../../store/store.js'
 					<p v-if="!anonymizationStore.hasFiles" class="drop-subtitle">
 						{{ t('docudesk', 'Only Word (.docx), PDF or TXT files are supported. Maximum file size 500 MB.') }}
 					</p>
-					<span class="fake-button">
+					<button type="button" class="fake-button" @click="$refs.fileInput.click()">
 						{{ anonymizationStore.hasFiles ? t('docudesk', '+ Add more files') : t('docudesk', '+ Select files') }}
-					</span>
+					</button>
 				</div>
 				<input
 					ref="fileInput"
@@ -490,7 +496,7 @@ export default {
 	border-radius: var(--border-radius-large);
 	padding: 32px;
 	background-color: var(--color-main-background);
-	cursor: pointer;
+	/* Not a click target any more — the picker is opened by .fake-button. */
 	transition: border-color 0.2s, background-color 0.2s;
 }
 
@@ -533,15 +539,25 @@ export default {
 	color: var(--color-text-maxcontrast);
 }
 
+/* A real <button> now, so the browser's own border/font defaults are reset
+   here to keep the previous appearance byte-for-byte. */
 .fake-button {
 	margin-top: 4px;
 	padding: 8px 16px;
+	border: none;
 	border-radius: var(--border-radius);
 	background-color: var(--color-primary-element);
 	color: var(--color-primary-element-text);
+	font-family: inherit;
 	font-size: 0.9rem;
 	font-weight: 500;
 	white-space: nowrap;
+	cursor: pointer;
+}
+
+.fake-button:focus-visible {
+	outline: 2px solid var(--color-primary-element);
+	outline-offset: 2px;
 }
 
 .file-input {
@@ -575,5 +591,13 @@ export default {
 
 .dossier-dialog :deep(.notecard) {
 	margin: 0;
+}
+
+/* WCAG 2.2 SC 2.3.3 — users who ask the OS for reduced motion get the state
+   change without the tween. */
+@media (prefers-reduced-motion: reduce) {
+	.drop-zone {
+		transition: none;
+	}
 }
 </style>

--- a/src/views/widgets/FileEntitiesDashboardWidget.vue
+++ b/src/views/widgets/FileEntitiesDashboardWidget.vue
@@ -34,17 +34,17 @@ import axios from '@nextcloud/axios'
 			<table class="results-table">
 				<thead>
 					<tr>
-						<th>{{ t('docudesk', 'File') }}</th>
-						<th class="col-number">
+						<th scope="col">{{ t('docudesk', 'File') }}</th>
+						<th scope="col" class="col-number">
 							{{ t('docudesk', 'Entities') }}
 						</th>
-						<th class="col-risk">
+						<th scope="col" class="col-risk">
 							{{ t('docudesk', 'Risk') }}
 						</th>
-						<th class="col-status">
+						<th scope="col" class="col-status">
 							{{ t('docudesk', 'Status') }}
 						</th>
-						<th class="col-ocr">
+						<th scope="col" class="col-ocr">
 							{{ t('docudesk', 'OCR') }}
 						</th>
 					</tr>


### PR DESCRIPTION
Closes the five accessibility gates that were red on `development`, all under `src/`. No waivers, no baselines, no excludes — every finding is closed by changing the markup or the behaviour.

## Measured, gate package `48c88ba1e0d049f8f38538c33e790d3e603c55d0`

| gate | before | after |
| --- | --- | --- |
| 32 semantic-controls | `FAIL — 7 non-semantic element(s) with @click but missing role/tabindex/keyboard handler` | `PASS — 72 markup file(s) inspected, 0 mouse-only click target` |
| 34 window-confirm | `FAIL — 7 native dialog call(s)` | `PASS` |
| 39 button-name | `FAIL — 2 icon-only button(s) without an accessible name` | `PASS` |
| 43 table-headers | `FAIL — 11 <table>(s) with a <th> missing scope=` | `PASS` |
| 45 prefers-reduced-motion | `FAIL — 10 <style> block(s) with motion but no reduced-motion fallback` | `PASS` |

Whole-repo run before and after: **13 gates failed → 8 gates failed.** The remaining 8 (1, 7, 19, 25, 26, 50, 54, 58) are pre-existing and untouched by this PR. gate-13 modal-isolation and gate-16 spec-coverage both stay green. No checker crashed — every `*.err` in the log dir is zero-length on all runs.

## What changed, and why this shape

**gate-32 — mouse-only click targets.** Fixed by using the element the job calls for, not by bolting `role`/`tabindex` onto a `<div>`.

- The four dashboard KPI tiles navigate, so they are `<RouterLink>` now — a real `<a href>`: focusable, Enter-activated, middle-clickable. An explicit `aria-label` names each, since the visible text renders inside `CnStatsBlock`.
- Both anonymisation drop zones opened the file picker from a click handler on the wrapper while `<input type="file">` was `display: none` — so a keyboard user could not open the picker **at all**. The decorative `<span class="fake-button">` is now a real `<button>`; the wrapper keeps only the drag handlers. This is the shape `openspec/changes/docudesk-upload-dropzone-keyboard-access` already asks for.
- `DdCardGrid`'s cell is layout only now. Where the slotted card is itself activatable (`DdDocumentCard` is `role="button"` with Enter/Space), the wrapper's click **also** fired as the event bubbled — the handler ran twice. `DdIndexPage` stops forwarding `row-click` from the card grid; the table path still forwards it, because a `<tr>` is not interactive on its own.

**gate-34 — `window.confirm`.** The confirmation is preserved, not dropped. New `src/dialogs/ConfirmActionDialog.vue` (focus-trapped `NcDialog`, own file per ADR-004/gate-13, modelled on `ConfirmDeleteTemplateDialog`). At every call site the handler is split: `confirmDelete()` / `revokeConsent()` / `removeTerm()` only records the target and opens the dialog, and the write lives in a separate `executeDelete()` reachable **only** from the dialog's `@confirm`.

**gate-43 — table headers.** Column headers get `scope="col"`. `ConsentDetail` was the different case flagged as `table-without-th`: a two-column name/value grid where every row was two `<td>`, so the values had no header to be announced against. Each row's first cell *is* the name of that row, so it becomes `<th scope="row">`; the CSS gains `text-align: start` to neutralise the UA's centred `<th>` default, leaving the rendering unchanged. Deliberately **not** scoped: the select-checkbox and row-actions headers in `DdDataTable` and the selection header in `BulkSigningPanel` — they carry no accessible name, so `scope=` on them would associate nothing.

**gate-39 — button names.** The `aria-label` carries the row index, because every match-rule row renders the same Delete icon: "Remove match rule" repeated N times says nothing about which row focus is on.

**gate-45 — reduced motion.** Each `<style>` block ends with a `@media (prefers-reduced-motion: reduce)` query setting `transition: none` on exactly the selectors that carry motion. State changes still happen — the toggle knob moves, the row tints — they just arrive instantly.

## Proof each gate can still fail

Five findings were re-seeded at once, one per gate, and the runner re-run. Each gate reported **exactly** its own seeded item and named the file:

```
[gate-32] semantic-controls: FAIL — 1 non-semantic element(s) ...
  src/components/DdCardGrid.vue:20: <div ... @click="$emit('row-click', object)"> rule=missing[role=,tabindex=,@keydown]
[gate-34] window-confirm: FAIL — 1 native dialog call(s) ...
  src/views/policy/ProhibitionIndex.vue:320:if (!window.confirm('temporary can-fail probe')) {
[gate-39] button-name: FAIL — 1 icon-only button(s) ...
  src/views/policy/ProhibitionFormModal.vue: <NcButton variant="tertiary" @click="removeRule(idx)"> rule=icon-only-button-without-accessible-name
[gate-43] table-headers: FAIL — 1 <table>(s) with a <th> missing scope= ...
  src/views/templates/TemplateIndex.vue: <table> unscoped=1/6 rule=th-without-scope
[gate-45] prefers-reduced-motion: FAIL — 1 <style> block(s) with motion ...
  src/components/DdToggle.vue: <style> rule=motion-without-reduced-motion-fallback
```

`unscoped=1/6` on gate-43 is the useful detail: the gate counts per header, so the other five `scope="col"` on that table are real and not a single attribute greening the whole table. All five probes were then reverted; `git diff` against the committed tree is empty.

## Not verified by this run

`npm ci` was not run (the only local `node_modules` is a Vue 2 tree from a different branch, and disk is tight), so **there is no local eslint / stylelint / webpack build behind this** — CI is the first thing to compile these templates. gate-60 icon-vocabulary is `SKIPPED (wiring)` for the same reason, exactly as on the `development` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
