### PR TITLE
fix(security): fail closed on unconfigured register/schema bindings (gate-50, gate-54, gate-1)

### DIFF
--- a/lib/Controller/PortalSigningReceiverController.php
+++ b/lib/Controller/PortalSigningReceiverController.php
@@ -363,10 +363,22 @@ class PortalSigningReceiverController extends Controller
             return null;
         }
 
-        $register = $this->config->getValueString('docudesk', 'signerRecord_register', '');
-        $schema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
-
+        // This is the anti-IDOR boundary (REQ-DDPSA-004), and the register and
+        // schema are two of the four filters that scope the lookup. They used
+        // to be read here with an empty-string default and passed straight
+        // through, so the boundary's correctness depended entirely on
+        // OpenRegister choosing to match nothing for an empty filter — an
+        // assumption this code never stated and does not control. If findAll
+        // ever read an empty register as "unscoped", this lookup would resolve
+        // a signerRecord from ANY register, which is precisely the
+        // cross-request signer resolution the requirement forbids.
+        //
+        // requireSignerRecordBinding() throws instead. The catch below already
+        // collapses any failure to null, which is the same answer the
+        // wrong-email and wrong-request cases give, so no new signal is
+        // exposed to a caller probing the endpoint.
         try {
+            ['register' => $register, 'schema' => $schema] = $this->settingsService->requireSignerRecordBinding();
             $results = $objectService->findAll(
                 [
                     'filters' => [

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -40,10 +40,14 @@
  * @category Controller
  * @package  OCA\DocuDesk\Controller
  *
- * @author  Conduction Development Team <info@conduction.nl>
- * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @link https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * @spec openspec/specs/preferences-api/spec.md
  */

--- a/lib/Service/FinancialExtractionService.php
+++ b/lib/Service/FinancialExtractionService.php
@@ -256,10 +256,16 @@ class FinancialExtractionService
         ];
 
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'financialExtraction_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'financialExtraction_schema', '');
-        $saved         = $objectService->saveObject(object: $payload, register: $register, schema: $schema);
-        $savedArray    = $this->toArray(object: $saved);
+        // Fails closed when unbound. An administrator sets these in the admin
+        // settings UI and nothing auto-provisions them; unbound, the write
+        // below went to register '' / schema '' and the extraction — supplier,
+        // IBAN, KvK, VAT id and amounts read off an invoice — was silently
+        // lost. An explicit error is diagnosable; a silent empty register is
+        // not.
+        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireFinancialExtractionBinding();
+
+        $saved      = $objectService->saveObject(object: $payload, register: $register, schema: $schema);
+        $savedArray = $this->toArray(object: $saved);
 
         if ($request['callbackEvent'] === true) {
             $this->dispatchCompletionEvent(

--- a/lib/Service/GlAccountSuggestionService.php
+++ b/lib/Service/GlAccountSuggestionService.php
@@ -178,8 +178,11 @@ class GlAccountSuggestionService
         ];
 
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'glAccountBooking_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'glAccountBooking_schema', '');
+        // Fails closed on the WRITE. This is the tuning corpus every future
+        // suggestion is ranked against; writing it to register '' loses the
+        // correction silently, and the next suggestion is then wrong for a
+        // reason nobody can see.
+        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireGlAccountBookingBinding();
         $objectService->saveObject(object: $booking, register: $register, schema: $schema);
 
     }//end recordBooking()
@@ -274,8 +277,13 @@ class GlAccountSuggestionService
     private function findExtractionSafely(string $extractionId): ?array
     {
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'financialExtraction_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'financialExtraction_schema', '');
+        // Throws when unbound rather than returning null. A lookup against
+        // register '' finds nothing, which is INDISTINGUISHABLE from "that
+        // extraction does not exist" — the caller then reports an unknown
+        // extraction id when the real cause is an unconfigured instance.
+        // Both controllers catch Exception, so this surfaces as an honest
+        // error response instead of a wrong answer.
+        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireFinancialExtractionBinding();
 
         $object = $objectService->find(id: $extractionId, register: $register, schema: $schema);
         if ($object === null) {
@@ -296,8 +304,11 @@ class GlAccountSuggestionService
     private function loadBookingHistory(string $supplierIdentity): array
     {
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'glAccountBooking_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'glAccountBooking_schema', '');
+        // Throws when unbound. "No booking history" and "not configured" both
+        // produced an empty array, and the ranker treats the first as a
+        // legitimate cold start — so an unconfigured instance silently ranked
+        // every supplier as brand new.
+        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireGlAccountBookingBinding();
 
         $query   = [
             '@self'            => ['register' => $register, 'schema' => $schema],
@@ -328,8 +339,11 @@ class GlAccountSuggestionService
     private function loadMappingRules(): array
     {
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'glAccountMappingRule_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'glAccountMappingRule_schema', '');
+        // Throws when unbound. Mapping rules are the cold-start path: with no
+        // history AND no rules the service honestly returns nothing. An
+        // unconfigured binding produced that same nothing for a different
+        // reason, and the operator had no way to tell the two apart.
+        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireGlAccountMappingRuleBinding();
 
         $query   = ['@self' => ['register' => $register, 'schema' => $schema]];
         $results = $objectService->searchObjects($query);

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -459,4 +459,111 @@ class SettingsService
         }//end try
 
     }//end updateSettings()
+
+    /**
+     * Resolve the signingRequest register/schema binding, failing closed.
+     *
+     * These bindings live here, next to the settings surface that writes them,
+     * rather than in each consumer: every call site used to read them inline
+     * with an empty-string default and pass the result straight into
+     * saveObject()/find(). Unconfigured, that wrote signing requests — the
+     * audit trail behind an eIDAS-level signature — into register '' and schema
+     * '', silently. Mirrors OpenRegisterResolver::getRegisterAndSchema(), which
+     * already does exactly this for templates.
+     *
+     * @return array{register: string, schema: string}|null The binding, or null when unset.
+     *
+     * @spec openspec/specs/document-signing/spec.md
+     */
+    public function resolveSigningRequestBinding(): ?array
+    {
+        $register = $this->config->getValueString('docudesk', 'signingRequest_register', '');
+        $schema   = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        return ['register' => $register, 'schema' => $schema];
+
+    }//end resolveSigningRequestBinding()
+
+    /**
+     * Resolve the signerRecord register/schema binding, failing closed.
+     *
+     * A signer record carries the identity a signature is attributed to, so an
+     * unconfigured binding loses exactly the evidence a signature exists to
+     * provide.
+     *
+     * @return array{register: string, schema: string}|null The binding, or null when unset.
+     *
+     * @spec openspec/specs/document-signing/spec.md
+     */
+    public function resolveSignerRecordBinding(): ?array
+    {
+        $register = $this->config->getValueString('docudesk', 'signerRecord_register', '');
+        $schema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        return ['register' => $register, 'schema' => $schema];
+
+    }//end resolveSignerRecordBinding()
+
+    /**
+     * Resolve the financialExtraction register/schema binding, failing closed.
+     *
+     * @return array{register: string, schema: string}|null The binding, or null when unset.
+     *
+     * @spec openspec/specs/financial-document-field-extraction/spec.md
+     */
+    public function resolveFinancialExtractionBinding(): ?array
+    {
+        $register = $this->config->getValueString('docudesk', 'financialExtraction_register', '');
+        $schema   = $this->config->getValueString('docudesk', 'financialExtraction_schema', '');
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        return ['register' => $register, 'schema' => $schema];
+
+    }//end resolveFinancialExtractionBinding()
+
+    /**
+     * Resolve the glAccountBooking register/schema binding, failing closed.
+     *
+     * @return array{register: string, schema: string}|null The binding, or null when unset.
+     *
+     * @spec openspec/specs/ai-gl-account-suggestion/spec.md
+     */
+    public function resolveGlAccountBookingBinding(): ?array
+    {
+        $register = $this->config->getValueString('docudesk', 'glAccountBooking_register', '');
+        $schema   = $this->config->getValueString('docudesk', 'glAccountBooking_schema', '');
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        return ['register' => $register, 'schema' => $schema];
+
+    }//end resolveGlAccountBookingBinding()
+
+    /**
+     * Resolve the glAccountMappingRule register/schema binding, failing closed.
+     *
+     * @return array{register: string, schema: string}|null The binding, or null when unset.
+     *
+     * @spec openspec/specs/ai-gl-account-suggestion/spec.md
+     */
+    public function resolveGlAccountMappingRuleBinding(): ?array
+    {
+        $register = $this->config->getValueString('docudesk', 'glAccountMappingRule_register', '');
+        $schema   = $this->config->getValueString('docudesk', 'glAccountMappingRule_schema', '');
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        return ['register' => $register, 'schema' => $schema];
+
+    }//end resolveGlAccountMappingRuleBinding()
 }//end class

--- a/lib/Service/SigningService.php
+++ b/lib/Service/SigningService.php
@@ -24,7 +24,7 @@ namespace OCA\DocuDesk\Service;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Exception;
-use OCP\IAppConfig;
+use OCA\DocuDesk\Exception\RegisterNotConfiguredException;
 use RuntimeException;
 
 /**
@@ -67,7 +67,6 @@ class SigningService
      *
      * @param SettingsService          $settingsService  Settings service
      * @param SigningAuditService      $auditService     Audit service
-     * @param IAppConfig               $config           App config
      * @param SignedArtifactProducer   $artifactProducer Produces + stores the verifiable signed artifact
      * @param SigningRequestValidator  $validator        Validates request data + the provider/level pair
      * @param SigningActorResolver     $actorResolver    Resolves the acting identity + authorises it
@@ -78,7 +77,6 @@ class SigningService
     public function __construct(
         private readonly SettingsService $settingsService,
         private readonly SigningAuditService $auditService,
-        private readonly IAppConfig $config,
         private readonly SignedArtifactProducer $artifactProducer,
         private readonly SigningRequestValidator $validator,
         private readonly SigningActorResolver $actorResolver,
@@ -122,10 +120,18 @@ class SigningService
         [$initiatorUserId, $initiatorDisplayName] = $this->actorResolver->resolveActingIdentity();
 
         $objectService = $this->settingsService->getObjectService();
-        $expiryDays    = (int) $this->config->getValueString('docudesk', 'signing_request_expiry_days', '30');
-        $deadline      = (new DateTimeImmutable())->modify('+'.$expiryDays.' days');
-        $defaultLevel  = $this->config->getValueString('docudesk', 'signing_default_level', 'SES');
-        $defaultProv   = $this->config->getValueString('docudesk', 'signing_provider', 'native');
+
+        // These three were read straight off IAppConfig here, duplicating both
+        // the keys AND the defaults ('30', 'SES', 'native') that
+        // SettingsService::loadFeatureToggles() already owns — two sources of
+        // truth for the same three settings, free to drift. getFeatureToggles()
+        // is the cheap accessor (plain IAppConfig reads, no register or schema
+        // discovery), which is why it is safe on a write path.
+        $toggles      = $this->settingsService->getFeatureToggles();
+        $expiryDays   = (int) $toggles['signing_request_expiry_days'];
+        $deadline     = (new DateTimeImmutable())->modify('+'.$expiryDays.' days');
+        $defaultLevel = (string) $toggles['signing_default_level'];
+        $defaultProv  = (string) $toggles['signing_provider'];
 
         $request = [
             'documentFileId'  => $data['documentFileId'] ?? '',
@@ -163,15 +169,13 @@ class SigningService
             }
         }
 
-        $register       = $this->config->getValueString('docudesk', 'signingRequest_register', '');
-        $schema         = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
+        ['register' => $register, 'schema' => $schema] = $this->requireSigningRequestBinding();
         $savedRequest   = $objectService->saveObject(object: $request, register: $register, schema: $schema);
         $createdRequest = $this->toArray(object: $savedRequest);
 
-        $signers        = $data['signers'] ?? [];
-        $signerIds      = [];
-        $signerRegister = $this->config->getValueString('docudesk', 'signerRecord_register', '');
-        $signerSchema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
+        $signers   = $data['signers'] ?? [];
+        $signerIds = [];
+        ['register' => $signerRegister, 'schema' => $signerSchema] = $this->requireSignerRecordBinding();
 
         foreach ($signers as $index => $signerData) {
             $signerRecord = [
@@ -245,8 +249,12 @@ class SigningService
     public function getRequest(string $requestId, string $callerUserId=''): ?array
     {
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
+        // gate-50 did not flag this pair (the null-check below sits inside its
+        // window), but it carries the same defect: a find() against register ''
+        // returns null, and this method reports null as "not found". An
+        // unconfigured instance therefore answered 404 for every signing
+        // request that does exist.
+        ['register' => $register, 'schema' => $schema] = $this->requireSigningRequestBinding();
 
         $object = $objectService->find(id: $requestId, register: $register, schema: $schema);
         if ($object === null) {
@@ -297,8 +305,7 @@ class SigningService
     public function listRequests(string $callerUserId=''): array
     {
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
+        ['register' => $register, 'schema' => $schema] = $this->requireSigningRequestBinding();
 
         // OpenRegister's findAll() resolves the register/schema from its own
         // context, not from a filters array — passing them as filters yields an
@@ -386,8 +393,7 @@ class SigningService
             throw new RuntimeException('Signing request is not in a signable state: '.$status);
         }
 
-        $signerRegister = $this->config->getValueString('docudesk', 'signerRecord_register', '');
-        $signerSchema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
+        ['register' => $signerRegister, 'schema' => $signerSchema] = $this->requireSignerRecordBinding();
 
         $signer = $this->actorResolver->loadAuthorisedSigner(
             requestId: $requestId,
@@ -462,8 +468,9 @@ class SigningService
         // REQ-DDSTR-003, closing the #282 residual where decline() skipped
         // isValidTransition() entirely — a COMPLETED/CANCELLED/EXPIRED
         // request could still be flipped to DECLINED).
-        $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
+        // Same latent defect as getRequest(): unconfigured, find() returns null
+        // and this reports "not found" for a request that exists.
+        ['register' => $register, 'schema' => $schema] = $this->requireSigningRequestBinding();
         $requestObject = $objectService->find(id: $requestId, register: $register, schema: $schema);
         if ($requestObject === null) {
             throw new RuntimeException('Signing request not found: '.$requestId);
@@ -475,8 +482,7 @@ class SigningService
             throw new RuntimeException('Cannot decline request in status: '.($request['status'] ?? 'unknown'));
         }
 
-        $signerRegister = $this->config->getValueString('docudesk', 'signerRecord_register', '');
-        $signerSchema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
+        ['register' => $signerRegister, 'schema' => $signerSchema] = $this->requireSignerRecordBinding();
 
         $signer = $this->actorResolver->loadAuthorisedSigner(
             requestId: $requestId,
@@ -541,8 +547,7 @@ class SigningService
         [$actorUserId, $actorDisplayName] = $this->actorResolver->resolveActingIdentity();
 
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
+        ['register' => $register, 'schema' => $schema] = $this->requireSigningRequestBinding();
 
         // Use getRequest() so not-found / access-denied collapse to the
         // same null shape. The controller already gated on initiator/admin
@@ -663,13 +668,11 @@ class SigningService
      */
     private function updateRequestStatus(string $requestId, array $request, ?array $verifiedActor=null): void
     {
-        $objectService  = $this->settingsService->getObjectService();
-        $register       = $this->config->getValueString('docudesk', 'signingRequest_register', '');
-        $schema         = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
-        $signerRegister = $this->config->getValueString('docudesk', 'signerRecord_register', '');
-        $signerSchema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
-        $signerIds      = $request['signerIds'] ?? [];
-        $allSigned      = true;
+        $objectService = $this->settingsService->getObjectService();
+        ['register' => $register, 'schema' => $schema] = $this->requireSigningRequestBinding();
+        ['register' => $signerRegister, 'schema' => $signerSchema] = $this->requireSignerRecordBinding();
+        $signerIds = $request['signerIds'] ?? [];
+        $allSigned = true;
 
         foreach ($signerIds as $signerId) {
             $signerObj = $objectService->find(id: $signerId, register: $signerRegister, schema: $signerSchema);
@@ -784,4 +787,60 @@ class SigningService
         return (array) $object;
 
     }//end toArray()
+
+    /**
+     * Resolve the signingRequest binding, failing closed when unconfigured.
+     *
+     * Every call site used to read these two keys inline with an empty-string
+     * default and pass the result straight into saveObject()/find(). On an
+     * instance where an administrator has not bound them, that wrote signing
+     * requests — the audit trail behind an eIDAS-level signature — into
+     * register '' and schema '', silently. SettingsService owns the read;
+     * this turns "unset" into the same RegisterNotConfiguredException
+     * SigningController already handles.
+     *
+     * @return array{register: string, schema: string} The resolved binding.
+     *
+     * @throws RegisterNotConfiguredException When either half is unset.
+     *
+     * @spec openspec/specs/document-signing/spec.md
+     */
+    private function requireSigningRequestBinding(): array
+    {
+        $binding = $this->settingsService->resolveSigningRequestBinding();
+        if ($binding === null) {
+            throw new RegisterNotConfiguredException(
+                message: 'Signing request register/schema not configured'
+            );
+        }
+
+        return $binding;
+
+    }//end requireSigningRequestBinding()
+
+    /**
+     * Resolve the signerRecord binding, failing closed when unconfigured.
+     *
+     * A signer record carries the identity a signature is attributed to, so an
+     * unconfigured binding loses exactly the evidence a signature exists to
+     * provide.
+     *
+     * @return array{register: string, schema: string} The resolved binding.
+     *
+     * @throws RegisterNotConfiguredException When either half is unset.
+     *
+     * @spec openspec/specs/document-signing/spec.md
+     */
+    private function requireSignerRecordBinding(): array
+    {
+        $binding = $this->settingsService->resolveSignerRecordBinding();
+        if ($binding === null) {
+            throw new RegisterNotConfiguredException(
+                message: 'Signer record register/schema not configured'
+            );
+        }
+
+        return $binding;
+
+    }//end requireSignerRecordBinding()
 }//end class

--- a/lib/Service/SigningVerificationService.php
+++ b/lib/Service/SigningVerificationService.php
@@ -255,7 +255,7 @@ class SigningVerificationService
         }
 
         $secret = $this->getSigningSecret();
-        if ($secret === '') {
+        if ($secret === null) {
             // No server secret configured: nothing can be verified.
             return ['status' => 'unverifiable', 'reason' => 'signing-secret-not-configured'];
         }
@@ -334,13 +334,27 @@ class SigningVerificationService
     }//end stripAssertionMac()
 
     /**
-     * Get the server-held signing secret used to verify assertions
+     * Get the server-held signing secret used to verify assertions.
      *
-     * @return string The configured secret, or an empty string if unset
+     * Returns null — not '' — when the secret is unset, so "not configured" is
+     * representable in the type rather than being a magic empty string that
+     * happens to be falsy. The single caller already fails closed on it, but an
+     * empty string is a VALID HMAC key: `hash_hmac('sha256', $payload, '')`
+     * computes a perfectly well-formed MAC that any attacker can also compute.
+     * A future caller that forgets the check would therefore not crash — it
+     * would verify signatures against a publicly-derivable key and report them
+     * genuine. A null cannot be passed to hash_hmac() by accident.
+     *
+     * @return string|null The configured secret, or null when unset.
      */
-    private function getSigningSecret(): string
+    private function getSigningSecret(): ?string
     {
-        return $this->config->getValueString('docudesk', 'signing_verification_secret', '');
+        $secret = $this->config->getValueString('docudesk', 'signing_verification_secret', '');
+        if ($secret === '') {
+            return null;
+        }
+
+        return $secret;
 
     }//end getSigningSecret()
 

--- a/lib/Settings/docudesk_register.json
+++ b/lib/Settings/docudesk_register.json
@@ -804,10 +804,9 @@
                         ]
                     },
                     "caseReference": {
-                        "description": "UUID verwijzing naar de bron zaak/case in Procest",
+                        "description": "UUID of the source Zaak (case) in Procest. Cross-app reference: the target schema lives in Procest's register, not DocuDesk's, so this is a plain identifier rather than an OpenRegister relation — see x-external-register.",
                         "type": "string",
                         "format": "uuid",
-                        "$ref": "case",
                         "x-external-register": "procest",
                         "visible": true,
                         "order": 5,
@@ -1025,10 +1024,9 @@
                         "maxLength": 64
                     },
                     "zaakId": {
-                        "description": "UUID van de gekoppelde zaak in Procest (optioneel)",
+                        "description": "UUID of the linked Zaak (case) in Procest (optional). Cross-app reference: the target schema lives in Procest's register, not DocuDesk's, so this is a plain identifier rather than an OpenRegister relation — see x-external-register.",
                         "type": "string",
                         "format": "uuid",
-                        "$ref": "case",
                         "x-external-register": "procest",
                         "visible": true,
                         "order": 9,

--- a/tests/unit/Controller/PortalSigningReceiverControllerTest.php
+++ b/tests/unit/Controller/PortalSigningReceiverControllerTest.php
@@ -133,6 +133,12 @@ class PortalSigningReceiverControllerTest extends TestCase
         $this->mockLogger          = $this->createMock(LoggerInterface::class);
 
         $this->mockSettingsService->method('getObjectService')->willReturn($this->mockObjectService);
+        // resolveInvitedSigner() is the anti-IDOR boundary (REQ-DDPSA-004) and
+        // now DENIES when the signerRecord binding is unset, rather than
+        // passing '' through as two of the four filters that scope the lookup.
+        // An unstubbed mock returns null, so the deny path fires.
+        $this->mockSettingsService->method('resolveSignerRecordBinding')
+            ->willReturn(['register' => 'signing', 'schema' => 'signerRecord']);
         $this->mockConfig->method('getValueString')->willReturnCallback(
             static fn (string $app, string $key, string $default=''): string => $default
         );

--- a/tests/unit/Service/FinancialExtractionServiceTest.php
+++ b/tests/unit/Service/FinancialExtractionServiceTest.php
@@ -110,6 +110,11 @@ TEXT;
 
         $this->settingsService = $this->createMock(SettingsService::class);
         $this->settingsService->method('getObjectService')->willReturn($this->objectService);
+        // The binding is resolved through SettingsService and FAILS CLOSED when
+        // unset, instead of defaulting to register '' / schema ''. An unstubbed
+        // mock returns null, which is precisely what the guard exists to catch.
+        $this->settingsService->method('resolveFinancialExtractionBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'financialExtraction']);
 
         $this->config = $this->createMock(IAppConfig::class);
         $this->config->method('getValueString')->willReturnCallback(

--- a/tests/unit/Service/GlAccountSuggestionServiceTest.php
+++ b/tests/unit/Service/GlAccountSuggestionServiceTest.php
@@ -77,6 +77,16 @@ class GlAccountSuggestionServiceTest extends TestCase
 
         $settingsService = $this->createMock(SettingsService::class);
         $settingsService->method('getObjectService')->willReturn($this->objectService);
+        // Bindings resolve through SettingsService and FAIL CLOSED when unset,
+        // instead of silently querying register ''. An unstubbed mock returns
+        // null — which is exactly what the guard exists to catch — so the
+        // configured path has to be stated for these tests to exercise it.
+        $settingsService->method('resolveFinancialExtractionBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'financialExtraction']);
+        $settingsService->method('resolveGlAccountBookingBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'glAccountBooking']);
+        $settingsService->method('resolveGlAccountMappingRuleBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'glAccountMappingRule']);
 
         $this->config = $this->createMock(IAppConfig::class);
         $this->config->method('getValueString')->willReturnCallback(
@@ -403,6 +413,16 @@ class GlAccountSuggestionServiceTest extends TestCase
 
         $settingsService = $this->createMock(SettingsService::class);
         $settingsService->method('getObjectService')->willReturn($this->objectService);
+        // Bindings resolve through SettingsService and FAIL CLOSED when unset,
+        // instead of silently querying register ''. An unstubbed mock returns
+        // null — which is exactly what the guard exists to catch — so the
+        // configured path has to be stated for these tests to exercise it.
+        $settingsService->method('resolveFinancialExtractionBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'financialExtraction']);
+        $settingsService->method('resolveGlAccountBookingBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'glAccountBooking']);
+        $settingsService->method('resolveGlAccountMappingRuleBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'glAccountMappingRule']);
 
         $service = new GlAccountSuggestionService(
             settingsService: $settingsService,
@@ -448,6 +468,16 @@ class GlAccountSuggestionServiceTest extends TestCase
 
         $settingsService = $this->createMock(SettingsService::class);
         $settingsService->method('getObjectService')->willReturn($this->objectService);
+        // Bindings resolve through SettingsService and FAIL CLOSED when unset,
+        // instead of silently querying register ''. An unstubbed mock returns
+        // null — which is exactly what the guard exists to catch — so the
+        // configured path has to be stated for these tests to exercise it.
+        $settingsService->method('resolveFinancialExtractionBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'financialExtraction']);
+        $settingsService->method('resolveGlAccountBookingBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'glAccountBooking']);
+        $settingsService->method('resolveGlAccountMappingRuleBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'glAccountMappingRule']);
 
         $service = new GlAccountSuggestionService(
             settingsService: $settingsService,

--- a/tests/unit/Service/SigningServiceTest.php
+++ b/tests/unit/Service/SigningServiceTest.php
@@ -127,6 +127,24 @@ class SigningServiceTest extends TestCase
         $this->settingsService = $this->createMock(SettingsService::class);
         $this->settingsService->method('getObjectService')->willReturn($this->objectService);
 
+        // SigningService now resolves its register/schema bindings through
+        // SettingsService and FAILS CLOSED when either half is unset, instead
+        // of reading them inline with an empty-string default and writing to
+        // register '' / schema ''. An unstubbed mock returns null, so these
+        // stubs are what keep the suite exercising the configured path — and
+        // their absence is what the fail-closed guard is there to catch.
+        $this->settingsService->method('resolveSigningRequestBinding')
+            ->willReturn(['register' => 'signing', 'schema' => 'signingRequest']);
+        $this->settingsService->method('resolveSignerRecordBinding')
+            ->willReturn(['register' => 'signing', 'schema' => 'signerRecord']);
+        $this->settingsService->method('getFeatureToggles')->willReturn(
+            [
+                'signing_request_expiry_days' => 30,
+                'signing_default_level'       => 'SES',
+                'signing_provider'            => 'native',
+            ]
+        );
+
         $this->auditService = $this->createMock(SigningAuditService::class);
 
         $this->config = $this->createMock(IAppConfig::class);
@@ -166,7 +184,6 @@ class SigningServiceTest extends TestCase
         $this->service = new SigningService(
             settingsService: $this->settingsService,
             auditService: $this->auditService,
-            config: $this->config,
             artifactProducer: new SignedArtifactProducer(
                 providerFactory: $this->providerFactory,
                 userSession: $this->userSession,


### PR DESCRIPTION
⚠️ **DRAFT — not merge-ready.** 18 unit tests are red. See "What is left" below.

## Gates closed (package `7f5f9e78`, = `.github` main + PR #286)

| gate | before | after |
|---|---|---|
| 1 spdx-headers | FAIL — 1 missing @copyright | **PASS** |
| 50 security-config-fail-mode | FAIL — 29 unsafe reads | **PASS** |
| 54 relation-dialect | FAIL — 2 findings | **PASS** (needs ConductionNL/.github#286) |

Can-fail proof for gate-50: removing one guard produced exactly `FAIL — 2`, naming `lib/Service/FinancialExtractionService.php:259` and `:260` — the two reads whose guard was removed, and nothing else.

⚠️ **gate-50 cannot see a read whose app-id argument is a plain variable**, so its zero is not proof the whole class is gone. All reads in the touched files use a literal `'docudesk'`, and the five accessors keep it that way — the reads stayed visible rather than being hidden behind a computed key.

## The defect

Every gate-50 finding was one shape: a register/schema binding read with an empty-string default, passed straight into `saveObject()`/`find()`. An administrator sets these in the admin UI and nothing auto-provisions them, so an unbound instance wrote to register `''` and schema `''` and carried on — for signing, the audit trail behind an eIDAS-level signature.

`SettingsService` now owns the reads with one guarded accessor per binding, returning `null` rather than throwing (so it needs no new import — see the coupling note). Each consumer decides what unconfigured means: `SigningService` throws `RegisterNotConfiguredException` (already handled by `SigningController`), `GlAccountSuggestionService` lets it propagate to controllers that catch `Exception`, `PortalSigningReceiverController` denies.

**Two sites gate-50 did NOT flag are fixed too** — `getRequest()` and the decline path sat inside the gate's 10-line window thanks to an adjacent null-check, but carry the same defect: `find()` against register `''` returns null and both report "not found", so an unconfigured instance answered **404 for every signing request that does exist**.

`SigningVerificationService::getSigningSecret()` now returns `?string`. Its single caller already failed closed 85 lines away, so there was no live defect — but `''` is a *valid* HMAC key, and a caller that forgot the check would verify signatures against a publicly derivable key and call them genuine.

## PHPMD: four metrics went over, no threshold changed
`composer phpmd` exit 0. `SigningService` coupling was resolved by **dropping `IAppConfig` entirely** — its three remaining reads duplicated the keys *and* the defaults (`'30'`, `'SES'`, `'native'`) that `SettingsService::loadFeatureToggles()` already owns, two sources of truth free to drift.

`lint` / `phpcs` / `psalm` / `phpstan` / `phpmd` all exit 0.

## What is left (why this is a draft)
`vendor/bin/phpunit`: **13 errors + 5 failures, all mine.** Three suites build `SettingsService` mocks without stubbing the new `resolve*Binding()` accessors, so they return null and the fail-closed guard fires — which is the guard working, not a code defect. `SigningServiceTest` is already fixed this way (33/33 green). Remaining: `GlAccountSuggestionServiceTest` builds three mocks (lines 78, 414, 469) and only two are stubbed; `PortalSigningReceiverControllerTest` and `FinancialExtractionServiceTest` each have an unstubbed instance. Mechanical, but unfinished and therefore not claimed as done.