### PR TITLE
fix(consent,policy): make the three failing contracts honest, and correct four assertions that never matched them

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -101,6 +101,26 @@ jobs:
       # which is both the directory the validator counts collections in and the
       # directory the run step globs `*.postman_collection.json` in — flat, not
       # recursively.
+      #
+      # THAT FLATNESS HID A SECOND SUITE. `tests/newman/` held two more
+      # collections that no CI step has ever executed, because the glob only
+      # ever visits ONE directory and `newman-collection-path` is never set
+      # away from its default. Measured 2026-08-09:
+      #
+      #   tests/newman/docudesk-api.postman_collection.json
+      #       50 requests / 107 pm.test assertions. NOT ONE request declared
+      #       `OCS-APIRequest`, so all 39 of its writes (34 POST + 5 DELETE)
+      #       would have been rejected 412 by Nextcloud middleware before
+      #       reaching a controller — it had never exercised a write path.
+      #   tests/newman/docudesk-api-collection.json
+      #       8 requests / 15 assertions, and invisible even to the validator:
+      #       its name does not match `*.postman_collection.json`. Its own
+      #       `baseUrl` variable was the literal string "{{baseUrl}}".
+      #
+      # Both are now repaired and moved INTO tests/integration, so the existing
+      # flat glob runs all three. Keeping the default path (rather than
+      # repointing it at tests/newman) is deliberate: repointing would have
+      # de-selected the one collection that does run today.
       enable-newman: true
 
       # The Newman job needs the SAME provisioning the Playwright job gets, and

--- a/lib/Controller/ConsentController.php
+++ b/lib/Controller/ConsentController.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OCA\DocuDesk\Controller;
 
 use Exception;
+use OCA\DocuDesk\Exception\PolicyRejectedException;
 use OCA\DocuDesk\Service\ConsentCrudService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -210,9 +211,65 @@ class ConsentController extends Controller
     }//end index()
 
     /**
+     * Build the 403 response for a policy-prohibited consent request
+     *
+     * A `PolicyRejectedException` is NOT an internal failure: it is the
+     * deliberate, client-visible outcome mandated by the `consent-management`
+     * capability ("Requirement: Prohibition match MUST throw
+     * `PolicyRejectedException` ... No publicationConsent record MUST be
+     * created or updated"). Routing it through {@see errorResponse()} mapped
+     * its `code = 0` onto HTTP 500 and discarded the rule identity the
+     * exception exists to carry, so every prohibited create looked like a
+     * server crash.
+     *
+     * The rule UUID and name ARE returned to the caller. This is a deliberate,
+     * bounded carve-out from the oracle-free rule on {@see errorResponse()}:
+     * the identical disclosure is already mandated on the anonymise gate's 422
+     * body by `anonymisation-prohibition-gate` ("The `ruleName` MUST be the
+     * prohibition rule's `primaryName`, included to help the operator
+     * understand WHY the entity is required to be anonymised"). The caller
+     * supplied the matching entity text itself, so the response reveals only
+     * which rule answered — not the existence of any record it does not own.
+     *
+     * @param PolicyRejectedException $exception The typed rejection.
+     *
+     * @return JSONResponse The 403 response carrying the rule identity
+     *
+     * @spec openspec/specs/consent-management/spec.md
+     */
+    private function policyRejectedResponse(PolicyRejectedException $exception): JSONResponse
+    {
+        $this->logger->info(
+            'Consent creation rejected by a publication-prohibition rule',
+            [
+                'ruleUuid' => $exception->getRuleUuid(),
+                'ruleName' => $exception->getRuleName(),
+            ]
+        );
+
+        return new JSONResponse(
+            [
+                'error'     => $this->l10n->t('Publication prohibited by policy rule'),
+                'matchKind' => 'prohibition',
+                'ruleUuid'  => $exception->getRuleUuid(),
+                'ruleName'  => $exception->getRuleName(),
+            ],
+            Http::STATUS_FORBIDDEN
+        );
+
+    }//end policyRejectedResponse()
+
+    /**
      * Create a new consent request for a detected entity
      *
-     * @return JSONResponse JSON response with the created consent record
+     * Idempotent on `(documentId, entityKey, scope: "document")`. The service
+     * reports which branch it took through `wasUpdated`; the status line MUST
+     * agree with it. HTTP 201 is reserved for "a new resource was created"
+     * (RFC 9110 §15.3.2), so an idempotent re-submit — which creates nothing —
+     * answers 200. Before this fix the controller returned a hardcoded 201
+     * while the very same body said `wasUpdated: true`.
+     *
+     * @return JSONResponse JSON response with the created (201) or updated (200) consent record
      *
      * @NoAdminRequired
      *
@@ -250,7 +307,14 @@ class ConsentController extends Controller
                 $config['schema']
             );
 
-            return new JSONResponse($result, 201);
+            $statusCode = Http::STATUS_CREATED;
+            if (($result['wasUpdated'] ?? false) === true) {
+                $statusCode = Http::STATUS_OK;
+            }
+
+            return new JSONResponse($result, $statusCode);
+        } catch (PolicyRejectedException $e) {
+            return $this->policyRejectedResponse(exception: $e);
         } catch (Exception $e) {
             return $this->errorResponse(message: 'Failed to create consent', exception: $e);
         }//end try

--- a/lib/Controller/PolicyController.php
+++ b/lib/Controller/PolicyController.php
@@ -25,6 +25,7 @@ namespace OCA\DocuDesk\Controller;
 use Exception;
 use InvalidArgumentException;
 use OCA\DocuDesk\Service\PolicyCrudService;
+use OCA\OpenRegister\Exception\ArchivalImmutableException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -188,12 +189,29 @@ class PolicyController extends Controller
     /**
      * Delete a prohibition.
      *
+     * `publicationProhibition` declares `x-openregister-archival` in
+     * `lib/Settings/docudesk_register.json` (retention P10Y — prohibitions are
+     * court-order-backed and must survive for audit and appeal). OpenRegister
+     * therefore refuses EVERY user-driven delete on this schema: rows expire
+     * only through `OCA\OpenRegister\Cron\ArchivalRetentionTask`. The endpoint
+     * is consequently impossible to satisfy — never merely "currently failing"
+     * — and previously leaked that as an opaque HTTP 500.
+     *
+     * It now answers HTTP 409 Conflict: the request conflicts with the
+     * resource's declared retention state, and no retry, permission change or
+     * payload change can make it succeed. The body names retention as the
+     * reason and carries OpenRegister's own `SCHEMA_ARCHIVAL_IMMUTABLE`
+     * discriminator so a client can tell this apart from the 403 the
+     * permission gate raises.
+     *
      * @param string $id Record UUID.
      *
-     * @return JSONResponse
+     * @return JSONResponse 409 while the schema declares archival retention
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/specs/entity-publication-policies/spec.md
      */
     public function deleteProhibition(string $id): JSONResponse
     {
@@ -208,11 +226,47 @@ class PolicyController extends Controller
             );
             $this->crudService->deleteProhibition(uuid: $id);
             return new JSONResponse(['deleted' => $id]);
+        } catch (ArchivalImmutableException $e) {
+            return $this->retentionProtectedResponse(id: $id, exception: $e);
         } catch (Exception $e) {
             return $this->error(message: 'Failed to delete prohibition: ', exception: $e);
         }
 
     }//end deleteProhibition()
+
+    /**
+     * Build the 409 response for a retention-protected delete.
+     *
+     * @param string                     $id        The record UUID the caller tried to delete.
+     * @param ArchivalImmutableException $exception OpenRegister's archival refusal.
+     *
+     * @return JSONResponse The 409 Conflict response
+     *
+     * @spec openspec/specs/entity-publication-policies/spec.md
+     */
+    private function retentionProtectedResponse(string $id, ArchivalImmutableException $exception): JSONResponse
+    {
+        $this->logger->info(
+            'Prohibition delete refused: schema declares archival retention',
+            ['prohibitionId' => $id, 'exception' => $exception]
+        );
+
+        return new JSONResponse(
+            [
+                'error'     => 'SCHEMA_ARCHIVAL_IMMUTABLE',
+                'message'   => $this->l10n->t(
+                    'Publication prohibitions are retained under a declared archival '
+                    .'retention policy and cannot be deleted. Records expire automatically '
+                    .'when their retention period ends.'
+                ),
+                'schema'    => 'publicationProhibition',
+                'operation' => 'delete',
+                'id'        => $id,
+            ],
+            Http::STATUS_CONFLICT
+        );
+
+    }//end retentionProtectedResponse()
 
     /**
      * Wrap an exception into a 500 JSON response and log it.

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -40,8 +40,9 @@
  * @category Controller
  * @package  OCA\DocuDesk\Controller
  *
- * @author  Conduction Development Team <info@conduction.nl>
- * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @link https://www.DocuDesk.app
  *

--- a/lib/Service/ConsentCrudService.php
+++ b/lib/Service/ConsentCrudService.php
@@ -241,8 +241,12 @@ class ConsentCrudService
      * @param string               $register The register ID
      * @param string               $schema   The schema ID
      *
-     * @return array<string, mixed> The created consent record
+     * @return array<string, mixed> The created or idempotently-updated consent
+     *                              record, including the `wasUpdated` discriminator
      *
+     * @throws \OCA\DocuDesk\Exception\PolicyRejectedException Propagated unwrapped when a
+     *                                                         publication-prohibition rule matches; the
+     *                                                         controller maps it to HTTP 403.
      * @throws Exception If creation fails
      *
      * @spec openspec/specs/consent-management/spec.md

--- a/lib/Service/ConsentRecordWriter.php
+++ b/lib/Service/ConsentRecordWriter.php
@@ -348,8 +348,12 @@ class ConsentRecordWriter
     /**
      * Create a brand-new consent record.
      *
-     * Sets notificationStatus=pending and computes objectionDeadline.
-     * No email or postal notification is dispatched (CONS-049).
+     * On the WOO fall-through path (no policy match) the record is created with
+     * notificationStatus=pending and a computed objectionDeadline. No email or
+     * postal notification is dispatched (CONS-049).
+     *
+     * On a standing-consent match the record is instead pre-empted — see
+     * {@see buildNewConsentPayload()} — and carries no objection deadline.
      *
      * The `$context` array carries the caller's inputs plus the resolved
      * policy discriminators:
@@ -401,9 +405,33 @@ class ConsentRecordWriter
     /**
      * Assemble the payload for a brand-new consent record.
      *
+     * Two mutually exclusive outcomes, both mandated by the canonical specs:
+     *
+     * - **No policy match** — the WOO objection workflow runs:
+     *   `consentStatus/publicationDecision/notificationStatus: "pending"` plus a
+     *   computed `objectionDeadline` (`entity-publication-policies`, scenario
+     *   "No policy match falls through to WOO workflow").
+     * - **Standing-consent match** — the record is policy-pre-empted:
+     *   `consentStatus: "consent_given"`, `publicationDecision:
+     *   "publish_with_consent"`, `notificationStatus: "skipped"` and NO
+     *   objection deadline (`consent-management`, scenario "Standing-consent
+     *   match resolves to existing 'consent_given' status"; and
+     *   `entity-publication-policies`, scenario "Standing consent match
+     *   short-circuits when no prohibition match").
+     *
+     * The pre-empted branch was previously unimplemented: every new record got
+     * the `pending` triple, so a matched standing consent silently started the
+     * WOO objection clock it is supposed to short-circuit. A prohibition match
+     * never reaches here — it aborts in `ConsentService` with a
+     * `PolicyRejectedException` — so `standingConsentUuid` is the only match
+     * kind this method has to resolve.
+     *
      * @param array<string, mixed> $context The consent-request context.
      *
      * @return array<string, mixed> The payload to persist.
+     *
+     * @spec openspec/specs/consent-management/spec.md
+     * @spec openspec/specs/entity-publication-policies/spec.md
      */
     private function buildNewConsentPayload(array $context): array
     {
@@ -434,6 +462,11 @@ class ConsentRecordWriter
             'objectionDeadline'   => $deadline->format(format: 'c'),
         ];
 
+        $consentData = $this->withStandingConsentPreEmption(
+            consentData: $consentData,
+            context: $context
+        );
+
         $entityKey = $context['entityKey'];
         if ($entityKey !== null && $entityKey !== '') {
             $consentData['entityKey'] = $entityKey;
@@ -455,19 +488,54 @@ class ConsentRecordWriter
             $consentData['contactAddress'] = $context['contactAddress'];
         }
 
-        if ($context['standingConsentUuid'] !== null) {
-            $consentData['policyMatch'] = $context['standingConsentUuid'];
-            // Persist the match discriminator so the standing-consent
-            // carve-out in ConsentUpdateHandler::guardPolicyPreemptedTransition
-            // can fire (PR #147 Thread B regression: the carve-out keyed on
-            // `matchKind`, which was never persisted here, so the operator
-            // override on publicationDecision was 400-locked).
-            $consentData['matchKind'] = (string) $context['policyMatchKind'];
-        }
-
         return $consentData;
 
     }//end buildNewConsentPayload()
+
+    /**
+     * Apply standing-consent pre-emption to a new-record payload.
+     *
+     * A standing consent short-circuits the WOO objection workflow: the record
+     * is born in its terminal state and carries no objection deadline. Both
+     * canonical specs state the same triple —
+     * `consentStatus: "consent_given"`, `publicationDecision:
+     * "publish_with_consent"`, `notificationStatus: "skipped"`, with
+     * `objectionDeadline: null` and `policyMatch` referencing the rule.
+     *
+     * No-op when the entity matched no standing consent, in which case the
+     * caller's WOO defaults (`pending` + computed deadline) stand.
+     *
+     * @param array<string, mixed> $consentData The payload assembled so far.
+     * @param array<string, mixed> $context     The consent-request context.
+     *
+     * @return array<string, mixed> The payload, pre-empted where applicable.
+     *
+     * @spec openspec/specs/consent-management/spec.md
+     * @spec openspec/specs/entity-publication-policies/spec.md
+     */
+    private function withStandingConsentPreEmption(array $consentData, array $context): array
+    {
+        if ($context['standingConsentUuid'] === null) {
+            return $consentData;
+        }
+
+        $consentData['consentStatus']       = 'consent_given';
+        $consentData['publicationDecision'] = 'publish_with_consent';
+        $consentData['notificationStatus']  = 'skipped';
+        unset($consentData['objectionDeadline']);
+
+        $consentData['policyMatch'] = $context['standingConsentUuid'];
+
+        // Persist the match discriminator so the standing-consent carve-out in
+        // ConsentUpdateHandler::guardPolicyPreemptedTransition can fire (PR #147
+        // Thread B regression: the carve-out keyed on `matchKind`, which was
+        // never persisted here, so the operator override on publicationDecision
+        // was 400-locked).
+        $consentData['matchKind'] = (string) $context['policyMatchKind'];
+
+        return $consentData;
+
+    }//end withStandingConsentPreEmption()
 
     /**
      * Get the ObjectService from OpenRegister.

--- a/lib/Service/PolicyCrudService.php
+++ b/lib/Service/PolicyCrudService.php
@@ -269,7 +269,7 @@ class PolicyCrudService
 
         $objectService = $this->settingsService->getObjectService();
         $objectService->deleteObject(
-            id: $uuid,
+            uuid: $uuid,
             register: self::REGISTER,
             schema: self::SCHEMA_PROHIBITION,
             _rbac: false,
@@ -361,7 +361,7 @@ class PolicyCrudService
 
         $objectService = $this->settingsService->getObjectService();
         $objectService->deleteObject(
-            id: $uuid,
+            uuid: $uuid,
             register: self::REGISTER,
             schema: self::SCHEMA_CONSENT,
             _rbac: false,

--- a/lib/Service/PolicyCrudService.php
+++ b/lib/Service/PolicyCrudService.php
@@ -257,11 +257,28 @@ class PolicyCrudService
     /**
      * Delete a prohibition record.
      *
+     * NOTE: this can never succeed while `publicationProhibition` declares
+     * `x-openregister-archival` (see `lib/Settings/docudesk_register.json`).
+     * OpenRegister's `ObjectService::deleteObject()` refuses every user-driven
+     * delete on an archival schema and throws
+     * `OCA\OpenRegister\Exception\ArchivalImmutableException`; rows are removed
+     * only by `OCA\OpenRegister\Cron\ArchivalRetentionTask` once their
+     * retention lapses. `PolicyController::deleteProhibition()` translates that
+     * refusal into HTTP 409 Conflict instead of letting it surface as a 500.
+     *
+     * In practice this method therefore always throws: an
+     * `ArchivalImmutableException` while the annotation is present, or another
+     * `Exception` on an unrelated failure. It is kept (rather than removed)
+     * because the annotation is a policy declaration that may be lifted, and
+     * because the endpoint must keep answering a specific, documented status.
+     *
      * @param string $uuid The record UUID.
      *
      * @return void
      *
-     * @throws Exception On deletion failure.
+     * @throws Exception On deletion failure, including OpenRegister's
+     *                   ArchivalImmutableException (not type-hinted here: the class is
+     *                   absent during static analysis, OpenRegister is a runtime sibling).
      */
     public function deleteProhibition(string $uuid): void
     {

--- a/lib/Service/PolicyCrudService.php
+++ b/lib/Service/PolicyCrudService.php
@@ -279,6 +279,8 @@ class PolicyCrudService
      * @throws Exception On deletion failure, including OpenRegister's
      *                   ArchivalImmutableException (not type-hinted here: the class is
      *                   absent during static analysis, OpenRegister is a runtime sibling).
+     *
+     * @spec openspec/specs/entity-publication-policies/spec.md
      */
     public function deleteProhibition(string $uuid): void
     {
@@ -361,11 +363,18 @@ class PolicyCrudService
     /**
      * Delete a standing consent.
      *
+     * Unlike {@see deleteProhibition()} this really can succeed: the
+     * `publicationConsent` schema declares NO `x-openregister-archival` in
+     * `lib/Settings/docudesk_register.json`, so OpenRegister's archival gate
+     * does not apply to it.
+     *
      * @param string $uuid The record UUID.
      *
      * @return void
      *
      * @throws Exception On deletion failure.
+     *
+     * @spec openspec/specs/entity-publication-policies/spec.md
      */
     public function deleteStandingConsent(string $uuid): void
     {

--- a/lib/Service/PolicyRuleNormaliser.php
+++ b/lib/Service/PolicyRuleNormaliser.php
@@ -89,10 +89,65 @@ class PolicyRuleNormaliser
             'matchRules'  => $this->wellFormedRules(matchRules: $matchRules),
             'validFrom'   => $window['from'],
             'validUntil'  => $window['until'],
-            'primaryName' => (string) ($object['primaryName'] ?? $object['entityText'] ?? ''),
+            'primaryName' => $this->flattenTranslatable(
+                value: ($object['primaryName'] ?? $object['entityText'] ?? '')
+            ),
         ];
 
     }//end normaliseRule()
+
+    /**
+     * Reduce a possibly language-keyed value to a single display string.
+     *
+     * `publicationProhibition.primaryName` is declared `translatable: true` in
+     * `lib/Settings/docudesk_register.json`, and OpenRegister wraps a
+     * translatable scalar under its default language on save
+     * (`SaveObject::…` — "Normalize translatable properties (wrap simple values
+     * under default language)"). So the stored value is `{"en": "…"}`, not a
+     * bare string.
+     *
+     * The HTTP read path never showed this, because DocuDesk registers OR's
+     * TranslationHandler and it resolves the map before the response is built.
+     * PolicyMatchService does NOT go through that path — it calls
+     * `searchObjectsBySlug()` directly — so the raw map reached a `(string)`
+     * cast here and every consumer received the literal string "Array":
+     * the prohibition rejection's `ruleName`, and the `ruleName` that
+     * `anonymisation-prohibition-gate` REQUIRES on the anonymise gate's 422
+     * body ("the prohibition rule's `primaryName`, included to help the
+     * operator understand WHY the entity is required to be anonymised").
+     *
+     * Fallback chain matches TemplateLanguageService::resolveFieldValue():
+     * nl → en → first available. That service is not reused here because it
+     * resolves the *user's* preferred language, and the matcher also runs in
+     * system contexts (cron, event listeners) where there is no user.
+     *
+     * @param mixed $value Raw value: a string, a language-keyed map, or null.
+     *
+     * @return string The display string, or '' when nothing usable is present.
+     *
+     * @spec openspec/specs/entity-publication-policies/spec.md
+     */
+    private function flattenTranslatable(mixed $value): string
+    {
+        if (is_array($value) === false) {
+            return (string) $value;
+        }
+
+        foreach (['nl', 'en'] as $language) {
+            if (isset($value[$language]) === true && is_scalar($value[$language]) === true) {
+                return (string) $value[$language];
+            }
+        }
+
+        foreach ($value as $candidate) {
+            if (is_scalar($candidate) === true && (string) $candidate !== '') {
+                return (string) $candidate;
+            }
+        }
+
+        return '';
+
+    }//end flattenTranslatable()
 
     /**
      * Resolve the row's validity window, or null when it is currently closed.

--- a/psalm.xml
+++ b/psalm.xml
@@ -89,6 +89,14 @@
                 <referencedClass name="OCA\OpenRegister\Mcp\IMcpToolProvider"/>
                 <referencedClass name="OCA\OpenRegister\Db\EntityRelationMapper"/>
                 <referencedClass name="OCA\OpenRegister\Service\RiskLevelService"/>
+                <!--
+                  Thrown by OpenRegister's ObjectService::deleteObject() for any
+                  user-driven delete on a schema declaring x-openregister-archival.
+                  PolicyController catches it to answer HTTP 409 instead of leaking a
+                  500; the real class lives in
+                  openregister/lib/Exception/ArchivalImmutableException.php.
+                -->
+                <referencedClass name="OCA\OpenRegister\Exception\ArchivalImmutableException"/>
                 <!-- OpenRegister DB types used in signing/approval events -->
                 <referencedClass name="OCA\OpenRegister\Db\ApprovalChain"/>
                 <referencedClass name="OCA\OpenRegister\Db\ApprovalStep"/>

--- a/tests/e2e/ci-seed.sh
+++ b/tests/e2e/ci-seed.sh
@@ -516,6 +516,37 @@ PY
 
 echo "[ci-seed] DocuDesk registers, schemas and object-type bindings provisioned."
 
+# ── 4a-bis. Policy RBAC groups ─────────────────────────────────────────────
+# The policy surface is group-gated, not admin-gated:
+#   PolicyCrudService::POLICY_GROUP           = docudesk-policy-admins
+#   PolicyCrudService::STANDING_CONSENT_GROUP = docudesk-standing-consent-admins
+# and docudesk_register.json grants create/update/delete on
+# publicationProhibition to `docudesk-policy-admins`. Neither group exists on a
+# fresh install and nothing creates them, so every prohibition / standing-consent
+# WRITE answered 403 — including from `admin`, because these are group
+# memberships and not the admin flag.
+#
+# The Newman collection papered over exactly this: its seeding requests carried
+# `if (pm.response.code === 403 ...) { pm.test.skip(...); return; }`, which turns
+# a 403 into a NON-FAILING result and then skips the outcome assertions that
+# depended on the seed. The whole "Detection-time outcomes" folder could report
+# green having exercised nothing. Creating the groups here is what makes those
+# assertions able to run — and able to fail.
+for _dd_group in docudesk-policy-admins docudesk-standing-consent-admins; do
+	php "${NC_ROOT}/occ" group:add "${_dd_group}" 2>&1 | tail -1 || true
+	php "${NC_ROOT}/occ" group:adduser "${_dd_group}" "${USER_NAME}" 2>&1 | tail -1 || true
+done
+
+# Fail loudly if the memberships did not take: a silent 403 later reads like an
+# authorization bug in the app rather than an unseeded fixture.
+_dd_groups_actual=$(php "${NC_ROOT}/occ" user:info "${USER_NAME}" --output=json 2>/dev/null || echo '{}')
+for _dd_group in docudesk-policy-admins docudesk-standing-consent-admins; do
+	case "${_dd_groups_actual}" in
+		*"${_dd_group}"*) echo "[ci-seed] ${USER_NAME} is in ${_dd_group}." ;;
+		*) echo "::error::${USER_NAME} is NOT in ${_dd_group} — every policy write will 403."; exit 1 ;;
+	esac
+done
+
 # ── 4b. Materialise the admin user's home, then probe WebDAV ────────────────
 # `occ maintenance:install` creates the admin ACCOUNT but not its files home —
 # that is built lazily, the first time something initialises the user's mount

--- a/tests/e2e/ci-seed.sh
+++ b/tests/e2e/ci-seed.sh
@@ -517,14 +517,25 @@ PY
 echo "[ci-seed] DocuDesk registers, schemas and object-type bindings provisioned."
 
 # ── 4a-bis. Policy RBAC groups ─────────────────────────────────────────────
-# The policy surface is group-gated, not admin-gated:
-#   PolicyCrudService::POLICY_GROUP           = docudesk-policy-admins
+# The policy surface is group-gated, not admin-gated, and THREE group names are
+# in play across two enforcement layers:
+#
+#   PolicyCrudService::PROHIBITION_GROUP      = docudesk-prohibition-admins
 #   PolicyCrudService::STANDING_CONSENT_GROUP = docudesk-standing-consent-admins
-# and docudesk_register.json grants create/update/delete on
-# publicationProhibition to `docudesk-policy-admins`. Neither group exists on a
-# fresh install and nothing creates them, so every prohibition / standing-consent
-# WRITE answered 403 — including from `admin`, because these are group
-# memberships and not the admin flag.
+#   docudesk_register.json RBAC on publicationProhibition
+#                          (create/update/delete) = docudesk-policy-admins
+#
+# ⚠️ The first and third DISAGREE, and they gate the same operation at two
+# different layers. A member of `docudesk-policy-admins` clears OpenRegister's
+# schema RBAC and is then rejected by the service check; a member of
+# `docudesk-prohibition-admins` clears the service check and is then rejected by
+# OpenRegister. So NO non-admin group can write a prohibition today — only the
+# admin flag can, via the short-circuit in assertProhibitionPermission(). Which
+# name is canonical is a product decision, so this script seeds all three rather
+# than silently picking one; the mismatch is reported separately.
+#
+# None of these groups exists on a fresh install and nothing creates them, so
+# every prohibition / standing-consent WRITE by a non-admin answered 403.
 #
 # The Newman collection papered over exactly this: its seeding requests carried
 # `if (pm.response.code === 403 ...) { pm.test.skip(...); return; }`, which turns
@@ -532,7 +543,7 @@ echo "[ci-seed] DocuDesk registers, schemas and object-type bindings provisioned
 # depended on the seed. The whole "Detection-time outcomes" folder could report
 # green having exercised nothing. Creating the groups here is what makes those
 # assertions able to run — and able to fail.
-for _dd_group in docudesk-policy-admins docudesk-standing-consent-admins; do
+for _dd_group in docudesk-policy-admins docudesk-prohibition-admins docudesk-standing-consent-admins; do
 	php "${NC_ROOT}/occ" group:add "${_dd_group}" 2>&1 | tail -1 || true
 	php "${NC_ROOT}/occ" group:adduser "${_dd_group}" "${USER_NAME}" 2>&1 | tail -1 || true
 done
@@ -540,7 +551,7 @@ done
 # Fail loudly if the memberships did not take: a silent 403 later reads like an
 # authorization bug in the app rather than an unseeded fixture.
 _dd_groups_actual=$(php "${NC_ROOT}/occ" user:info "${USER_NAME}" --output=json 2>/dev/null || echo '{}')
-for _dd_group in docudesk-policy-admins docudesk-standing-consent-admins; do
+for _dd_group in docudesk-policy-admins docudesk-prohibition-admins docudesk-standing-consent-admins; do
 	case "${_dd_groups_actual}" in
 		*"${_dd_group}"*) echo "[ci-seed] ${USER_NAME} is in ${_dd_group}." ;;
 		*) echo "::error::${USER_NAME} is NOT in ${_dd_group} — every policy write will 403."; exit 1 ;;

--- a/tests/integration/docudesk-api-negative.postman_collection.json
+++ b/tests/integration/docudesk-api-negative.postman_collection.json
@@ -8,13 +8,39 @@
   "variable": [
     {
       "key": "baseUrl",
-      "value": "{{baseUrl}}",
-      "description": "Nextcloud base URL — set via environment (never hardcode)"
+      "value": "http://localhost:8080/index.php",
+      "description": "Nextcloud entry point. This was literally \"{{baseUrl}}\" — a variable whose value referenced itself, so it never resolved and every request in this collection went to an unusable URL. The CI runner supplies `base_url` (snake_case), which never fed this key, so nothing corrected it at run time either."
     },
     {
-      "key": "authToken",
-      "value": "{{authToken}}",
-      "description": "Bearer token or Basic auth — set via environment"
+      "key": "username",
+      "value": "admin",
+      "description": "Matches the `admin_user` the CI Newman step provisions."
+    },
+    {
+      "key": "password",
+      "value": "admin",
+      "description": "Matches the `admin_password` the CI Newman step provisions."
+    }
+  ],
+  "auth": {
+    "type": "basic",
+    "basic": [
+      { "key": "username", "value": "{{username}}", "type": "string" },
+      { "key": "password", "value": "{{password}}", "type": "string" }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Nextcloud rejects state-changing requests without this header with 412,",
+          "// before any controller runs. `upsert` is case-insensitive on the key, so",
+          "// requests that already declare OCS-APIREQUEST are left alone.",
+          "pm.request.headers.upsert({ key: 'OCS-APIRequest', value: 'true' });"
+        ]
+      }
     }
   ],
   "item": [
@@ -26,7 +52,6 @@
           "request": {
             "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{authToken}}" },
               { "key": "OCS-APIREQUEST", "value": "true" }
             ],
             "url": {
@@ -60,7 +85,6 @@
           "request": {
             "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{authToken}}" },
               { "key": "OCS-APIREQUEST", "value": "true" }
             ],
             "url": {
@@ -87,6 +111,7 @@
         {
           "name": "GET /api/templates - 401 without auth",
           "request": {
+            "auth": { "type": "noauth" },
             "method": "GET",
             "header": [],
             "url": {
@@ -153,6 +178,7 @@
         {
           "name": "GET /api/preferences/:key - 401 without auth",
           "request": {
+            "auth": { "type": "noauth" },
             "method": "GET",
             "header": [],
             "url": {
@@ -180,7 +206,6 @@
           "request": {
             "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{authToken}}" },
               { "key": "OCS-APIREQUEST", "value": "true" }
             ],
             "url": {
@@ -209,17 +234,16 @@
       "name": "Anonymization Batch",
       "item": [
         {
-          "name": "GET /api/anonymization/batch/:id - 404 for unknown batch",
+          "name": "GET /api/anonymization/batch/:id/status - 404 for unknown batch",
           "request": {
             "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{authToken}}" },
               { "key": "OCS-APIREQUEST", "value": "true" }
             ],
             "url": {
-              "raw": "{{baseUrl}}/apps/docudesk/api/anonymization/batch/non-existent-batch-id",
+              "raw": "{{baseUrl}}/apps/docudesk/api/anonymization/batch/non-existent-batch-id/status",
               "host": ["{{baseUrl}}"],
-              "path": ["apps", "docudesk", "api", "anonymization", "batch", "non-existent-batch-id"]
+              "path": ["apps", "docudesk", "api", "anonymization", "batch", "non-existent-batch-id", "status"]
             }
           },
           "event": [
@@ -227,7 +251,18 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('Status is 404', () => pm.response.to.have.status(404));"
+                  "// This targeted `api/anonymization/batch/{id}`, which is not a route:",
+                  "// appinfo/routes.php only registers batch/{batchId}/status, /extract,",
+                  "// /entities, /anonymize and /report. An unrouted GET falls through to",
+                  "// Nextcloud's SPA shell — 200 with HTML — so the assertion below could",
+                  "// only ever have failed, and a status-only assertion could never have",
+                  "// told the two cases apart. batchStatus() is the method that really",
+                  "// answers 404 ('Batch not found') for an unknown id.",
+                  "pm.test('Status is 404', () => pm.response.to.have.status(404));",
+                  "pm.test('404 is a JSON error, not the SPA HTML fallback', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type') || '').to.include('application/json');",
+                  "    pm.expect(pm.response.json()).to.have.property('error');",
+                  "});"
                 ],
                 "type": "text/javascript"
               }
@@ -244,7 +279,6 @@
           "request": {
             "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{authToken}}" },
               { "key": "OCS-APIREQUEST", "value": "true" }
             ],
             "url": {

--- a/tests/integration/docudesk-api-negative.postman_collection.json
+++ b/tests/integration/docudesk-api-negative.postman_collection.json
@@ -20,6 +20,11 @@
       "key": "password",
       "value": "admin",
       "description": "Matches the `admin_password` the CI Newman step provisions."
+    },
+    {
+      "key": "noAuthBase",
+      "value": "http://127.0.0.1:8080/index.php",
+      "description": "A DIFFERENT host alias for the same server, used only by the deliberate 401 tests. Newman keeps one cookie jar for the whole run, and Nextcloud's session cookie is host-scoped — so an unauthenticated request sent to the SAME host as the authenticated ones still carries the session and answers 200. Measured 2026-08-09: both 401 tests failed with 'expected [401, 302] to include 200' for exactly this reason, which reads like an authorization hole and is not one. Same technique as docudesk.postman_collection.json."
     }
   ],
   "auth": {
@@ -115,8 +120,8 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/apps/docudesk/api/templates",
-              "host": ["{{baseUrl}}"],
+              "raw": "{{noAuthBase}}/apps/docudesk/api/templates",
+              "host": ["{{noAuthBase}}"],
               "path": ["apps", "docudesk", "api", "templates"]
             }
           },
@@ -182,8 +187,8 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/apps/docudesk/api/preferences/test-key",
-              "host": ["{{baseUrl}}"],
+              "raw": "{{noAuthBase}}/apps/docudesk/api/preferences/test-key",
+              "host": ["{{noAuthBase}}"],
               "path": ["apps", "docudesk", "api", "preferences", "test-key"]
             }
           },

--- a/tests/integration/docudesk-api.postman_collection.json
+++ b/tests/integration/docudesk-api.postman_collection.json
@@ -1085,9 +1085,26 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
+                  "// CORRECTED ASSERTION. This step used to require 'Seed prohibitions",
+                  "// present' (length >= 1). The premise was false: tests/e2e/ci-seed.sh",
+                  "// creates the three docudesk-*-admins groups but seeds NO",
+                  "// publicationProhibition rows, and this request runs before the",
+                  "// create below, so on a fresh CI instance the honest answer is an",
+                  "// empty list. The old assertion could only ever pass on a dirty",
+                  "// instance — and publicationProhibition is archival-immutable, so",
+                  "// 'dirty' meant leftovers from an earlier run. It is replaced by the",
+                  "// 'listed after create' step further down, which asserts the real",
+                  "// invariant (a created prohibition appears in the list) instead of",
+                  "// asserting the fixture setup of a different script.",
                   "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
                   "pm.test('Response is JSON array', function () { var json = pm.response.json(); pm.expect(json).to.be.an('array'); });",
-                  "pm.test('Seed prohibitions present', function () { var json = pm.response.json(); pm.expect(json.length).to.be.at.least(1); });"
+                  "pm.test('Every listed prohibition carries an identifier', function () {",
+                  "    var json = pm.response.json();",
+                  "    json.forEach(function (row) {",
+                  "        pm.expect((row['@self'] && row['@self'].id) || row.id || row.uuid).to.be.a('string');",
+                  "    });",
+                  "});",
+                  "pm.collectionVariables.set('prohibitionCountBeforeCreate', String(pm.response.json().length));"
                 ]
               }
             }
@@ -1121,6 +1138,37 @@
           ]
         },
         {
+          "name": "GET /api/policy/prohibitions (created record is listed)",
+          "request": {
+            "method": "GET",
+            "url": { "raw": "{{baseUrl}}/api/policy/prohibitions", "host": ["{{baseUrl}}"], "path": ["api", "policy", "prohibitions"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Replaces the false-premise 'Seed prohibitions present' check above.",
+                  "// This one is real: it asserts the list grew by the record THIS run",
+                  "// created, so it fails if the index endpoint stops returning writes.",
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "var json = pm.response.json();",
+                  "pm.test('List grew by exactly the record this run created', function () {",
+                  "    var before = parseInt(pm.collectionVariables.get('prohibitionCountBeforeCreate'), 10);",
+                  "    pm.expect(json.length).to.equal(before + 1);",
+                  "});",
+                  "pm.test('The created prohibition is listed', function () {",
+                  "    var wanted = pm.collectionVariables.get('createdProhibitionId');",
+                  "    var ids = json.map(function (row) { return (row['@self'] && row['@self'].id) || row.id || row.uuid; });",
+                  "    pm.expect(ids).to.include(wanted);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
           "name": "GET /api/policy/prohibitions/{id}",
           "request": {
             "method": "GET",
@@ -1140,7 +1188,7 @@
           ]
         },
         {
-          "name": "DELETE /api/policy/prohibitions/{id}",
+          "name": "DELETE /api/policy/prohibitions/{id} (409 — archival retention)",
           "request": {
             "method": "DELETE",
             "url": { "raw": "{{baseUrl}}/api/policy/prohibitions/{{createdProhibitionId}}", "host": ["{{baseUrl}}"], "path": ["api", "policy", "prohibitions", "{{createdProhibitionId}}"] }
@@ -1151,7 +1199,47 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+                  "// CORRECTED ASSERTION. This step used to expect 200. That outcome is",
+                  "// unreachable BY DESIGN: publicationProhibition declares",
+                  "// x-openregister-archival (retention P10Y) in",
+                  "// lib/Settings/docudesk_register.json, and OpenRegister refuses every",
+                  "// user-driven delete on an archival schema",
+                  "// (ArchivalImmutableException; rows expire only via",
+                  "// OCA\\OpenRegister\\Cron\\ArchivalRetentionTask). Prohibitions are",
+                  "// court-order-backed and must survive for audit and appeal, so the",
+                  "// annotation stays. The endpoint was leaking that refusal as an",
+                  "// opaque 500; PolicyController now answers 409 Conflict naming",
+                  "// retention. 500 is deliberately NOT accepted here — that would",
+                  "// enshrine the bug this assertion caught.",
+                  "pm.test('Status code is 409 (retention conflict)', function () { pm.response.to.have.status(409); });",
+                  "var json = pm.response.json();",
+                  "pm.test('Body carries the archival discriminator', function () { pm.expect(json.error).to.equal('SCHEMA_ARCHIVAL_IMMUTABLE'); });",
+                  "pm.test('Body names the schema and the blocked operation', function () {",
+                  "    pm.expect(json.schema).to.equal('publicationProhibition');",
+                  "    pm.expect(json.operation).to.equal('delete');",
+                  "});",
+                  "pm.test('Body explains retention as the reason', function () { pm.expect((json.message || '').toLowerCase()).to.include('retention'); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /api/policy/prohibitions/{id} (still present after the refused delete)",
+          "request": {
+            "method": "GET",
+            "url": { "raw": "{{baseUrl}}/api/policy/prohibitions/{{createdProhibitionId}}", "host": ["{{baseUrl}}"], "path": ["api", "policy", "prohibitions", "{{createdProhibitionId}}"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// A 409 must mean the record survived. Without this step a controller",
+                  "// that deleted the row AND THEN answered 409 would look identical.",
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('The record is still readable', function () { var json = pm.response.json(); pm.expect(json.primaryName).to.equal('Newman Test Subject'); });"
                 ]
               }
             }
@@ -1299,7 +1387,7 @@
           ]
         },
         {
-          "name": "prohibition: POST /api/consent → prohibition wins (matchKind=prohibition)",
+          "name": "prohibition: POST /api/consent → prohibition rejects the request (403 + rule identity)",
           "request": {
             "method": "POST",
             "url": { "raw": "{{baseUrl}}/api/consents", "host": ["{{baseUrl}}"], "path": ["api", "consents"] },
@@ -1321,20 +1409,70 @@
                   "// pm.test.skip() guard removed: ci-seed.sh binds consent_register /",
                   "// consent_schema, so a 400/500 here is a real regression, not an",
                   "// unconfigured environment.",
-                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
+                  "//",
+                  "// CORRECTED ASSERTIONS. This step used to expect 201 plus a persisted",
+                  "// record with matchKind/policyMatch/consentStatus=anonymized/",
+                  "// publicationDecision=anonymize/notificationStatus=skipped. That is not",
+                  "// what this code path does. The consent-management capability states:",
+                  "// 'Requirement: Prohibition match MUST throw PolicyRejectedException ...",
+                  "// No publicationConsent record MUST be created or updated.'",
+                  "// ConsentService::createConsentRequest() implements exactly that, and",
+                  "// tests/unit/Service/ConsentServiceTest.php pins it. So no record is",
+                  "// created, nothing can be read back, and 201 was unreachable.",
+                  "// The assertions below are NOT deleted — they are moved onto the real",
+                  "// contract: the rejection, and the rule identity the exception carries.",
+                  "//",
+                  "// The 500 that this step reported before was a separate, real defect:",
+                  "// PolicyRejectedException is constructed with code 0, so ConsentController",
+                  "// mapped a deliberate business-rule rejection onto an internal server",
+                  "// error and discarded ruleUuid/ruleName. Fixed in the same commit.",
+                  "//",
+                  "// KNOWN SPEC CONFLICT (issue filed, deliberately NOT resolved here):",
+                  "// openspec/specs/entity-publication-policies/spec.md — scenario",
+                  "// 'Prohibition match short-circuits' — instead requires a record with",
+                  "// consentStatus=anonymized. Two canonical specs disagree about this one",
+                  "// path. This collection asserts the SHIPPED, unit-pinned behaviour; it",
+                  "// must be revisited when the product question is answered.",
+                  "pm.test('Status code is 403 (prohibited by policy)', function () { pm.response.to.have.status(403); });",
                   "var json = pm.response.json();",
                   "pm.test('matchKind = prohibition', function () { pm.expect(json.matchKind).to.equal('prohibition'); });",
-                  "pm.test('policyMatch = seeded UUID', function () { pm.expect(json.policyMatch).to.equal(pm.collectionVariables.get('detectionProhibitionId')); });",
-                  "pm.test('consentStatus = anonymized', function () { pm.expect(json.consentStatus).to.equal('anonymized'); });",
-                  "pm.test('publicationDecision = anonymize', function () { pm.expect(json.publicationDecision).to.equal('anonymize'); });",
-                  "pm.test('notificationStatus = skipped', function () { pm.expect(json.notificationStatus).to.equal('skipped'); });"
+                  "pm.test('ruleUuid = seeded UUID', function () { pm.expect(json.ruleUuid).to.equal(pm.collectionVariables.get('detectionProhibitionId')); });",
+                  "pm.test('ruleName identifies the matching rule', function () { pm.expect(json.ruleName).to.equal('Newman Detect Prohibition Subject'); });",
+                  "pm.test('An operator-facing error message is present', function () { pm.expect(json.error).to.be.a('string').and.not.empty; });"
                 ]
               }
             }
           ]
         },
         {
-          "name": "prohibition: CLEANUP DELETE seeded prohibition",
+          "name": "prohibition: no publicationConsent record was created",
+          "request": {
+            "method": "GET",
+            "url": { "raw": "{{baseUrl}}/api/consents/document/newman-detect-doc-prohibition", "host": ["{{baseUrl}}"], "path": ["api", "consents", "document", "newman-detect-doc-prohibition"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// The other half of the contract: 'No publicationConsent record MUST be",
+                  "// created or updated' (consent-management). Without this step a",
+                  "// controller that persisted the record AND THEN answered 403 would look",
+                  "// identical to one that rejected cleanly.",
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('No consent record exists for the prohibited document', function () {",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json).to.be.an('array');",
+                  "    pm.expect(json.length).to.equal(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "prohibition: TEARDOWN DELETE seeded prohibition (409 — retained by design)",
           "request": {
             "method": "DELETE",
             "url": { "raw": "{{baseUrl}}/api/policy/prohibitions/{{detectionProhibitionId}}", "host": ["{{baseUrl}}"], "path": ["api", "policy", "prohibitions", "{{detectionProhibitionId}}"] }
@@ -1346,12 +1484,26 @@
                 "type": "text/javascript",
                 "exec": [
                   "// Was a pm.test.skip() guard. The seed is asserted now, so there is",
-                  "// always something to clean and a failed teardown must be reported —",
-                  "// a leaked fixture makes the NEXT run's assertions lie.",
+                  "// always something to clean and a failed teardown must be reported.",
+                  "//",
+                  "// CORRECTED ASSERTION. This step used to expect [200, 204, 404] and",
+                  "// was named CLEANUP. Neither was truthful: publicationProhibition",
+                  "// declares x-openregister-archival, so OpenRegister refuses every",
+                  "// user-driven delete and this fixture CANNOT be cleaned up — it is",
+                  "// retained until ArchivalRetentionTask expires it. The step is kept",
+                  "// (not deleted) because it pins that the refusal is now an honest 409",
+                  "// rather than the 500 it used to leak, and because a future change",
+                  "// that drops the annotation must break here loudly.",
+                  "//",
+                  "// Consequence for suite design: this collection is only safe on a",
+                  "// disposable instance. Every run leaves its prohibition fixtures",
+                  "// behind, which is why the list assertions above compare against a",
+                  "// count captured in the same run instead of an absolute number.",
                   "pm.test('Seeded prohibition was available to clean up', function () {",
                   "    pm.expect(pm.collectionVariables.get('detectionProhibitionSeeded')).to.equal('true');",
                   "});",
-                  "pm.test('Cleanup deleted seeded prohibition', function () { pm.expect([200, 204, 404]).to.include(pm.response.code); });"
+                  "pm.test('Teardown refused with 409 (archival retention)', function () { pm.response.to.have.status(409); });",
+                  "pm.test('Refusal carries the archival discriminator', function () { pm.expect(pm.response.json().error).to.equal('SCHEMA_ARCHIVAL_IMMUTABLE'); });"
                 ]
               }
             }
@@ -1521,19 +1673,26 @@
                   "// pm.test.skip() guard removed: ci-seed.sh binds consent_register /",
                   "// consent_schema, so a 400/500 here is a real regression, not an",
                   "// unconfigured environment.",
-                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
+                  "//",
+                  "// CORRECTED ASSERTIONS — same reason as the prohibition-only arm above:",
+                  "// a prohibition match rejects the create outright (PolicyRejectedException),",
+                  "// so there is no record to read matchKind/consentStatus/publicationDecision",
+                  "// off. The prohibition-wins property this step exists to prove is still",
+                  "// asserted, and in fact more sharply: the rejection must name the",
+                  "// PROHIBITION rule and not the standing consent that also matched.",
+                  "pm.test('Status code is 403 (prohibited by policy)', function () { pm.response.to.have.status(403); });",
                   "var json = pm.response.json();",
                   "pm.test('matchKind = prohibition (prohibition beats standing consent)', function () { pm.expect(json.matchKind).to.equal('prohibition'); });",
-                  "pm.test('policyMatch = prohibition UUID', function () { pm.expect(json.policyMatch).to.equal(pm.collectionVariables.get('detectionConflictProhibitionId')); });",
-                  "pm.test('consentStatus = anonymized', function () { pm.expect(json.consentStatus).to.equal('anonymized'); });",
-                  "pm.test('publicationDecision = anonymize', function () { pm.expect(json.publicationDecision).to.equal('anonymize'); });"
+                  "pm.test('ruleUuid = prohibition UUID', function () { pm.expect(json.ruleUuid).to.equal(pm.collectionVariables.get('detectionConflictProhibitionId')); });",
+                  "pm.test('ruleUuid is NOT the standing-consent UUID', function () { pm.expect(json.ruleUuid).to.not.equal(pm.collectionVariables.get('detectionConflictStandingId')); });",
+                  "pm.test('ruleName identifies the prohibition rule', function () { pm.expect(json.ruleName).to.equal('Newman Detect Conflict Subject'); });"
                 ]
               }
             }
           ]
         },
         {
-          "name": "both-match: CLEANUP DELETE seeded prohibition",
+          "name": "both-match: TEARDOWN DELETE seeded prohibition (409 — retained by design)",
           "request": {
             "method": "DELETE",
             "url": { "raw": "{{baseUrl}}/api/policy/prohibitions/{{detectionConflictProhibitionId}}", "host": ["{{baseUrl}}"], "path": ["api", "policy", "prohibitions", "{{detectionConflictProhibitionId}}"] }
@@ -1544,10 +1703,14 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Conflict prohibition id was captured for cleanup', function () {",
+                  "// CORRECTED ASSERTION — see the prohibition arm's teardown above.",
+                  "// publicationProhibition is archival-immutable, so [200, 204, 404] was",
+                  "// unreachable. The refusal is asserted instead of being tolerated.",
+                  "pm.test('Conflict prohibition id was captured for teardown', function () {",
                   "    pm.expect(pm.collectionVariables.get('detectionConflictProhibitionId')).to.be.ok;",
                   "});",
-                  "pm.test('Cleanup deleted prohibition arm', function () { pm.expect([200, 204, 404]).to.include(pm.response.code); });"
+                  "pm.test('Teardown refused with 409 (archival retention)', function () { pm.response.to.have.status(409); });",
+                  "pm.test('Refusal carries the archival discriminator', function () { pm.expect(pm.response.json().error).to.equal('SCHEMA_ARCHIVAL_IMMUTABLE'); });"
                 ]
               }
             }

--- a/tests/integration/docudesk-api.postman_collection.json
+++ b/tests/integration/docudesk-api.postman_collection.json
@@ -34,6 +34,25 @@
       }
     ]
   },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Nextcloud's OCS/CSRF middleware rejects every state-changing request",
+          "// that does not carry `OCS-APIRequest: true` with HTTP 412, BEFORE the",
+          "// request ever reaches a DocuDesk controller. Not one of this",
+          "// collection's requests declared the header, so all 39 of its writes",
+          "// (34 POST + 5 DELETE) were answered 412 and no write path had ever",
+          "// been exercised. Upserting it here covers every request in the",
+          "// collection at once, and `upsert` leaves an explicit per-request",
+          "// header untouched.",
+          "pm.request.headers.upsert({ key: 'OCS-APIRequest', value: 'true' });"
+        ]
+      }
+    }
+  ],
   "item": [
     {
       "name": "Health",
@@ -481,19 +500,20 @@
           ]
         },
         {
-          "name": "POST /api/anonymization/batchAnonymize/test-clearance-batch (accepts unredactedEntities)",
+          "name": "POST /api/anonymization/batch/test-clearance-batch/anonymize (accepts unredactedEntities)",
           "request": {
             "method": "POST",
             "url": {
-              "raw": "{{baseUrl}}/api/anonymization/batchAnonymize/test-clearance-batch",
+              "raw": "{{baseUrl}}/api/anonymization/batch/test-clearance-batch/anonymize",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
                 "anonymization",
-                "batchAnonymize",
-                "test-clearance-batch"
+                "batch",
+                "test-clearance-batch",
+                "anonymize"
               ]
             },
             "header": [
@@ -829,17 +849,17 @@
       "name": "Consent",
       "item": [
         {
-          "name": "GET /api/consent",
+          "name": "GET /api/consents",
           "request": {
             "method": "GET",
             "url": {
-              "raw": "{{baseUrl}}/api/consent",
+              "raw": "{{baseUrl}}/api/consents",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
-                "consent"
+                "consents"
               ]
             }
           },
@@ -849,8 +869,24 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Status code is 200 or 400', function () { pm.expect([200, 400]).to.include(pm.response.code); });",
-                  "pm.test('Response is JSON', function () { pm.response.to.be.json; });"
+                  "// 400 was accepted here because the consent register/schema",
+                  "// bindings were never provisioned for this suite; CI now runs",
+                  "// `ci-seed.sh api`, which binds consent_register/consent_schema,",
+                  "// so ConsentController::notConfiguredResponse() can no longer",
+                  "// fire and a 400 is a real regression.",
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "// An unknown subpath under a Nextcloud app answers 200 with the",
+                  "// SPA HTML shell, so a status assertion alone proves nothing about",
+                  "// whether a controller ran. Pin the content type and the shape.",
+                  "pm.test('Response is JSON, not the SPA HTML fallback', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type') || '').to.include('application/json');",
+                  "});",
+                  "// ConsentController::index() returns JSONResponse(listConsents(...)),",
+                  "// and ConsentCrudService::listConsents() builds a PHP list — so the",
+                  "// body is a JSON ARRAY, not an envelope.",
+                  "pm.test('Body is a consent array', function () {",
+                  "    pm.expect(pm.response.json()).to.be.an('array');",
+                  "});"
                 ]
               }
             }
@@ -861,13 +897,13 @@
           "request": {
             "method": "POST",
             "url": {
-              "raw": "{{baseUrl}}/api/consent",
+              "raw": "{{baseUrl}}/api/consents",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
-                "consent"
+                "consents"
               ]
             },
             "header": [
@@ -905,13 +941,13 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/api/consent",
+              "raw": "{{baseUrl}}/api/consents",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
-                "consent"
+                "consents"
               ]
             },
             "body": {
@@ -947,13 +983,13 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/api/consent",
+              "raw": "{{baseUrl}}/api/consents",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
-                "consent"
+                "consents"
               ]
             },
             "body": {
@@ -988,13 +1024,13 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/api/consent",
+              "raw": "{{baseUrl}}/api/consents",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
-                "consent"
+                "consents"
               ]
             },
             "body": {
@@ -1187,7 +1223,7 @@
           "name": "no-match: POST /api/consent → WOO default (pending across the board)",
           "request": {
             "method": "POST",
-            "url": { "raw": "{{baseUrl}}/api/consent", "host": ["{{baseUrl}}"], "path": ["api", "consent"] },
+            "url": { "raw": "{{baseUrl}}/api/consents", "host": ["{{baseUrl}}"], "path": ["api", "consents"] },
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
@@ -1200,7 +1236,8 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.response.code === 500 || pm.response.code === 400) { pm.test.skip('Consent register/schema not configured in this env'); return; }",
+                  "// pm.test.skip() guard removed: ci-seed.sh binds consent_register /",
+                  "// consent_schema, so a 400/500 here is a real regression.",
                   "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
                   "pm.test('matchKind is null (no rule fired)', function () { pm.expect(json.matchKind).to.satisfy(function (v) { return v === null || v === undefined; }); });",
@@ -1230,7 +1267,11 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.response.code === 403 || pm.response.code === 500) { pm.collectionVariables.set('detectionProhibitionSeeded', 'false'); pm.test.skip('Seeding requires docudesk-policy-admins group; not configured in env'); return; }",
+                  "// The 403/500 guard that stood here called pm.test.skip() and",
+                  "// returned — a skipped test is NON-FAILING, so an unseeded",
+                  "// environment reported green and every outcome assertion below was",
+                  "// skipped too. ci-seed.sh now creates docudesk-policy-admins and puts",
+                  "// the admin user in it, so a 403 here is a real regression.",
                   "pm.collectionVariables.set('detectionProhibitionSeeded', 'true');",
                   "pm.test('Seed prohibition created (201)', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
@@ -1245,7 +1286,7 @@
           "name": "prohibition: POST /api/consent → prohibition wins (matchKind=prohibition)",
           "request": {
             "method": "POST",
-            "url": { "raw": "{{baseUrl}}/api/consent", "host": ["{{baseUrl}}"], "path": ["api", "consent"] },
+            "url": { "raw": "{{baseUrl}}/api/consents", "host": ["{{baseUrl}}"], "path": ["api", "consents"] },
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
@@ -1258,8 +1299,12 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.collectionVariables.get('detectionProhibitionSeeded') !== 'true') { pm.test.skip('Seed step skipped — cannot exercise outcome'); return; }",
-                  "if (pm.response.code === 500 || pm.response.code === 400) { pm.test.skip('Consent register/schema not configured'); return; }",
+                  "// Dead guard removed: the seed step now asserts its own 201 instead of",
+                  "// recording 'false', so this variable can no longer be anything but",
+                  "// 'true' — and a skipped outcome is exactly what hid the failure.",
+                  "// pm.test.skip() guard removed: ci-seed.sh binds consent_register /",
+                  "// consent_schema, so a 400/500 here is a real regression, not an",
+                  "// unconfigured environment.",
                   "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
                   "pm.test('matchKind = prohibition', function () { pm.expect(json.matchKind).to.equal('prohibition'); });",
@@ -1284,7 +1329,12 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.collectionVariables.get('detectionProhibitionSeeded') !== 'true') { pm.test.skip('No seed to clean'); return; }",
+                  "// Was a pm.test.skip() guard. The seed is asserted now, so there is",
+                  "// always something to clean and a failed teardown must be reported —",
+                  "// a leaked fixture makes the NEXT run's assertions lie.",
+                  "pm.test('Seeded prohibition was available to clean up', function () {",
+                  "    pm.expect(pm.collectionVariables.get('detectionProhibitionSeeded')).to.equal('true');",
+                  "});",
                   "pm.test('Cleanup deleted seeded prohibition', function () { pm.expect([200, 204, 404]).to.include(pm.response.code); });"
                 ]
               }
@@ -1308,7 +1358,9 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.response.code === 403 || pm.response.code === 500) { pm.collectionVariables.set('detectionStandingSeeded', 'false'); pm.test.skip('Seeding requires docudesk-standing-consent-admins group; not configured in env'); return; }",
+                  "// See the prohibition seed above: the pm.test.skip() guard that stood",
+                  "// here made an unseeded 403 non-failing. ci-seed.sh now creates",
+                  "// docudesk-standing-consent-admins and adds the admin user to it.",
                   "pm.collectionVariables.set('detectionStandingSeeded', 'true');",
                   "pm.test('Seed standing-consent created (201)', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
@@ -1323,7 +1375,7 @@
           "name": "standing-consent: POST /api/consent → consent_given + publish_with_consent",
           "request": {
             "method": "POST",
-            "url": { "raw": "{{baseUrl}}/api/consent", "host": ["{{baseUrl}}"], "path": ["api", "consent"] },
+            "url": { "raw": "{{baseUrl}}/api/consents", "host": ["{{baseUrl}}"], "path": ["api", "consents"] },
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
@@ -1336,8 +1388,10 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.collectionVariables.get('detectionStandingSeeded') !== 'true') { pm.test.skip('Seed step skipped — cannot exercise outcome'); return; }",
-                  "if (pm.response.code === 500 || pm.response.code === 400) { pm.test.skip('Consent register/schema not configured'); return; }",
+                  "// Dead guard removed — see the prohibition outcome above.",
+                  "// pm.test.skip() guard removed: ci-seed.sh binds consent_register /",
+                  "// consent_schema, so a 400/500 here is a real regression, not an",
+                  "// unconfigured environment.",
                   "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
                   "pm.test('matchKind = standing_consent', function () { pm.expect(json.matchKind).to.equal('standing_consent'); });",
@@ -1362,7 +1416,9 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.collectionVariables.get('detectionStandingSeeded') !== 'true') { pm.test.skip('No seed to clean'); return; }",
+                  "pm.test('Seeded standing consent was available to clean up', function () {",
+                  "    pm.expect(pm.collectionVariables.get('detectionStandingSeeded')).to.equal('true');",
+                  "});",
                   "pm.test('Cleanup deleted seeded standing consent', function () { pm.expect([200, 204, 404]).to.include(pm.response.code); });"
                 ]
               }
@@ -1386,7 +1442,8 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.response.code === 403 || pm.response.code === 500) { pm.collectionVariables.set('detectionConflictSeeded', 'false'); pm.test.skip('Seeding requires docudesk-policy-admins group; not configured in env'); return; }",
+                  "// pm.test.skip() guard removed — ci-seed.sh now provisions the",
+                  "// docudesk-policy-admins group, so a 403 here is a real regression.",
                   "pm.collectionVariables.set('detectionConflictSeeded', 'partial');",
                   "pm.test('Seed prohibition created (201)', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
@@ -1414,8 +1471,9 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.collectionVariables.get('detectionConflictSeeded') !== 'partial') { pm.test.skip('Prohibition seed skipped — cannot complete conflict setup'); return; }",
-                  "if (pm.response.code === 403 || pm.response.code === 500) { pm.collectionVariables.set('detectionConflictSeeded', 'false'); pm.test.skip('Standing-consent seeding requires its admin group'); return; }",
+                  "// Both pm.test.skip() guards removed — the prohibition seed above is",
+                  "// now asserted rather than optional, and ci-seed.sh provisions",
+                  "// docudesk-standing-consent-admins.",
                   "pm.collectionVariables.set('detectionConflictSeeded', 'true');",
                   "pm.test('Seed standing-consent created (201)', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
@@ -1430,7 +1488,7 @@
           "name": "both-match: POST /api/consent → prohibition wins over standing consent",
           "request": {
             "method": "POST",
-            "url": { "raw": "{{baseUrl}}/api/consent", "host": ["{{baseUrl}}"], "path": ["api", "consent"] },
+            "url": { "raw": "{{baseUrl}}/api/consents", "host": ["{{baseUrl}}"], "path": ["api", "consents"] },
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
@@ -1443,8 +1501,10 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.collectionVariables.get('detectionConflictSeeded') !== 'true') { pm.test.skip('Conflict setup incomplete — cannot exercise outcome'); return; }",
-                  "if (pm.response.code === 500 || pm.response.code === 400) { pm.test.skip('Consent register/schema not configured'); return; }",
+                  "// Dead guard removed — both conflict seeds now assert their own status.",
+                  "// pm.test.skip() guard removed: ci-seed.sh binds consent_register /",
+                  "// consent_schema, so a 400/500 here is a real regression, not an",
+                  "// unconfigured environment.",
                   "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
                   "var json = pm.response.json();",
                   "pm.test('matchKind = prohibition (prohibition beats standing consent)', function () { pm.expect(json.matchKind).to.equal('prohibition'); });",
@@ -1468,7 +1528,9 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (!pm.collectionVariables.get('detectionConflictProhibitionId')) { pm.test.skip('No prohibition seed to clean'); return; }",
+                  "pm.test('Conflict prohibition id was captured for cleanup', function () {",
+                  "    pm.expect(pm.collectionVariables.get('detectionConflictProhibitionId')).to.be.ok;",
+                  "});",
                   "pm.test('Cleanup deleted prohibition arm', function () { pm.expect([200, 204, 404]).to.include(pm.response.code); });"
                 ]
               }
@@ -1487,7 +1549,9 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (!pm.collectionVariables.get('detectionConflictStandingId')) { pm.test.skip('No standing-consent seed to clean'); return; }",
+                  "pm.test('Conflict standing-consent id was captured for cleanup', function () {",
+                  "    pm.expect(pm.collectionVariables.get('detectionConflictStandingId')).to.be.ok;",
+                  "});",
                   "pm.test('Cleanup deleted standing-consent arm', function () { pm.expect([200, 204, 404]).to.include(pm.response.code); });"
                 ]
               }
@@ -1647,8 +1711,17 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Status code is 200 or 500', function () { pm.expect([200, 500]).to.include(pm.response.code); });",
-                  "pm.test('Response is JSON', function () { pm.response.to.be.json; });"
+                  "// 500 was accepted here because template_register/template_schema",
+                  "// were never provisioned for this suite, so",
+                  "// OpenRegisterResolver::getRegisterAndSchema() threw",
+                  "// RegisterNotConfiguredException and TemplateRequestHandler mapped it",
+                  "// to 500. `ci-seed.sh api` now binds them, so a 500 is a real",
+                  "// regression and must not be an accepted outcome.",
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "// A status assertion alone passes on Nextcloud's SPA HTML fallback.",
+                  "pm.test('Response is JSON, not the SPA HTML fallback', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type') || '').to.include('application/json');",
+                  "});"
                 ]
               }
             }
@@ -1712,7 +1785,17 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "// This request is the SPA fallback trap in its purest form: ANY",
+                  "// unknown subpath under /apps/docudesk also answers 200 with the same",
+                  "// HTML shell, so 'status is 200' here was satisfied by a route that",
+                  "// need not exist. Assert that what came back is actually DocuDesk's",
+                  "// own page — the template emits the #docudesk app root that",
+                  "// src/main.js mounts onto.",
+                  "pm.test('Response is the DocuDesk SPA shell, not a generic fallback', function () {",
+                  "    pm.expect(pm.response.headers.get('Content-Type') || '').to.include('text/html');",
+                  "    pm.expect(pm.response.text()).to.include('docudesk');",
+                  "});"
                 ]
               }
             }

--- a/tests/integration/docudesk-api.postman_collection.json
+++ b/tests/integration/docudesk-api.postman_collection.json
@@ -217,7 +217,12 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Status code is 500 for non-existent file', function () { pm.response.to.have.status(500); });",
+                  "// Was `have.status(500)`. AnonymizationController::extract()",
+                  "// calls verifyFileAccess() before doing any work, and that",
+                  "// answers 404 for a file that does not exist — which is the",
+                  "// correct code. The 500 expectation encoded an older, worse",
+                  "// behaviour; asserting it would have demanded a regression.",
+                  "pm.test('Status code is 404 for non-existent file', function () { pm.response.to.have.status(404); });",
                   "pm.test('Has error field', function () { var json = pm.response.json(); pm.expect(json).to.have.property('error'); });"
                 ]
               }
@@ -297,7 +302,16 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Rejects invalid bases (non-array) with 400', function () { pm.response.to.have.status(400); });",
+                  "// This asserted 400 for a per-entity `bases` field that is not",
+                  "// part of the anonymize contract at all — AnonymizeRequestValidator",
+                  "// validates entities/appendBasisSummary/unredactedEntities/",
+                  "// acknowledgedOverrides, and the publication bases live on",
+                  "// unredactedEntities as `publicationBases`. Two SIBLING requests in",
+                  "// this same collection assert that a stray `bases` key is silently",
+                  "// ignored, so the collection demanded both behaviours at once and",
+                  "// one of the two had to be wrong. The unknown key is ignored and the",
+                  "// request proceeds to the file-access check, which 404s on 999999.",
+                  "pm.test('Unknown per-entity key is ignored; file check answers 404', function () { pm.response.to.have.status(404); });",
                   "pm.test('Has error field', function () { var json = pm.response.json(); pm.expect(json).to.have.property('error'); });"
                 ]
               }
@@ -337,7 +351,8 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Rejects invalid bases item (non-string) with 400', function () { pm.response.to.have.status(400); });",
+                  "// See the sibling non-array case: `bases` is not a validated key.",
+                  "pm.test('Unknown per-entity key is ignored; file check answers 404', function () { pm.response.to.have.status(404); });",
                   "pm.test('Has error field', function () { var json = pm.response.json(); pm.expect(json).to.have.property('error'); });"
                 ]
               }
@@ -367,10 +382,11 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "// Extract on a non-existent file returns 500, but we verify the field shape when entities are returned.",
+                  "// Extract on a non-existent file returns 404 (verifyFileAccess",
+                  "// runs first); the comment below still applies for the shape.",
                   "// For live tests, replace 999999 with a real fileId and assert prohibitionMatch is present.",
                   "pm.test('Response has error for non-existent file (expected)', function () {",
-                  "  pm.response.to.have.status(500);",
+                  "  pm.response.to.have.status(404);",
                   "});"
                 ]
               }

--- a/tests/integration/run-newman.sh
+++ b/tests/integration/run-newman.sh
@@ -29,7 +29,21 @@ if [ "${DOCUDESK_NEWMAN_LOCKED:-}" != "1" ] && command -v flock >/dev/null 2>&1;
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-COLLECTION="${SCRIPT_DIR}/docudesk.postman_collection.json"
+
+# Run EVERY collection in this directory, exactly as CI does. This named a
+# single file, so a local "newman is green" reported on one of three
+# collections while CI's flat `*.postman_collection.json` glob ran all of
+# them — a local runner that covers less than CI turns a passing local run
+# into evidence for a claim it never tested.
+COLLECTIONS=()
+while IFS= read -r _c; do
+  COLLECTIONS+=("${_c}")
+done < <(find "${SCRIPT_DIR}" -maxdepth 1 -name '*.postman_collection.json' | sort)
+
+if [ "${#COLLECTIONS[@]}" -eq 0 ]; then
+  echo "ERROR: no *.postman_collection.json found in ${SCRIPT_DIR}" >&2
+  exit 1
+fi
 
 BASE_URL="${BASE_URL:-http://localhost:8080}"
 ADMIN_USER="${ADMIN_USER:-admin}"
@@ -55,12 +69,37 @@ fi
 
 # --ignore-redirects: assert NC's 401-on-unauthenticated directly instead of
 # following a 303 to the login page (so the authz tests are honest).
-"${NEWMAN[@]}" run "${COLLECTION}" \
-  --env-var "baseUrl=${BASE_URL}" \
-  --env-var "noAuthBase=${NOAUTH_BASE}" \
-  --env-var "adminUser=${ADMIN_USER}" \
-  --env-var "adminPass=${ADMIN_PASS}" \
-  --ignore-redirects \
-  --reporters cli \
-  --color on \
-  "$@"
+FAILED=0
+for COLLECTION in "${COLLECTIONS[@]}"; do
+  echo ""
+  echo "=== Running: $(basename "${COLLECTION}") ==="
+  # `baseUrl` differs per collection: docudesk.postman_collection.json builds
+  # full /index.php/apps/docudesk/... paths from a bare origin, while the two
+  # collections moved here from tests/newman carry their own baseUrl defaults.
+  # An --env-var always overrides a collection variable, so only pass the ones
+  # a collection actually declares.
+  if [ "$(basename "${COLLECTION}")" = "docudesk.postman_collection.json" ]; then
+    "${NEWMAN[@]}" run "${COLLECTION}" \
+      --env-var "baseUrl=${BASE_URL}" \
+      --env-var "noAuthBase=${NOAUTH_BASE}" \
+      --env-var "adminUser=${ADMIN_USER}" \
+      --env-var "adminPass=${ADMIN_PASS}" \
+      --ignore-redirects \
+      --reporters cli \
+      --color on \
+      "$@" || FAILED=1
+  else
+    "${NEWMAN[@]}" run "${COLLECTION}" \
+      --env-var "username=${ADMIN_USER}" \
+      --env-var "password=${ADMIN_PASS}" \
+      --ignore-redirects \
+      --reporters cli \
+      --color on \
+      "$@" || FAILED=1
+  fi
+done
+
+if [ "${FAILED}" -ne 0 ]; then
+  echo "ERROR: one or more Newman collections failed." >&2
+  exit 1
+fi

--- a/tests/stubs/OpenRegisterStubs.php
+++ b/tests/stubs/OpenRegisterStubs.php
@@ -2099,6 +2099,71 @@ class ApprovalStepMapper
 }//end class
 
 
+namespace OCA\OpenRegister\Exception;
+
+/**
+ * Stub for ArchivalImmutableException.
+ *
+ * Mirrors the real class in `openregister/lib/Exception/`: OpenRegister's
+ * `ObjectService::deleteObject()` throws it for every user-driven delete on a
+ * schema that declares `x-openregister-archival`. DocuDesk's
+ * `publicationProhibition` schema does, so `PolicyController` must translate
+ * this into an honest client status rather than a 500.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Exception
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ */
+class ArchivalImmutableException extends \Exception
+{
+    /**
+     * The schema slug that triggered the refusal.
+     *
+     * @var string
+     */
+    private string $schemaIdentifier;
+
+    /**
+     * Construct the stub exception with the real class's signature.
+     *
+     * @param string          $schemaIdentifier The schema slug, UUID or ID.
+     * @param string          $operation        The blocked operation name.
+     * @param \Throwable|null $previous         Previous exception.
+     */
+    public function __construct(
+        string $schemaIdentifier,
+        string $operation='delete',
+        ?\Throwable $previous=null
+    ) {
+        $this->schemaIdentifier = $schemaIdentifier;
+
+        parent::__construct(
+            sprintf(
+                'SCHEMA_ARCHIVAL_IMMUTABLE: Schema "%s" declares x-openregister-archival; '
+                .'user-driven %s operations are not permitted. Rows expire automatically '
+                .'via the ArchivalRetentionTask cron.',
+                $schemaIdentifier,
+                $operation
+            ),
+            403,
+            $previous
+        );
+    }//end __construct()
+
+    /**
+     * Get the schema identifier that triggered this exception.
+     *
+     * @return string
+     */
+    public function getSchemaIdentifier(): string
+    {
+        return $this->schemaIdentifier;
+    }//end getSchemaIdentifier()
+}//end class
+
+
 namespace OCA\OpenRegister\Event;
 
 use OCA\OpenRegister\Db\ApprovalChain;

--- a/tests/unit/Controller/ConsentControllerTest.php
+++ b/tests/unit/Controller/ConsentControllerTest.php
@@ -21,6 +21,7 @@
 namespace OCA\DocuDesk\Tests\Unit\Controller;
 
 use OCA\DocuDesk\Controller\ConsentController;
+use OCA\DocuDesk\Exception\PolicyRejectedException;
 use OCA\DocuDesk\Service\ConsentCrudService;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IGroupManager;
@@ -172,6 +173,116 @@ class ConsentControllerTest extends TestCase
         $this->assertEquals(400, $result->getStatus());
 
     }//end testCreateReturns400WhenMissingFields()
+
+    /**
+     * A brand-new consent record answers HTTP 201.
+     *
+     * Positive control for the 200-on-update test below: without it, a
+     * controller that always answered 200 would pass that test for the wrong
+     * reason.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/consent-management/spec.md
+     */
+    public function testCreateReturns201WhenANewRecordWasCreated(): void
+    {
+        $this->mockRequest->method('getParams')->willReturn(
+            [
+                'documentId' => 'doc-1',
+                'entityType' => 'PERSON',
+                'entityText' => 'Anneke Jansen',
+            ]
+        );
+        $this->mockCrudService->method('getConsentConfig')
+            ->willReturn(['register' => 'reg-1', 'schema' => 'sch-1']);
+        $this->mockCrudService->method('createFromRequest')
+            ->willReturn(['id' => 'consent-1', 'wasUpdated' => false]);
+
+        $result = $this->controller->create();
+
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertEquals(201, $result->getStatus());
+
+    }//end testCreateReturns201WhenANewRecordWasCreated()
+
+    /**
+     * An idempotent re-submit answers HTTP 200, not 201.
+     *
+     * The service reports the branch it took through `wasUpdated`
+     * (`consent-management`: "The method's return shape MUST include a
+     * `wasUpdated` boolean"). HTTP 201 means a new resource was created
+     * (RFC 9110 §15.3.2); on the update branch nothing is created. The
+     * controller previously hardcoded 201, so the status line contradicted the
+     * `wasUpdated: true` in its own body.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/consent-management/spec.md
+     */
+    public function testCreateReturns200WhenAnExistingRecordWasUpdated(): void
+    {
+        $this->mockRequest->method('getParams')->willReturn(
+            [
+                'documentId' => 'doc-1',
+                'entityType' => 'PERSON',
+                'entityText' => 'Anneke Jansen',
+            ]
+        );
+        $this->mockCrudService->method('getConsentConfig')
+            ->willReturn(['register' => 'reg-1', 'schema' => 'sch-1']);
+        $this->mockCrudService->method('createFromRequest')
+            ->willReturn(['id' => 'consent-1', 'wasUpdated' => true]);
+
+        $result = $this->controller->create();
+
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertEquals(200, $result->getStatus());
+
+    }//end testCreateReturns200WhenAnExistingRecordWasUpdated()
+
+    /**
+     * A prohibition match answers HTTP 403 carrying the rule identity.
+     *
+     * `PolicyRejectedException` is constructed with `code = 0`, so before this
+     * fix it fell through to `errorResponse()` and was reported as HTTP 500 —
+     * a deliberate business-rule rejection presented as a server crash — while
+     * the rule UUID and name the exception exists to carry were discarded.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/consent-management/spec.md
+     */
+    public function testCreateReturns403WithRuleIdentityOnProhibitionMatch(): void
+    {
+        $this->mockRequest->method('getParams')->willReturn(
+            [
+                'documentId' => 'doc-1',
+                'entityType' => 'PERSON',
+                'entityText' => 'Beschermde Getuige A',
+            ]
+        );
+        $this->mockCrudService->method('getConsentConfig')
+            ->willReturn(['register' => 'reg-1', 'schema' => 'sch-1']);
+        $this->mockCrudService->method('createFromRequest')
+            ->willThrowException(
+                new PolicyRejectedException(
+                    ruleUuid: 'rule-uuid-99',
+                    ruleName: 'Witness Protection Rule'
+                )
+            );
+
+        $result = $this->controller->create();
+
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertEquals(403, $result->getStatus());
+
+        $body = $result->getData();
+        $this->assertSame('prohibition', $body['matchKind'] ?? null);
+        $this->assertSame('rule-uuid-99', $body['ruleUuid'] ?? null);
+        $this->assertSame('Witness Protection Rule', $body['ruleName'] ?? null);
+
+    }//end testCreateReturns403WithRuleIdentityOnProhibitionMatch()
 
     /**
      * Test show returns 404 when not found

--- a/tests/unit/Controller/PolicyControllerDeleteTest.php
+++ b/tests/unit/Controller/PolicyControllerDeleteTest.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Unit tests for PolicyController's prohibition-delete status mapping.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+namespace OCA\DocuDesk\Tests\Unit\Controller;
+
+use OCA\DocuDesk\Controller\PolicyController;
+use OCA\DocuDesk\Service\PolicyCrudService;
+use OCA\OpenRegister\Exception\ArchivalImmutableException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * `DELETE /api/policy/prohibitions/{id}` can never succeed.
+ *
+ * `publicationProhibition` declares `x-openregister-archival` (retention P10Y)
+ * in `lib/Settings/docudesk_register.json`, and OpenRegister refuses every
+ * user-driven delete on an archival schema — rows expire only via
+ * `ArchivalRetentionTask`. The endpoint therefore answered HTTP 500 for a
+ * condition that is permanent and fully known in advance, which is how the
+ * Newman suite first surfaced it (`expected [200, 204, 404] to include 500`).
+ *
+ * These tests pin the honest answer: HTTP 409 Conflict with a body that names
+ * retention, distinguishable from the 403 the permission gate raises. Verified
+ * to FAIL (500) without the `ArchivalImmutableException` catch in
+ * `PolicyController::deleteProhibition()`.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class PolicyControllerDeleteTest extends TestCase
+{
+
+    /**
+     * CRUD service double.
+     *
+     * @var PolicyCrudService|MockObject
+     */
+    private PolicyCrudService|MockObject $mockCrudService;
+
+    /**
+     * The controller under test.
+     *
+     * @var PolicyController
+     */
+    private PolicyController $controller;
+
+
+    /**
+     * Wire the controller over an authenticated session.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $mockRequest = $this->createMock(originalClassName: IRequest::class);
+        $mockLogger  = $this->createMock(originalClassName: LoggerInterface::class);
+        $mockL10n    = $this->createMock(originalClassName: IL10N::class);
+        $mockL10n->method('t')->willReturnCallback(
+            static function (string $text, array $params=[]): string {
+                return vsprintf($text, $params);
+            }
+        );
+
+        $this->mockCrudService = $this->createMock(originalClassName: PolicyCrudService::class);
+
+        $user = $this->createMock(originalClassName: IUser::class);
+        $user->method('getUID')->willReturn('admin');
+        $mockUserSession = $this->createMock(originalClassName: IUserSession::class);
+        $mockUserSession->method('getUser')->willReturn($user);
+
+        $this->controller = new PolicyController(
+            'docudesk',
+            $mockRequest,
+            $mockLogger,
+            $this->mockCrudService,
+            $mockL10n,
+            $mockUserSession
+        );
+
+    }//end setUp()
+
+
+    /**
+     * An archival-immutable refusal answers 409, not 500.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/entity-publication-policies/spec.md
+     */
+    public function testDeleteAnswers409WhenTheSchemaDeclaresArchivalRetention(): void
+    {
+        $this->mockCrudService->method('deleteProhibition')
+            ->willThrowException(
+                new ArchivalImmutableException('publicationProhibition', 'delete')
+            );
+
+        $result = $this->controller->deleteProhibition('prohibition-uuid-1');
+
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertSame(
+            expected: 409,
+            actual: $result->getStatus(),
+            message: 'A permanently impossible delete must not be reported as a server error.'
+        );
+
+        $body = $result->getData();
+        $this->assertSame('SCHEMA_ARCHIVAL_IMMUTABLE', $body['error'] ?? null);
+        $this->assertSame('publicationProhibition', $body['schema'] ?? null);
+        $this->assertSame('delete', $body['operation'] ?? null);
+        $this->assertSame('prohibition-uuid-1', $body['id'] ?? null);
+        $this->assertStringContainsString(
+            needle: 'retention',
+            haystack: strtolower((string) ($body['message'] ?? '')),
+            message: 'The 409 body must name retention as the reason.'
+        );
+
+    }//end testDeleteAnswers409WhenTheSchemaDeclaresArchivalRetention()
+
+
+    /**
+     * A genuine failure is still reported as 500.
+     *
+     * Positive control: without it, a controller that answered 409 for every
+     * exception would pass the test above for the wrong reason.
+     *
+     * @return void
+     */
+    public function testDeleteStillAnswers500OnAnUnrelatedFailure(): void
+    {
+        $this->mockCrudService->method('deleteProhibition')
+            ->willThrowException(new \RuntimeException('database is on fire'));
+
+        $result = $this->controller->deleteProhibition('prohibition-uuid-1');
+
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertSame(expected: 500, actual: $result->getStatus());
+
+    }//end testDeleteStillAnswers500OnAnUnrelatedFailure()
+}//end class

--- a/tests/unit/Service/ConsentServiceTest.php
+++ b/tests/unit/Service/ConsentServiceTest.php
@@ -568,6 +568,116 @@ class ConsentServiceTest extends TestCase
     }//end testPolicyMatchIsNotClearedOnUpdateWhenNoLongerMatching()
 
     /**
+     * A standing-consent match pre-empts the WOO workflow on a brand-new record.
+     *
+     * `consent-management` — "Standing-consent match resolves to existing
+     * 'consent_given' status" — and `entity-publication-policies` — "Standing
+     * consent match short-circuits when no prohibition match" — both require
+     * `consentStatus: consent_given`, `publicationDecision:
+     * publish_with_consent`, `notificationStatus: skipped` and NO objection
+     * deadline. Before the fix `buildNewConsentPayload()` wrote the `pending`
+     * triple plus a computed deadline for EVERY new record, so a matched
+     * standing consent started the very objection clock it must short-circuit.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/consent-management/spec.md
+     * @spec openspec/specs/entity-publication-policies/spec.md
+     */
+    public function testStandingConsentMatchPreEmptsTheWooWorkflowOnCreate(): void
+    {
+        $standingConsentResult = [
+            'uuid'        => 'standing-uuid-7',
+            'kind'        => PolicyMatchService::KIND_STANDING_CONSENT,
+            'entityType'  => 'PERSON',
+            'primaryName' => 'Burgemeester De Vries',
+        ];
+
+        // No search results => the create branch, not the idempotent update.
+        $bag             = $this->buildService(policyResult: $standingConsentResult);
+        $capturedSaveArg = &$bag['capturedSaveArg'];
+        $service         = $bag['service'];
+
+        $service->createConsentRequest(
+            documentId: 'doc-standing-1',
+            entityType: 'PERSON',
+            entityText: 'Burgemeester De Vries',
+            register: 'reg-1',
+            schema: 'sch-1'
+        );
+
+        $this->assertSame(
+            expected: 'consent_given',
+            actual: $capturedSaveArg['consentStatus'] ?? null,
+            message: 'A standing-consent match must resolve consentStatus to consent_given.'
+        );
+        $this->assertSame(
+            expected: 'publish_with_consent',
+            actual: $capturedSaveArg['publicationDecision'] ?? null,
+            message: 'A standing-consent match must resolve publicationDecision to publish_with_consent.'
+        );
+        $this->assertSame(
+            expected: 'skipped',
+            actual: $capturedSaveArg['notificationStatus'] ?? null,
+            message: 'A standing-consent match must skip the WOO notification.'
+        );
+        $this->assertArrayNotHasKey(
+            key: 'objectionDeadline',
+            array: $capturedSaveArg,
+            message: 'A pre-empted record must carry no objection deadline.'
+        );
+        $this->assertSame(
+            expected: 'standing-uuid-7',
+            actual: $capturedSaveArg['policyMatch'] ?? null,
+            message: 'policyMatch must reference the matching standing consent.'
+        );
+
+    }//end testStandingConsentMatchPreEmptsTheWooWorkflowOnCreate()
+
+    /**
+     * With no policy match at all the WOO objection workflow still runs.
+     *
+     * Positive control for the pre-emption test above: without it, a payload
+     * builder that unconditionally wrote `consent_given` would pass that test
+     * for the wrong reason.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/entity-publication-policies/spec.md
+     */
+    public function testNoPolicyMatchStillStartsTheWooWorkflowOnCreate(): void
+    {
+        $bag             = $this->buildService(policyResult: null);
+        $capturedSaveArg = &$bag['capturedSaveArg'];
+        $service         = $bag['service'];
+
+        $service->createConsentRequest(
+            documentId: 'doc-woo-1',
+            entityType: 'PERSON',
+            entityText: 'Onbekende Burger',
+            register: 'reg-1',
+            schema: 'sch-1'
+        );
+
+        $this->assertSame(
+            expected: 'pending',
+            actual: $capturedSaveArg['consentStatus'] ?? null,
+            message: 'An unmatched entity must fall through to the pending WOO workflow.'
+        );
+        $this->assertSame(
+            expected: 'pending',
+            actual: $capturedSaveArg['notificationStatus'] ?? null,
+            message: 'An unmatched entity must keep notificationStatus pending.'
+        );
+        $this->assertArrayHasKey(
+            key: 'objectionDeadline',
+            array: $capturedSaveArg,
+            message: 'An unmatched entity must receive a computed objection deadline.'
+        );
+
+    }//end testNoPolicyMatchStillStartsTheWooWorkflowOnCreate()
+
+    /**
      * Prohibition match throws PolicyRejectedException; no record is created or updated.
      *
      * @return void

--- a/tests/unit/Service/PolicyCrudServiceDeleteTest.php
+++ b/tests/unit/Service/PolicyCrudServiceDeleteTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Unit tests for PolicyCrudService deletion — the named argument passed to
+ * OpenRegister's ObjectService::deleteObject().
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+namespace OCA\DocuDesk\Tests\Unit\Service;
+
+use OCA\DocuDesk\Service\ConsentService;
+use OCA\DocuDesk\Service\PolicyCrudService;
+use OCA\DocuDesk\Service\SettingsService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * A named argument that does not exist on the callee is a RUNTIME error, not a
+ * compile-time one: PHP raises `Error: Unknown named parameter $id` only when
+ * the line actually executes. Both DocuDesk deletion paths passed `id:` to
+ * ObjectService::deleteObject(), whose parameter is `$uuid` — so every
+ * prohibition delete and every standing-consent delete answered HTTP 500.
+ *
+ * Nothing caught it. No unit test exercised these methods, and the Newman
+ * collection that would have — `tests/newman/docudesk-api.postman_collection.json`
+ * — had never been executed by CI (its directory was outside the runner's flat
+ * glob). When it was finally run on 2026-08-09 it produced 5 server-side
+ * `Unknown named parameter $id` exceptions, at PolicyCrudService.php:272 and
+ * :364, which cascaded into 19 of the 25 assertion failures in that collection.
+ *
+ * These tests execute both deletion paths against a fake ObjectService whose
+ * signature mirrors OpenRegister's (`$uuid`, not `$id`), so the wrong argument
+ * name throws exactly as it does in production. Verified to FAIL with `id:` and
+ * pass with `uuid:`.
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ * @phpstan-extends TestCase
+ */
+class PolicyCrudServiceDeleteTest extends TestCase
+{
+
+
+    /**
+     * Build a PolicyCrudService whose ObjectService records deleteObject calls.
+     *
+     * @param ObjectService $objectService Fake object service to hand back.
+     *
+     * @return PolicyCrudService
+     */
+    private function buildService(ObjectService $objectService): PolicyCrudService
+    {
+        $settings = $this->createMock(SettingsService::class);
+        $settings->method('getObjectService')->willReturn($objectService);
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+
+        // Admin short-circuits the group check in assertProhibitionPermission()
+        // before `isInGroup` is ever consulted, so only `isAdmin` is stubbed —
+        // the NextcloudStubs IGroupManager does not declare `isInGroup`.
+        $groups = $this->createMock(IGroupManager::class);
+        $groups->method('isAdmin')->willReturn(true);
+
+        return new PolicyCrudService(
+            $settings,
+            $this->createMock(ConsentService::class),
+            $groups,
+            $session,
+            $this->createMock(LoggerInterface::class)
+        );
+
+    }//end buildService()
+
+
+    /**
+     * deleteProhibition() must reach ObjectService with the uuid.
+     *
+     * A PHPUnit mock reproduces the callee's parameter NAMES, so `id:` raises
+     * the same `Error: Unknown named parameter $id` here that it raises in
+     * production — this test cannot pass while the wrong name is used.
+     *
+     * @return void
+     */
+    public function testDeleteProhibitionPassesTheUuidByItsRealParameterName(): void
+    {
+        $captured = null;
+
+        $objectService = $this->createMock(ObjectService::class);
+        $objectService->method('deleteObject')->willReturnCallback(
+            function (string $uuid='', ...$rest) use (&$captured): bool {
+                $captured = $uuid;
+                return true;
+            }
+        );
+
+        $service = $this->buildService($objectService);
+
+        $service->deleteProhibition('11111111-2222-3333-4444-555555555555');
+
+        $this->assertSame(
+            '11111111-2222-3333-4444-555555555555',
+            $captured,
+            'deleteProhibition must call ObjectService::deleteObject with the '
+            .'uuid; passing it as `id:` raises "Unknown named parameter $id" '
+            .'and answers HTTP 500.'
+        );
+
+    }//end testDeleteProhibitionPassesTheUuidByItsRealParameterName()
+
+
+}//end class

--- a/tests/unit/Service/PolicyRuleNormaliserTranslatableTest.php
+++ b/tests/unit/Service/PolicyRuleNormaliserTranslatableTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Unit tests for translatable-value flattening in PolicyRuleNormaliser.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+namespace OCA\DocuDesk\Tests\Unit\Service;
+
+use OCA\DocuDesk\Service\PolicyRuleNormaliser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `publicationProhibition.primaryName` is declared `translatable: true`, so
+ * OpenRegister stores it as a language-keyed map, not a bare string. The
+ * matcher reads rows through `searchObjectsBySlug()` — bypassing the
+ * TranslationHandler that resolves the map on the HTTP read path — so the raw
+ * map reached a `(string)` cast and every consumer got the literal "Array":
+ * the prohibition rejection's `ruleName`, and the `ruleName` that
+ * `anonymisation-prohibition-gate` requires on the anonymise gate's 422 body.
+ *
+ * Newman caught it as `expected 'Array' to equal 'Newman Detect Prohibition
+ * Subject'` once the rejection started returning the rule identity at all.
+ *
+ * Verified to FAIL ('Array') without flattenTranslatable().
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class PolicyRuleNormaliserTranslatableTest extends TestCase
+{
+
+    /**
+     * The normaliser under test.
+     *
+     * @var PolicyRuleNormaliser
+     */
+    private PolicyRuleNormaliser $normaliser;
+
+
+    /**
+     * Build the normaliser.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->normaliser = new PolicyRuleNormaliser();
+
+    }//end setUp()
+
+
+    /**
+     * Build a minimal admissible prohibition row around one primaryName value.
+     *
+     * @param mixed $primaryName The stored primaryName (string or language map).
+     *
+     * @return array<string, mixed>
+     */
+    private function row(mixed $primaryName): array
+    {
+        return [
+            'id'          => 'R-PROHIBIT-1',
+            'active'      => true,
+            'entityType'  => 'PERSON',
+            'primaryName' => $primaryName,
+            'matchRules'  => [['type' => 'exact', 'value' => 'Jansen']],
+        ];
+    }//end row()
+
+
+    /**
+     * A language-keyed primaryName is flattened to a display string.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/entity-publication-policies/spec.md
+     */
+    public function testLanguageKeyedPrimaryNameIsFlattened(): void
+    {
+        $rule = $this->normaliser->normaliseRule(
+            kind: 'prohibition',
+            object: $this->row(['en' => 'Newman Detect Prohibition Subject'])
+        );
+
+        $this->assertIsArray($rule);
+        $this->assertSame(
+            expected: 'Newman Detect Prohibition Subject',
+            actual: $rule['primaryName'],
+            message: 'A translatable primaryName must not be cast to the string "Array".'
+        );
+
+    }//end testLanguageKeyedPrimaryNameIsFlattened()
+
+
+    /**
+     * Dutch wins over English when both are stored.
+     *
+     * @return void
+     */
+    public function testDutchIsPreferredOverEnglish(): void
+    {
+        $rule = $this->normaliser->normaliseRule(
+            kind: 'prohibition',
+            object: $this->row(['en' => 'Protected witness', 'nl' => 'Beschermde getuige'])
+        );
+
+        $this->assertIsArray($rule);
+        $this->assertSame('Beschermde getuige', $rule['primaryName']);
+
+    }//end testDutchIsPreferredOverEnglish()
+
+
+    /**
+     * An unexpected locale key still yields a usable string.
+     *
+     * @return void
+     */
+    public function testAnUnknownLocaleFallsBackToTheFirstAvailableValue(): void
+    {
+        $rule = $this->normaliser->normaliseRule(
+            kind: 'prohibition',
+            object: $this->row(['de' => 'Geschützter Zeuge'])
+        );
+
+        $this->assertIsArray($rule);
+        $this->assertSame('Geschützter Zeuge', $rule['primaryName']);
+
+    }//end testAnUnknownLocaleFallsBackToTheFirstAvailableValue()
+
+
+    /**
+     * A plain string is still passed through unchanged.
+     *
+     * Positive control: without it, a flattener that always returned '' or a
+     * fixed value would pass the tests above.
+     *
+     * @return void
+     */
+    public function testAPlainStringPrimaryNameIsUnchanged(): void
+    {
+        $rule = $this->normaliser->normaliseRule(
+            kind: 'prohibition',
+            object: $this->row('Politiemedewerker undercover')
+        );
+
+        $this->assertIsArray($rule);
+        $this->assertSame('Politiemedewerker undercover', $rule['primaryName']);
+
+    }//end testAPlainStringPrimaryNameIsUnchanged()
+}//end class


### PR DESCRIPTION
Supersedes #411 (same work, rebased onto `development` and finished). #411 is closed in favour of this PR.

## What #411 established, and this PR keeps

**1. CI now runs all three Postman collections for the first time.** `tests/newman/` — 58 requests / 122 assertions — had **never executed**. The reusable workflow's `newman-collection-path` glob is flat and visits ONE directory, so a second collection directory is invisible to it. Fixed by **moving** the collections into `tests/integration`, *not* by repointing the path, which would have de-selected the suite that already ran.

**2. Zero of the 50 requests sent `OCS-APIRequest`.** All 39 writes were 412'd by Nextcloud middleware before reaching a controller. Every write assertion in that collection had been meaningless from the day it was written.

**3. Four requests carried a wrong path in the parsed `path[]` while `raw` looked correct.** Newman resolves from `path[]`, so a raw-only fix would have *looked* done and changed nothing.

Also from #411: all 16 `pm.test.skip()` guards removed. **`pm.test.skip()` is non-failing** — a skipped assertion reports green. None are reintroduced (the 9 remaining occurrences are comments explaining their removal).

## Measured outcome

`docudesk-api.postman_collection.json`, the collection CI had never run:

| | requests | assertions | **failed** |
|---|---|---|---|
| before (job 93259478764) | 50 | 113 | **19** |
| after the app + assertion fixes (job 93299573639) | 53 | 124 | **2** |
| after the `"Array"` fix (job 93300910194) | 53 | 124 | **0** |

The other two collections were and remain 33/66/**0** and 8/16/**0**. `gh pr checks`: **27 pass, 3 skipping** (`Features Extract`, `Journeydoc Capture`, `SBOM` — conditionally skipped on PRs), **0 failing**.

## Five real defects, fixed in the app

**`PolicyRejectedException` was reported as HTTP 500.** `ConsentService` throws it deliberately on a prohibition match; `consent-management` requires exactly that ("Prohibition match MUST throw `PolicyRejectedException` … No publicationConsent record MUST be created or updated"). But it is constructed with `code = 0`, `ConsentController` never caught it, and `errorResponse()` maps `code 0` → 500. A deliberate, client-visible business-rule rejection was presented as a server crash, and the `ruleUuid` / `ruleName` the class exists to carry were thrown away. → **403** with `matchKind` / `ruleUuid` / `ruleName`. Returning the rule identity is a bounded carve-out from the oracle-free rule on `errorResponse()`: `anonymisation-prohibition-gate` already mandates the identical disclosure on the anonymise gate's 422 body, and the caller supplied the matching entity text itself.

**An idempotent re-submit answered 201 while its own body said `wasUpdated: true`.** 201 means a resource was created (RFC 9110 §15.3.2); the update branch creates nothing. The lookup was working — `wasUpdated is true on re-submit` passed on the same request that failed the status assertion. → **200** on the update branch, 201 on create.

**A matched standing consent still started the WOO objection clock.** `buildNewConsentPayload()` wrote the `pending` triple plus a computed `objectionDeadline` for *every* new record. Both canonical specs require the opposite for a standing-consent match: `consent_given` / `publish_with_consent` / `skipped`, no deadline (`consent-management` "Standing-consent match resolves to existing 'consent_given' status"; `entity-publication-policies` "Standing consent match short-circuits when no prohibition match"). The pre-emption branch had never been implemented.

**`DELETE /api/policy/prohibitions/{id}` leaked a 500 for a permanent refusal.** `publicationProhibition` declares `x-openregister-archival` (P10Y, "court-order-backed; retain at least 10 years for audit + appeal"), so OpenRegister refuses every user-driven delete and throws `ArchivalImmutableException`; rows expire only via `ArchivalRetentionTask`. → **409 Conflict** naming retention, carrying OpenRegister's `SCHEMA_ARCHIVAL_IMMUTABLE` discriminator so a client can tell it apart from the permission gate's 403. The annotation stays — it is a compliance declaration. `publicationConsent` carries no such annotation, which is why standing-consent deletes were never affected.

**Every rule name the matcher produced was the literal string `"Array"`.** Found only because the 403 above started returning a rule name at all. `primaryName` is `translatable: true`, so OpenRegister stores it as a language-keyed map. The HTTP read path resolves it via `TranslationHandler` (which is why `GET /api/policy/prohibitions/{id}` always passed); `PolicyMatchService` calls `searchObjectsBySlug()` directly and bypasses that, so the raw map hit a `(string)` cast in `PolicyRuleNormaliser`. This is **pre-existing** and also corrupts `matchProhibitionHint()`'s `ruleName` — the one `anonymisation-prohibition-gate` REQUIRES on the anonymise gate's 422 body. Nothing reported it because nothing had ever read a rule name back over HTTP.

Every app fix ships a unit test **verified to fail first** (500 / 201 / `'pending'` vs `'consent_given'` / 500 / `'Array'`), plus positive controls so a blanket implementation cannot pass for the wrong reason.

## Assertion corrections

Nothing is skipped, waived, baselined or deleted. Each corrected expectation is replaced by the real contract, with the reason inline.

- **`prohibition:` and `both-match:` POST /api/consent** expected 201 + a persisted record. That create is rejected outright, so 201 was unreachable and there was never a record to read those fields off. Now assert the rejection and the rule identity — the both-match arm *more* sharply, since it also asserts the named rule is **not** the standing consent that also matched.
- **"Seed prohibitions present" (`length >= 1`)** had a false premise: `ci-seed.sh` seeds no `publicationProhibition` rows, and the request runs before the create. On a fresh instance the honest answer is an empty list; the assertion could only pass on an instance dirtied by an earlier run — and prohibitions are archival-immutable, so leftovers are permanent. Replaced by a real invariant: a new step after the create asserts the list grew by exactly one and contains this run's id.
- **The prohibition DELETEs** expected 200 / `[200,204,404]`. Impossible by design. They now assert the 409. **500 is deliberately not accepted** — that would enshrine the bug the suite caught. The teardown steps are renamed to say what they do: the fixture is *retained*, so this collection is only safe on a disposable instance.

Three new requests strengthen the suite: no consent record exists after a prohibited create (the "no record MUST be created" half of the contract), the prohibition is still readable after the refused delete (a controller that deleted *and then* answered 409 would otherwise look identical), and the created record is listed. **50 → 53 requests.**

## Known spec conflict — filed, deliberately not resolved here

Two canonical specs disagree about the prohibition-at-create path:

- `openspec/specs/consent-management/spec.md` — "Prohibition match MUST throw `PolicyRejectedException` … No publicationConsent record MUST be created or updated."
- `openspec/specs/entity-publication-policies/spec.md` — "Prohibition match short-circuits": a `publicationConsent` record **is** created, with `consentStatus: "anonymized"`, `publicationDecision: "anonymize"`, `notificationStatus: "skipped"`, `objectionDeadline: null`.

The original assertions were written against the second. The shipped code — and its unit tests — implement the first. This collection asserts the shipped behaviour and says so inline; the product question is filed separately. `matchKind: 'prohibition'` *is* a value the app persists elsewhere (`ConsentUpdateHandlerTest`), so a consent record can carry it — just not via this create path.

## Verification

- `composer check:strict` — **ALL CHECKS PASSED** (lint, phpcs, phpmd, psalm, phpstan, 1176 tests / 3544 assertions).
- Hydra gates on the merged tree: **gates 19, 25, 26 only** — the repo's known backlog, unchanged. No `.err` file was non-empty, so no checker crashed. Measured against an `origin/development` control worktree before #414 landed, this branch also took gate-25 from 26 findings to 18.
- `development` was merged in after #414 landed (force-push is blocked, so a merge rather than a rebase). #414 independently closed gates 1, 50 and 54, and its `PreferencesController` `@copyright` fix and mine auto-merged cleanly.

## Left red, with reason

`ProhibitionIndex.vue` offers a **Delete** action that can never succeed (same archival reason). Not touched here — removing a documented affordance is a product decision, and no e2e test exercises it. Worth a follow-up issue.

