### PR TITLE
test(contract): close gate-25 — 26 public endpoints get real PHPUnit wire-contract tests

### DIFF
--- a/tests/stubs/NextcloudStubs.php
+++ b/tests/stubs/NextcloudStubs.php
@@ -697,6 +697,20 @@ class TemplateResponse
     }//end getStatus()
 
     /**
+     * Get the app the template belongs to.
+     *
+     * Mirrors OCP\AppFramework\Http\TemplateResponse::getApp(), which exists on
+     * the real class; the stub omitted it, so any test asserting which app a
+     * TemplateResponse renders from could not run.
+     *
+     * @return string
+     */
+    public function getApp(): string
+    {
+        return $this->appName;
+    }//end getApp()
+
+    /**
      * Get template name.
      *
      * @return string

--- a/tests/unit/Controller/AnonymizationControllerContractTest.php
+++ b/tests/unit/Controller/AnonymizationControllerContractTest.php
@@ -1,0 +1,537 @@
+<?php
+
+/**
+ * Wire-contract tests for AnonymizationController::upload() and updateRelation()
+ *
+ * Covers `anonymization#upload` (POST api/anonymization/upload) and
+ * `anonymization#updateRelation` (PATCH api/anonymization/relations/{id}).
+ *
+ * `upload()` is asserted on the multipart contract itself: a missing file and
+ * a failed multipart transfer are 400s, a real temporary file is read from
+ * disk and handed to the listing service byte-for-byte, and an anonymous
+ * caller is refused with 401 before any write.
+ *
+ * `updateRelation()` is asserted on the prohibition-gate contract: a
+ * non-boolean `skipAnonymization` is a 400, an allowed decision is forwarded
+ * with its `force` / `bases` arguments and answered 200, a
+ * prohibition-blocked skip surfaces the service's 422 body verbatim (so the UI
+ * can show `threshold` / `prohibitionMatch`), and an anonymous caller is
+ * refused with 401 before the decision is applied.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/anonymization/spec.md
+ * @spec openspec/changes/anonymisation-prohibition-gate/tasks.md#task-6
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Controller;
+
+use OCA\DocuDesk\Controller\AnonymizationController;
+use OCA\DocuDesk\Service\AnonymizationService;
+use OCA\DocuDesk\Service\FileListingService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\IAppConfig;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Tests for the anonymization upload and relation-decision endpoints.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress                                 PropertyNotSetInConstructor
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class AnonymizationControllerContractTest extends TestCase
+{
+
+    /**
+     * Mocked request.
+     *
+     * @var IRequest|MockObject
+     */
+    private IRequest|MockObject $request;
+
+    /**
+     * Mocked anonymization service.
+     *
+     * @var AnonymizationService|MockObject
+     */
+    private AnonymizationService|MockObject $anonService;
+
+    /**
+     * Mocked file listing service.
+     *
+     * @var FileListingService|MockObject
+     */
+    private FileListingService|MockObject $fileService;
+
+    /**
+     * Mocked localisation.
+     *
+     * @var IL10N|MockObject
+     */
+    private IL10N|MockObject $l10n;
+
+    /**
+     * Controller under test, with an authenticated session.
+     *
+     * @var AnonymizationController
+     */
+    private AnonymizationController $controller;
+
+    /**
+     * Temporary files created by a test, removed in tearDown().
+     *
+     * @var string[]
+     */
+    private array $tempFiles = [];
+
+
+    /**
+     * Set up an authenticated controller.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request     = $this->createMock(IRequest::class);
+        $this->anonService = $this->createMock(AnonymizationService::class);
+        $this->fileService = $this->createMock(FileListingService::class);
+        $this->l10n        = $this->createMock(IL10N::class);
+        $this->l10n->method('t')->willReturnCallback(
+            static function (string $text, array $params=[]): string {
+                if ($params === []) {
+                    return $text;
+                }
+
+                return vsprintf($text, $params);
+            }
+        );
+
+        $this->controller = $this->buildController($this->authenticatedSession());
+
+    }//end setUp()
+
+
+    /**
+     * Remove any temporary upload files.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $path) {
+            if (is_file($path) === true) {
+                unlink($path);
+            }
+        }
+
+        $this->tempFiles = [];
+
+        parent::tearDown();
+
+    }//end tearDown()
+
+
+    /**
+     * Build the controller for a given session.
+     *
+     * @param IUserSession $session The session the controller should see.
+     *
+     * @return AnonymizationController The controller under test.
+     */
+    private function buildController(IUserSession $session): AnonymizationController
+    {
+        $folder = $this->createMock(Folder::class);
+        $folder->method('getById')->willReturn([]);
+        $rootFolder = $this->createMock(IRootFolder::class);
+        $rootFolder->method('getUserFolder')->willReturn($folder);
+
+        return new AnonymizationController(
+            appName: 'docudesk',
+            request: $this->request,
+            logger: $this->createMock(LoggerInterface::class),
+            anonymizationService: $this->anonService,
+            fileListingService: $this->fileService,
+            l10n: $this->l10n,
+            appConfig: $this->createMock(IAppConfig::class),
+            userSession: $session,
+            rootFolder: $rootFolder
+        );
+
+    }//end buildController()
+
+
+    /**
+     * Build a session with a logged-in user.
+     *
+     * @return IUserSession The authenticated session.
+     */
+    private function authenticatedSession(): IUserSession
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+
+        return $session;
+
+    }//end authenticatedSession()
+
+
+    /**
+     * Build a session with no logged-in user.
+     *
+     * @return IUserSession The anonymous session.
+     */
+    private function anonymousSession(): IUserSession
+    {
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn(null);
+
+        return $session;
+
+    }//end anonymousSession()
+
+
+    /**
+     * Create a real temporary file standing in for PHP's multipart tmp file.
+     *
+     * @param string $contents The bytes the "uploaded" file should hold.
+     *
+     * @return string The temporary file path.
+     */
+    private function makeUploadTempFile(string $contents): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'dd-upload-');
+        $this->assertIsString($path);
+        file_put_contents($path, $contents);
+        $this->tempFiles[] = $path;
+
+        return $path;
+
+    }//end makeUploadTempFile()
+
+
+    /**
+     * A well-formed multipart upload is read off disk and handed to the
+     * listing service with its original filename and exact bytes; the
+     * service's result is returned as-is with HTTP 200.
+     *
+     * @return void
+     */
+    public function testUploadStoresFileAndReturnsServiceResult(): void
+    {
+        $contents = "%PDF-1.4 fake document bytes\n";
+        $tmpPath  = $this->makeUploadTempFile($contents);
+
+        $this->request->method('getUploadedFile')->with('file')->willReturn(
+            [
+                'name'     => 'contract.pdf',
+                'type'     => 'application/pdf',
+                'tmp_name' => $tmpPath,
+                'error'    => UPLOAD_ERR_OK,
+                'size'     => strlen($contents),
+            ]
+        );
+
+        $this->fileService->expects($this->once())
+            ->method('uploadFile')
+            ->with('contract.pdf', $contents)
+            ->willReturn(['fileId' => 42, 'name' => 'contract.pdf']);
+
+        $response = $this->controller->upload();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['fileId' => 42, 'name' => 'contract.pdf'], $response->getData());
+
+    }//end testUploadStoresFileAndReturnsServiceResult()
+
+
+    /**
+     * A request without a `file` part answers 400 and stores nothing.
+     *
+     * @return void
+     */
+    public function testUploadRejectsMissingFile(): void
+    {
+        $this->request->method('getUploadedFile')->willReturn(null);
+        $this->fileService->expects($this->never())->method('uploadFile');
+
+        $response = $this->controller->upload();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertSame(['error' => 'No file uploaded'], $response->getData());
+
+    }//end testUploadRejectsMissingFile()
+
+
+    /**
+     * A multipart transfer that PHP flagged as failed answers 400 with the
+     * error code echoed back, and nothing is written.
+     *
+     * @return void
+     */
+    public function testUploadRejectsFailedMultipartTransfer(): void
+    {
+        $this->request->method('getUploadedFile')->willReturn(
+            [
+                'name'     => 'huge.pdf',
+                'type'     => 'application/pdf',
+                'tmp_name' => '',
+                'error'    => UPLOAD_ERR_INI_SIZE,
+                'size'     => 0,
+            ]
+        );
+        $this->fileService->expects($this->never())->method('uploadFile');
+
+        $response = $this->controller->upload();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertStringContainsString(
+            (string) UPLOAD_ERR_INI_SIZE,
+            $response->getData()['error']
+        );
+
+    }//end testUploadRejectsFailedMultipartTransfer()
+
+
+    /**
+     * A storage failure surfaces the exception's own HTTP code (e.g. 507 quota
+     * exceeded) instead of a blanket 500.
+     *
+     * @return void
+     */
+    public function testUploadSurfacesCodedStorageFailure(): void
+    {
+        $tmpPath = $this->makeUploadTempFile('bytes');
+
+        $this->request->method('getUploadedFile')->willReturn(
+            [
+                'name'     => 'contract.pdf',
+                'type'     => 'application/pdf',
+                'tmp_name' => $tmpPath,
+                'error'    => UPLOAD_ERR_OK,
+                'size'     => 5,
+            ]
+        );
+        $this->fileService->method('uploadFile')
+            ->willThrowException(new RuntimeException('Quota exceeded', 507));
+
+        $response = $this->controller->upload();
+
+        $this->assertSame(507, $response->getStatus());
+        $this->assertArrayHasKey('error', $response->getData());
+
+    }//end testUploadSurfacesCodedStorageFailure()
+
+
+    /**
+     * An anonymous caller cannot upload into someone else's DocuDesk folder.
+     *
+     * @return void
+     */
+    public function testUploadRejectsAnonymousCaller(): void
+    {
+        $this->fileService->expects($this->never())->method('uploadFile');
+
+        $response = $this->buildController($this->anonymousSession())->upload();
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+        $this->assertSame(['error' => 'Not authenticated'], $response->getData());
+
+    }//end testUploadRejectsAnonymousCaller()
+
+
+    /**
+     * An allowed include/skip decision is forwarded with its parsed arguments
+     * and answered with the service's own status and body.
+     *
+     * @return void
+     */
+    public function testUpdateRelationForwardsDecision(): void
+    {
+        $this->request->method('getParams')->willReturn(
+            [
+                'skipAnonymization' => true,
+                'bases'             => ['basis-a', 'basis-b'],
+                'force'             => 'true',
+            ]
+        );
+
+        $this->anonService->expects($this->once())
+            ->method('applyRelationSkipDecision')
+            ->with(
+                relationId: 77,
+                skip: true,
+                bases: ['basis-a', 'basis-b'],
+                force: true
+            )
+            ->willReturn(
+                [
+                    'status' => 200,
+                    'body'   => ['id' => 77, 'skipAnonymization' => true],
+                ]
+            );
+
+        $response = $this->controller->updateRelation(77);
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['id' => 77, 'skipAnonymization' => true], $response->getData());
+
+    }//end testUpdateRelationForwardsDecision()
+
+
+    /**
+     * An omitted `skipAnonymization` defaults to an include decision
+     * (`skip: false`) with no bases and no force.
+     *
+     * @return void
+     */
+    public function testUpdateRelationDefaultsToIncludeDecision(): void
+    {
+        $this->request->method('getParams')->willReturn([]);
+
+        $this->anonService->expects($this->once())
+            ->method('applyRelationSkipDecision')
+            ->with(
+                relationId: 5,
+                skip: false,
+                bases: null,
+                force: false
+            )
+            ->willReturn(
+                [
+                    'status' => 200,
+                    'body'   => ['id' => 5, 'skipAnonymization' => false],
+                ]
+            );
+
+        $response = $this->controller->updateRelation(5);
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+
+    }//end testUpdateRelationDefaultsToIncludeDecision()
+
+
+    /**
+     * A non-boolean `skipAnonymization` is a client error: 400, and the
+     * decision never reaches the prohibition policy.
+     *
+     * @return void
+     */
+    public function testUpdateRelationRejectsNonBooleanSkipFlag(): void
+    {
+        $this->request->method('getParams')->willReturn(['skipAnonymization' => 'yes']);
+
+        $this->anonService->expects($this->never())->method('applyRelationSkipDecision');
+
+        $response = $this->controller->updateRelation(77);
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertStringContainsString('skipAnonymization', $response->getData()['error']);
+
+    }//end testUpdateRelationRejectsNonBooleanSkipFlag()
+
+
+    /**
+     * A prohibition-blocked skip surfaces the policy's 422 body verbatim, so
+     * the review UI can render `threshold` and `prohibitionMatch`.
+     *
+     * @return void
+     */
+    public function testUpdateRelationSurfacesProhibitionBlock(): void
+    {
+        $this->request->method('getParams')->willReturn(['skipAnonymization' => true]);
+
+        $blocked = [
+            'error'            => 'Entity is covered by a publication prohibition',
+            'threshold'        => 0.8,
+            'prohibitionMatch' => ['id' => 'proh-1', 'confidence' => 0.93],
+        ];
+
+        $this->anonService->method('applyRelationSkipDecision')->willReturn(
+            [
+                'status' => 422,
+                'body'   => $blocked,
+            ]
+        );
+
+        $response = $this->controller->updateRelation(77);
+
+        $this->assertSame(422, $response->getStatus());
+        $this->assertSame($blocked, $response->getData());
+
+    }//end testUpdateRelationSurfacesProhibitionBlock()
+
+
+    /**
+     * A backend failure is contained as a 500 error envelope — the Throwable
+     * must not escape, and the caller must not read it as a stored decision.
+     *
+     * @return void
+     */
+    public function testUpdateRelationContainsBackendFailure(): void
+    {
+        $this->request->method('getParams')->willReturn(['skipAnonymization' => false]);
+
+        $this->anonService->method('applyRelationSkipDecision')
+            ->willThrowException(new RuntimeException('OpenRegister unreachable'));
+
+        $response = $this->controller->updateRelation(77);
+
+        $this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+        $this->assertSame(
+            ['error' => 'Failed to update entity relation decision'],
+            $response->getData()
+        );
+
+    }//end testUpdateRelationContainsBackendFailure()
+
+
+    /**
+     * An anonymous caller cannot record a relation decision.
+     *
+     * @return void
+     */
+    public function testUpdateRelationRejectsAnonymousCaller(): void
+    {
+        $this->anonService->expects($this->never())->method('applyRelationSkipDecision');
+
+        $response = $this->buildController($this->anonymousSession())->updateRelation(77);
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+        $this->assertSame(['error' => 'Not authenticated'], $response->getData());
+
+    }//end testUpdateRelationRejectsAnonymousCaller()
+
+
+}//end class

--- a/tests/unit/Controller/BatchAnonymizationControllerContractTest.php
+++ b/tests/unit/Controller/BatchAnonymizationControllerContractTest.php
@@ -1,0 +1,576 @@
+<?php
+
+/**
+ * Wire-contract tests for the batch-anonymization HTTP surface
+ *
+ * Covers `batchAnonymization#batchUpload` (POST api/anonymization/batch/upload),
+ * `batchAnonymization#batchExtract` (POST .../batch/{batchId}/extract),
+ * `batchAnonymization#batchStatus` (GET .../batch/{batchId}/status),
+ * `batchAnonymization#batchReport` (GET .../batch/{batchId}/report) and
+ * `batchAnonymization#getProfiles` (GET api/anonymization/profiles).
+ *
+ * Each endpoint is asserted on the status code and body shape it documents,
+ * on its 401 anonymous rejection, and on the failure mapping the controller
+ * promises (400 for a rejected upload, the exception's own HTTP code for a
+ * coded failure, 500 otherwise). The report endpoint is additionally asserted
+ * to be a CSV *download*, not a JSON envelope.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-creation-via-multi-file-upload
+ * @spec openspec/specs/batch-anonymization/spec.md#requirement-sequential-batch-extraction
+ * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-status-endpoint
+ * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-completion-report
+ * @spec openspec/specs/batch-anonymization/spec.md#requirement-woo-entity-category-profiles
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Controller;
+
+use OCA\DocuDesk\Controller\BatchAnonymizationController;
+use OCA\DocuDesk\Service\BatchAnonymizeService;
+use OCA\DocuDesk\Service\BatchExtractionService;
+use OCA\DocuDesk\Service\BatchReportService;
+use OCA\DocuDesk\Service\BatchStateService;
+use OCA\DocuDesk\Service\BatchUploadService;
+use OCA\DocuDesk\Service\EntityConsolidationService;
+use OCA\DocuDesk\Service\FolderBatchService;
+use OCA\DocuDesk\Service\WooProfileService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataDownloadResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IAppConfig;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Tests for the five batch endpoints that had no contract test.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress                                 PropertyNotSetInConstructor
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class BatchAnonymizationControllerContractTest extends TestCase
+{
+
+    /**
+     * Mocked request.
+     *
+     * @var IRequest|MockObject
+     */
+    private IRequest|MockObject $request;
+
+    /**
+     * Mocked batch state store.
+     *
+     * @var BatchStateService|MockObject
+     */
+    private BatchStateService|MockObject $stateService;
+
+    /**
+     * Mocked upload service.
+     *
+     * @var BatchUploadService|MockObject
+     */
+    private BatchUploadService|MockObject $uploadService;
+
+    /**
+     * Mocked extraction service.
+     *
+     * @var BatchExtractionService|MockObject
+     */
+    private BatchExtractionService|MockObject $extractService;
+
+    /**
+     * Mocked report service.
+     *
+     * @var BatchReportService|MockObject
+     */
+    private BatchReportService|MockObject $reportService;
+
+    /**
+     * Mocked WOO profile service.
+     *
+     * @var WooProfileService|MockObject
+     */
+    private WooProfileService|MockObject $profileService;
+
+    /**
+     * Mocked localisation.
+     *
+     * @var IL10N|MockObject
+     */
+    private IL10N|MockObject $l10n;
+
+    /**
+     * Controller under test, with an authenticated session.
+     *
+     * @var BatchAnonymizationController
+     */
+    private BatchAnonymizationController $controller;
+
+
+    /**
+     * Set up an authenticated controller.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request        = $this->createMock(IRequest::class);
+        $this->stateService   = $this->createMock(BatchStateService::class);
+        $this->uploadService  = $this->createMock(BatchUploadService::class);
+        $this->extractService = $this->createMock(BatchExtractionService::class);
+        $this->reportService  = $this->createMock(BatchReportService::class);
+        $this->profileService = $this->createMock(WooProfileService::class);
+        $this->l10n           = $this->createMock(IL10N::class);
+        $this->l10n->method('t')->willReturnCallback(
+            static function (string $text): string {
+                return $text;
+            }
+        );
+
+        $this->controller = $this->buildController($this->authenticatedSession());
+
+    }//end setUp()
+
+
+    /**
+     * Build the controller for a given session.
+     *
+     * @param IUserSession $session The session the controller should see.
+     *
+     * @return BatchAnonymizationController The controller under test.
+     */
+    private function buildController(IUserSession $session): BatchAnonymizationController
+    {
+        return new BatchAnonymizationController(
+            'docudesk',
+            $this->request,
+            $this->createMock(LoggerInterface::class),
+            $this->stateService,
+            $this->uploadService,
+            $this->extractService,
+            $this->createMock(BatchAnonymizeService::class),
+            $this->reportService,
+            $this->createMock(EntityConsolidationService::class),
+            $this->profileService,
+            $this->createMock(FolderBatchService::class),
+            $this->l10n,
+            $this->createMock(IAppConfig::class),
+            $session
+        );
+
+    }//end buildController()
+
+
+    /**
+     * Build a session with a logged-in user.
+     *
+     * @return IUserSession The authenticated session.
+     */
+    private function authenticatedSession(): IUserSession
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+
+        return $session;
+
+    }//end authenticatedSession()
+
+
+    /**
+     * Build a session with no logged-in user.
+     *
+     * @return IUserSession The anonymous session.
+     */
+    private function anonymousSession(): IUserSession
+    {
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn(null);
+
+        return $session;
+
+    }//end anonymousSession()
+
+
+    /**
+     * A multi-file upload answers 200 with `{batchId, fileCount, files}`, and
+     * `fileCount` is derived from the stored batch, not from the request.
+     *
+     * @return void
+     */
+    public function testBatchUploadReturnsBatchMetadata(): void
+    {
+        $files = [['name' => 'a.pdf'], ['name' => 'b.pdf']];
+
+        $this->uploadService->method('collectFiles')->willReturn($files);
+        $this->uploadService->method('getUserId')->willReturn('alice');
+        $this->stateService->method('getMaxFiles')->willReturn(50);
+        $this->uploadService->expects($this->once())
+            ->method('processBatchUpload')
+            ->with('alice', $files)
+            ->willReturn(
+                [
+                    'batchId' => 'batch-1',
+                    'files'   => [
+                        ['fileId' => 1, 'name' => 'a.pdf', 'status' => 'pending'],
+                        ['fileId' => 2, 'name' => 'b.pdf', 'status' => 'pending'],
+                    ],
+                ]
+            );
+
+        $response = $this->controller->batchUpload();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $data = $response->getData();
+        $this->assertSame('batch-1', $data['batchId']);
+        $this->assertSame(2, $data['fileCount']);
+        $this->assertCount(2, $data['files']);
+
+    }//end testBatchUploadReturnsBatchMetadata()
+
+
+    /**
+     * An upload with no files answers 400 and nothing is persisted.
+     *
+     * @return void
+     */
+    public function testBatchUploadRejectsEmptyUpload(): void
+    {
+        $this->uploadService->method('collectFiles')->willReturn([]);
+        $this->uploadService->expects($this->never())->method('processBatchUpload');
+
+        $response = $this->controller->batchUpload();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertSame(['error' => 'No files uploaded'], $response->getData());
+
+    }//end testBatchUploadRejectsEmptyUpload()
+
+
+    /**
+     * An upload above the configured maximum answers 400 before any file is
+     * written — the size limit is enforced server-side, not only in the UI.
+     *
+     * @return void
+     */
+    public function testBatchUploadRejectsOversizedBatch(): void
+    {
+        $this->uploadService->method('collectFiles')->willReturn(
+            [['name' => 'a.pdf'], ['name' => 'b.pdf'], ['name' => 'c.pdf']]
+        );
+        $this->stateService->method('getMaxFiles')->willReturn(2);
+        $this->uploadService->expects($this->never())->method('processBatchUpload');
+
+        $response = $this->controller->batchUpload();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertSame(['error' => 'Batch size exceeds maximum'], $response->getData());
+
+    }//end testBatchUploadRejectsOversizedBatch()
+
+
+    /**
+     * An anonymous caller cannot create a batch.
+     *
+     * @return void
+     */
+    public function testBatchUploadRejectsAnonymousCaller(): void
+    {
+        $this->uploadService->expects($this->never())->method('processBatchUpload');
+
+        $response = $this->buildController($this->anonymousSession())->batchUpload();
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+        $this->assertSame(['error' => 'Not authenticated'], $response->getData());
+
+    }//end testBatchUploadRejectsAnonymousCaller()
+
+
+    /**
+     * Extracting the next file answers 200 with the service's per-file result
+     * verbatim, so the UI can drive the sequential loop from `remaining`.
+     *
+     * @return void
+     */
+    public function testBatchExtractReturnsPerFileResult(): void
+    {
+        $result = [
+            'fileId'      => 1,
+            'status'      => 'extracted',
+            'entityCount' => 4,
+            'remaining'   => 1,
+        ];
+
+        $this->extractService->expects($this->once())
+            ->method('extractNext')
+            ->with('batch-1')
+            ->willReturn($result);
+
+        $response = $this->controller->batchExtract('batch-1');
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame($result, $response->getData());
+
+    }//end testBatchExtractReturnsPerFileResult()
+
+
+    /**
+     * An unknown batch surfaces the service's own HTTP code (404) rather than
+     * a blanket 500.
+     *
+     * @return void
+     */
+    public function testBatchExtractSurfacesCodedFailureStatus(): void
+    {
+        $this->extractService->method('extractNext')
+            ->willThrowException(new RuntimeException('Batch not found', 404));
+
+        $response = $this->controller->batchExtract('missing');
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $this->assertArrayHasKey('error', $response->getData());
+
+    }//end testBatchExtractSurfacesCodedFailureStatus()
+
+
+    /**
+     * An uncoded backend failure is normalised to 500 — an exception code of 0
+     * must never become the HTTP status.
+     *
+     * @return void
+     */
+    public function testBatchExtractNormalisesUncodedFailureTo500(): void
+    {
+        $this->extractService->method('extractNext')
+            ->willThrowException(new RuntimeException('presidio unreachable'));
+
+        $response = $this->controller->batchExtract('batch-1');
+
+        $this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+
+    }//end testBatchExtractNormalisesUncodedFailureTo500()
+
+
+    /**
+     * An anonymous caller cannot advance a batch.
+     *
+     * @return void
+     */
+    public function testBatchExtractRejectsAnonymousCaller(): void
+    {
+        $this->extractService->expects($this->never())->method('extractNext');
+
+        $response = $this->buildController($this->anonymousSession())->batchExtract('batch-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testBatchExtractRejectsAnonymousCaller()
+
+
+    /**
+     * Status answers 200 with the documented snapshot, and the aggregate
+     * fields are computed from the stored per-file records: two of four files
+     * in a terminal state is 50% progress and 7 entities.
+     *
+     * @return void
+     */
+    public function testBatchStatusReturnsAggregatedSnapshot(): void
+    {
+        $this->stateService->method('getBatch')->with('batch-1')->willReturn(
+            [
+                'batchId' => 'batch-1',
+                'status'  => 'extracting',
+                'files'   => [
+                    ['fileId' => 1, 'status' => 'extracted', 'entityCount' => 3],
+                    ['fileId' => 2, 'status' => 'error', 'entityCount' => 4],
+                    ['fileId' => 3, 'status' => 'pending', 'entityCount' => 0],
+                    ['fileId' => 4, 'status' => 'pending', 'entityCount' => 0],
+                ],
+            ]
+        );
+
+        $response = $this->controller->batchStatus('batch-1');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $data = $response->getData();
+        $this->assertSame('batch-1', $data['batchId']);
+        $this->assertSame('extracting', $data['batchStatus']);
+        $this->assertSame(7, $data['totalEntities']);
+        $this->assertSame(50.0, $data['progress']);
+        $this->assertSame(4, $data['totalFiles']);
+        $this->assertCount(4, $data['files']);
+
+    }//end testBatchStatusReturnsAggregatedSnapshot()
+
+
+    /**
+     * An unknown batch answers 404 with an error body, never an empty snapshot
+     * that the UI would render as "0 files, done".
+     *
+     * @return void
+     */
+    public function testBatchStatusReturnsNotFoundForUnknownBatch(): void
+    {
+        $this->stateService->method('getBatch')->willReturn(null);
+
+        $response = $this->controller->batchStatus('missing');
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $this->assertSame(['error' => 'Batch not found'], $response->getData());
+
+    }//end testBatchStatusReturnsNotFoundForUnknownBatch()
+
+
+    /**
+     * An anonymous caller cannot poll batch status.
+     *
+     * @return void
+     */
+    public function testBatchStatusRejectsAnonymousCaller(): void
+    {
+        $this->stateService->expects($this->never())->method('getBatch');
+
+        $response = $this->buildController($this->anonymousSession())->batchStatus('batch-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testBatchStatusRejectsAnonymousCaller()
+
+
+    /**
+     * The report endpoint answers with a CSV download whose filename carries
+     * the batch id — not a JSON envelope the browser would render as text.
+     *
+     * @return void
+     */
+    public function testBatchReportReturnsCsvDownload(): void
+    {
+        $csv = "file,entities\na.pdf,3\n";
+
+        $this->reportService->expects($this->once())
+            ->method('generateReport')
+            ->with('batch-1')
+            ->willReturn($csv);
+
+        $response = $this->controller->batchReport('batch-1');
+
+        $this->assertInstanceOf(DataDownloadResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame($csv, $response->getData());
+        $this->assertSame(
+            'attachment; filename="anonymization-report-batch-1.csv"',
+            $response->getHeaders()['Content-Disposition']
+        );
+
+    }//end testBatchReportReturnsCsvDownload()
+
+
+    /**
+     * A failing report answers a JSON error with the exception's HTTP code —
+     * the client must not receive a half-written CSV.
+     *
+     * @return void
+     */
+    public function testBatchReportSurfacesFailureAsJsonError(): void
+    {
+        $this->reportService->method('generateReport')
+            ->willThrowException(new RuntimeException('Batch not found', 404));
+
+        $response = $this->controller->batchReport('missing');
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $this->assertArrayHasKey('error', $response->getData());
+
+    }//end testBatchReportSurfacesFailureAsJsonError()
+
+
+    /**
+     * An anonymous caller cannot download a batch report.
+     *
+     * @return void
+     */
+    public function testBatchReportRejectsAnonymousCaller(): void
+    {
+        $this->reportService->expects($this->never())->method('generateReport');
+
+        $response = $this->buildController($this->anonymousSession())->batchReport('batch-1');
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testBatchReportRejectsAnonymousCaller()
+
+
+    /**
+     * The profiles endpoint answers 200 with the stored WOO profile — the
+     * `anonymize` / `keep` entity-type arrays the review UI pre-selects from.
+     *
+     * @return void
+     */
+    public function testGetProfilesReturnsActiveProfile(): void
+    {
+        $profile = [
+            'anonymize' => ['PERSON', 'BSN', 'EMAIL'],
+            'keep'      => ['ORGANIZATION'],
+        ];
+
+        $this->profileService->expects($this->once())
+            ->method('getProfile')
+            ->willReturn($profile);
+
+        $response = $this->controller->getProfiles();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame($profile, $response->getData());
+
+    }//end testGetProfilesReturnsActiveProfile()
+
+
+    /**
+     * An anonymous caller cannot read the instance profile.
+     *
+     * @return void
+     */
+    public function testGetProfilesRejectsAnonymousCaller(): void
+    {
+        $this->profileService->expects($this->never())->method('getProfile');
+
+        $response = $this->buildController($this->anonymousSession())->getProfiles();
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+        $this->assertSame(['error' => 'Not authenticated'], $response->getData());
+
+    }//end testGetProfilesRejectsAnonymousCaller()
+
+
+}//end class

--- a/tests/unit/Controller/CustomDictionaryControllerTest.php
+++ b/tests/unit/Controller/CustomDictionaryControllerTest.php
@@ -1,0 +1,507 @@
+<?php
+
+/**
+ * Wire-contract tests for the CustomDictionaryController term endpoints
+ *
+ * Covers `customDictionary#indexTerms` (GET api/custom-dictionaries/{id}/terms),
+ * `customDictionary#createTerm` (POST, same path),
+ * `customDictionary#deleteTerm` (DELETE .../terms/{termId}) and
+ * `customDictionary#import` (POST .../import). Each is asserted on its
+ * documented status code and body, on the shared guard order
+ * (401 unauthenticated before 503 OpenRegister-absent), and on the
+ * exception-to-status mapping the controller promises: 404 for a missing
+ * record, 403 for the organisation gate, 400 for bad input.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Controller;
+
+use OCA\DocuDesk\Controller\CustomDictionaryController;
+use OCA\DocuDesk\Service\CustomDictionaryService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Tests for the custom-dictionary term endpoints.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress                              PropertyNotSetInConstructor
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class CustomDictionaryControllerTest extends TestCase
+{
+
+    /**
+     * Mocked request.
+     *
+     * @var IRequest|MockObject
+     */
+    private IRequest|MockObject $request;
+
+    /**
+     * Mocked dictionary service.
+     *
+     * @var CustomDictionaryService|MockObject
+     */
+    private CustomDictionaryService|MockObject $service;
+
+    /**
+     * Mocked localisation.
+     *
+     * @var IL10N|MockObject
+     */
+    private IL10N|MockObject $l10n;
+
+    /**
+     * Controller under test: authenticated caller, OpenRegister available.
+     *
+     * @var CustomDictionaryController
+     */
+    private CustomDictionaryController $controller;
+
+
+    /**
+     * Set up an authenticated controller with an available backend.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request = $this->createMock(IRequest::class);
+        $this->service = $this->createMock(CustomDictionaryService::class);
+        $this->l10n    = $this->createMock(IL10N::class);
+        $this->l10n->method('t')->willReturnCallback(
+            static function (string $text, array $params=[]): string {
+                if ($params === []) {
+                    return $text;
+                }
+
+                return vsprintf($text, $params);
+            }
+        );
+
+        $this->service->method('isAvailable')->willReturn(true);
+
+        $this->controller = $this->buildController($this->authenticatedSession());
+
+    }//end setUp()
+
+
+    /**
+     * Build the controller for a given session.
+     *
+     * @param IUserSession $session The session the controller should see.
+     *
+     * @return CustomDictionaryController The controller under test.
+     */
+    private function buildController(IUserSession $session): CustomDictionaryController
+    {
+        return new CustomDictionaryController(
+            'docudesk',
+            $this->request,
+            $this->createMock(LoggerInterface::class),
+            $this->service,
+            $this->l10n,
+            $session
+        );
+
+    }//end buildController()
+
+
+    /**
+     * Build a session with a logged-in user.
+     *
+     * @return IUserSession The authenticated session.
+     */
+    private function authenticatedSession(): IUserSession
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+
+        return $session;
+
+    }//end authenticatedSession()
+
+
+    /**
+     * Build a session with no logged-in user.
+     *
+     * @return IUserSession The anonymous session.
+     */
+    private function anonymousSession(): IUserSession
+    {
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn(null);
+
+        return $session;
+
+    }//end anonymousSession()
+
+
+    /**
+     * GET .../terms answers 200 with the dictionary's term list.
+     *
+     * @return void
+     */
+    public function testIndexTermsReturnsTermList(): void
+    {
+        $terms = [
+            ['id' => 'term-1', 'value' => 'Zaaknummer'],
+            ['id' => 'term-2', 'value' => 'Kenmerk'],
+        ];
+
+        $this->service->expects($this->once())
+            ->method('listTerms')
+            ->with('dict-1')
+            ->willReturn($terms);
+
+        $response = $this->controller->indexTerms('dict-1');
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame($terms, $response->getData());
+
+    }//end testIndexTermsReturnsTermList()
+
+
+    /**
+     * An anonymous caller is refused with 401 before the backend is consulted.
+     *
+     * @return void
+     */
+    public function testIndexTermsRejectsAnonymousCaller(): void
+    {
+        $this->service->expects($this->never())->method('listTerms');
+
+        $response = $this->buildController($this->anonymousSession())->indexTerms('dict-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+        $this->assertSame(['error' => 'Not authenticated'], $response->getData());
+
+    }//end testIndexTermsRejectsAnonymousCaller()
+
+
+    /**
+     * With OpenRegister absent the endpoint answers 503 with an explanatory
+     * body rather than a 500 stack trace.
+     *
+     * @return void
+     */
+    public function testIndexTermsReportsBackendUnavailable(): void
+    {
+        $service = $this->createMock(CustomDictionaryService::class);
+        $service->method('isAvailable')->willReturn(false);
+        $service->expects($this->never())->method('listTerms');
+
+        $controller = new CustomDictionaryController(
+            'docudesk',
+            $this->request,
+            $this->createMock(LoggerInterface::class),
+            $service,
+            $this->l10n,
+            $this->authenticatedSession()
+        );
+
+        $response = $controller->indexTerms('dict-1');
+
+        $this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
+        $this->assertStringContainsString('OpenRegister', $response->getData()['error']);
+
+    }//end testIndexTermsReportsBackendUnavailable()
+
+
+    /**
+     * An unknown dictionary answers 404 with the localised not-found message.
+     *
+     * @return void
+     */
+    public function testIndexTermsReturnsNotFoundForUnknownDictionary(): void
+    {
+        $this->service->method('listTerms')
+            ->willThrowException(new DoesNotExistException('no such dictionary'));
+
+        $response = $this->controller->indexTerms('missing');
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $this->assertSame(['error' => 'Custom dictionary not found'], $response->getData());
+
+    }//end testIndexTermsReturnsNotFoundForUnknownDictionary()
+
+
+    /**
+     * POST .../terms answers 201 with the created term and forwards the body.
+     *
+     * @return void
+     */
+    public function testCreateTermReturnsCreated(): void
+    {
+        $body    = ['value' => 'Zaaknummer', 'entityType' => 'CASE_NUMBER'];
+        $created = ['id' => 'term-new'] + $body;
+
+        $this->request->method('getParams')->willReturn($body);
+        $this->service->expects($this->once())
+            ->method('createTerm')
+            ->with('dict-1', $body)
+            ->willReturn($created);
+
+        $response = $this->controller->createTerm('dict-1');
+
+        $this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+        $this->assertSame($created, $response->getData());
+
+    }//end testCreateTermReturnsCreated()
+
+
+    /**
+     * A dictionary outside the caller's organisations answers 403 — the
+     * organisation gate, surfaced as its own status rather than a 500.
+     *
+     * @return void
+     */
+    public function testCreateTermIsRefusedByOrganisationGate(): void
+    {
+        $this->request->method('getParams')->willReturn(['value' => 'Zaaknummer']);
+        $this->service->method('createTerm')
+            ->willThrowException(new RuntimeException('organisation gate'));
+
+        $response = $this->controller->createTerm('dict-of-another-org');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+        $this->assertArrayHasKey('error', $response->getData());
+
+    }//end testCreateTermIsRefusedByOrganisationGate()
+
+
+    /**
+     * An anonymous caller cannot add a term.
+     *
+     * @return void
+     */
+    public function testCreateTermRejectsAnonymousCaller(): void
+    {
+        $this->service->expects($this->never())->method('createTerm');
+
+        $response = $this->buildController($this->anonymousSession())->createTerm('dict-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testCreateTermRejectsAnonymousCaller()
+
+
+    /**
+     * DELETE .../terms/{termId} answers 200 with `{deleted: <termId>}` and
+     * passes both path segments to the service.
+     *
+     * @return void
+     */
+    public function testDeleteTermReturnsDeletedTermId(): void
+    {
+        $this->service->expects($this->once())
+            ->method('deleteTerm')
+            ->with('dict-1', 'term-7');
+
+        $response = $this->controller->deleteTerm('dict-1', 'term-7');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['deleted' => 'term-7'], $response->getData());
+
+    }//end testDeleteTermReturnsDeletedTermId()
+
+
+    /**
+     * An unknown term answers 404 with the term-specific message — and never a
+     * success body that would make the UI drop a row it did not delete.
+     *
+     * @return void
+     */
+    public function testDeleteTermReturnsNotFoundForUnknownTerm(): void
+    {
+        $this->service->method('deleteTerm')
+            ->willThrowException(new DoesNotExistException('no such term'));
+
+        $response = $this->controller->deleteTerm('dict-1', 'missing');
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $this->assertSame(['error' => 'Term not found'], $response->getData());
+
+    }//end testDeleteTermReturnsNotFoundForUnknownTerm()
+
+
+    /**
+     * An anonymous caller cannot delete a term.
+     *
+     * @return void
+     */
+    public function testDeleteTermRejectsAnonymousCaller(): void
+    {
+        $this->service->expects($this->never())->method('deleteTerm');
+
+        $response = $this->buildController($this->anonymousSession())->deleteTerm('dict-1', 'term-7');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testDeleteTermRejectsAnonymousCaller()
+
+
+    /**
+     * POST .../import with a pasted newline list answers 200 with the import
+     * summary, and the content is parsed as a newline list by default.
+     *
+     * @return void
+     */
+    public function testImportAcceptsPastedNewlineList(): void
+    {
+        $this->request->method('getUploadedFile')->willReturn(null);
+        $this->request->method('getParam')->willReturnMap(
+            [
+                ['content', null, "Zaaknummer\nKenmerk"],
+                ['format', 'newline', 'newline'],
+            ]
+        );
+
+        $this->service->expects($this->once())
+            ->method('importTerms')
+            ->with('dict-1', "Zaaknummer\nKenmerk", false)
+            ->willReturn(['imported' => 2, 'skipped' => 0]);
+
+        $response = $this->controller->import('dict-1');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['imported' => 2, 'skipped' => 0], $response->getData());
+
+    }//end testImportAcceptsPastedNewlineList()
+
+
+    /**
+     * `format=csv` on pasted content flips the parser to CSV.
+     *
+     * @return void
+     */
+    public function testImportHonoursCsvFormatParam(): void
+    {
+        $this->request->method('getUploadedFile')->willReturn(null);
+        $this->request->method('getParam')->willReturnMap(
+            [
+                ['content', null, "value,type\nZaaknummer,CASE"],
+                ['format', 'newline', 'CSV'],
+            ]
+        );
+
+        $this->service->expects($this->once())
+            ->method('importTerms')
+            ->with('dict-1', "value,type\nZaaknummer,CASE", true)
+            ->willReturn(['imported' => 1, 'skipped' => 0]);
+
+        $response = $this->controller->import('dict-1');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(1, $response->getData()['imported']);
+
+    }//end testImportHonoursCsvFormatParam()
+
+
+    /**
+     * A real multipart `.csv` upload is read from disk and imported as CSV —
+     * the uploaded filename, not a request param, decides the parser.
+     *
+     * @return void
+     */
+    public function testImportReadsUploadedCsvFile(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'dd-import-');
+        $this->assertIsString($tmp);
+        file_put_contents($tmp, "value,type\nKenmerk,CASE");
+
+        $this->request->method('getUploadedFile')->willReturn(
+            [
+                'name'     => 'terms.csv',
+                'type'     => 'text/csv',
+                'tmp_name' => $tmp,
+                'error'    => UPLOAD_ERR_OK,
+                'size'     => filesize($tmp),
+            ]
+        );
+
+        $this->service->expects($this->once())
+            ->method('importTerms')
+            ->with('dict-1', "value,type\nKenmerk,CASE", true)
+            ->willReturn(['imported' => 1, 'skipped' => 0]);
+
+        $response = $this->controller->import('dict-1');
+
+        unlink($tmp);
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(1, $response->getData()['imported']);
+
+    }//end testImportReadsUploadedCsvFile()
+
+
+    /**
+     * An import with neither an upload nor content answers 400 with the
+     * documented message, and nothing is imported.
+     *
+     * @return void
+     */
+    public function testImportRejectsEmptyPayload(): void
+    {
+        $this->request->method('getUploadedFile')->willReturn(null);
+        $this->request->method('getParam')->willReturn(null);
+
+        $this->service->expects($this->never())->method('importTerms');
+
+        $response = $this->controller->import('dict-1');
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertSame(['error' => 'No import content provided'], $response->getData());
+
+    }//end testImportRejectsEmptyPayload()
+
+
+    /**
+     * An anonymous caller cannot import terms.
+     *
+     * @return void
+     */
+    public function testImportRejectsAnonymousCaller(): void
+    {
+        $this->service->expects($this->never())->method('importTerms');
+
+        $response = $this->buildController($this->anonymousSession())->import('dict-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testImportRejectsAnonymousCaller()
+
+
+}//end class

--- a/tests/unit/Controller/DashboardControllerTest.php
+++ b/tests/unit/Controller/DashboardControllerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Wire-contract tests for DashboardController
+ *
+ * Covers `GET /` (dashboard#page) and the Vue history-mode catch-all
+ * `GET /{path}` (dashboard#catchAll). Both must answer HTTP 200 with a
+ * TemplateResponse that renders the `index` template of the `docudesk` app —
+ * the SPA host that info.xml navigation and every dashboard widget link to.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Controller;
+
+use OCA\DocuDesk\Controller\DashboardController;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the SPA host endpoints.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class DashboardControllerTest extends TestCase
+{
+
+    /**
+     * Controller under test.
+     *
+     * @var DashboardController
+     */
+    private DashboardController $controller;
+
+
+    /**
+     * Set up the controller.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->controller = new DashboardController($this->createMock(IRequest::class));
+
+    }//end setUp()
+
+
+    /**
+     * `dashboard#page` renders the docudesk `index` template with HTTP 200.
+     *
+     * @return void
+     */
+    public function testPageRendersIndexTemplate(): void
+    {
+        $response = $this->controller->page();
+
+        $this->assertInstanceOf(TemplateResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame('index', $response->getTemplateName());
+        $this->assertSame('docudesk', $response->getApp());
+
+    }//end testPageRendersIndexTemplate()
+
+
+    /**
+     * `dashboard#catchAll` serves the same SPA host, so a deep link such as
+     * `/apps/docudesk/templates/abc` boots the Vue router instead of 404ing.
+     *
+     * @return void
+     */
+    public function testCatchAllServesTheSameSpaHost(): void
+    {
+        $response = $this->controller->catchAll();
+
+        $this->assertInstanceOf(TemplateResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame('index', $response->getTemplateName());
+        $this->assertSame('docudesk', $response->getApp());
+
+    }//end testCatchAllServesTheSameSpaHost()
+
+
+    /**
+     * The catch-all is defined as a delegate of `page()`, so the two responses
+     * must be interchangeable — a divergence here means a deep link renders a
+     * different document than the app root.
+     *
+     * @return void
+     */
+    public function testCatchAllMatchesPageResponse(): void
+    {
+        $page     = $this->controller->page();
+        $catchAll = $this->controller->catchAll();
+
+        $this->assertSame($page->getTemplateName(), $catchAll->getTemplateName());
+        $this->assertSame($page->getApp(), $catchAll->getApp());
+        $this->assertSame($page->getStatus(), $catchAll->getStatus());
+        $this->assertSame($page->getRenderAs(), $catchAll->getRenderAs());
+
+    }//end testCatchAllMatchesPageResponse()
+
+
+}//end class

--- a/tests/unit/Controller/PolicyControllerTest.php
+++ b/tests/unit/Controller/PolicyControllerTest.php
@@ -1,0 +1,449 @@
+<?php
+
+/**
+ * Wire-contract tests for PolicyController
+ *
+ * Covers the five `api/policy/prohibitions` endpoints —
+ * `policy#indexProhibitions` (GET), `policy#createProhibition` (POST),
+ * `policy#showProhibition` (GET /{id}), `policy#updateProhibition` (PUT /{id})
+ * and `policy#deleteProhibition` (DELETE /{id}). Each is asserted on its
+ * documented status code and body shape, on the 401 anonymous rejection, and on
+ * the permission check running BEFORE the record is touched.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Controller;
+
+use InvalidArgumentException;
+use OCA\DocuDesk\Controller\PolicyController;
+use OCA\DocuDesk\Service\PolicyCrudService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Tests for the prohibition policy-surface CRUD endpoints.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress                              PropertyNotSetInConstructor
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class PolicyControllerTest extends TestCase
+{
+
+    /**
+     * Mocked request.
+     *
+     * @var IRequest|MockObject
+     */
+    private IRequest|MockObject $request;
+
+    /**
+     * Mocked CRUD service.
+     *
+     * @var PolicyCrudService|MockObject
+     */
+    private PolicyCrudService|MockObject $crudService;
+
+    /**
+     * Mocked localisation.
+     *
+     * @var IL10N|MockObject
+     */
+    private IL10N|MockObject $l10n;
+
+    /**
+     * Controller under test, with an authenticated session.
+     *
+     * @var PolicyController
+     */
+    private PolicyController $controller;
+
+
+    /**
+     * Set up an authenticated controller.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request     = $this->createMock(IRequest::class);
+        $this->crudService = $this->createMock(PolicyCrudService::class);
+        $this->l10n        = $this->createMock(IL10N::class);
+        $this->l10n->method('t')->willReturnCallback(
+            static function (string $text, array $params=[]): string {
+                if ($params === []) {
+                    return $text;
+                }
+
+                return vsprintf($text, $params);
+            }
+        );
+
+        $user    = $this->createMock(IUser::class);
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+
+        $this->controller = new PolicyController(
+            'docudesk',
+            $this->request,
+            $this->createMock(LoggerInterface::class),
+            $this->crudService,
+            $this->l10n,
+            $session
+        );
+
+    }//end setUp()
+
+
+    /**
+     * Build a controller whose session has no logged-in user.
+     *
+     * @return PolicyController The anonymous-session controller.
+     */
+    private function anonymousController(): PolicyController
+    {
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn(null);
+
+        return new PolicyController(
+            'docudesk',
+            $this->request,
+            $this->createMock(LoggerInterface::class),
+            $this->crudService,
+            $this->l10n,
+            $session
+        );
+
+    }//end anonymousController()
+
+
+    /**
+     * GET api/policy/prohibitions returns 200 with the service's list verbatim.
+     *
+     * @return void
+     */
+    public function testIndexProhibitionsReturnsList(): void
+    {
+        $records = [
+            ['id' => 'uuid-1', 'name' => 'Board members'],
+            ['id' => 'uuid-2', 'name' => 'Whistleblowers'],
+        ];
+
+        $this->crudService->expects($this->once())
+            ->method('requirePolicyPermission')
+            ->with(PolicyCrudService::SURFACE_PROHIBITION, 'read');
+        $this->crudService->method('listProhibitions')->willReturn($records);
+
+        $response = $this->controller->indexProhibitions();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame($records, $response->getData());
+
+    }//end testIndexProhibitionsReturnsList()
+
+
+    /**
+     * An anonymous caller is refused with 401 before any permission check runs.
+     *
+     * @return void
+     */
+    public function testIndexProhibitionsRejectsAnonymousCaller(): void
+    {
+        $this->crudService->expects($this->never())->method('requirePolicyPermission');
+        $this->crudService->expects($this->never())->method('listProhibitions');
+
+        $response = $this->anonymousController()->indexProhibitions();
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+        $this->assertSame(['error' => 'Not authenticated'], $response->getData());
+
+    }//end testIndexProhibitionsRejectsAnonymousCaller()
+
+
+    /**
+     * A denied read permission is mapped to the 500 error envelope rather than
+     * leaking the raw exception — and the list is never read.
+     *
+     * @return void
+     */
+    public function testIndexProhibitionsSurfacesPermissionFailureAsError(): void
+    {
+        $this->crudService->method('requirePolicyPermission')
+            ->willThrowException(new RuntimeException('Not permitted'));
+        $this->crudService->expects($this->never())->method('listProhibitions');
+
+        $response = $this->controller->indexProhibitions();
+
+        $this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+        $this->assertArrayHasKey('error', $response->getData());
+
+    }//end testIndexProhibitionsSurfacesPermissionFailureAsError()
+
+
+    /**
+     * GET api/policy/prohibitions/{id} returns 200 with the record.
+     *
+     * @return void
+     */
+    public function testShowProhibitionReturnsRecord(): void
+    {
+        $record = ['id' => 'uuid-1', 'name' => 'Board members'];
+
+        $this->crudService->expects($this->once())
+            ->method('getProhibition')
+            ->with('uuid-1')
+            ->willReturn($record);
+
+        $response = $this->controller->showProhibition('uuid-1');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame($record, $response->getData());
+
+    }//end testShowProhibitionReturnsRecord()
+
+
+    /**
+     * An unknown UUID yields 404 with an `error` body, not an empty 200.
+     *
+     * @return void
+     */
+    public function testShowProhibitionReturnsNotFound(): void
+    {
+        $this->crudService->method('getProhibition')->willReturn(null);
+
+        $response = $this->controller->showProhibition('missing');
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $this->assertSame(['error' => 'Prohibition not found'], $response->getData());
+
+    }//end testShowProhibitionReturnsNotFound()
+
+
+    /**
+     * An anonymous caller cannot read a single prohibition either.
+     *
+     * @return void
+     */
+    public function testShowProhibitionRejectsAnonymousCaller(): void
+    {
+        $this->crudService->expects($this->never())->method('getProhibition');
+
+        $response = $this->anonymousController()->showProhibition('uuid-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testShowProhibitionRejectsAnonymousCaller()
+
+
+    /**
+     * POST api/policy/prohibitions answers 201 with the created record, and
+     * forwards the request body to the service.
+     *
+     * @return void
+     */
+    public function testCreateProhibitionReturnsCreated(): void
+    {
+        $body    = ['name' => 'Board members', 'scope' => 'entity'];
+        $created = ['id' => 'uuid-new'] + $body;
+
+        $this->request->method('getParams')->willReturn($body);
+        $this->crudService->expects($this->once())
+            ->method('requirePolicyPermission')
+            ->with(PolicyCrudService::SURFACE_PROHIBITION, 'create');
+        $this->crudService->expects($this->once())
+            ->method('createProhibition')
+            ->with($body)
+            ->willReturn($created);
+
+        $response = $this->controller->createProhibition();
+
+        $this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+        $this->assertSame($created, $response->getData());
+
+    }//end testCreateProhibitionReturnsCreated()
+
+
+    /**
+     * A malformed body is rejected with 400 carrying the validation message —
+     * not the generic 500 envelope.
+     *
+     * @return void
+     */
+    public function testCreateProhibitionRejectsInvalidBody(): void
+    {
+        $this->request->method('getParams')->willReturn(['name' => '']);
+        $this->crudService->method('createProhibition')
+            ->willThrowException(new InvalidArgumentException('name is required'));
+
+        $response = $this->controller->createProhibition();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertSame(['error' => 'name is required'], $response->getData());
+
+    }//end testCreateProhibitionRejectsInvalidBody()
+
+
+    /**
+     * An anonymous caller cannot create a prohibition.
+     *
+     * @return void
+     */
+    public function testCreateProhibitionRejectsAnonymousCaller(): void
+    {
+        $this->crudService->expects($this->never())->method('createProhibition');
+
+        $response = $this->anonymousController()->createProhibition();
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testCreateProhibitionRejectsAnonymousCaller()
+
+
+    /**
+     * PUT api/policy/prohibitions/{id} answers 200 with the updated record and
+     * passes both the UUID and the body through.
+     *
+     * @return void
+     */
+    public function testUpdateProhibitionReturnsUpdatedRecord(): void
+    {
+        $body    = ['name' => 'Renamed'];
+        $updated = ['id' => 'uuid-1', 'name' => 'Renamed'];
+
+        $this->request->method('getParams')->willReturn($body);
+        $this->crudService->expects($this->once())
+            ->method('requirePolicyPermission')
+            ->with(PolicyCrudService::SURFACE_PROHIBITION, 'update');
+        $this->crudService->expects($this->once())
+            ->method('updateProhibition')
+            ->with('uuid-1', $body)
+            ->willReturn($updated);
+
+        $response = $this->controller->updateProhibition('uuid-1');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame($updated, $response->getData());
+
+    }//end testUpdateProhibitionReturnsUpdatedRecord()
+
+
+    /**
+     * A rejected update payload answers 400 with the validation message.
+     *
+     * @return void
+     */
+    public function testUpdateProhibitionRejectsInvalidBody(): void
+    {
+        $this->request->method('getParams')->willReturn(['scope' => 'nonsense']);
+        $this->crudService->method('updateProhibition')
+            ->willThrowException(new InvalidArgumentException('scope is invalid'));
+
+        $response = $this->controller->updateProhibition('uuid-1');
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertSame(['error' => 'scope is invalid'], $response->getData());
+
+    }//end testUpdateProhibitionRejectsInvalidBody()
+
+
+    /**
+     * An anonymous caller cannot update a prohibition.
+     *
+     * @return void
+     */
+    public function testUpdateProhibitionRejectsAnonymousCaller(): void
+    {
+        $this->crudService->expects($this->never())->method('updateProhibition');
+
+        $response = $this->anonymousController()->updateProhibition('uuid-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testUpdateProhibitionRejectsAnonymousCaller()
+
+
+    /**
+     * DELETE api/policy/prohibitions/{id} answers 200 with `{deleted: <id>}`.
+     *
+     * @return void
+     */
+    public function testDeleteProhibitionReturnsDeletedId(): void
+    {
+        $this->crudService->expects($this->once())
+            ->method('requirePolicyPermission')
+            ->with(PolicyCrudService::SURFACE_PROHIBITION, 'delete');
+        $this->crudService->expects($this->once())
+            ->method('deleteProhibition')
+            ->with('uuid-1');
+
+        $response = $this->controller->deleteProhibition('uuid-1');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['deleted' => 'uuid-1'], $response->getData());
+
+    }//end testDeleteProhibitionReturnsDeletedId()
+
+
+    /**
+     * A failing delete is reported as a 500 error envelope, and never as a
+     * success body that would make the UI drop the row.
+     *
+     * @return void
+     */
+    public function testDeleteProhibitionSurfacesFailureAsError(): void
+    {
+        $this->crudService->method('deleteProhibition')
+            ->willThrowException(new RuntimeException('register unavailable'));
+
+        $response = $this->controller->deleteProhibition('uuid-1');
+
+        $this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+        $this->assertArrayHasKey('error', $response->getData());
+        $this->assertArrayNotHasKey('deleted', $response->getData());
+
+    }//end testDeleteProhibitionSurfacesFailureAsError()
+
+
+    /**
+     * An anonymous caller cannot delete a prohibition.
+     *
+     * @return void
+     */
+    public function testDeleteProhibitionRejectsAnonymousCaller(): void
+    {
+        $this->crudService->expects($this->never())->method('deleteProhibition');
+
+        $response = $this->anonymousController()->deleteProhibition('uuid-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testDeleteProhibitionRejectsAnonymousCaller()
+
+
+}//end class

--- a/tests/unit/Controller/PreferencesControllerTest.php
+++ b/tests/unit/Controller/PreferencesControllerTest.php
@@ -1,0 +1,291 @@
+<?php
+
+/**
+ * Wire-contract tests for PreferencesController
+ *
+ * Covers `GET /api/preferences/{key}` (preferences#getPreference) and
+ * `PUT /api/preferences/{key}` (preferences#setPreference): the documented
+ * `{value: string|null}` success body, the 401 anonymous rejection, the 400
+ * invalid-key rejection, the per-user storage scoping (`pref_<safeKey>` under
+ * the docudesk app id) and the empty-value delete semantics.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Controller;
+
+use OCA\DocuDesk\Controller\PreferencesController;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the per-user preference read/write endpoints.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class PreferencesControllerTest extends TestCase
+{
+
+    /**
+     * Mocked Nextcloud config service.
+     *
+     * @var IConfig|MockObject
+     */
+    private IConfig|MockObject $config;
+
+    /**
+     * Mocked user session.
+     *
+     * @var IUserSession|MockObject
+     */
+    private IUserSession|MockObject $userSession;
+
+    /**
+     * Controller under test, with an authenticated session.
+     *
+     * @var PreferencesController
+     */
+    private PreferencesController $controller;
+
+
+    /**
+     * Set up an authenticated controller.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->config      = $this->createMock(IConfig::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->userSession->method('getUser')->willReturn($user);
+
+        $this->controller = new PreferencesController(
+            $this->createMock(IRequest::class),
+            $this->config,
+            $this->userSession
+        );
+
+    }//end setUp()
+
+
+    /**
+     * Build a controller whose session has no logged-in user.
+     *
+     * @return PreferencesController The anonymous-session controller.
+     */
+    private function anonymousController(): PreferencesController
+    {
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn(null);
+
+        return new PreferencesController(
+            $this->createMock(IRequest::class),
+            $this->config,
+            $session
+        );
+
+    }//end anonymousController()
+
+
+    /**
+     * GET returns 200 with `{value: <stored>}` and reads the per-user,
+     * `pref_`-prefixed key under the docudesk app id.
+     *
+     * @return void
+     */
+    public function testGetPreferenceReturnsStoredValue(): void
+    {
+        $this->config->expects($this->once())
+            ->method('getUserValue')
+            ->with('alice', 'docudesk', 'pref_support-dialog-seen', '')
+            ->willReturn('1');
+
+        $response = $this->controller->getPreference('support-dialog-seen');
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['value' => '1'], $response->getData());
+
+    }//end testGetPreferenceReturnsStoredValue()
+
+
+    /**
+     * An unset preference is reported as `{value: null}`, not as an empty
+     * string — the UI distinguishes "never stored" from "stored empty".
+     *
+     * @return void
+     */
+    public function testGetPreferenceReturnsNullWhenUnset(): void
+    {
+        $this->config->method('getUserValue')->willReturn('');
+
+        $response = $this->controller->getPreference('support-dialog-seen');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['value' => null], $response->getData());
+
+    }//end testGetPreferenceReturnsNullWhenUnset()
+
+
+    /**
+     * The caller-supplied key is sanitised before it reaches storage:
+     * uppercase is lowered, hyphens survive, and everything outside
+     * `[a-z0-9-]` (including path separators) is dropped.
+     *
+     * @return void
+     */
+    public function testGetPreferenceSanitisesKeyBeforeReading(): void
+    {
+        $this->config->expects($this->once())
+            ->method('getUserValue')
+            ->with('alice', 'docudesk', 'pref_my-key12', '')
+            ->willReturn('x');
+
+        $response = $this->controller->getPreference('My-Key_1../2!');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['value' => 'x'], $response->getData());
+
+    }//end testGetPreferenceSanitisesKeyBeforeReading()
+
+
+    /**
+     * A key that sanitises to nothing is rejected with 400 and never reaches
+     * storage.
+     *
+     * @return void
+     */
+    public function testGetPreferenceRejectsUnusableKey(): void
+    {
+        $this->config->expects($this->never())->method('getUserValue');
+
+        $response = $this->controller->getPreference('***');
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertSame(['message' => 'Invalid key'], $response->getData());
+
+    }//end testGetPreferenceRejectsUnusableKey()
+
+
+    /**
+     * An anonymous caller gets 401 and no storage read is attempted.
+     *
+     * @return void
+     */
+    public function testGetPreferenceRejectsAnonymousCaller(): void
+    {
+        $this->config->expects($this->never())->method('getUserValue');
+
+        $response = $this->anonymousController()->getPreference('theme');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+        $this->assertSame(['message' => 'Not logged in'], $response->getData());
+
+    }//end testGetPreferenceRejectsAnonymousCaller()
+
+
+    /**
+     * PUT with a value writes it per-user and echoes it back with 200.
+     *
+     * @return void
+     */
+    public function testSetPreferenceStoresValue(): void
+    {
+        $this->config->expects($this->once())
+            ->method('setUserValue')
+            ->with('alice', 'docudesk', 'pref_theme', 'dark');
+        $this->config->expects($this->never())->method('deleteUserValue');
+
+        $response = $this->controller->setPreference('theme', 'dark');
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['value' => 'dark'], $response->getData());
+
+    }//end testSetPreferenceStoresValue()
+
+
+    /**
+     * PUT with an empty value deletes the stored preference and answers
+     * `{value: null}` — the documented clear semantics.
+     *
+     * @return void
+     */
+    public function testSetPreferenceWithEmptyValueDeletesIt(): void
+    {
+        $this->config->expects($this->once())
+            ->method('deleteUserValue')
+            ->with('alice', 'docudesk', 'pref_theme');
+        $this->config->expects($this->never())->method('setUserValue');
+
+        $response = $this->controller->setPreference('theme', '');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['value' => null], $response->getData());
+
+    }//end testSetPreferenceWithEmptyValueDeletesIt()
+
+
+    /**
+     * A key that sanitises to nothing is rejected with 400 and nothing is
+     * written.
+     *
+     * @return void
+     */
+    public function testSetPreferenceRejectsUnusableKey(): void
+    {
+        $this->config->expects($this->never())->method('setUserValue');
+        $this->config->expects($this->never())->method('deleteUserValue');
+
+        $response = $this->controller->setPreference('!!!', 'dark');
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertSame(['message' => 'Invalid key'], $response->getData());
+
+    }//end testSetPreferenceRejectsUnusableKey()
+
+
+    /**
+     * An anonymous caller cannot write another session's preferences.
+     *
+     * @return void
+     */
+    public function testSetPreferenceRejectsAnonymousCaller(): void
+    {
+        $this->config->expects($this->never())->method('setUserValue');
+
+        $response = $this->anonymousController()->setPreference('theme', 'dark');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+        $this->assertSame(['message' => 'Not logged in'], $response->getData());
+
+    }//end testSetPreferenceRejectsAnonymousCaller()
+
+
+}//end class

--- a/tests/unit/Controller/SigningControllerAuditTest.php
+++ b/tests/unit/Controller/SigningControllerAuditTest.php
@@ -1,0 +1,252 @@
+<?php
+
+/**
+ * Wire-contract tests for SigningController::getAudit()
+ *
+ * Covers `GET api/signing/requests/{id}/audit` (`signing#getAudit`): the
+ * 200 audit-trail body, the 401 anonymous rejection, and the access rule that
+ * makes this endpoint safe to expose — a non-admin caller who is neither the
+ * initiator nor a listed signer gets a plain 404, identical to the answer for
+ * a request that does not exist, and the audit trail is never read for them.
+ *
+ * An admin skips the per-request scoping and reads the trail directly.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/document-signing/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Controller;
+
+use OCA\DocuDesk\Controller\SigningController;
+use OCA\DocuDesk\Service\SigningAuditService;
+use OCA\DocuDesk\Service\SigningService;
+use OCA\DocuDesk\Service\SigningVerificationService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Tests for the signing audit-trail endpoint.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class SigningControllerAuditTest extends TestCase
+{
+
+    /**
+     * Mocked signing service.
+     *
+     * @var SigningService|MockObject
+     */
+    private SigningService|MockObject $signingService;
+
+    /**
+     * Mocked audit service.
+     *
+     * @var SigningAuditService|MockObject
+     */
+    private SigningAuditService|MockObject $auditService;
+
+    /**
+     * Mocked localisation.
+     *
+     * @var IL10N|MockObject
+     */
+    private IL10N|MockObject $l10n;
+
+
+    /**
+     * Set up the shared mocks.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->signingService = $this->createMock(SigningService::class);
+        $this->auditService   = $this->createMock(SigningAuditService::class);
+        $this->l10n           = $this->createMock(IL10N::class);
+        $this->l10n->method('t')->willReturnCallback(
+            static function (string $text): string {
+                return $text;
+            }
+        );
+
+    }//end setUp()
+
+
+    /**
+     * Build the controller for a given caller.
+     *
+     * @param string|null $uid     The caller's UID, or null for an anonymous session.
+     * @param bool        $isAdmin Whether the caller is an instance admin.
+     *
+     * @return SigningController The controller under test.
+     */
+    private function buildController(?string $uid, bool $isAdmin=false): SigningController
+    {
+        $session = $this->createMock(IUserSession::class);
+        if ($uid === null) {
+            $session->method('getUser')->willReturn(null);
+        } else {
+            $user = $this->createMock(IUser::class);
+            $user->method('getUID')->willReturn($uid);
+            $session->method('getUser')->willReturn($user);
+        }
+
+        $groupManager = $this->createMock(IGroupManager::class);
+        $groupManager->method('isAdmin')->willReturn($isAdmin);
+
+        return new SigningController(
+            'docudesk',
+            $this->createMock(IRequest::class),
+            $this->signingService,
+            $this->auditService,
+            $this->createMock(SigningVerificationService::class),
+            $session,
+            $this->createMock(LoggerInterface::class),
+            $this->l10n,
+            $groupManager
+        );
+
+    }//end buildController()
+
+
+    /**
+     * A participant reads the trail: the request is first resolved scoped to
+     * the caller's own UID, then the audit trail is returned with HTTP 200.
+     *
+     * @return void
+     */
+    public function testGetAuditReturnsTrailForParticipant(): void
+    {
+        $trail = [
+            ['action' => 'docudesk.signing.created', 'actor' => 'alice'],
+            ['action' => 'docudesk.signing.signed', 'actor' => 'bob'],
+        ];
+
+        $this->signingService->expects($this->once())
+            ->method('getRequest')
+            ->with('req-1', 'alice')
+            ->willReturn(['id' => 'req-1']);
+        $this->auditService->expects($this->once())
+            ->method('getAuditTrail')
+            ->with('req-1')
+            ->willReturn($trail);
+
+        $response = $this->buildController('alice')->getAudit('req-1');
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame($trail, $response->getData());
+
+    }//end testGetAuditReturnsTrailForParticipant()
+
+
+    /**
+     * An unrelated caller gets 404 and the audit trail — which carries IP
+     * addresses and user identifiers — is never read.
+     *
+     * @return void
+     */
+    public function testGetAuditHidesTrailFromUnrelatedCaller(): void
+    {
+        $this->signingService->method('getRequest')->willReturn(null);
+        $this->auditService->expects($this->never())->method('getAuditTrail');
+
+        $response = $this->buildController('mallory')->getAudit('req-1');
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $this->assertSame(['error' => 'Signing request not found'], $response->getData());
+
+    }//end testGetAuditHidesTrailFromUnrelatedCaller()
+
+
+    /**
+     * An admin reads any trail without the per-request scoping step.
+     *
+     * @return void
+     */
+    public function testGetAuditAllowsAdminWithoutScopedLookup(): void
+    {
+        $this->signingService->expects($this->never())->method('getRequest');
+        $this->auditService->expects($this->once())
+            ->method('getAuditTrail')
+            ->with('req-1')
+            ->willReturn([['action' => 'docudesk.signing.created', 'actor' => 'alice']]);
+
+        $response = $this->buildController('admin', true)->getAudit('req-1');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertCount(1, $response->getData());
+
+    }//end testGetAuditAllowsAdminWithoutScopedLookup()
+
+
+    /**
+     * An anonymous caller is refused with 401 before any lookup.
+     *
+     * @return void
+     */
+    public function testGetAuditRejectsAnonymousCaller(): void
+    {
+        $this->signingService->expects($this->never())->method('getRequest');
+        $this->auditService->expects($this->never())->method('getAuditTrail');
+
+        $response = $this->buildController(null)->getAudit('req-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+        $this->assertSame(['error' => 'Not authenticated'], $response->getData());
+
+    }//end testGetAuditRejectsAnonymousCaller()
+
+
+    /**
+     * A backend failure answers 500 with a generic body — the exception text
+     * must never reach the client, since distinct messages would confirm
+     * whether a request ID exists (docudesk#100).
+     *
+     * @return void
+     */
+    public function testGetAuditDoesNotLeakExceptionText(): void
+    {
+        $this->signingService->method('getRequest')->willReturn(['id' => 'req-1']);
+        $this->auditService->method('getAuditTrail')
+            ->willThrowException(new RuntimeException('Access denied: belongs to another user'));
+
+        $response = $this->buildController('alice')->getAudit('req-1');
+
+        $this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+        $body = json_encode($response->getData());
+        $this->assertIsString($body);
+        $this->assertStringNotContainsString('another user', $body);
+
+    }//end testGetAuditDoesNotLeakExceptionText()
+
+
+}//end class

--- a/tests/unit/Controller/TemplateVersionsControllerTest.php
+++ b/tests/unit/Controller/TemplateVersionsControllerTest.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * Wire-contract tests for TemplateVersionsController::diffVersions()
+ *
+ * Covers `GET api/templates/{id}/versions/diff`
+ * (`templateVersions#diffVersions`): the documented `{from, to}` success body,
+ * the 401 anonymous rejection, the 400 raised when either version UUID is
+ * missing, and the pass-through of the caller's `from` / `to` query params to
+ * the version service.
+ *
+ * The real TemplateRequestHandler is used (it needs only a logger) so the
+ * exception-to-status mapping under test is the shipped one, not a stub.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/template-management/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Controller;
+
+use Exception;
+use OCA\DocuDesk\Controller\TemplateRequestHandler;
+use OCA\DocuDesk\Controller\TemplateVersionsController;
+use OCA\DocuDesk\Service\TemplateService;
+use OCA\DocuDesk\Service\TemplateVersionService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for the template version-diff endpoint.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class TemplateVersionsControllerTest extends TestCase
+{
+
+    /**
+     * Mocked request.
+     *
+     * @var IRequest|MockObject
+     */
+    private IRequest|MockObject $request;
+
+    /**
+     * Mocked version service.
+     *
+     * @var TemplateVersionService|MockObject
+     */
+    private TemplateVersionService|MockObject $versionService;
+
+
+    /**
+     * Set up the shared mocks.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request        = $this->createMock(IRequest::class);
+        $this->versionService = $this->createMock(TemplateVersionService::class);
+
+    }//end setUp()
+
+
+    /**
+     * Build the controller for a given session.
+     *
+     * @param IUserSession $session The session the controller should see.
+     *
+     * @return TemplateVersionsController The controller under test.
+     */
+    private function buildController(IUserSession $session): TemplateVersionsController
+    {
+        return new TemplateVersionsController(
+            'docudesk',
+            $this->request,
+            $this->createMock(TemplateService::class),
+            new TemplateRequestHandler($this->createMock(LoggerInterface::class)),
+            $this->versionService,
+            $session
+        );
+
+    }//end buildController()
+
+
+    /**
+     * Build a session with a logged-in user.
+     *
+     * @return IUserSession The authenticated session.
+     */
+    private function authenticatedSession(): IUserSession
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+
+        return $session;
+
+    }//end authenticatedSession()
+
+
+    /**
+     * A diff of two known versions answers 200 with both version objects under
+     * `from` and `to`, resolved purely from the query params.
+     *
+     * @return void
+     */
+    public function testDiffVersionsReturnsBothVersions(): void
+    {
+        $this->request->method('getParam')->willReturnMap(
+            [
+                ['from', '', 'ver-1'],
+                ['to', '', 'ver-2'],
+            ]
+        );
+
+        $diff = [
+            'from' => ['id' => 'ver-1', 'content' => 'old'],
+            'to'   => ['id' => 'ver-2', 'content' => 'new'],
+        ];
+
+        $this->versionService->expects($this->once())
+            ->method('getDiff')
+            ->with('ver-1', 'ver-2')
+            ->willReturn($diff);
+
+        $response = $this->buildController($this->authenticatedSession())->diffVersions();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame($diff, $response->getData());
+
+    }//end testDiffVersionsReturnsBothVersions()
+
+
+    /**
+     * An anonymous caller is refused with 401 and no version is read.
+     *
+     * @return void
+     */
+    public function testDiffVersionsRejectsAnonymousCaller(): void
+    {
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn(null);
+
+        $this->versionService->expects($this->never())->method('getDiff');
+
+        $response = $this->buildController($session)->diffVersions();
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+        $this->assertSame(['error' => 'Not authenticated'], $response->getData());
+
+    }//end testDiffVersionsRejectsAnonymousCaller()
+
+
+    /**
+     * A missing `to` param is a client error: 400 with an explanatory message,
+     * and the service is never called with a half-empty pair.
+     *
+     * @return void
+     */
+    public function testDiffVersionsRequiresBothVersionIds(): void
+    {
+        $this->request->method('getParam')->willReturnMap(
+            [
+                ['from', '', 'ver-1'],
+                ['to', '', ''],
+            ]
+        );
+
+        $this->versionService->expects($this->never())->method('getDiff');
+
+        $response = $this->buildController($this->authenticatedSession())->diffVersions();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertStringContainsString('required', $response->getData()['error']);
+
+    }//end testDiffVersionsRequiresBothVersionIds()
+
+
+    /**
+     * A version UUID that does not resolve surfaces the service's own coded
+     * exception as that status, not a blanket 500.
+     *
+     * @return void
+     */
+    public function testDiffVersionsSurfacesServiceStatusCode(): void
+    {
+        $this->request->method('getParam')->willReturnMap(
+            [
+                ['from', '', 'ver-1'],
+                ['to', '', 'ver-missing'],
+            ]
+        );
+
+        $this->versionService->method('getDiff')
+            ->willThrowException(new Exception('Version not found', 404));
+
+        $response = $this->buildController($this->authenticatedSession())->diffVersions();
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $this->assertSame(['error' => 'Version not found'], $response->getData());
+
+    }//end testDiffVersionsSurfacesServiceStatusCode()
+
+
+}//end class

--- a/tests/unit/Controller/TemplatesControllerLockingTest.php
+++ b/tests/unit/Controller/TemplatesControllerLockingTest.php
@@ -1,0 +1,348 @@
+<?php
+
+/**
+ * Wire-contract tests for the template duplicate / lock / unlock endpoints
+ *
+ * Covers `templates#duplicate` (POST api/templates/{id}/duplicate),
+ * `templates#lock` (POST api/templates/{id}/lock) and `templates#unlock`
+ * (DELETE api/templates/{id}/lock).
+ *
+ * The real TemplateRequestHandler is used (it needs only a logger) so the
+ * exception-to-status mapping asserted here is the shipped one. The 409
+ * conflict body of `lock()` is asserted structurally, because the UI reads
+ * `lockedBy` / `lockedAt` out of it to tell the user who holds the lock.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/template-management/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Controller;
+
+use Exception;
+use OCA\DocuDesk\Controller\TemplateRequestHandler;
+use OCA\DocuDesk\Controller\TemplatesController;
+use OCA\DocuDesk\Service\TemplateService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for template duplication and edit locking.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress                              PropertyNotSetInConstructor
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class TemplatesControllerLockingTest extends TestCase
+{
+
+    /**
+     * Mocked template service.
+     *
+     * @var TemplateService|MockObject
+     */
+    private TemplateService|MockObject $templateService;
+
+    /**
+     * Controller under test, with an authenticated session.
+     *
+     * @var TemplatesController
+     */
+    private TemplatesController $controller;
+
+
+    /**
+     * Set up an authenticated controller.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->templateService = $this->createMock(TemplateService::class);
+        $this->controller      = $this->buildController($this->authenticatedSession());
+
+    }//end setUp()
+
+
+    /**
+     * Build the controller for a given session.
+     *
+     * @param IUserSession $session The session the controller should see.
+     *
+     * @return TemplatesController The controller under test.
+     */
+    private function buildController(IUserSession $session): TemplatesController
+    {
+        return new TemplatesController(
+            'docudesk',
+            $this->createMock(IRequest::class),
+            $this->templateService,
+            new TemplateRequestHandler($this->createMock(LoggerInterface::class)),
+            $session,
+            $this->createMock(LoggerInterface::class)
+        );
+
+    }//end buildController()
+
+
+    /**
+     * Build a session with a logged-in user.
+     *
+     * @return IUserSession The authenticated session.
+     */
+    private function authenticatedSession(): IUserSession
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+
+        return $session;
+
+    }//end authenticatedSession()
+
+
+    /**
+     * Build a session with no logged-in user.
+     *
+     * @return IUserSession The anonymous session.
+     */
+    private function anonymousSession(): IUserSession
+    {
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn(null);
+
+        return $session;
+
+    }//end anonymousSession()
+
+
+    /**
+     * Duplicating answers 200 with the NEW template object — a different id
+     * from the source, which is what the UI navigates to.
+     *
+     * @return void
+     */
+    public function testDuplicateReturnsNewTemplate(): void
+    {
+        $duplicate = ['id' => 'uuid-copy', 'name' => 'Invoice (copy)'];
+
+        $this->templateService->expects($this->once())
+            ->method('duplicateTemplate')
+            ->with('uuid-1')
+            ->willReturn($duplicate);
+
+        $response = $this->controller->duplicate('uuid-1');
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame($duplicate, $response->getData());
+        $this->assertNotSame('uuid-1', $response->getData()['id']);
+
+    }//end testDuplicateReturnsNewTemplate()
+
+
+    /**
+     * Duplicating an unknown template surfaces the service's own 404.
+     *
+     * @return void
+     */
+    public function testDuplicateSurfacesNotFound(): void
+    {
+        $this->templateService->method('duplicateTemplate')
+            ->willThrowException(new Exception('Template not found', 404));
+
+        $response = $this->controller->duplicate('missing');
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $this->assertSame(['error' => 'Template not found'], $response->getData());
+
+    }//end testDuplicateSurfacesNotFound()
+
+
+    /**
+     * An anonymous caller cannot duplicate a template.
+     *
+     * @return void
+     */
+    public function testDuplicateRejectsAnonymousCaller(): void
+    {
+        $this->templateService->expects($this->never())->method('duplicateTemplate');
+
+        $response = $this->buildController($this->anonymousSession())->duplicate('uuid-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+        $this->assertSame(['error' => 'Not authenticated'], $response->getData());
+
+    }//end testDuplicateRejectsAnonymousCaller()
+
+
+    /**
+     * Acquiring a free lock answers 200 with the locked template, and the lock
+     * is taken in the calling user's name.
+     *
+     * @return void
+     */
+    public function testLockReturnsLockedTemplate(): void
+    {
+        $locked = [
+            'id'       => 'uuid-1',
+            'lockedBy' => 'alice',
+            'lockedAt' => '2026-08-09T10:00:00+00:00',
+        ];
+
+        $this->templateService->expects($this->once())
+            ->method('acquireLock')
+            ->with('uuid-1', 'alice')
+            ->willReturn($locked);
+
+        $response = $this->controller->lock('uuid-1');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame($locked, $response->getData());
+
+    }//end testLockReturnsLockedTemplate()
+
+
+    /**
+     * A lock held by someone else answers 409 with the service's structured
+     * conflict body decoded — the UI shows `lockedBy` / `lockedAt` from it, so
+     * the body must arrive as an array, not as a JSON string.
+     *
+     * @return void
+     */
+    public function testLockReturnsDecodedConflictBody(): void
+    {
+        $conflict = [
+            'error'    => 'Template is locked',
+            'lockedBy' => 'bob',
+            'lockedAt' => '2026-08-09T09:00:00+00:00',
+        ];
+
+        $this->templateService->method('acquireLock')
+            ->willThrowException(new Exception((string) json_encode($conflict), 409));
+
+        $response = $this->controller->lock('uuid-1');
+
+        $this->assertSame(Http::STATUS_CONFLICT, $response->getStatus());
+        $this->assertSame($conflict, $response->getData());
+
+    }//end testLockReturnsDecodedConflictBody()
+
+
+    /**
+     * A 409 whose message is not JSON still answers 409, with the raw message
+     * under `error` — the status must not degrade to 500.
+     *
+     * @return void
+     */
+    public function testLockHandlesNonJsonConflictMessage(): void
+    {
+        $this->templateService->method('acquireLock')
+            ->willThrowException(new Exception('Template is locked by bob', 409));
+
+        $response = $this->controller->lock('uuid-1');
+
+        $this->assertSame(Http::STATUS_CONFLICT, $response->getStatus());
+        $this->assertSame(['error' => 'Template is locked by bob'], $response->getData());
+
+    }//end testLockHandlesNonJsonConflictMessage()
+
+
+    /**
+     * An anonymous caller cannot take an edit lock.
+     *
+     * @return void
+     */
+    public function testLockRejectsAnonymousCaller(): void
+    {
+        $this->templateService->expects($this->never())->method('acquireLock');
+
+        $response = $this->buildController($this->anonymousSession())->lock('uuid-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testLockRejectsAnonymousCaller()
+
+
+    /**
+     * Releasing a lock answers 200 with the unlocked template, released in the
+     * calling user's name.
+     *
+     * @return void
+     */
+    public function testUnlockReturnsUnlockedTemplate(): void
+    {
+        $unlocked = ['id' => 'uuid-1', 'lockedBy' => null];
+
+        $this->templateService->expects($this->once())
+            ->method('releaseLock')
+            ->with('uuid-1', 'alice')
+            ->willReturn($unlocked);
+
+        $response = $this->controller->unlock('uuid-1');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame($unlocked, $response->getData());
+
+    }//end testUnlockReturnsUnlockedTemplate()
+
+
+    /**
+     * Releasing a lock held by another user surfaces the service's 403 — not a
+     * silent success that would let a second editor steal the lock.
+     *
+     * @return void
+     */
+    public function testUnlockSurfacesForbidden(): void
+    {
+        $this->templateService->method('releaseLock')
+            ->willThrowException(new Exception('Lock held by another user', 403));
+
+        $response = $this->controller->unlock('uuid-1');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+        $this->assertSame(['error' => 'Lock held by another user'], $response->getData());
+
+    }//end testUnlockSurfacesForbidden()
+
+
+    /**
+     * An anonymous caller cannot release an edit lock.
+     *
+     * @return void
+     */
+    public function testUnlockRejectsAnonymousCaller(): void
+    {
+        $this->templateService->expects($this->never())->method('releaseLock');
+
+        $response = $this->buildController($this->anonymousSession())->unlock('uuid-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testUnlockRejectsAnonymousCaller()
+
+
+}//end class

--- a/tests/unit/Controller/VersionControllerTest.php
+++ b/tests/unit/Controller/VersionControllerTest.php
@@ -1,0 +1,226 @@
+<?php
+
+/**
+ * Wire-contract tests for VersionController::restore()
+ *
+ * Covers `POST api/documents/{fileId}/versions/{versionTimestamp}/restore`
+ * (`version#restore`): the documented `{restored: true}` success body, the 401
+ * anonymous rejection, the IDOR-safe 404/`{error, reason}` mapping of a
+ * ComparisonException, and the generic 500 fallback that must never let a
+ * Throwable escape to a white-screen.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/document-versions/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Controller;
+
+use OCA\DocuDesk\Controller\VersionController;
+use OCA\DocuDesk\Exception\ComparisonException;
+use OCA\DocuDesk\Service\DocumentVersionService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Tests for the document file-version restore endpoint.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Controller
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class VersionControllerTest extends TestCase
+{
+
+    /**
+     * Mocked version service.
+     *
+     * @var DocumentVersionService|MockObject
+     */
+    private DocumentVersionService|MockObject $service;
+
+    /**
+     * Mocked localisation.
+     *
+     * @var IL10N|MockObject
+     */
+    private IL10N|MockObject $l10n;
+
+    /**
+     * Controller under test, with an authenticated session.
+     *
+     * @var VersionController
+     */
+    private VersionController $controller;
+
+
+    /**
+     * Set up an authenticated controller.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = $this->createMock(DocumentVersionService::class);
+        $this->l10n    = $this->createMock(IL10N::class);
+        $this->l10n->method('t')->willReturnCallback(
+            static function (string $text): string {
+                return $text;
+            }
+        );
+
+        $user    = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+
+        $this->controller = new VersionController(
+            'docudesk',
+            $this->createMock(IRequest::class),
+            $this->createMock(LoggerInterface::class),
+            $this->service,
+            $this->l10n,
+            $session
+        );
+
+    }//end setUp()
+
+
+    /**
+     * A successful restore answers 200 with `{restored: true}` and forwards
+     * both path parameters to the service.
+     *
+     * @return void
+     */
+    public function testRestoreReturnsRestoredTrue(): void
+    {
+        $this->service->expects($this->once())
+            ->method('restoreVersion')
+            ->with(1234, 1700000000);
+
+        $response = $this->controller->restore(1234, 1700000000);
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['restored' => true], $response->getData());
+
+    }//end testRestoreReturnsRestoredTrue()
+
+
+    /**
+     * An anonymous caller is refused with 401 and no restore is attempted —
+     * restore is a write, so this guard is the boundary, not a nicety.
+     *
+     * @return void
+     */
+    public function testRestoreRejectsAnonymousCaller(): void
+    {
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn(null);
+
+        $controller = new VersionController(
+            'docudesk',
+            $this->createMock(IRequest::class),
+            $this->createMock(LoggerInterface::class),
+            $this->service,
+            $this->l10n,
+            $session
+        );
+
+        $this->service->expects($this->never())->method('restoreVersion');
+
+        $response = $controller->restore(1234, 1700000000);
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+        $this->assertSame(['error' => 'Not authenticated'], $response->getData());
+
+    }//end testRestoreRejectsAnonymousCaller()
+
+
+    /**
+     * A file the caller cannot reach yields the service's 404 with a
+     * `{error, reason}` body — the same answer as a file that does not exist,
+     * so the endpoint discloses nothing (ADR-005).
+     *
+     * @return void
+     */
+    public function testRestoreMapsInaccessibleFileToNotFound(): void
+    {
+        $this->service->method('restoreVersion')
+            ->willThrowException(new ComparisonException(404, 'not-found', 'no such file'));
+
+        $response = $this->controller->restore(999, 1700000000);
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $data = $response->getData();
+        $this->assertSame('Document not found', $data['error']);
+        $this->assertSame('not-found', $data['reason']);
+
+    }//end testRestoreMapsInaccessibleFileToNotFound()
+
+
+    /**
+     * An instance without files_versions answers with the service's own status
+     * and the dedicated `versions-unavailable` reason, so the UI can explain
+     * the deployment gap instead of reporting a missing document.
+     *
+     * @return void
+     */
+    public function testRestoreReportsVersionsUnavailable(): void
+    {
+        $this->service->method('restoreVersion')
+            ->willThrowException(new ComparisonException(501, 'versions-unavailable', 'app disabled'));
+
+        $response = $this->controller->restore(1234, 1700000000);
+
+        $this->assertSame(501, $response->getStatus());
+        $data = $response->getData();
+        $this->assertSame('File versions are not available on this instance', $data['error']);
+        $this->assertSame('versions-unavailable', $data['reason']);
+
+    }//end testRestoreReportsVersionsUnavailable()
+
+
+    /**
+     * Any other failure is contained as a localised 500 body — the Throwable
+     * must not escape to the framework's raw error page.
+     *
+     * @return void
+     */
+    public function testRestoreContainsUnexpectedFailure(): void
+    {
+        $this->service->method('restoreVersion')
+            ->willThrowException(new RuntimeException('storage backend exploded'));
+
+        $response = $this->controller->restore(1234, 1700000000);
+
+        $this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+        $this->assertSame(['error' => 'Could not restore version'], $response->getData());
+
+    }//end testRestoreContainsUnexpectedFailure()
+
+
+}//end class


### PR DESCRIPTION
## What

Closes hydra **gate-25 (contract-coverage)**: **26 → 0** routed public endpoints without an automated proof that their wire contract holds.

All 26 are closed with **real PHPUnit controller tests** — each one calls the controller method and asserts the HTTP status and the response body shape the endpoint documents. No `@contract exclude`, no skips, no baseline or threshold change, no `continue-on-error`, and no test that merely names a method.

## Measured

Both numbers are quoted from the runner's own STDOUT (`run-hydra-gates.sh .`, full-tree scope), read from the log dir printed by that run — never from the exit byte.

**Before**
```
[gate-25] contract-coverage: FAIL — 26 new public endpoint(s) missing a contract test
```

**After**
```
[gate-25] contract-coverage: PASS — 96 new endpoint(s), all covered
```

## The gate was proven able to fail

A green gate that cannot go red measures nothing, so the ratchet was tested against a planted true positive.

1. Deleting the single test method `testCatchAllServesTheSameSpaHost()` did **not** make the gate fire — it still printed `PASS — 96 new endpoint(s), all covered`, because a second test in the same file also drives `catchAll()`. Worth recording: the gate is satisfied per *endpoint*, not per test, so one deleted method is not necessarily a coverage hole.
2. Removing the endpoint's **last** exercising call made the runner print, on its own STDOUT:

```
[gate-25] contract-coverage: FAIL — 1 new public endpoint(s) missing a contract test — see /tmp/hydra-gates.4cUDrjBb/hydra-gate-contract-coverage.log
```

and that log named exactly the endpoint whose coverage was removed, and nothing else:

```
dashboard#catchAll — new public endpoint (url=?) missing Newman/PHPUnit contract test or @contract exclude
[gate-25] contract-coverage: FAIL — 1 new public endpoint(s) without a contract test
```

The finding then **disappeared from the log** once the test was restored, and the restored tree is byte-identical to the committed one (`git status` clean, empty `git diff`).

## Endpoints now covered

| Controller | Endpoints |
|---|---|
| `AnonymizationController` | `upload`, `updateRelation` |
| `BatchAnonymizationController` | `batchUpload`, `batchExtract`, `batchStatus`, `batchReport`, `getProfiles` |
| `CustomDictionaryController` | `indexTerms`, `createTerm`, `deleteTerm`, `import` |
| `DashboardController` | `page`, `catchAll` |
| `PolicyController` | `indexProhibitions`, `showProhibition`, `createProhibition`, `updateProhibition`, `deleteProhibition` |
| `PreferencesController` | `getPreference`, `setPreference` |
| `SigningController` | `getAudit` |
| `TemplateVersionsController` | `diffVersions` |
| `TemplatesController` | `duplicate`, `lock`, `unlock` |
| `VersionController` | `restore` |

**26 endpoints, 0 left red.**

## What the tests actually assert

Beyond "returns 200", each suite pins the behaviour a client depends on:

- **Security postures, not just happy paths.** Every endpoint is asserted to refuse an anonymous session with 401 *and* to leave the backend untouched (`expects($this->never())`). `signing#getAudit` is asserted to resolve the request **scoped to the caller's own UID** and to answer an unrelated caller with a plain 404 while `getAuditTrail()` is never called — the audit trail carries IP addresses and user identifiers. Its 500 body is asserted **not** to echo the exception text (docudesk#100).
- **Failure mapping, which is where wire contracts actually break.** A coded exception keeps its own HTTP status (507 quota on upload, 404 on an unknown batch), an *un*coded one is normalised to 500 rather than surfacing code `0` as a status, and `version#restore` maps `ComparisonException` so an inaccessible file answers the same 404 + `{error, reason}` as a nonexistent one (ADR-005).
- **Body shape, not just presence.** `batchStatus` asserts the computed aggregate (two of four files terminal ⇒ `progress: 50.0`, `totalEntities: 7`), `batchReport` asserts a CSV `DataDownloadResponse` with the batch id in its `Content-Disposition` — not a JSON envelope, `templates#lock` asserts the 409 conflict body arrives **decoded** because the UI reads `lockedBy` / `lockedAt` out of it, and `updateRelation` asserts the policy's 422 body (`threshold`, `prohibitionMatch`) is passed through verbatim.
- **Real I/O where the contract is I/O.** `anonymization#upload` and `customDictionary#import` drive a real temporary file through the multipart path, so the bytes-from-disk and CSV-detection-from-filename branches genuinely execute.
- **The shipped error mapper.** Four suites construct the real `TemplateRequestHandler` (it needs only a logger) instead of mocking `buildErrorResponse`, so the exception-to-status mapping under test is the one that ships.

## One stub fix

`TemplateResponse::getApp()` exists on the real `OCP\AppFramework\Http\TemplateResponse` but was **missing from `tests/stubs/NextcloudStubs.php`**, so no test could assert which app a `TemplateResponse` renders from. Added to the stub with the real signature. An incomplete stub silently caps what the suite is able to ask.

## Checks

- `composer check:strict` → **ALL CHECKS PASSED** (lint, phpcs, phpmd, psalm, phpstan, phpunit).
- Suite: **1141 → 1234 tests**, **3486 → 3764 assertions**, all green (the 2 pre-existing skips are unchanged).
- Coverage cannot drop: the diff touches **zero files under `lib/`** (test-only, +3554 lines), so the clover denominator is unchanged while the new tests execute controller paths that previously had none. No local coverage number is quoted because this machine has neither xdebug nor pcov installed — CI's `Coverage Baseline Protection` (baseline 52.88) is the measurement that counts.
