### PR TITLE
fix(security): fail closed when a register/schema binding is unconfigured (gates 1, 50, 54)

### DIFF
--- a/lib/Controller/PortalSigningReceiverController.php
+++ b/lib/Controller/PortalSigningReceiverController.php
@@ -363,10 +363,22 @@ class PortalSigningReceiverController extends Controller
             return null;
         }
 
-        $register = $this->config->getValueString('docudesk', 'signerRecord_register', '');
-        $schema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
-
+        // This is the anti-IDOR boundary (REQ-DDPSA-004), and the register and
+        // schema are two of the four filters that scope the lookup. They used
+        // to be read here with an empty-string default and passed straight
+        // through, so the boundary's correctness depended entirely on
+        // OpenRegister choosing to match nothing for an empty filter — an
+        // assumption this code never stated and does not control. If findAll
+        // ever read an empty register as "unscoped", this lookup would resolve
+        // a signerRecord from ANY register, which is precisely the
+        // cross-request signer resolution the requirement forbids.
+        //
+        // requireSignerRecordBinding() throws instead. The catch below already
+        // collapses any failure to null, which is the same answer the
+        // wrong-email and wrong-request cases give, so no new signal is
+        // exposed to a caller probing the endpoint.
         try {
+            ['register' => $register, 'schema' => $schema] = $this->settingsService->requireSignerRecordBinding();
             $results = $objectService->findAll(
                 [
                     'filters' => [

--- a/lib/Controller/PortalSigningReceiverController.php
+++ b/lib/Controller/PortalSigningReceiverController.php
@@ -48,7 +48,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\IAppConfig;
+use OCA\DocuDesk\Service\OpenRegisterResolver;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -87,7 +87,7 @@ class PortalSigningReceiverController extends Controller
      * @param PortalAssertionVerifier       $verifier         Verifies the X-Portal-Subject assertion.
      * @param SigningService                $signingService   The honest signing primitive.
      * @param SettingsService               $settingsService  Settings service (resolves OR's ObjectService).
-     * @param IAppConfig                    $config           App config (resolves signerRecord/signingRequest register/schema).
+     * @param OpenRegisterResolver          $registerResolver Resolves register/schema bindings, failing closed.
      * @param LoggerInterface               $logger           Logger.
      * @param PortalSigningDocumentResolver $documentResolver Resolves the target document for viewDocument.
      *
@@ -99,7 +99,7 @@ class PortalSigningReceiverController extends Controller
         private readonly PortalAssertionVerifier $verifier,
         private readonly SigningService $signingService,
         private readonly SettingsService $settingsService,
-        private readonly IAppConfig $config,
+        private readonly OpenRegisterResolver $registerResolver,
         private readonly LoggerInterface $logger,
         private readonly PortalSigningDocumentResolver $documentResolver
     ) {
@@ -378,7 +378,7 @@ class PortalSigningReceiverController extends Controller
         // wrong-email and wrong-request cases give, so no new signal is
         // exposed to a caller probing the endpoint.
         try {
-            ['register' => $register, 'schema' => $schema] = $this->settingsService->requireSignerRecordBinding();
+            ['register' => $register, 'schema' => $schema] = $this->registerResolver->getSignerRecordRegisterAndSchema();
             $results = $objectService->findAll(
                 [
                     'filters' => [

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -40,10 +40,14 @@
  * @category Controller
  * @package  OCA\DocuDesk\Controller
  *
- * @author  Conduction Development Team <info@conduction.nl>
- * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @link https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * @spec openspec/specs/preferences-api/spec.md
  */

--- a/lib/Service/FinancialExtractionService.php
+++ b/lib/Service/FinancialExtractionService.php
@@ -39,7 +39,6 @@ use OCA\DocuDesk\Service\Extraction\VatIdExtractor;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\File;
 use OCP\Files\IRootFolder;
-use OCP\IAppConfig;
 use OCP\IUserSession;
 use OCP\TaskProcessing\Task as TaskProcessingTask;
 use OCP\TaskProcessing\TaskTypes\TextToText;
@@ -187,26 +186,26 @@ class FinancialExtractionService
     /**
      * Constructor.
      *
-     * @param SettingsService    $settingsService  Resolves OpenRegister's ObjectService.
-     * @param IAppConfig         $config           App configuration (register/schema ids).
-     * @param IUserSession       $userSession      User session, for file resolution.
-     * @param IRootFolder        $rootFolder       Root folder, for file resolution.
-     * @param OcrService         $ocrService       OCR service (text acquisition seam).
-     * @param IEventDispatcher   $eventDispatcher  Dispatches the completion event.
-     * @param ContainerInterface $container        DI container, for the optional AI provider.
-     * @param LoggerInterface    $logger           Logger.
-     * @param IbanExtractor      $ibanExtractor    Pure IBAN extractor.
-     * @param KvkExtractor       $kvkExtractor     Pure KvK extractor.
-     * @param VatIdExtractor     $vatIdExtractor   Pure BTW-nummer extractor.
-     * @param DateExtractor      $dateExtractor    Pure date extractor.
-     * @param AmountExtractor    $amountExtractor  Pure amount extractor.
-     * @param TotalsReconciler   $totalsReconciler Pure totals reconciler.
+     * @param SettingsService      $settingsService  Resolves OpenRegister's ObjectService.
+     * @param OpenRegisterResolver $registerResolver Resolves register/schema bindings, failing closed.
+     * @param IUserSession         $userSession      User session, for file resolution.
+     * @param IRootFolder          $rootFolder       Root folder, for file resolution.
+     * @param OcrService           $ocrService       OCR service (text acquisition seam).
+     * @param IEventDispatcher     $eventDispatcher  Dispatches the completion event.
+     * @param ContainerInterface   $container        DI container, for the optional AI provider.
+     * @param LoggerInterface      $logger           Logger.
+     * @param IbanExtractor        $ibanExtractor    Pure IBAN extractor.
+     * @param KvkExtractor         $kvkExtractor     Pure KvK extractor.
+     * @param VatIdExtractor       $vatIdExtractor   Pure BTW-nummer extractor.
+     * @param DateExtractor        $dateExtractor    Pure date extractor.
+     * @param AmountExtractor      $amountExtractor  Pure amount extractor.
+     * @param TotalsReconciler     $totalsReconciler Pure totals reconciler.
      *
      * @return void
      */
     public function __construct(
         private readonly SettingsService $settingsService,
-        private readonly IAppConfig $config,
+        private readonly OpenRegisterResolver $registerResolver,
         private readonly IUserSession $userSession,
         private readonly IRootFolder $rootFolder,
         private readonly OcrService $ocrService,
@@ -262,7 +261,7 @@ class FinancialExtractionService
         // IBAN, KvK, VAT id and amounts read off an invoice — was silently
         // lost. An explicit error is diagnosable; a silent empty register is
         // not.
-        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireFinancialExtractionBinding();
+        ['register' => $register, 'schema' => $schema] = $this->registerResolver->getFinancialExtractionRegisterAndSchema();
 
         $saved      = $objectService->saveObject(object: $payload, register: $register, schema: $schema);
         $savedArray = $this->toArray(object: $saved);
@@ -383,8 +382,11 @@ class FinancialExtractionService
     public function addCorrection(string $id, array $correctedFields, string $correctedBy): array
     {
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'financialExtraction_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'financialExtraction_schema', '');
+        // Gate-50 did not flag this pair — the null-check below sits inside its
+        // 10-line window — but it carries the same defect: find() against
+        // register '' returns null and this reports 404 "not found", so an
+        // unconfigured instance denied corrections for extractions that exist.
+        ['register' => $register, 'schema' => $schema] = $this->registerResolver->getFinancialExtractionRegisterAndSchema();
 
         $object = $objectService->find(id: $id, register: $register, schema: $schema);
         if ($object === null) {

--- a/lib/Service/FinancialExtractionService.php
+++ b/lib/Service/FinancialExtractionService.php
@@ -256,10 +256,16 @@ class FinancialExtractionService
         ];
 
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'financialExtraction_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'financialExtraction_schema', '');
-        $saved         = $objectService->saveObject(object: $payload, register: $register, schema: $schema);
-        $savedArray    = $this->toArray(object: $saved);
+        // Fails closed when unbound. An administrator sets these in the admin
+        // settings UI and nothing auto-provisions them; unbound, the write
+        // below went to register '' / schema '' and the extraction — supplier,
+        // IBAN, KvK, VAT id and amounts read off an invoice — was silently
+        // lost. An explicit error is diagnosable; a silent empty register is
+        // not.
+        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireFinancialExtractionBinding();
+
+        $saved      = $objectService->saveObject(object: $payload, register: $register, schema: $schema);
+        $savedArray = $this->toArray(object: $saved);
 
         if ($request['callbackEvent'] === true) {
             $this->dispatchCompletionEvent(

--- a/lib/Service/GlAccountSuggestionService.php
+++ b/lib/Service/GlAccountSuggestionService.php
@@ -178,8 +178,11 @@ class GlAccountSuggestionService
         ];
 
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'glAccountBooking_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'glAccountBooking_schema', '');
+        // Fails closed on the WRITE. This is the tuning corpus every future
+        // suggestion is ranked against; writing it to register '' loses the
+        // correction silently, and the next suggestion is then wrong for a
+        // reason nobody can see.
+        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireGlAccountBookingBinding();
         $objectService->saveObject(object: $booking, register: $register, schema: $schema);
 
     }//end recordBooking()
@@ -274,8 +277,13 @@ class GlAccountSuggestionService
     private function findExtractionSafely(string $extractionId): ?array
     {
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'financialExtraction_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'financialExtraction_schema', '');
+        // Throws when unbound rather than returning null. A lookup against
+        // register '' finds nothing, which is INDISTINGUISHABLE from "that
+        // extraction does not exist" — the caller then reports an unknown
+        // extraction id when the real cause is an unconfigured instance.
+        // Both controllers catch Exception, so this surfaces as an honest
+        // error response instead of a wrong answer.
+        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireFinancialExtractionBinding();
 
         $object = $objectService->find(id: $extractionId, register: $register, schema: $schema);
         if ($object === null) {
@@ -296,8 +304,11 @@ class GlAccountSuggestionService
     private function loadBookingHistory(string $supplierIdentity): array
     {
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'glAccountBooking_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'glAccountBooking_schema', '');
+        // Throws when unbound. "No booking history" and "not configured" both
+        // produced an empty array, and the ranker treats the first as a
+        // legitimate cold start — so an unconfigured instance silently ranked
+        // every supplier as brand new.
+        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireGlAccountBookingBinding();
 
         $query   = [
             '@self'            => ['register' => $register, 'schema' => $schema],
@@ -328,8 +339,11 @@ class GlAccountSuggestionService
     private function loadMappingRules(): array
     {
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'glAccountMappingRule_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'glAccountMappingRule_schema', '');
+        // Throws when unbound. Mapping rules are the cold-start path: with no
+        // history AND no rules the service honestly returns nothing. An
+        // unconfigured binding produced that same nothing for a different
+        // reason, and the operator had no way to tell the two apart.
+        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireGlAccountMappingRuleBinding();
 
         $query   = ['@self' => ['register' => $register, 'schema' => $schema]];
         $results = $objectService->searchObjects($query);

--- a/lib/Service/GlAccountSuggestionService.php
+++ b/lib/Service/GlAccountSuggestionService.php
@@ -40,7 +40,6 @@ use OCA\DocuDesk\Service\Suggestion\CategoryKeywordMapper;
 use OCA\DocuDesk\Service\Suggestion\HistoryRanker;
 use OCA\DocuDesk\Service\Suggestion\SupplierIdentityResolver;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\IAppConfig;
 use OCP\TaskProcessing\Task as TaskProcessingTask;
 use OCP\TaskProcessing\TaskTypes\TextToText;
 use OCP\TextProcessing\FreePromptTaskType;
@@ -69,7 +68,7 @@ class GlAccountSuggestionService
      * Constructor.
      *
      * @param SettingsService          $settingsService  Resolves OpenRegister's ObjectService.
-     * @param IAppConfig               $config           App configuration (register/schema ids).
+     * @param OpenRegisterResolver     $registerResolver Resolves register/schema bindings, failing closed.
      * @param IEventDispatcher         $eventDispatcher  Dispatches the sibling suggestion event.
      * @param ContainerInterface       $container        DI container, for the optional AI provider.
      * @param LoggerInterface          $logger           Logger.
@@ -81,7 +80,7 @@ class GlAccountSuggestionService
      */
     public function __construct(
         private readonly SettingsService $settingsService,
-        private readonly IAppConfig $config,
+        private readonly OpenRegisterResolver $registerResolver,
         private readonly IEventDispatcher $eventDispatcher,
         private readonly ContainerInterface $container,
         private readonly LoggerInterface $logger,
@@ -182,7 +181,7 @@ class GlAccountSuggestionService
         // suggestion is ranked against; writing it to register '' loses the
         // correction silently, and the next suggestion is then wrong for a
         // reason nobody can see.
-        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireGlAccountBookingBinding();
+        ['register' => $register, 'schema' => $schema] = $this->registerResolver->getGlAccountBookingRegisterAndSchema();
         $objectService->saveObject(object: $booking, register: $register, schema: $schema);
 
     }//end recordBooking()
@@ -283,7 +282,7 @@ class GlAccountSuggestionService
         // extraction id when the real cause is an unconfigured instance.
         // Both controllers catch Exception, so this surfaces as an honest
         // error response instead of a wrong answer.
-        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireFinancialExtractionBinding();
+        ['register' => $register, 'schema' => $schema] = $this->registerResolver->getFinancialExtractionRegisterAndSchema();
 
         $object = $objectService->find(id: $extractionId, register: $register, schema: $schema);
         if ($object === null) {
@@ -308,7 +307,7 @@ class GlAccountSuggestionService
         // produced an empty array, and the ranker treats the first as a
         // legitimate cold start — so an unconfigured instance silently ranked
         // every supplier as brand new.
-        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireGlAccountBookingBinding();
+        ['register' => $register, 'schema' => $schema] = $this->registerResolver->getGlAccountBookingRegisterAndSchema();
 
         $query   = [
             '@self'            => ['register' => $register, 'schema' => $schema],
@@ -343,7 +342,7 @@ class GlAccountSuggestionService
         // history AND no rules the service honestly returns nothing. An
         // unconfigured binding produced that same nothing for a different
         // reason, and the operator had no way to tell the two apart.
-        ['register' => $register, 'schema' => $schema] = $this->settingsService->requireGlAccountMappingRuleBinding();
+        ['register' => $register, 'schema' => $schema] = $this->registerResolver->getGlAccountMappingRuleRegisterAndSchema();
 
         $query   = ['@self' => ['register' => $register, 'schema' => $schema]];
         $results = $objectService->searchObjects($query);

--- a/lib/Service/OpenRegisterResolver.php
+++ b/lib/Service/OpenRegisterResolver.php
@@ -120,4 +120,100 @@ class OpenRegisterResolver
         return true;
 
     }//end validateNamespace()
+
+    /**
+     * Resolve the financialExtraction register/schema binding, failing closed.
+     *
+     * SettingsService owns the READ and returns null when either half is unset;
+     * this turns that null into the same RegisterNotConfiguredException the
+     * template accessors above already raise. The split exists so the two
+     * concerns sit where they belong — the settings surface reads config, this
+     * resolver decides that an unset binding is an error — and it keeps the
+     * exception type out of SettingsService, whose object coupling is at its
+     * PHPMD ceiling.
+     *
+     * @return array{register: string, schema: string} The resolved binding.
+     *
+     * @throws RegisterNotConfiguredException If the binding is not configured.
+     *
+     * @spec openspec/specs/financial-document-field-extraction/spec.md
+     */
+    public function getFinancialExtractionRegisterAndSchema(): array
+    {
+        $binding = $this->settingsService->resolveFinancialExtractionBinding();
+        if ($binding === null) {
+            throw new RegisterNotConfiguredException(
+                message: 'Financial extraction register/schema not configured'
+            );
+        }
+
+        return $binding;
+
+    }//end getFinancialExtractionRegisterAndSchema()
+
+    /**
+     * Resolve the glAccountBooking register/schema binding, failing closed.
+     *
+     * @return array{register: string, schema: string} The resolved binding.
+     *
+     * @throws RegisterNotConfiguredException If the binding is not configured.
+     *
+     * @spec openspec/specs/ai-gl-account-suggestion/spec.md
+     */
+    public function getGlAccountBookingRegisterAndSchema(): array
+    {
+        $binding = $this->settingsService->resolveGlAccountBookingBinding();
+        if ($binding === null) {
+            throw new RegisterNotConfiguredException(
+                message: 'GL account booking register/schema not configured'
+            );
+        }
+
+        return $binding;
+
+    }//end getGlAccountBookingRegisterAndSchema()
+
+    /**
+     * Resolve the glAccountMappingRule register/schema binding, failing closed.
+     *
+     * @return array{register: string, schema: string} The resolved binding.
+     *
+     * @throws RegisterNotConfiguredException If the binding is not configured.
+     *
+     * @spec openspec/specs/ai-gl-account-suggestion/spec.md
+     */
+    public function getGlAccountMappingRuleRegisterAndSchema(): array
+    {
+        $binding = $this->settingsService->resolveGlAccountMappingRuleBinding();
+        if ($binding === null) {
+            throw new RegisterNotConfiguredException(
+                message: 'GL account mapping rule register/schema not configured'
+            );
+        }
+
+        return $binding;
+
+    }//end getGlAccountMappingRuleRegisterAndSchema()
+
+    /**
+     * Resolve the signerRecord register/schema binding, failing closed.
+     *
+     * @return array{register: string, schema: string} The resolved binding.
+     *
+     * @throws RegisterNotConfiguredException If the binding is not configured.
+     *
+     * @spec openspec/specs/document-signing/spec.md
+     */
+    public function getSignerRecordRegisterAndSchema(): array
+    {
+        $binding = $this->settingsService->resolveSignerRecordBinding();
+        if ($binding === null) {
+            throw new RegisterNotConfiguredException(
+                message: 'Signer record register/schema not configured'
+            );
+        }
+
+        return $binding;
+
+    }//end getSignerRecordRegisterAndSchema()
 }//end class

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -459,4 +459,111 @@ class SettingsService
         }//end try
 
     }//end updateSettings()
+
+    /**
+     * Resolve the signingRequest register/schema binding, failing closed.
+     *
+     * These bindings live here, next to the settings surface that writes them,
+     * rather than in each consumer: every call site used to read them inline
+     * with an empty-string default and pass the result straight into
+     * saveObject()/find(). Unconfigured, that wrote signing requests — the
+     * audit trail behind an eIDAS-level signature — into register '' and schema
+     * '', silently. Mirrors OpenRegisterResolver::getRegisterAndSchema(), which
+     * already does exactly this for templates.
+     *
+     * @return array{register: string, schema: string}|null The binding, or null when unset.
+     *
+     * @spec openspec/specs/document-signing/spec.md
+     */
+    public function resolveSigningRequestBinding(): ?array
+    {
+        $register = $this->config->getValueString('docudesk', 'signingRequest_register', '');
+        $schema   = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        return ['register' => $register, 'schema' => $schema];
+
+    }//end resolveSigningRequestBinding()
+
+    /**
+     * Resolve the signerRecord register/schema binding, failing closed.
+     *
+     * A signer record carries the identity a signature is attributed to, so an
+     * unconfigured binding loses exactly the evidence a signature exists to
+     * provide.
+     *
+     * @return array{register: string, schema: string}|null The binding, or null when unset.
+     *
+     * @spec openspec/specs/document-signing/spec.md
+     */
+    public function resolveSignerRecordBinding(): ?array
+    {
+        $register = $this->config->getValueString('docudesk', 'signerRecord_register', '');
+        $schema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        return ['register' => $register, 'schema' => $schema];
+
+    }//end resolveSignerRecordBinding()
+
+    /**
+     * Resolve the financialExtraction register/schema binding, failing closed.
+     *
+     * @return array{register: string, schema: string}|null The binding, or null when unset.
+     *
+     * @spec openspec/specs/financial-document-field-extraction/spec.md
+     */
+    public function resolveFinancialExtractionBinding(): ?array
+    {
+        $register = $this->config->getValueString('docudesk', 'financialExtraction_register', '');
+        $schema   = $this->config->getValueString('docudesk', 'financialExtraction_schema', '');
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        return ['register' => $register, 'schema' => $schema];
+
+    }//end resolveFinancialExtractionBinding()
+
+    /**
+     * Resolve the glAccountBooking register/schema binding, failing closed.
+     *
+     * @return array{register: string, schema: string}|null The binding, or null when unset.
+     *
+     * @spec openspec/specs/ai-gl-account-suggestion/spec.md
+     */
+    public function resolveGlAccountBookingBinding(): ?array
+    {
+        $register = $this->config->getValueString('docudesk', 'glAccountBooking_register', '');
+        $schema   = $this->config->getValueString('docudesk', 'glAccountBooking_schema', '');
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        return ['register' => $register, 'schema' => $schema];
+
+    }//end resolveGlAccountBookingBinding()
+
+    /**
+     * Resolve the glAccountMappingRule register/schema binding, failing closed.
+     *
+     * @return array{register: string, schema: string}|null The binding, or null when unset.
+     *
+     * @spec openspec/specs/ai-gl-account-suggestion/spec.md
+     */
+    public function resolveGlAccountMappingRuleBinding(): ?array
+    {
+        $register = $this->config->getValueString('docudesk', 'glAccountMappingRule_register', '');
+        $schema   = $this->config->getValueString('docudesk', 'glAccountMappingRule_schema', '');
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        return ['register' => $register, 'schema' => $schema];
+
+    }//end resolveGlAccountMappingRuleBinding()
 }//end class

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -461,7 +461,7 @@ class SettingsService
     }//end updateSettings()
 
     /**
-     * Resolve the signingRequest register/schema binding, failing closed.
+     * Resolve the signingRequest register/schema binding, or null when unset.
      *
      * These bindings live here, next to the settings surface that writes them,
      * rather than in each consumer: every call site used to read them inline
@@ -488,7 +488,7 @@ class SettingsService
     }//end resolveSigningRequestBinding()
 
     /**
-     * Resolve the signerRecord register/schema binding, failing closed.
+     * Resolve the signerRecord register/schema binding, or null when unset.
      *
      * A signer record carries the identity a signature is attributed to, so an
      * unconfigured binding loses exactly the evidence a signature exists to
@@ -511,7 +511,7 @@ class SettingsService
     }//end resolveSignerRecordBinding()
 
     /**
-     * Resolve the financialExtraction register/schema binding, failing closed.
+     * Resolve the financialExtraction register/schema binding, or null when unset.
      *
      * @return array{register: string, schema: string}|null The binding, or null when unset.
      *
@@ -530,7 +530,7 @@ class SettingsService
     }//end resolveFinancialExtractionBinding()
 
     /**
-     * Resolve the glAccountBooking register/schema binding, failing closed.
+     * Resolve the glAccountBooking register/schema binding, or null when unset.
      *
      * @return array{register: string, schema: string}|null The binding, or null when unset.
      *
@@ -549,7 +549,7 @@ class SettingsService
     }//end resolveGlAccountBookingBinding()
 
     /**
-     * Resolve the glAccountMappingRule register/schema binding, failing closed.
+     * Resolve the glAccountMappingRule register/schema binding, or null when unset.
      *
      * @return array{register: string, schema: string}|null The binding, or null when unset.
      *

--- a/lib/Service/SigningService.php
+++ b/lib/Service/SigningService.php
@@ -24,7 +24,7 @@ namespace OCA\DocuDesk\Service;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Exception;
-use OCP\IAppConfig;
+use OCA\DocuDesk\Exception\RegisterNotConfiguredException;
 use RuntimeException;
 
 /**
@@ -67,7 +67,6 @@ class SigningService
      *
      * @param SettingsService          $settingsService  Settings service
      * @param SigningAuditService      $auditService     Audit service
-     * @param IAppConfig               $config           App config
      * @param SignedArtifactProducer   $artifactProducer Produces + stores the verifiable signed artifact
      * @param SigningRequestValidator  $validator        Validates request data + the provider/level pair
      * @param SigningActorResolver     $actorResolver    Resolves the acting identity + authorises it
@@ -78,7 +77,6 @@ class SigningService
     public function __construct(
         private readonly SettingsService $settingsService,
         private readonly SigningAuditService $auditService,
-        private readonly IAppConfig $config,
         private readonly SignedArtifactProducer $artifactProducer,
         private readonly SigningRequestValidator $validator,
         private readonly SigningActorResolver $actorResolver,
@@ -122,10 +120,18 @@ class SigningService
         [$initiatorUserId, $initiatorDisplayName] = $this->actorResolver->resolveActingIdentity();
 
         $objectService = $this->settingsService->getObjectService();
-        $expiryDays    = (int) $this->config->getValueString('docudesk', 'signing_request_expiry_days', '30');
-        $deadline      = (new DateTimeImmutable())->modify('+'.$expiryDays.' days');
-        $defaultLevel  = $this->config->getValueString('docudesk', 'signing_default_level', 'SES');
-        $defaultProv   = $this->config->getValueString('docudesk', 'signing_provider', 'native');
+
+        // These three were read straight off IAppConfig here, duplicating both
+        // the keys AND the defaults ('30', 'SES', 'native') that
+        // SettingsService::loadFeatureToggles() already owns — two sources of
+        // truth for the same three settings, free to drift. getFeatureToggles()
+        // is the cheap accessor (plain IAppConfig reads, no register or schema
+        // discovery), which is why it is safe on a write path.
+        $toggles      = $this->settingsService->getFeatureToggles();
+        $expiryDays   = (int) $toggles['signing_request_expiry_days'];
+        $deadline     = (new DateTimeImmutable())->modify('+'.$expiryDays.' days');
+        $defaultLevel = (string) $toggles['signing_default_level'];
+        $defaultProv  = (string) $toggles['signing_provider'];
 
         $request = [
             'documentFileId'  => $data['documentFileId'] ?? '',
@@ -163,15 +169,13 @@ class SigningService
             }
         }
 
-        $register       = $this->config->getValueString('docudesk', 'signingRequest_register', '');
-        $schema         = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
+        ['register' => $register, 'schema' => $schema] = $this->requireSigningRequestBinding();
         $savedRequest   = $objectService->saveObject(object: $request, register: $register, schema: $schema);
         $createdRequest = $this->toArray(object: $savedRequest);
 
-        $signers        = $data['signers'] ?? [];
-        $signerIds      = [];
-        $signerRegister = $this->config->getValueString('docudesk', 'signerRecord_register', '');
-        $signerSchema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
+        $signers   = $data['signers'] ?? [];
+        $signerIds = [];
+        ['register' => $signerRegister, 'schema' => $signerSchema] = $this->requireSignerRecordBinding();
 
         foreach ($signers as $index => $signerData) {
             $signerRecord = [
@@ -245,8 +249,12 @@ class SigningService
     public function getRequest(string $requestId, string $callerUserId=''): ?array
     {
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
+        // gate-50 did not flag this pair (the null-check below sits inside its
+        // window), but it carries the same defect: a find() against register ''
+        // returns null, and this method reports null as "not found". An
+        // unconfigured instance therefore answered 404 for every signing
+        // request that does exist.
+        ['register' => $register, 'schema' => $schema] = $this->requireSigningRequestBinding();
 
         $object = $objectService->find(id: $requestId, register: $register, schema: $schema);
         if ($object === null) {
@@ -297,8 +305,7 @@ class SigningService
     public function listRequests(string $callerUserId=''): array
     {
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
+        ['register' => $register, 'schema' => $schema] = $this->requireSigningRequestBinding();
 
         // OpenRegister's findAll() resolves the register/schema from its own
         // context, not from a filters array — passing them as filters yields an
@@ -386,8 +393,7 @@ class SigningService
             throw new RuntimeException('Signing request is not in a signable state: '.$status);
         }
 
-        $signerRegister = $this->config->getValueString('docudesk', 'signerRecord_register', '');
-        $signerSchema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
+        ['register' => $signerRegister, 'schema' => $signerSchema] = $this->requireSignerRecordBinding();
 
         $signer = $this->actorResolver->loadAuthorisedSigner(
             requestId: $requestId,
@@ -462,8 +468,9 @@ class SigningService
         // REQ-DDSTR-003, closing the #282 residual where decline() skipped
         // isValidTransition() entirely — a COMPLETED/CANCELLED/EXPIRED
         // request could still be flipped to DECLINED).
-        $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
+        // Same latent defect as getRequest(): unconfigured, find() returns null
+        // and this reports "not found" for a request that exists.
+        ['register' => $register, 'schema' => $schema] = $this->requireSigningRequestBinding();
         $requestObject = $objectService->find(id: $requestId, register: $register, schema: $schema);
         if ($requestObject === null) {
             throw new RuntimeException('Signing request not found: '.$requestId);
@@ -475,8 +482,7 @@ class SigningService
             throw new RuntimeException('Cannot decline request in status: '.($request['status'] ?? 'unknown'));
         }
 
-        $signerRegister = $this->config->getValueString('docudesk', 'signerRecord_register', '');
-        $signerSchema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
+        ['register' => $signerRegister, 'schema' => $signerSchema] = $this->requireSignerRecordBinding();
 
         $signer = $this->actorResolver->loadAuthorisedSigner(
             requestId: $requestId,
@@ -541,8 +547,7 @@ class SigningService
         [$actorUserId, $actorDisplayName] = $this->actorResolver->resolveActingIdentity();
 
         $objectService = $this->settingsService->getObjectService();
-        $register      = $this->config->getValueString('docudesk', 'signingRequest_register', '');
-        $schema        = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
+        ['register' => $register, 'schema' => $schema] = $this->requireSigningRequestBinding();
 
         // Use getRequest() so not-found / access-denied collapse to the
         // same null shape. The controller already gated on initiator/admin
@@ -663,13 +668,11 @@ class SigningService
      */
     private function updateRequestStatus(string $requestId, array $request, ?array $verifiedActor=null): void
     {
-        $objectService  = $this->settingsService->getObjectService();
-        $register       = $this->config->getValueString('docudesk', 'signingRequest_register', '');
-        $schema         = $this->config->getValueString('docudesk', 'signingRequest_schema', '');
-        $signerRegister = $this->config->getValueString('docudesk', 'signerRecord_register', '');
-        $signerSchema   = $this->config->getValueString('docudesk', 'signerRecord_schema', '');
-        $signerIds      = $request['signerIds'] ?? [];
-        $allSigned      = true;
+        $objectService = $this->settingsService->getObjectService();
+        ['register' => $register, 'schema' => $schema] = $this->requireSigningRequestBinding();
+        ['register' => $signerRegister, 'schema' => $signerSchema] = $this->requireSignerRecordBinding();
+        $signerIds = $request['signerIds'] ?? [];
+        $allSigned = true;
 
         foreach ($signerIds as $signerId) {
             $signerObj = $objectService->find(id: $signerId, register: $signerRegister, schema: $signerSchema);
@@ -784,4 +787,60 @@ class SigningService
         return (array) $object;
 
     }//end toArray()
+
+    /**
+     * Resolve the signingRequest binding, failing closed when unconfigured.
+     *
+     * Every call site used to read these two keys inline with an empty-string
+     * default and pass the result straight into saveObject()/find(). On an
+     * instance where an administrator has not bound them, that wrote signing
+     * requests — the audit trail behind an eIDAS-level signature — into
+     * register '' and schema '', silently. SettingsService owns the read;
+     * this turns "unset" into the same RegisterNotConfiguredException
+     * SigningController already handles.
+     *
+     * @return array{register: string, schema: string} The resolved binding.
+     *
+     * @throws RegisterNotConfiguredException When either half is unset.
+     *
+     * @spec openspec/specs/document-signing/spec.md
+     */
+    private function requireSigningRequestBinding(): array
+    {
+        $binding = $this->settingsService->resolveSigningRequestBinding();
+        if ($binding === null) {
+            throw new RegisterNotConfiguredException(
+                message: 'Signing request register/schema not configured'
+            );
+        }
+
+        return $binding;
+
+    }//end requireSigningRequestBinding()
+
+    /**
+     * Resolve the signerRecord binding, failing closed when unconfigured.
+     *
+     * A signer record carries the identity a signature is attributed to, so an
+     * unconfigured binding loses exactly the evidence a signature exists to
+     * provide.
+     *
+     * @return array{register: string, schema: string} The resolved binding.
+     *
+     * @throws RegisterNotConfiguredException When either half is unset.
+     *
+     * @spec openspec/specs/document-signing/spec.md
+     */
+    private function requireSignerRecordBinding(): array
+    {
+        $binding = $this->settingsService->resolveSignerRecordBinding();
+        if ($binding === null) {
+            throw new RegisterNotConfiguredException(
+                message: 'Signer record register/schema not configured'
+            );
+        }
+
+        return $binding;
+
+    }//end requireSignerRecordBinding()
 }//end class

--- a/lib/Service/SigningService.php
+++ b/lib/Service/SigningService.php
@@ -249,7 +249,7 @@ class SigningService
     public function getRequest(string $requestId, string $callerUserId=''): ?array
     {
         $objectService = $this->settingsService->getObjectService();
-        // gate-50 did not flag this pair (the null-check below sits inside its
+        // Gate-50 did not flag this pair (the null-check below sits inside its
         // window), but it carries the same defect: a find() against register ''
         // returns null, and this method reports null as "not found". An
         // unconfigured instance therefore answered 404 for every signing

--- a/lib/Service/SigningVerificationService.php
+++ b/lib/Service/SigningVerificationService.php
@@ -255,7 +255,7 @@ class SigningVerificationService
         }
 
         $secret = $this->getSigningSecret();
-        if ($secret === '') {
+        if ($secret === null) {
             // No server secret configured: nothing can be verified.
             return ['status' => 'unverifiable', 'reason' => 'signing-secret-not-configured'];
         }
@@ -334,13 +334,27 @@ class SigningVerificationService
     }//end stripAssertionMac()
 
     /**
-     * Get the server-held signing secret used to verify assertions
+     * Get the server-held signing secret used to verify assertions.
      *
-     * @return string The configured secret, or an empty string if unset
+     * Returns null — not '' — when the secret is unset, so "not configured" is
+     * representable in the type rather than being a magic empty string that
+     * happens to be falsy. The single caller already fails closed on it, but an
+     * empty string is a VALID HMAC key: `hash_hmac('sha256', $payload, '')`
+     * computes a perfectly well-formed MAC that any attacker can also compute.
+     * A future caller that forgets the check would therefore not crash — it
+     * would verify signatures against a publicly-derivable key and report them
+     * genuine. A null cannot be passed to hash_hmac() by accident.
+     *
+     * @return string|null The configured secret, or null when unset.
      */
-    private function getSigningSecret(): string
+    private function getSigningSecret(): ?string
     {
-        return $this->config->getValueString('docudesk', 'signing_verification_secret', '');
+        $secret = $this->config->getValueString('docudesk', 'signing_verification_secret', '');
+        if ($secret === '') {
+            return null;
+        }
+
+        return $secret;
 
     }//end getSigningSecret()
 

--- a/lib/Settings/docudesk_register.json
+++ b/lib/Settings/docudesk_register.json
@@ -804,10 +804,9 @@
                         ]
                     },
                     "caseReference": {
-                        "description": "UUID verwijzing naar de bron zaak/case in Procest",
+                        "description": "UUID of the source Zaak (case) in Procest. Cross-app reference: the target schema lives in Procest's register, not DocuDesk's, so this is a plain identifier rather than an OpenRegister relation — see x-external-register.",
                         "type": "string",
                         "format": "uuid",
-                        "$ref": "case",
                         "x-external-register": "procest",
                         "visible": true,
                         "order": 5,
@@ -1025,10 +1024,9 @@
                         "maxLength": 64
                     },
                     "zaakId": {
-                        "description": "UUID van de gekoppelde zaak in Procest (optioneel)",
+                        "description": "UUID of the linked Zaak (case) in Procest (optional). Cross-app reference: the target schema lives in Procest's register, not DocuDesk's, so this is a plain identifier rather than an OpenRegister relation — see x-external-register.",
                         "type": "string",
                         "format": "uuid",
-                        "$ref": "case",
                         "x-external-register": "procest",
                         "visible": true,
                         "order": 9,

--- a/tests/unit/Controller/PortalSigningReceiverControllerTest.php
+++ b/tests/unit/Controller/PortalSigningReceiverControllerTest.php
@@ -37,6 +37,7 @@ namespace OCA\DocuDesk\Tests\Unit\Controller;
 
 use OCA\DocuDesk\Controller\PortalSigningReceiverController;
 use OCA\DocuDesk\Portal\PortalAssertionVerifier;
+use OCA\DocuDesk\Service\OpenRegisterResolver;
 use OCA\DocuDesk\Service\PortalSigningDocumentResolver;
 use OCA\DocuDesk\Service\SettingsService;
 use OCA\DocuDesk\Service\SigningService;
@@ -158,7 +159,11 @@ class PortalSigningReceiverControllerTest extends TestCase
             verifier: new PortalAssertionVerifier(config: null, secretOverride: self::SECRET),
             signingService: $this->mockSigningService,
             settingsService: $this->mockSettingsService,
-            config: $this->mockConfig,
+            // A REAL resolver over the stubbed SettingsService, not a mock: it
+            // is the piece that turns an unset signerRecord binding into a
+            // DENY on the anti-IDOR boundary (REQ-DDPSA-004), so mocking it
+            // away would remove exactly the behaviour under test.
+            registerResolver: new OpenRegisterResolver(settingsService: $this->mockSettingsService),
             logger: $this->mockLogger,
             documentResolver: new PortalSigningDocumentResolver(rootFolder: $this->mockRootFolder)
         );

--- a/tests/unit/Controller/PortalSigningReceiverControllerTest.php
+++ b/tests/unit/Controller/PortalSigningReceiverControllerTest.php
@@ -133,6 +133,12 @@ class PortalSigningReceiverControllerTest extends TestCase
         $this->mockLogger          = $this->createMock(LoggerInterface::class);
 
         $this->mockSettingsService->method('getObjectService')->willReturn($this->mockObjectService);
+        // resolveInvitedSigner() is the anti-IDOR boundary (REQ-DDPSA-004) and
+        // now DENIES when the signerRecord binding is unset, rather than
+        // passing '' through as two of the four filters that scope the lookup.
+        // An unstubbed mock returns null, so the deny path fires.
+        $this->mockSettingsService->method('resolveSignerRecordBinding')
+            ->willReturn(['register' => 'signing', 'schema' => 'signerRecord']);
         $this->mockConfig->method('getValueString')->willReturnCallback(
             static fn (string $app, string $key, string $default=''): string => $default
         );

--- a/tests/unit/Service/FinancialExtractionServiceTest.php
+++ b/tests/unit/Service/FinancialExtractionServiceTest.php
@@ -31,6 +31,7 @@ use OCA\DocuDesk\Service\Extraction\IbanExtractor;
 use OCA\DocuDesk\Service\Extraction\KvkExtractor;
 use OCA\DocuDesk\Service\Extraction\TotalsReconciler;
 use OCA\DocuDesk\Service\Extraction\VatIdExtractor;
+use OCA\DocuDesk\Service\OpenRegisterResolver;
 use OCA\DocuDesk\Service\FinancialExtractionService;
 use OCA\DocuDesk\Service\OcrService;
 use OCA\DocuDesk\Service\SettingsService;
@@ -141,7 +142,11 @@ TEXT;
 
         $this->service = new FinancialExtractionService(
             settingsService: $this->settingsService,
-            config: $this->config,
+            // A REAL resolver over the stubbed SettingsService, not a mock: it
+            // is the piece that turns an unset binding into
+            // RegisterNotConfiguredException, so mocking it away would remove
+            // the behaviour these tests are meant to run through.
+            registerResolver: new OpenRegisterResolver(settingsService: $this->settingsService),
             userSession: $this->userSession,
             rootFolder: $this->rootFolder,
             ocrService: $this->ocrService,

--- a/tests/unit/Service/FinancialExtractionServiceTest.php
+++ b/tests/unit/Service/FinancialExtractionServiceTest.php
@@ -110,6 +110,11 @@ TEXT;
 
         $this->settingsService = $this->createMock(SettingsService::class);
         $this->settingsService->method('getObjectService')->willReturn($this->objectService);
+        // The binding is resolved through SettingsService and FAILS CLOSED when
+        // unset, instead of defaulting to register '' / schema ''. An unstubbed
+        // mock returns null, which is precisely what the guard exists to catch.
+        $this->settingsService->method('resolveFinancialExtractionBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'financialExtraction']);
 
         $this->config = $this->createMock(IAppConfig::class);
         $this->config->method('getValueString')->willReturnCallback(

--- a/tests/unit/Service/GlAccountSuggestionServiceTest.php
+++ b/tests/unit/Service/GlAccountSuggestionServiceTest.php
@@ -27,6 +27,7 @@ namespace OCA\DocuDesk\Tests\Unit\Service;
 
 use Exception;
 use OCA\DocuDesk\Service\GlAccountSuggestionService;
+use OCA\DocuDesk\Service\OpenRegisterResolver;
 use OCA\DocuDesk\Service\Suggestion\CategoryKeywordMapper;
 use OCA\DocuDesk\Service\Suggestion\HistoryRanker;
 use OCA\DocuDesk\Service\Suggestion\SupplierIdentityResolver;
@@ -110,7 +111,11 @@ class GlAccountSuggestionServiceTest extends TestCase
 
         $this->service = new GlAccountSuggestionService(
             settingsService: $settingsService,
-            config: $this->config,
+            // A REAL resolver over the stubbed SettingsService, not a mock: it
+            // is the piece that turns an unset binding into
+            // RegisterNotConfiguredException, so mocking it away would remove
+            // the behaviour these tests are meant to run through.
+            registerResolver: new OpenRegisterResolver(settingsService: $settingsService),
             eventDispatcher: $this->eventDispatcher,
             container: $this->container,
             logger: $logger,
@@ -426,7 +431,11 @@ class GlAccountSuggestionServiceTest extends TestCase
 
         $service = new GlAccountSuggestionService(
             settingsService: $settingsService,
-            config: $this->config,
+            // A REAL resolver over the stubbed SettingsService, not a mock: it
+            // is the piece that turns an unset binding into
+            // RegisterNotConfiguredException, so mocking it away would remove
+            // the behaviour these tests are meant to run through.
+            registerResolver: new OpenRegisterResolver(settingsService: $settingsService),
             eventDispatcher: $this->eventDispatcher,
             container: $this->container,
             logger: $this->createMock(LoggerInterface::class),
@@ -481,7 +490,11 @@ class GlAccountSuggestionServiceTest extends TestCase
 
         $service = new GlAccountSuggestionService(
             settingsService: $settingsService,
-            config: $this->config,
+            // A REAL resolver over the stubbed SettingsService, not a mock: it
+            // is the piece that turns an unset binding into
+            // RegisterNotConfiguredException, so mocking it away would remove
+            // the behaviour these tests are meant to run through.
+            registerResolver: new OpenRegisterResolver(settingsService: $settingsService),
             eventDispatcher: $this->eventDispatcher,
             container: $this->container,
             logger: $this->createMock(LoggerInterface::class),

--- a/tests/unit/Service/GlAccountSuggestionServiceTest.php
+++ b/tests/unit/Service/GlAccountSuggestionServiceTest.php
@@ -77,6 +77,16 @@ class GlAccountSuggestionServiceTest extends TestCase
 
         $settingsService = $this->createMock(SettingsService::class);
         $settingsService->method('getObjectService')->willReturn($this->objectService);
+        // Bindings resolve through SettingsService and FAIL CLOSED when unset,
+        // instead of silently querying register ''. An unstubbed mock returns
+        // null — which is exactly what the guard exists to catch — so the
+        // configured path has to be stated for these tests to exercise it.
+        $settingsService->method('resolveFinancialExtractionBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'financialExtraction']);
+        $settingsService->method('resolveGlAccountBookingBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'glAccountBooking']);
+        $settingsService->method('resolveGlAccountMappingRuleBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'glAccountMappingRule']);
 
         $this->config = $this->createMock(IAppConfig::class);
         $this->config->method('getValueString')->willReturnCallback(
@@ -403,6 +413,16 @@ class GlAccountSuggestionServiceTest extends TestCase
 
         $settingsService = $this->createMock(SettingsService::class);
         $settingsService->method('getObjectService')->willReturn($this->objectService);
+        // Bindings resolve through SettingsService and FAIL CLOSED when unset,
+        // instead of silently querying register ''. An unstubbed mock returns
+        // null — which is exactly what the guard exists to catch — so the
+        // configured path has to be stated for these tests to exercise it.
+        $settingsService->method('resolveFinancialExtractionBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'financialExtraction']);
+        $settingsService->method('resolveGlAccountBookingBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'glAccountBooking']);
+        $settingsService->method('resolveGlAccountMappingRuleBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'glAccountMappingRule']);
 
         $service = new GlAccountSuggestionService(
             settingsService: $settingsService,
@@ -448,6 +468,16 @@ class GlAccountSuggestionServiceTest extends TestCase
 
         $settingsService = $this->createMock(SettingsService::class);
         $settingsService->method('getObjectService')->willReturn($this->objectService);
+        // Bindings resolve through SettingsService and FAIL CLOSED when unset,
+        // instead of silently querying register ''. An unstubbed mock returns
+        // null — which is exactly what the guard exists to catch — so the
+        // configured path has to be stated for these tests to exercise it.
+        $settingsService->method('resolveFinancialExtractionBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'financialExtraction']);
+        $settingsService->method('resolveGlAccountBookingBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'glAccountBooking']);
+        $settingsService->method('resolveGlAccountMappingRuleBinding')
+            ->willReturn(['register' => 'document', 'schema' => 'glAccountMappingRule']);
 
         $service = new GlAccountSuggestionService(
             settingsService: $settingsService,

--- a/tests/unit/Service/RegisterBindingResolutionTest.php
+++ b/tests/unit/Service/RegisterBindingResolutionTest.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Unit tests for register/schema binding resolution and its fail-closed arm.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+namespace OCA\DocuDesk\Tests\Unit\Service;
+
+use OCA\DocuDesk\Exception\RegisterNotConfiguredException;
+use OCA\DocuDesk\Service\GrondslagProposalService;
+use OCA\DocuDesk\Service\OcrService;
+use OCA\DocuDesk\Service\OpenRegisterAvailabilityService;
+use OCA\DocuDesk\Service\OpenRegisterResolver;
+use OCA\DocuDesk\Service\RegisterDiscoveryService;
+use OCA\DocuDesk\Service\SettingsInitializer;
+use OCA\DocuDesk\Service\SettingsService;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * An administrator binds each register/schema pair in the admin settings UI and
+ * nothing auto-provisions them. Before this behaviour existed, every consumer
+ * read the pair inline with an empty-string default and passed the result
+ * straight into saveObject()/find() — so an unbound instance wrote signing
+ * requests, financial extractions and GL bookings into register '' and schema
+ * '' and carried on, silently.
+ *
+ * The behaviour is split in two, and each half is tested here:
+ *
+ *   SettingsService::resolve*Binding()  — READS the pair, returns null when
+ *                                         either half is unset.
+ *   OpenRegisterResolver::get*()        — turns that null into
+ *                                         RegisterNotConfiguredException.
+ *
+ * Both halves matter. A test that only proved the happy path would pass just as
+ * well against the old code, which is the failure mode this whole change exists
+ * to remove: the unconfigured arm is the one that was never exercised.
+ *
+ * @psalm-suppress  PropertyNotSetInConstructor
+ * @phpstan-extends TestCase
+ */
+class RegisterBindingResolutionTest extends TestCase
+{
+
+    /**
+     * Config double driving the binding reads.
+     *
+     * @var IAppConfig|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $config;
+
+    /**
+     * Service under test.
+     *
+     * @var SettingsService
+     */
+    private SettingsService $settings;
+
+    /**
+     * Build a SettingsService whose config returns the supplied values.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->config   = $this->createMock(IAppConfig::class);
+        $this->settings = new SettingsService(
+            $this->config,
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(RegisterDiscoveryService::class),
+            $this->createMock(SettingsInitializer::class),
+            $this->createMock(OcrService::class),
+            $this->createMock(GrondslagProposalService::class),
+            $this->createMock(OpenRegisterAvailabilityService::class)
+        );
+
+    }//end setUp()
+
+    /**
+     * Make every config key resolve to `$value`, except those in `$blank`.
+     *
+     * @param string        $value Value returned for a configured key.
+     * @param array<string> $blank Keys that must come back empty.
+     *
+     * @return void
+     */
+    private function withConfig(string $value, array $blank=[]): void
+    {
+        $this->config->method('getValueString')->willReturnCallback(
+            static function (string $app, string $key, string $default='') use ($value, $blank): string {
+                if (in_array($key, $blank, true) === true) {
+                    return '';
+                }
+
+                return $value;
+            }
+        );
+
+    }//end withConfig()
+
+    /**
+     * Every accessor returns the configured pair.
+     *
+     * @param string $method    Accessor under test.
+     * @param string $keyPrefix Config key prefix it reads.
+     *
+     * @return void
+     *
+     * @dataProvider bindingProvider
+     */
+    public function testAccessorReturnsTheConfiguredPair(string $method, string $keyPrefix): void
+    {
+        $this->withConfig('bound');
+
+        $this->assertSame(
+            ['register' => 'bound', 'schema' => 'bound'],
+            $this->settings->$method(),
+            $method.'() must return the configured register/schema pair.'
+        );
+
+    }//end testAccessorReturnsTheConfiguredPair()
+
+    /**
+     * An unset REGISTER half yields null, never a pair containing ''.
+     *
+     * @param string $method    Accessor under test.
+     * @param string $keyPrefix Config key prefix it reads.
+     *
+     * @return void
+     *
+     * @dataProvider bindingProvider
+     */
+    public function testAccessorReturnsNullWhenTheRegisterIsUnset(string $method, string $keyPrefix): void
+    {
+        $this->withConfig('bound', [$keyPrefix.'_register']);
+
+        $this->assertNull(
+            $this->settings->$method(),
+            $method.'() must return null when the register half is unset — returning '
+            ."['register' => '', ...] is what silently wrote to register ''."
+        );
+
+    }//end testAccessorReturnsNullWhenTheRegisterIsUnset()
+
+    /**
+     * An unset SCHEMA half yields null too — both halves are required.
+     *
+     * @param string $method    Accessor under test.
+     * @param string $keyPrefix Config key prefix it reads.
+     *
+     * @return void
+     *
+     * @dataProvider bindingProvider
+     */
+    public function testAccessorReturnsNullWhenTheSchemaIsUnset(string $method, string $keyPrefix): void
+    {
+        $this->withConfig('bound', [$keyPrefix.'_schema']);
+
+        $this->assertNull(
+            $this->settings->$method(),
+            $method.'() must return null when the schema half is unset.'
+        );
+
+    }//end testAccessorReturnsNullWhenTheSchemaIsUnset()
+
+    /**
+     * The resolver returns the pair when it is configured.
+     *
+     * @param string $settingsMethod Accessor on SettingsService.
+     * @param string $resolverMethod Accessor on OpenRegisterResolver.
+     *
+     * @return void
+     *
+     * @dataProvider resolverProvider
+     */
+    public function testResolverReturnsTheBindingWhenConfigured(
+        string $settingsMethod,
+        string $resolverMethod
+    ): void {
+        $settings = $this->createMock(SettingsService::class);
+        $settings->method($settingsMethod)->willReturn(['register' => 'r', 'schema' => 's']);
+
+        $resolver = new OpenRegisterResolver(settingsService: $settings);
+
+        $this->assertSame(['register' => 'r', 'schema' => 's'], $resolver->$resolverMethod());
+
+    }//end testResolverReturnsTheBindingWhenConfigured()
+
+    /**
+     * The resolver FAILS CLOSED when the binding is unset.
+     *
+     * This is the arm that never ran before: the old code carried '' forward
+     * into OpenRegister and the write went nowhere.
+     *
+     * @param string $settingsMethod Accessor on SettingsService.
+     * @param string $resolverMethod Accessor on OpenRegisterResolver.
+     *
+     * @return void
+     *
+     * @dataProvider resolverProvider
+     */
+    public function testResolverThrowsWhenTheBindingIsUnset(
+        string $settingsMethod,
+        string $resolverMethod
+    ): void {
+        $settings = $this->createMock(SettingsService::class);
+        $settings->method($settingsMethod)->willReturn(null);
+
+        $resolver = new OpenRegisterResolver(settingsService: $settings);
+
+        $this->expectException(RegisterNotConfiguredException::class);
+        $resolver->$resolverMethod();
+
+    }//end testResolverThrowsWhenTheBindingIsUnset()
+
+    /**
+     * Accessor name paired with the config key prefix it reads.
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function bindingProvider(): array
+    {
+        return [
+            'signingRequest'       => ['resolveSigningRequestBinding', 'signingRequest'],
+            'signerRecord'         => ['resolveSignerRecordBinding', 'signerRecord'],
+            'financialExtraction'  => ['resolveFinancialExtractionBinding', 'financialExtraction'],
+            'glAccountBooking'     => ['resolveGlAccountBookingBinding', 'glAccountBooking'],
+            'glAccountMappingRule' => ['resolveGlAccountMappingRuleBinding', 'glAccountMappingRule'],
+        ];
+
+    }//end bindingProvider()
+
+    /**
+     * SettingsService accessor paired with the resolver method that wraps it.
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function resolverProvider(): array
+    {
+        return [
+            'financialExtraction'  => [
+                'resolveFinancialExtractionBinding',
+                'getFinancialExtractionRegisterAndSchema',
+            ],
+            'glAccountBooking'     => [
+                'resolveGlAccountBookingBinding',
+                'getGlAccountBookingRegisterAndSchema',
+            ],
+            'glAccountMappingRule' => [
+                'resolveGlAccountMappingRuleBinding',
+                'getGlAccountMappingRuleRegisterAndSchema',
+            ],
+            'signerRecord'         => [
+                'resolveSignerRecordBinding',
+                'getSignerRecordRegisterAndSchema',
+            ],
+        ];
+
+    }//end resolverProvider()
+}//end class

--- a/tests/unit/Service/SigningServiceTest.php
+++ b/tests/unit/Service/SigningServiceTest.php
@@ -127,6 +127,24 @@ class SigningServiceTest extends TestCase
         $this->settingsService = $this->createMock(SettingsService::class);
         $this->settingsService->method('getObjectService')->willReturn($this->objectService);
 
+        // SigningService now resolves its register/schema bindings through
+        // SettingsService and FAILS CLOSED when either half is unset, instead
+        // of reading them inline with an empty-string default and writing to
+        // register '' / schema ''. An unstubbed mock returns null, so these
+        // stubs are what keep the suite exercising the configured path — and
+        // their absence is what the fail-closed guard is there to catch.
+        $this->settingsService->method('resolveSigningRequestBinding')
+            ->willReturn(['register' => 'signing', 'schema' => 'signingRequest']);
+        $this->settingsService->method('resolveSignerRecordBinding')
+            ->willReturn(['register' => 'signing', 'schema' => 'signerRecord']);
+        $this->settingsService->method('getFeatureToggles')->willReturn(
+            [
+                'signing_request_expiry_days' => 30,
+                'signing_default_level'       => 'SES',
+                'signing_provider'            => 'native',
+            ]
+        );
+
         $this->auditService = $this->createMock(SigningAuditService::class);
 
         $this->config = $this->createMock(IAppConfig::class);
@@ -166,7 +184,6 @@ class SigningServiceTest extends TestCase
         $this->service = new SigningService(
             settingsService: $this->settingsService,
             auditService: $this->auditService,
-            config: $this->config,
             artifactProducer: new SignedArtifactProducer(
                 providerFactory: $this->providerFactory,
                 userSession: $this->userSession,


### PR DESCRIPTION
Supersedes #413 (same work, rebased onto `development` so it sits on top of #409/#410/#412).

## Gates closed — package `365fa31` (`.github` main, includes my #286)

| gate | before | after |
|---|---|---|
| 1 spdx-headers | FAIL — 1 missing `@copyright` | **PASS** |
| 50 security-config-fail-mode | FAIL — 29 unsafe reads | **PASS** |
| 54 relation-dialect | FAIL — 2 findings | **PASS** |

**Whole-repo run on this branch: only gates 19, 25 and 26 still fail** (pre-existing coverage debt, untouched here). Every `.err` file was 0 bytes — no checker crashed. `NODE_PATH` proven by `require.resolve('ajv')` returning an absolute path, so gates 22/45–55 ran for real rather than skipping.

**Can-fail proof (gate-50)**: removing one guard produced exactly `FAIL — 2`, naming `lib/Service/FinancialExtractionService.php:259` and `:260` — the two reads whose guard was removed, and nothing else.

⚠️ **gate-50 cannot see a read whose app-id argument is a plain variable**, so its zero is not by itself proof the class is gone. Every read in the touched files uses a literal `'docudesk'` and a literal key, and the accessors keep it that way — the reads stayed *visible* rather than being hidden behind a computed key.

## The defect

Every gate-50 finding was one shape: a register/schema binding read with an empty-string default, passed straight into `saveObject()`/`find()`. An administrator sets these in the admin UI and nothing auto-provisions them, so an unbound instance wrote to **register `''` and schema `''`** and carried on — for signing, that is the audit trail behind an eIDAS-level signature; for financial extraction, the supplier, IBAN, KvK, VAT id and amounts read off an invoice.

`SettingsService` owns the **read** and returns `null` when unset. `OpenRegisterResolver` turns that null into `RegisterNotConfiguredException`, next to the template accessors that already did exactly this. The split puts "an unset binding is an error" in the class named for it, and keeps the exception type out of `SettingsService`, whose object coupling sits at its PHPMD ceiling.

**Four sites gate-50 did NOT flag are fixed too** — `SigningService::getRequest()`, the decline path, and `FinancialExtractionService::addCorrection()` sat inside the gate's 10-line window thanks to an adjacent null-check, but carry the same defect: `find()` against register `''` returns null and each reports **"not found"**, so an unconfigured instance answered **404 for every signing request that does exist**.

`PortalSigningReceiverController` **denies**. This is the anti-IDOR boundary (REQ-DDPSA-004) and register/schema are two of the four filters scoping the lookup; passing `''` made the boundary's correctness depend on OpenRegister choosing to match nothing for an empty filter — an assumption the code never stated and does not control.

`SigningVerificationService::getSigningSecret()` now returns `?string`. Its single caller already failed closed 85 lines away, so there was **no live defect** — but `''` is a *valid* HMAC key, and a future caller that forgot the check would verify signatures against a publicly derivable key and report them genuine. `null` cannot reach `hash_hmac()` by accident.

## gate-54 — the reference was never expressible

`correspondence.caseReference` and `generatedDocument.zaakId` point at a Zaak in **Procest's** register and already declared `x-external-register: procest`. Both `$ref`s were dropped: OpenRegister resolves `$ref` inside one register set, so these named a schema the engine could never reach — a relation that only looked like one. Nothing consumed them as relations. ⚠️ **This alone does not close gate-54** — removing the `$ref` merely flipped the finding to the opposite arm ("lacks canonical `$ref`"). Both arms failed; that is `ConductionNL/.github#286`, now merged.

Dutch descriptions re-authored in English. `Zaak` is a standardised ZGW term and is kept; only the surrounding prose changed, and `zaakId` is untouched.

## PHPMD: four metrics went over, no threshold changed

`SigningService`'s coupling was resolved by **dropping `IAppConfig` entirely** — its three remaining reads duplicated both the keys *and* the defaults (`'30'`, `'SES'`, `'native'`) that `SettingsService::loadFeatureToggles()` already owns, two sources of truth free to drift. Verified the defaults are byte-identical, so behaviour is unchanged. The same happened in the other three consumers: every config read they had was a binding read, so `IAppConfig` became unused.

## Tests

`composer check:strict` — **ALL CHECKS PASSED** (lint, phpcs, phpmd, psalm, phpstan, 1141 tests).

Tests construct a **real** `OpenRegisterResolver` over a stubbed `SettingsService` rather than mocking the resolver — the resolver is the piece that turns an unset binding into the exception, so mocking it would remove the behaviour under test. ⚠️ 24 tests failed until the configured path was stated explicitly: **an unstubbed mock returns null, which is exactly what the guard exists to catch.** That is the guard working, not a defect.