### PR TITLE
test(e2e): close gate-26 visual-coverage with real page-component tests (19 → 4)

### DIFF
--- a/tests/e2e/spec-coverage/page-components.spec.ts
+++ b/tests/e2e/spec-coverage/page-components.spec.ts
@@ -1,0 +1,212 @@
+/*
+ * SPDX-FileCopyrightText: 2026 DocuDesk Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Gate-26 visual-coverage — per-page-component rendering tests.
+ *
+ * WHAT THIS FILE IS FOR
+ * ---------------------
+ * Every DocuDesk page component under `src/views/` needs a visual proof:
+ * either a pixel baseline under `tests/e2e/visual/**` or an e2e test that
+ * drives the component in a browser (hydra gate-26). Pixel baselines are not
+ * an option here — `tests/e2e/playwright.config.ts` deliberately excludes
+ * `**\/visual/**` from the CI project because the PNGs are host-font/GPU
+ * specific and a dev-container baseline cannot byte-match a CI Linux runner.
+ * So the proof is behavioural: navigate to the component's real route and
+ * assert on markup that ONLY that component renders.
+ *
+ * THE RULE EVERY TEST HERE FOLLOWS
+ * --------------------------------
+ * An unknown subpath under a Nextcloud app answers **200 with the SPA HTML
+ * shell**, so `toHaveURL(...)`, a status check, or `expect(body).toBeVisible()`
+ * all pass for a route that does not exist. None of those prove a component
+ * rendered. Each test below therefore asserts a string or a class that is
+ * written in that component's own template and nowhere else — a heading, a
+ * form control, an empty state. Where two components render near-identical
+ * markup (the two anonymisation drop zones), the assertion is pinned to the
+ * text that differs between them, so neither test can be satisfied by the
+ * other component.
+ *
+ * No `.catch(() => {})` anywhere: a swallowed timeout is a false pass. No
+ * `networkidle` either — it never settles on Nextcloud (ADR-074 rule 4 /
+ * gate-58); `go()` waits for the app shell and then each assertion retries
+ * over the route-specific markup.
+ */
+
+import { test, expect } from '@playwright/test'
+import { go, waitForNcContentReady, dismissOverlays } from './_helpers'
+
+/**
+ * A syntactically valid UUID that no DocuDesk object can have.
+ *
+ * Used by the two detail-page tests. Both detail components catch their own
+ * fetch failure (`customDictionaryStore.fetchDictionary` / the consent store
+ * both `catch` and return null), so the route still mounts the component and
+ * paints its own not-found / empty state — which is exactly the state under
+ * test. Seeding a real object would test the happy path of a different
+ * component (the index that created it); this tests the detail page itself.
+ */
+const ABSENT_ID = '00000000-0000-4000-8000-000000000000'
+
+// ---------------------------------------------------------------------------
+// Anonymisation surfaces
+// ---------------------------------------------------------------------------
+
+test.describe('page components — anonymization', () => {
+	test('AnonymizationIndex paints its own page heading at /anonymization', async ({ page }) => {
+		await go(page, 'anonymization')
+		// `.anonymization-page__title` exists in exactly one template in the
+		// app. The SPA shell renders no such element, so this cannot pass on
+		// the bare shell.
+		await expect(page.locator('.anonymization-page__title')).toHaveText('Anonymization')
+	})
+
+	test('AnonymizationWidget paints its upload drop zone inside /anonymization', async ({ page }) => {
+		await go(page, 'anonymization')
+		const widget = page.locator('.anonymization-page .anonymization-widget')
+		await expect(widget).toBeVisible()
+		await expect(widget.locator('.drop-title'))
+			.toHaveText('Drag and drop one or more documents')
+		// ODT appears in THIS widget's subtitle and NOT in the dashboard
+		// widget's (which lists only .docx/PDF/TXT), so this assertion pins the
+		// test to the component it names.
+		await expect(widget.locator('.drop-subtitle'))
+			.toHaveText('Only Word (.docx), ODT, PDF or TXT files are supported. Maximum file size 500 MB.')
+		await expect(widget.getByRole('button', { name: '+ Select files' })).toBeVisible()
+		await expect(widget.locator('input[type="file"]'))
+			.toHaveAttribute('aria-label', 'Select files to anonymise')
+	})
+
+	test('FolderAnonymizationView paints its folder-path form at /folder-anonymization', async ({ page }) => {
+		await go(page, 'folder-anonymization')
+		const view = page.locator('.folder-anonymization')
+		await expect(view.getByRole('heading', { name: 'Folder Analysis & Anonymization' })).toBeVisible()
+		await expect(view.getByText('Enter a folder path from your Nextcloud files to analyze all documents in it.')).toBeVisible()
+		// Step 1 of the view — the only step reachable without a completed
+		// extraction run.
+		await expect(view.locator('input.folder-path-input'))
+			.toHaveAttribute('aria-label', 'Folder path to analyse')
+		await expect(view.getByRole('button', { name: 'Analyze Folder' })).toBeVisible()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Dashboard
+// ---------------------------------------------------------------------------
+
+test.describe('page components — dashboard', () => {
+	test('DashboardIndex paints its consent KPI links at the app root', async ({ page }) => {
+		await go(page, '')
+		// The KPI tiles are <RouterLink>s with explicit aria-labels written in
+		// DashboardIndex's template — the shell has no such links.
+		await expect(page.getByRole('link', { name: /^Total Consents/ })).toBeVisible()
+		await expect(page.getByRole('link', { name: /^Pending consents/ })).toBeVisible()
+		await expect(page.getByRole('link', { name: /^Approved consents/ })).toBeVisible()
+		await expect(page.getByRole('link', { name: /^Objected consents/ })).toBeVisible()
+	})
+
+	test('AnonymizationDashboardWidget paints its quick-anonymisation panel on the dashboard', async ({ page }) => {
+		await go(page, '')
+		const widget = page.locator('.docudesk-anon-widget')
+		await expect(widget).toBeVisible()
+		// The dashboard widget's supported-format line omits ODT; the in-app
+		// AnonymizationWidget's includes it. Asserting the exact string keeps
+		// the two components' tests non-interchangeable.
+		await expect(widget.locator('.drop-subtitle'))
+			.toHaveText('Only Word (.docx), PDF or TXT files are supported. Maximum file size 500 MB.')
+		await expect(widget.getByRole('button', { name: '+ Select files' })).toBeVisible()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Consent
+// ---------------------------------------------------------------------------
+
+test.describe('page components — consent', () => {
+	test('ConsentIndex paints its workflow description and stats strip at /consent', async ({ page }) => {
+		await go(page, 'consent')
+		await expect(page.getByText('Per-document consent records produced by the publication-clearance workflow.')).toBeVisible()
+		// `.consent-stats` is ConsentIndex's own `#above-table` slot content.
+		await expect(page.locator('.consent-stats')).toBeVisible()
+	})
+
+	test('ConsentDetail paints its no-record state at /consent/<absent-id>', async ({ page }) => {
+		await go(page, `consent/${ABSENT_ID}`)
+		// CnDetailPage's error slot, filled by ConsentDetail with its own copy.
+		await expect(page.getByText('No consent record selected.')).toBeVisible()
+		await expect(page.getByRole('button', { name: 'Back to Consents' }).first()).toBeVisible()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Custom dictionaries
+// ---------------------------------------------------------------------------
+
+test.describe('page components — custom dictionaries', () => {
+	test('CustomDictionaryIndex paints its list description at /custom-dictionaries', async ({ page }) => {
+		await go(page, 'custom-dictionaries')
+		await expect(page.getByText(/Organisation-managed term lists/)).toBeVisible()
+		await expect(page.getByText(/add an extra recognizer alongside Presidio and regex/)).toBeVisible()
+	})
+
+	test('CustomDictionaryDetail paints its term-management panel at /custom-dictionaries/<absent-id>', async ({ page }) => {
+		await go(page, `custom-dictionaries/${ABSENT_ID}`)
+		const detail = page.locator('.custom-dictionary-detail')
+		await expect(detail.getByRole('button', { name: 'Back to custom dictionaries' })).toBeVisible()
+		await expect(detail.getByRole('heading', { name: 'Terms' })).toBeVisible()
+		await expect(detail.getByRole('button', { name: 'Add term' })).toBeVisible()
+		// No dictionary resolved, so the terms panel shows its empty state.
+		await expect(detail.getByText('No terms yet')).toBeVisible()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Comparison, gallery, documents
+// ---------------------------------------------------------------------------
+
+test.describe('page components — standalone pages', () => {
+	test('ComparisonView paints its two file pickers at /comparison', async ({ page }) => {
+		await go(page, 'comparison')
+		const view = page.locator('.comparison-view')
+		await expect(view.getByRole('heading', { name: 'Document comparison' })).toBeVisible()
+		await expect(view.locator('.comparison-view__subtitle'))
+			.toHaveText('Compare two versions of a file or two distinct files side by side.')
+		await expect(view.locator('.comparison-view__pickers')).toBeVisible()
+		await expect(view.getByRole('button', { name: 'Compare', exact: true })).toBeVisible()
+	})
+
+	test('ComponentGallery paints its masthead and component sections at /gallery', async ({ page }) => {
+		await go(page, 'gallery')
+		const gallery = page.locator('.dd-gallery')
+		await expect(gallery.getByRole('heading', { name: 'DocuDesk component gallery', level: 1 })).toBeVisible()
+		await expect(gallery.getByRole('navigation', { name: 'Components' })).toBeVisible()
+		// A section heading, not the table-of-contents link of the same name.
+		await expect(gallery.getByRole('heading', { name: 'DdPageHeader' })).toBeVisible()
+	})
+
+	test('MyDocumentsIndex paints its documents header and search bar at /my-documents', async ({ page }) => {
+		await go(page, 'my-documents')
+		const view = page.locator('.my-documents-wrapper')
+		await expect(view.locator('.dd-page-header__title')).toHaveText('Documents')
+		await expect(view.locator('.my-documents-search input').first())
+			.toHaveAttribute('placeholder', 'Search by name')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Admin settings
+// ---------------------------------------------------------------------------
+
+test.describe('page components — admin settings', () => {
+	test('EntityTypeSelector paints its detection hint on the DocuDesk admin settings page', async ({ page }) => {
+		await page.goto('/index.php/settings/admin/docudesk', { waitUntil: 'domcontentloaded' })
+		await waitForNcContentReady(page)
+		await dismissOverlays(page)
+		const selector = page.locator('.entity-type-selector')
+		await expect(selector).toBeVisible()
+		// The component computes one of three hints; all three name entity
+		// types, and none of them is rendered by the settings shell around it.
+		await expect(selector.locator('.entity-type-selector__hint'))
+			.toHaveText(/entity types (are|available)|Only the enabled types are detected/i)
+	})
+})

--- a/tests/e2e/spec-coverage/page-components.spec.ts
+++ b/tests/e2e/spec-coverage/page-components.spec.ts
@@ -123,11 +123,28 @@ test.describe('page components — dashboard', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('page components — consent', () => {
-	test('ConsentIndex paints its workflow description and stats strip at /consent', async ({ page }) => {
+	test('ConsentIndex paints its workflow heading, description and record list at /consent', async ({ page }) => {
 		await go(page, 'consent')
+		// Title + description are ConsentIndex's own props on CnIndexPage; the
+		// manifest page is titled "Consent Management", so neither string can
+		// come from the shell.
+		await expect(page.getByRole('heading', { name: 'Consent Workflow' })).toBeVisible()
 		await expect(page.getByText('Per-document consent records produced by the publication-clearance workflow.')).toBeVisible()
-		// `.consent-stats` is ConsentIndex's own `#above-table` slot content.
-		await expect(page.locator('.consent-stats')).toBeVisible()
+		// The list itself: real rows, or this page's own empty text.
+		const table = page.locator('#content table, .app-content table').first()
+		const empty = page.getByText('No consent records found')
+		await expect(table.or(empty).first(), 'the consent list must render rows or its empty state').toBeVisible()
+		// NOTE: this page also declares a `<template #above-table>` stats strip
+		// (`.consent-stats`, four CnStatsBlocks). It is NOT asserted here
+		// because it does not render at all: CnIndexPage exposes no
+		// `above-table` slot — the slot between the header and the actions bar
+		// is `below-header` — so the markup is silently dropped. Measured on
+		// this suite: the description assertion above passed on the same run
+		// where `.consent-stats` was "element(s) not found". Four views carry
+		// the same dead slot name (this one, views/policy/ProhibitionIndex,
+		// views/policy/StandingConsentIndex, views/consent/StandingConsentIndex).
+		// Renaming the slot is a visible UI change and belongs in a consent /
+		// policy change with its own review, not in a coverage PR.
 	})
 
 	test('ConsentDetail paints its no-record state at /consent/<absent-id>', async ({ page }) => {

--- a/tests/e2e/spec-coverage/page-components.spec.ts
+++ b/tests/e2e/spec-coverage/page-components.spec.ts
@@ -123,28 +123,38 @@ test.describe('page components — dashboard', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('page components — consent', () => {
-	test('ConsentIndex paints its workflow heading, description and record list at /consent', async ({ page }) => {
+	test('ConsentIndex paints its workflow description and record list at /consent', async ({ page }) => {
 		await go(page, 'consent')
-		// Title + description are ConsentIndex's own props on CnIndexPage; the
-		// manifest page is titled "Consent Management", so neither string can
-		// come from the shell.
-		await expect(page.getByRole('heading', { name: 'Consent Workflow' })).toBeVisible()
+		// The description is ConsentIndex's own `description` prop on
+		// CnIndexPage; no other page and no shell chrome carries this string.
 		await expect(page.getByText('Per-document consent records produced by the publication-clearance workflow.')).toBeVisible()
-		// The list itself: real rows, or this page's own empty text.
+		// The list itself: real rows, or this page's own `empty-text`.
 		const table = page.locator('#content table, .app-content table').first()
 		const empty = page.getByText('No consent records found')
 		await expect(table.or(empty).first(), 'the consent list must render rows or its empty state').toBeVisible()
-		// NOTE: this page also declares a `<template #above-table>` stats strip
-		// (`.consent-stats`, four CnStatsBlocks). It is NOT asserted here
-		// because it does not render at all: CnIndexPage exposes no
-		// `above-table` slot — the slot between the header and the actions bar
-		// is `below-header` — so the markup is silently dropped. Measured on
-		// this suite: the description assertion above passed on the same run
-		// where `.consent-stats` was "element(s) not found". Four views carry
-		// the same dead slot name (this one, views/policy/ProhibitionIndex,
-		// views/policy/StandingConsentIndex, views/consent/StandingConsentIndex).
-		// Renaming the slot is a visible UI change and belongs in a consent /
-		// policy change with its own review, not in a coverage PR.
+
+		// TWO THINGS THIS PAGE DECLARES AND DOES NOT RENDER — measured from the
+		// accessibility snapshot of run 31335736716, where `<main>` was exactly:
+		//     heading "Consent Management" [level=1]
+		//     paragraph: Per-document consent records produced by the …
+		//     button "Refresh" / note "No consent records found" / button "Actions"
+		//
+		// 1. `<template #above-table>` (`.consent-stats`, four CnStatsBlocks)
+		//    is dropped on the floor: CnIndexPage has no `above-table` slot —
+		//    the slot between the page header and the actions bar is
+		//    `below-header`. Three sibling views carry the same dead slot name
+		//    (views/policy/ProhibitionIndex, views/policy/StandingConsentIndex,
+		//    views/consent/StandingConsentIndex).
+		// 2. The h1 reads "Consent Management" (the manifest page title), not
+		//    the "Consent Workflow" this component binds to CnIndexPage's
+		//    `title`: CnPageRenderer forwards the manifest's top-level `title`
+		//    to the page component, ConsentIndex declares no `title` prop, so
+		//    it falls through onto CnIndexPage and wins over the explicit
+		//    binding.
+		//
+		// Both are real defects, both are visible UI changes to fix, and both
+		// belong in a consent/policy change with its own review rather than in
+		// a coverage PR — so they are recorded here and not asserted.
 	})
 
 	test('ConsentDetail paints its no-record state at /consent/<absent-id>', async ({ page }) => {

--- a/tests/e2e/workflows/dashboard-widget.spec.ts
+++ b/tests/e2e/workflows/dashboard-widget.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: 2026 DocuDesk Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * DEEP, data-dependent workflow test — the Nextcloud Dashboard widget.
+ *
+ * `src/views/widgets/FileEntitiesDashboardWidget.vue` is mounted by
+ * `src/dashboard.js` through `OCA.Dashboard.register('docudesk-file-entities')`
+ * and by nothing else — it has no in-app route, so the ONLY surface that can
+ * render it is Nextcloud's Dashboard. A widget renders there only when it is
+ * in the viewing user's dashboard layout, and the shipped default layout is
+ * `recommendations,spreed,mail,calendar`; nothing puts a third-party widget
+ * in it.
+ *
+ * So the layout is set first, through the Dashboard app's own public API
+ * (`POST /ocs/v2.php/apps/dashboard/api/v3/layout` — `DashboardApiController::
+ * updateLayout`), which is exactly what the Dashboard's "Customize" panel
+ * calls when a user adds a widget. That is test SETUP; the assertions below
+ * are all on markup that only this widget's template produces.
+ */
+
+import { test, expect } from '@playwright/test'
+import { harvestToken } from './_fixtures'
+
+/** Widget id — `FileEntitiesWidget::getId()` in lib/Dashboard/. */
+const WIDGET_ID = 'docudesk-file-entities'
+
+test('FileEntitiesDashboardWidget renders on the Nextcloud Dashboard once added to the layout', async ({ page }) => {
+	const token = await harvestToken(page)
+
+	// Add the widget the way the Dashboard's own "Customize" panel does.
+	const layout = await page.request.post('/ocs/v2.php/apps/dashboard/api/v3/layout', {
+		headers: {
+			requesttoken: token,
+			'OCS-APIRequest': 'true',
+			'Content-Type': 'application/json',
+			Accept: 'application/json',
+		},
+		data: { layout: [WIDGET_ID] },
+	})
+	expect(layout.status(), `set dashboard layout (body: ${await layout.text()})`).toBe(200)
+
+	await page.goto('/index.php/apps/dashboard', { waitUntil: 'domcontentloaded' })
+	// Not `networkidle` — it never settles on Nextcloud (ADR-074 rule 4 /
+	// gate-58). Wait for the widget's own root element, which only appears
+	// once `dashboard.js` has mounted the Vue component into the slot the
+	// Dashboard handed it.
+	const widget = page.locator('.file-entities-widget')
+	await expect(widget).toBeVisible({ timeout: 30_000 })
+
+	// `GET /api/anonymization/files` returns a clean JSON 200 with no
+	// processed files on a fresh instance (the same endpoint
+	// anonymization-workflow.spec.ts pins to JSON), so the widget settles on
+	// its own empty state. A populated instance shows its table instead —
+	// both are this component's markup; an error state is NOT accepted.
+	const empty = widget.getByText('No processed files yet')
+	const table = widget.locator('table.results-table')
+	await expect(empty.or(table).first()).toBeVisible()
+	await expect(widget.locator('.error-area'), 'the widget must not surface a load error').toHaveCount(0)
+
+	// The widget's own footer link back into the app.
+	await expect(widget.getByRole('link', { name: 'Open DocuDesk' })).toBeVisible()
+})

--- a/tests/e2e/workflows/file-viewer.spec.ts
+++ b/tests/e2e/workflows/file-viewer.spec.ts
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: 2026 DocuDesk Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * DEEP, data-dependent workflow test — the in-app file viewer.
+ *
+ * `src/views/fileViewer/FileViewerPage.vue` has no route of its own: it
+ * renders inside `MyDocumentsIndex` only while `fileViewerStore.currentFile`
+ * is set, and the only way to set it from the UI is to open a row in the
+ * My Documents list. So the only honest proof this component renders is to
+ * put a REAL file where the list reads from (`/DocuDesk` via WebDAV), open it,
+ * and assert the viewer's own chrome and the document's own contents.
+ *
+ * Deliberately a `.txt` fixture: TextViewer is the one viewer that needs no
+ * conversion backend, so what lands on screen is the exact text this test
+ * wrote — an assertion the SPA shell cannot satisfy by accident.
+ */
+
+import { test, expect } from '@playwright/test'
+import { go } from '../spec-coverage/_helpers'
+import {
+	harvestToken, TEST_PREFIX, createDavFile, createDavFolder, deleteDavPath,
+} from './_fixtures'
+
+/** The folder MyDocumentsIndex lists by default (`myDocumentsStore.currentPath`). */
+const DOCS_FOLDER = 'DocuDesk'
+
+const VIEWER_FILE = `${TEST_PREFIX}-viewer.txt`
+const VIEWER_PATH = `${DOCS_FOLDER}/${VIEWER_FILE}`
+
+/** Contents asserted verbatim in the viewer body — unique to this run. */
+const VIEWER_BODY = `Signed statement ${TEST_PREFIX}: the quarterly report has been reviewed.`
+
+test.afterAll(async ({ request }) => {
+	// Cleanup of this run's fixture only; the shared /DocuDesk folder stays,
+	// because the app and other specs use it. WebDAV writes authenticate on
+	// the session cookie jar, not on the CSRF token, so the empty token here
+	// is the same one signing-workflow.spec.ts's purge passes.
+	await deleteDavPath(request, '', VIEWER_PATH)
+})
+
+test('FileViewerPage renders a real document opened from My Documents', async ({ page }) => {
+	const token = await harvestToken(page)
+	const req = page.request
+
+	// MKCOL is 405 when the collection already exists — that is success for
+	// our purposes, so accept it explicitly rather than swallowing the status.
+	const mkcol = await createDavFolder(req, token, DOCS_FOLDER)
+	expect([201, 405], `MKCOL /${DOCS_FOLDER} (201 created / 405 already there)`).toContain(mkcol)
+
+	const seeded = await createDavFile(req, token, VIEWER_PATH, VIEWER_BODY)
+	expect(seeded.status, `PUT /${VIEWER_PATH}`).toBeLessThan(300)
+
+	await go(page, 'my-documents')
+
+	// The list strips the extension for display (MyDocumentsIndex.displayName),
+	// so the row is identified by the stem.
+	const stem = VIEWER_FILE.replace(/\.txt$/, '')
+	const row = page.locator('tr').filter({ hasText: stem }).first()
+	await expect(row, 'the seeded document must appear in My Documents').toBeVisible()
+	await row.click()
+
+	// FileViewerPage replaces the list inside `.my-documents-wrapper`.
+	const viewer = page.locator('.file-viewer-page')
+	await expect(viewer).toBeVisible()
+	// Its own header component, carrying the full file name (extension and all).
+	await expect(viewer.locator('.dd-file-viewer-header__title')).toHaveText(VIEWER_FILE)
+	// And the document's own text, rendered by TextViewer inside the viewer
+	// body. Nothing but a working viewer can put this string on screen.
+	await expect(viewer.locator('.text-viewer__content')).toContainText(VIEWER_BODY)
+})


### PR DESCRIPTION
## What

Gate-26 `visual-coverage` reported **19** page components under `src/views/` with no visual proof. This PR closes **15** of them with real Playwright tests, and leaves **4** honestly red with a measured reason.

Pixel baselines were not an option: `tests/e2e/playwright.config.ts` deliberately excludes the `visual` project from CI because the PNGs are host-font/GPU specific and a dev-container baseline cannot byte-match a CI Linux runner. So the proof is behavioural — navigate to the component's real route and assert on markup only that component renders.

**Gate-26: `FAIL — 19` → `FAIL — 4`. Playwright: `93 passed (8.2m)`, 0 failed, 0 flaky.**

## The trap this PR does not fall into

Gate-26 matches the component name against the **concatenated text** of `tests/e2e/**`, so a test that merely mentions `AnonymizationIndex.vue` in a comment would satisfy it while proving nothing. Every test here navigates to the component's real route and asserts a string or a class written in **that component's own template**.

An unknown subpath under a Nextcloud app answers **200 with the SPA HTML shell**, so `expect(page).toHaveURL(...)`, a status check, and `expect(body).toBeVisible()` all pass for a route that does not exist. None of those is used as the proof.

Where two components ship near-identical markup — the in-app `AnonymizationWidget` and the dashboard `AnonymizationDashboardWidget` both render a drop zone with the same title and button — the assertion is pinned to the supported-format line that **differs** between them (`ODT` is in one and not the other), so neither test can be satisfied by the other component.

No `@visual exclude`, no `.skip`, no `test.fixme`, no `continue-on-error`, no baselines, no threshold changes. No `networkidle` (gate-58), and no `.catch(() => {})` — a swallowed timeout is a false pass.

### Proof the gate can still fail

With the finished tree at 4 findings, the `ComparisonView` test was deleted and the checker re-run. STDOUT:

```
src/views/anonymization/EntityReviewTable.vue — …
src/views/comparison/ComparisonView.vue — …
src/views/signing/BulkSigningPanel.vue — …
src/views/signing/SigningRequestDetail.vue — …
src/views/signing/SigningRequestList.vue — …
[gate-26] visual-coverage: FAIL — 5 new page component(s) without a visual baseline
```

Exactly the one item, by name, and only that one. Restoring the test returned STDOUT to the 4-item list.

## Closed (15)

`tests/e2e/spec-coverage/page-components.spec.ts` — 13 route-reachable views:

| Component | Route | Asserted |
|---|---|---|
| `AnonymizationIndex` | `/anonymization` | `.anonymization-page__title` = "Anonymization" |
| `AnonymizationWidget` | `/anonymization` | drop zone + the **ODT**-bearing format line + file input aria-label |
| `FolderAnonymizationView` | `/folder-anonymization` | "Folder Analysis & Anonymization" + folder-path input + "Analyze Folder" |
| `DashboardIndex` | `/` | the four consent KPI `RouterLink`s by aria-label |
| `AnonymizationDashboardWidget` | `/` | `.docudesk-anon-widget` + the **non-ODT** format line |
| `ConsentIndex` | `/consent` | its own description + record list / empty text |
| `ConsentDetail` | `/consent/<absent-id>` | its own "No consent record selected." state |
| `CustomDictionaryIndex` | `/custom-dictionaries` | list description |
| `CustomDictionaryDetail` | `/custom-dictionaries/<absent-id>` | "Back to custom dictionaries" + "Terms" + "Add term" + "No terms yet" |
| `ComparisonView` | `/comparison` | heading + subtitle + pickers + "Compare" |
| `ComponentGallery` | `/gallery` | h1 masthead + TOC nav + a section heading |
| `MyDocumentsIndex` | `/my-documents` | `.dd-page-header__title` = "Documents" + search placeholder |
| `EntityTypeSelector` | `/settings/admin/docudesk` | `.entity-type-selector` + its computed hint |

The two components with no route of their own get data-dependent workflow tests:

- `tests/e2e/workflows/file-viewer.spec.ts` — **`FileViewerPage`** renders only while `fileViewerStore.currentFile` is set, and only My Documents can set it. The test PUTs a real `.txt` into `/DocuDesk` over WebDAV, opens the row, and asserts the viewer header carries the file name and `TextViewer` renders the exact bytes it wrote.
- `tests/e2e/workflows/dashboard-widget.spec.ts` — **`FileEntitiesDashboardWidget`** is mounted only by `OCA.Dashboard.register`, and only for widgets in the user's layout (the shipped default is `recommendations,spreed,mail,calendar`). The test adds it through the Dashboard app's own API — the same call its "Customize" panel makes — then asserts the widget's own empty state (or table) and footer link, and that it did **not** surface a load error.

## Two defects the tests found

Both measured from the failing run's accessibility snapshot, both left unfixed on purpose — each is a visible UI change that belongs in a consent/policy change with its own review, not in a coverage PR. Both are recorded inline in the test.

1. **`<template #above-table>` matches no slot.** `CnIndexPage` has no `above-table` slot; the slot between the page header and the actions bar is `below-header`. So the four `CnStatsBlock`s on the consent overview have **never** rendered. Same dead slot name in `src/views/consent/ConsentIndex.vue`, `src/views/policy/ProhibitionIndex.vue`, `src/views/policy/StandingConsentIndex.vue`, `src/views/consent/StandingConsentIndex.vue`.
2. **The page title is overridden by the manifest.** `ConsentIndex` binds `:title="Consent Workflow"` to `CnIndexPage`, but the rendered h1 is **"Consent Management"** — the manifest page title. `CnPageRenderer` forwards the manifest's top-level `title` to the page component; `ConsentIndex` declares no `title` prop, so it falls through onto `CnIndexPage` and beats the explicit binding.

## Left red (4) — measured reasons

| Component | Reason |
|---|---|
| `src/views/anonymization/EntityReviewTable.vue` | Renders only under `folderAnonymizationStore.batchStatus === 'review'`, which requires a completed NER extraction. The **NER sidecar is absent on CI** — `tests/e2e/workflows/anonymization-workflow.spec.ts` already records this ("the regex fallback does not detect arbitrary BSN/name/email on the fly") and keeps its detection test `fixme` for exactly this reason. Reachable only once the sidecar is provisioned. |
| `src/views/signing/BulkSigningPanel.vue` | Not routed and not registered, by an explicit recorded decision: `tests/unit/reachability.spec.js` lists it as `orphaned-view … owned-by:bulk-signing-field-builder`, and `openspec/specs/orphaned-surface-restoration/spec.md` states it MUST NOT be registered by that change. There is no URL that mounts it. |
| `src/views/signing/SigningRequestList.vue` | Not routed and not registered: superseded by the `type:"index"` SigningRequests page (Phase-8 decomposition). `src/registry.js` and `tests/unit/reachability.spec.js` both record it as a `legacy-dangling-registration` left on disk for a later cleanup. There is no URL that mounts it. |
| `src/views/signing/SigningRequestDetail.vue` | See below — a third genuine defect, reported rather than papered over. |

### `SigningRequestDetail` — the route cannot deliver its id

The manifest declares `/signing/:id` and the component declares `props: { requestId: { type: String, required: true } }`. `CnPageRenderer.resolvedProps()` forwards `$route.params` verbatim (plus an `objectId` alias, and only for `type:"detail"` pages), so the dispatched component receives `id`, never `requestId`. `setup()` therefore calls `fetchSigningRequest(undefined)`, the store's fetch 404s, `signingStore.signingRequest` stays null and the template renders an **empty `<div class="signing-request-detail">`** — no heading, no audit trail, nothing.

Its siblings avoid this by reading the param directly (`CustomDictionaryDetail` uses a `dictionaryId()` computed over `this.$route.params.id`). Asserting on the empty container would be exactly the hollow pass this work is meant to avoid, so the page stays red and the defect is reported. The fix is one of: a `dictionaryId`-style computed, or `"config": { "requestId": "@route.id" }` on the manifest page (the library's route-param sentinel already supports it) — either belongs in a signing change with its own test, not in a coverage PR.

## No other gate moved

Full `run-hydra-gates.sh` before and after are identical except gate-26. Still failing for pre-existing reasons, unchanged by this PR: gate-1 (1 missing `@copyright`), gate-19 (375), gate-25 (26), gate-50 (29), gate-54 (2). gate-58 `e2e-networkidle` stays PASS.