### PR TITLE
test(gate-19): 375 → 357 — 12 real e2e tests, 5 anchors invisible to the gate, 1 exclusion

### DIFF
--- a/openspec/specs/custom-dictionary-recognition/spec.md
+++ b/openspec/specs/custom-dictionary-recognition/spec.md
@@ -27,7 +27,7 @@ it (fail-closed).
 - GIVEN a new dictionary created without an explicit match mode
 - WHEN it is persisted and read back
 - THEN its match mode is `caseInsensitive`
-- @e2e tests/e2e/spec-coverage/custom-dictionary-recognition.spec.ts
+- @e2e exclude not observable in a browser — both rendering paths substitute the default themselves, so the DOM is identical whether or not the value was persisted. `matchModeLabel()` is byte-identical in CustomDictionaryIndex.vue and CustomDictionaryDetail.vue and both end `|| t('docudesk', 'Case-insensitive')`, so a NULL match mode renders exactly like a persisted `caseInsensitive` one. Asserted where the value IS visible: tests/unit/Service/CustomDictionaryServiceTest.php::testCreateDictionaryDefaultsMatchMode, which asserts `saveObject()` received `matchMode === 'caseInsensitive'`.
 
 ### Requirement: Deterministic term matching engine (REQ-DDCDR-002)
 

--- a/src/dialogs/CustomDictionaryFormDialog.vue
+++ b/src/dialogs/CustomDictionaryFormDialog.vue
@@ -118,15 +118,33 @@ export default {
 					:label="t('docudesk', 'Hex value')"
 					class="custom-dictionary-form__colour-hex" />
 			</div>
+			<!--
+				`v-model`, NOT `:value` + `@input`.
+
+				This was a Vue 2 binding left behind by the Vue 3 migration, and
+				it made the control INERT rather than merely mis-styled.
+				`@nextcloud/vue` 9.9.0's NcSelect declares a `modelValue` prop,
+				declares NO `value` prop at all, and its only declared emit is
+				`update:modelValue` (verified in the installed
+				dist/chunks/NcSelect-*.mjs). So `:value` bound nothing — the
+				select rendered with no `.vs__selected` at all — and `@input`
+				never fired, so picking a match mode did not change
+				`form.matchMode`. Every dictionary created or edited through this
+				dialog was written with the `caseInsensitive` default no matter
+				what the user chose, silently.
+
+				The sibling select in StandingConsentFormModal.vue already uses
+				`v-model` and works; this was the only `:value`-bound NcSelect
+				left in src/ (swept 2026-08-11).
+			-->
 			<NcSelect
-				:value="form.matchMode"
+				v-model="form.matchMode"
 				:options="matchModeOptions"
 				label="label"
 				:reduce="(o) => o.value"
 				:clearable="false"
 				:input-label="t('docudesk', 'Match mode')"
-				required
-				@input="form.matchMode = $event" />
+				required />
 			<p class="custom-dictionary-form__hint">
 				{{ t('docudesk', 'Exact matches case-sensitively; case-insensitive (default) folds case; word boundary is case-insensitive but never matches inside a longer word.') }}
 			</p>

--- a/tests/e2e/spec-coverage/_helpers.ts
+++ b/tests/e2e/spec-coverage/_helpers.ts
@@ -184,8 +184,67 @@ export async function waitForNcContentReady(page: Page, timeout = 30_000): Promi
 		.waitFor({ state: 'visible', timeout })
 }
 
+/**
+ * The app base the SPA ROUTER actually uses, read from the running instance.
+ *
+ * ⚠️ `APP` above is the right entry point but the wrong ROUTER BASE, and the
+ * difference is invisible until a test deep-links.
+ *
+ * `src/main.js:306` builds the router as
+ * `createWebHistory(generateUrl('/apps/docudesk'))`, and Nextcloud's
+ * `generateUrl` includes the `index.php` segment only when
+ * `OC.config.modRewriteWorking` is FALSE:
+ *
+ *   - CI (`php -S`, no rewrite)  modRewriteWorking = false
+ *                                -> router base `/index.php/apps/docudesk`
+ *   - Apache with mod_rewrite    modRewriteWorking = true   (measured on a
+ *     (any normal dev/prod NC)   `nextcloud:34-apache` rig)
+ *                                -> router base `/apps/docudesk`
+ *
+ * So on Apache a navigation to `/index.php/apps/docudesk/custom-dictionaries`
+ * lands on a path the router does not recognise and it falls back to the app
+ * root. The failure is quiet and very easy to misread: the page renders fine,
+ * the URL is still under `/apps/docudesk`, and only an assertion that names
+ * the ROUTE catches it. Every assertion in this suite of the shape
+ * `expect(page).toHaveURL(/\/apps\/docudesk/)` passes on the WRONG PAGE.
+ * (Measured: three deep-link specs failed on Apache with
+ *  `Received string: "http://localhost:8097/apps/docudesk/"`.)
+ *
+ * Hardcoding either form is therefore wrong on one of the two environments.
+ * Ask the app instead: land once on `APP` — which is served correctly with and
+ * without rewriting — and read the same `generateUrl` the router itself used.
+ * On CI this resolves to exactly the previous hardcoded value, so the change is
+ * a no-op there and a repair everywhere else.
+ *
+ * Cached per worker: one extra navigation per run, not per test.
+ */
+let cachedAppBase: string | null = null
+
+async function resolveAppBase(page: Page): Promise<string> {
+	if (cachedAppBase !== null) return cachedAppBase
+	await page.goto(APP, { waitUntil: 'domcontentloaded' })
+	await waitForAppReady(page)
+	cachedAppBase = await page.evaluate(() => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const oc = (window as any).OC
+		return (oc?.generateUrl?.('/apps/docudesk') as string) || ''
+	})
+	// An empty answer means `OC` was not on the page — that is a broken load,
+	// not a base to guess around. Fail loudly rather than silently reinstating
+	// the hardcoded value and producing the exact bug this function exists to
+	// remove.
+	if (!cachedAppBase) {
+		throw new Error(
+			'Could not read OC.generateUrl("/apps/docudesk") from the running app. '
+			+ `The page at ${APP} did not expose window.OC, so the SPA router base is unknown.`,
+		)
+	}
+	return cachedAppBase
+}
+
 export async function go(page: Page, route: string): Promise<void> {
-	const url = route ? `${APP}/${route}` : APP
+	const base = await resolveAppBase(page)
+	const url = route ? `${base}/${route}` : base
 	// Wait for `domcontentloaded`, not the default `load`. Nextcloud keeps
 	// long-lived connections open (notifications polling, user-status
 	// heartbeat), so on a busy instance the `load` event can be minutes late
@@ -196,6 +255,22 @@ export async function go(page: Page, route: string): Promise<void> {
 	await waitForAppReady(page)
 	await dismissOverlays(page)
 	await page.waitForTimeout(800)
+}
+
+/**
+ * Build an absolute in-app URL for a route, using the router's real base.
+ *
+ * Use this instead of `${APP}/${route}` whenever a spec needs `page.goto`
+ * directly rather than `go()` — see `resolveAppBase` for why the hardcoded
+ * form is wrong on a rewriting server.
+ *
+ * @param page  A page in the same context (used once to read the base).
+ * @param route The in-app route, without a leading slash.
+ * @return The absolute path to navigate to.
+ */
+export async function appUrl(page: Page, route: string): Promise<string> {
+	const base = await resolveAppBase(page)
+	return route ? `${base}/${route}` : base
 }
 
 /** Click a left-hand app-navigation entry by its `title` attribute. */

--- a/tests/e2e/spec-coverage/anonymiser-backend-warning.spec.ts
+++ b/tests/e2e/spec-coverage/anonymiser-backend-warning.spec.ts
@@ -1,0 +1,179 @@
+/*
+ * SPDX-FileCopyrightText: 2026 DocuDesk Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Gate-19 e2e spec-coverage — the "Admin Warning When No Anonymiser Backend
+ * Is Available" requirement of openspec/specs/anonymization/spec.md.
+ *
+ * WHY THESE SCENARIOS AND NOT THE OTHER 45
+ * ----------------------------------------
+ * `anonymization` is the app's largest spec (78 scenarios) and most of what is
+ * uncovered in it is service-layer behaviour — `outputFormat` cascades,
+ * conversion-backend fallbacks, the skip-marked-relation gate — none of which
+ * a browser can observe. This requirement is the exception: it is defined
+ * ENTIRELY in terms of what an admin sees on a page, so every assertion below
+ * is the scenario's own wording rather than a proxy for it.
+ *
+ * PRECONDITION, AND WHY IT IS ASSERTED RATHER THAN ASSUMED
+ * -------------------------------------------------------
+ * Every scenario here is conditioned on `method = 'regex'` — i.e. NO anonymiser
+ * backend installed. On a seeded CI instance that is the state (`GET
+ * /api/settings` returns `anonymiserBackend.method = "regex"`,
+ * `showWarning = true`), but it is a property of the ENVIRONMENT, not of the
+ * app. If a backend were ever installed on the runner, the banner would
+ * correctly disappear and these tests would go red for a reason that is not a
+ * defect. So the precondition is read from the API and asserted first, in
+ * `test.beforeAll`: a wrong environment fails ONCE, loudly, naming itself —
+ * instead of six selector timeouts that read like a broken banner.
+ *
+ * Deliberately NOT a `test.skip()` on that precondition. A self-skip here would
+ * be indistinguishable from a healthy run in the summary line, which is exactly
+ * how six tests in this suite went green-by-skipping for months
+ * (see the long comment in orphaned-surface-restoration.spec.ts).
+ */
+
+import { test, expect, type Page, type APIRequestContext } from '@playwright/test'
+import { waitForNcContentReady, dismissOverlays, go } from './_helpers'
+
+const SETTINGS = '/index.php/settings/admin/docudesk'
+const API_SETTINGS = '/index.php/apps/docudesk/api/settings'
+
+interface BackendState {
+	method: string
+	appApiInstalled: boolean
+	warningDismissed: boolean
+	showWarning: boolean
+}
+
+async function readBackendState(request: APIRequestContext): Promise<BackendState> {
+	const res = await request.get(API_SETTINGS, { headers: { 'OCS-APIRequest': 'true' } })
+	// Print the STATUS CODE, always. A 403 body parses as an empty object and
+	// then reads as "the field is absent", which is a different finding.
+	expect(res.status(), `GET ${API_SETTINGS} must answer 200`).toBe(200)
+	const body = await res.json()
+	return body.anonymiserBackend as BackendState
+}
+
+async function goSettings(page: Page): Promise<void> {
+	await page.goto(SETTINGS, { waitUntil: 'domcontentloaded' })
+	// Not `networkidle` — Nextcloud holds notification-polling and
+	// user-status connections open, so it never fires (ADR-074 rule 4 /
+	// gate-58). Wait for the region the assertions actually read.
+	await waitForNcContentReady(page)
+	await dismissOverlays(page)
+}
+
+/** The banner root. Scoped to its own class so nothing else can satisfy it. */
+const banner = (page: Page) => page.locator('.anonymiser-backend-warning')
+
+test.describe('anonymization — admin warning when no anonymiser backend is available', () => {
+	test.beforeAll(async ({ request }) => {
+		const state = await readBackendState(request)
+		expect(
+			state.method,
+			'PRECONDITION: these scenarios are all conditioned on regex-only mode. '
+			+ `This instance reports method="${state.method}", so an anonymiser backend IS `
+			+ 'configured and the banner is CORRECTLY hidden. Nothing below is a defect — '
+			+ 'remove the backend, or run this suite on a clean instance.',
+		).toBe('regex')
+	})
+
+	test('the banner renders on the admin settings page with all four required elements', async ({ page, request }) => {
+		// @e2e openspec/specs/anonymization/spec.md#admin-opens-docudesk-admin-settings-with-no-backend-configured
+		const state = await readBackendState(request)
+		expect(state.warningDismissed, 'admin must not have dismissed the warning yet').toBe(false)
+
+		await goSettings(page)
+		await expect(banner(page)).toBeVisible()
+
+		// The scenario names four things the banner MUST contain. Each is a
+		// separate assertion so a partial regression names which half broke.
+		await expect(
+			banner(page).locator('a[href="/settings/apps/discover/openanonymiser_light"]'),
+			'deep link to the App Store entry for openanonymiser_light',
+		).toHaveCount(1)
+		await expect(
+			banner(page).locator('a[href="/settings/apps/discover/openanonymiser"]'),
+			'deep link to the App Store entry for openanonymiser',
+		).toHaveCount(1)
+		await expect(
+			banner(page).locator('a[href="/settings/admin/openregister"]'),
+			'link to OpenRegister settings for a custom endpoint',
+		).toHaveCount(1)
+		await expect(
+			banner(page).getByRole('button', { name: 'Dismiss' }),
+			'"Dismiss" action',
+		).toBeVisible()
+	})
+
+	test('the banner renders at the top of the DocuDesk dashboard', async ({ page }) => {
+		// @e2e openspec/specs/anonymization/spec.md#admin-opens-docudesk-dashboard-with-no-backend-configured
+		await go(page, '')
+		await expect(banner(page)).toBeVisible()
+
+		// "at the top of the dashboard" is the load-bearing half of this
+		// scenario — a banner rendered below the fold satisfies "is shown" and
+		// still fails the requirement. Assert the ordering against the
+		// dashboard body rather than a pixel coordinate: the banner's box must
+		// start above the dashboard page component's box.
+		const bannerBox = await banner(page).boundingBox()
+		const dashboardBox = await page.locator('.cn-dashboard-page, [class*="dashboard-page"]').first()
+			.boundingBox()
+		expect(bannerBox, 'banner must have a rendered box').not.toBeNull()
+		expect(dashboardBox, 'dashboard body must have a rendered box').not.toBeNull()
+		expect(
+			bannerBox!.y,
+			'the banner must render ABOVE the dashboard body, not below it',
+		).toBeLessThan(dashboardBox!.y)
+	})
+
+	test('the banner states that AppAPI must be installed first, without hiding the ExApp CTAs', async ({ page, request }) => {
+		// @e2e openspec/specs/anonymization/spec.md#appapi-is-not-installed
+		const state = await readBackendState(request)
+		expect(
+			state.appApiInstalled,
+			'PRECONDITION: this scenario needs app_api absent. It is installed on this instance.',
+		).toBe(false)
+
+		await goSettings(page)
+		await expect(banner(page)).toBeVisible()
+		await expect(
+			banner(page).locator('.anonymiser-backend-warning__appapi-line'),
+			'the AppAPI notice line',
+		).toBeVisible()
+		await expect(banner(page).locator('.anonymiser-backend-warning__appapi-line'))
+			.toContainText('AppAPI is not installed')
+		// "AND the deep-link CTAs to the ExApp entries remain visible" — the
+		// half of this scenario a naive implementation breaks by replacing the
+		// body with the AppAPI notice.
+		await expect(banner(page).locator('a[href="/settings/apps/discover/openanonymiser_light"]')).toBeVisible()
+		await expect(banner(page).locator('a[href="/settings/apps/discover/openanonymiser"]')).toBeVisible()
+	})
+
+	test('the OpenAnonymiser Light CTA navigates to the App Store discover page and installs nothing', async ({ page }) => {
+		// @e2e openspec/specs/anonymization/spec.md#click-on-install-openanonymiser-light
+		await goSettings(page)
+		const cta = banner(page).locator('a[href="/settings/apps/discover/openanonymiser_light"]')
+		await expect(cta).toBeVisible()
+
+		// "no install action is triggered automatically" — record every request
+		// the click produces and assert none of them is an app-install call.
+		// A plain assertion on the destination URL cannot see a side effect.
+		const installCalls: string[] = []
+		page.on('request', (r) => {
+			const u = r.url()
+			if (/\/settings\/apps\/enable|\/apps\/[^/]+\/enable|app_api\/apps\/install/.test(u)) {
+				installCalls.push(`${r.method()} ${u}`)
+			}
+		})
+
+		await cta.click()
+		await page.waitForURL(/\/settings\/apps\/discover\/openanonymiser_light/, { timeout: 30_000 })
+		await waitForNcContentReady(page)
+
+		expect(
+			installCalls,
+			`the CTA must not trigger an install; observed: ${installCalls.join(' | ')}`,
+		).toEqual([])
+	})
+})

--- a/tests/e2e/spec-coverage/anonymization.spec.ts
+++ b/tests/e2e/spec-coverage/anonymization.spec.ts
@@ -15,12 +15,11 @@
 // @e2e openspec/specs/anonymization/spec.md#anonymize-another-document
 
 import { test, expect, type Page } from '@playwright/test'
-import { waitForAppReady } from './_helpers'
+import { appUrl, waitForAppReady } from './_helpers'
 
-// `index.php`-prefixed — see the APP constant in ./_helpers.ts for why the
-// prefix is required on CI (`php -S` does not rewrite, so `/apps/...` hits
-// PHP's own 404 page instead of Nextcloud).
-const APP = '/index.php/apps/docudesk'
+// The local `const APP = '/index.php/apps/docudesk'` that used to live here is
+// gone — navigation now goes through `appUrl()`, which reads the base from the
+// running app. See the note in `go()` below and `resolveAppBase` in ./_helpers.
 
 async function dismissOverlays(page: Page): Promise<void> {
 	const wizard = page.locator('#firstrunwizard')
@@ -31,7 +30,13 @@ async function dismissOverlays(page: Page): Promise<void> {
 }
 
 async function go(page: Page, route: string): Promise<void> {
-	const url = `${APP}/${route}`
+	// `appUrl`, not the local `APP` constant. The router base is
+	// `generateUrl('/apps/docudesk')`, which carries the `index.php` segment
+	// only when `OC.config.modRewriteWorking` is false (CI's `php -S`) — on a
+	// rewriting Apache the hardcoded form silently falls back to the app root
+	// and every `toHaveURL(/\/apps\/docudesk/)` below then passes on the
+	// DASHBOARD. See `resolveAppBase` in ./_helpers. No-op on CI.
+	const url = await appUrl(page, route)
 	// `domcontentloaded`, not the default `load` — NC's long-lived polling
 	// connections can delay `load` past any sane timeout. See _helpers.ts.
 	await page.goto(url, { waitUntil: 'domcontentloaded' })

--- a/tests/e2e/spec-coverage/consent-management.spec.ts
+++ b/tests/e2e/spec-coverage/consent-management.spec.ts
@@ -14,12 +14,13 @@
 // @e2e openspec/specs/consent-management/spec.md#empty-consent-list
 
 import { test, expect, type Page } from '@playwright/test'
-import { waitForAppReady } from './_helpers'
+import { appUrl, waitForAppReady } from './_helpers'
 
 // `index.php`-prefixed — see the APP constant in ./_helpers.ts for why the
 // prefix is required on CI (`php -S` does not rewrite, so `/apps/...` hits
 // PHP's own 404 page instead of Nextcloud).
-const APP = '/index.php/apps/docudesk'
+// (The local `const APP` that used to sit here is gone — navigation goes
+// through `appUrl()`, which reads the base from the running app.)
 
 async function dismissOverlays(page: Page): Promise<void> {
 	const wizard = page.locator('#firstrunwizard')
@@ -30,7 +31,13 @@ async function dismissOverlays(page: Page): Promise<void> {
 }
 
 async function go(page: Page, route: string): Promise<void> {
-	const url = `${APP}/${route}`
+	// `appUrl`, not a hardcoded `/index.php/...`. The router base is
+	// `generateUrl('/apps/docudesk')`, which carries the `index.php` segment
+	// only when `OC.config.modRewriteWorking` is false (CI's `php -S`) — on a
+	// rewriting Apache the hardcoded form silently falls back to the app root,
+	// so `toHaveURL(/\/apps\/docudesk/)` below would pass on the DASHBOARD.
+	// See `resolveAppBase` in ./_helpers. No-op on CI.
+	const url = await appUrl(page, route)
 	// `domcontentloaded`, not the default `load` — NC's long-lived polling
 	// connections can delay `load` past any sane timeout. See _helpers.ts.
 	await page.goto(url, { waitUntil: 'domcontentloaded' })

--- a/tests/e2e/spec-coverage/custom-dictionary-detection.spec.ts
+++ b/tests/e2e/spec-coverage/custom-dictionary-detection.spec.ts
@@ -1,0 +1,186 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Gate-19 e2e spec-coverage —
+ * custom-dictionary-recognition::a-dictionary-hit-is-detected-reviewable-and-redacted
+ *
+ * WHY THIS FILE EXISTS SEPARATELY, AND WHY IT NEARLY DID NOT EXIST AT ALL
+ * ----------------------------------------------------------------------
+ * This scenario spans the whole pipeline — dictionary → file → extraction →
+ * detection → the review workbench — so it does not belong in the admin-UI file
+ * next to the dictionaries list.
+ *
+ * It was very nearly excluded instead, on two reasons that were both FALSE, and
+ * both are worth recording because each is a trap the next reader can fall into:
+ *
+ *   1. "It needs a real anonymiser backend, and CI runs regex-only." Wrong.
+ *      Custom-dictionary matching does not go through the NER backend at all —
+ *      `CustomDictionaryDetectionRunner` is a pure term matcher over the
+ *      extracted text. Measured on an instance reporting
+ *      `anonymiserBackend.method = "regex"` with no backend installed:
+ *        POST api/anonymization/extract/{fileId} -> 200
+ *        {"entities":[{"type":"CUSTOM_DICTIONARY","value":"Operatie Zilverreiger",
+ *                      "confidence":"1.00",...}],"entityCount":1}
+ *      A degraded SUBSYSTEM is not a degraded PIPELINE.
+ *
+ *   2. "There is no per-file review surface." Wrong, and the lookup could not
+ *      have found it: the grep covered `src/views` and `src/components`, and the
+ *      workbench lives in `src/sidebars/FileViewerSidebar.vue` (mounted through
+ *      `src/sidebars/SideBars.vue`). A directory-scoped grep is not a search.
+ *
+ * An `@e2e exclude` on this scenario would therefore have been a false
+ * statement — the strongest reason to write the test instead.
+ *
+ * WHAT MAKES IT FALSIFIABLE
+ * -------------------------
+ * The term is unique per run, so the assertion cannot be satisfied by anything
+ * already on the instance, and the file is seeded with the term embedded in
+ * ordinary prose so a substring match is genuinely about detection rather than
+ * about the filename. Delete the dictionary pass from
+ * `AnonymizationService`, or break `CustomDictionaryMatchService`, and the
+ * `CUSTOM_DICTIONARY` card disappears while everything else still renders.
+ */
+
+import { test, expect, type APIRequestContext } from '@playwright/test'
+import { go, waitForAppReady } from './_helpers'
+import { harvestToken, jsonHeaders, API } from '../workflows/_fixtures'
+
+/** Unique per run — the whole point of the assertion is that only WE seeded it. */
+const RUN = `g19cdd-${Date.now()}`
+const TERM = `Operatie Zilverreiger ${RUN}`
+/**
+ * ⚠️ Two names, deliberately. My Documents renders the file's BASE name — the
+ * row for `x-dossier.txt` reads `x-dossier` — so a locator built from the
+ * on-disk name matches nothing and fails as "the document is not listed" when
+ * it is listed perfectly well.
+ */
+const FILE_BASE = `${RUN}-dossier`
+const FILE_NAME = `${FILE_BASE}.txt`
+
+/**
+ * `/DocuDesk` is the root `myDocumentsStore` lists (`currentPath` default), so
+ * the seeded file has to live there to be clickable in the UI.
+ */
+const DAV_DIR = '/DocuDesk'
+
+let dictionaryId = ''
+let fileId = 0
+
+async function dav(
+	req: APIRequestContext,
+	token: string,
+	method: 'MKCOL' | 'PUT',
+	path: string,
+	body?: string,
+) {
+	return req.fetch(`/remote.php/dav/files/admin${path}`, {
+		method,
+		headers: { requesttoken: token },
+		data: body,
+	})
+}
+
+test.describe('custom-dictionary-recognition — a dictionary hit is detected, reviewable and redacted', () => {
+	test.beforeAll(async ({ browser }) => {
+		const ctx = await browser.newContext()
+		const page = await ctx.newPage()
+		const token = await harvestToken(page)
+		const req = ctx.request
+
+		// 1. An active dictionary carrying the term.
+		const dict = await req.post(`${API}/custom-dictionaries`, {
+			headers: jsonHeaders(token),
+			data: { label: `${RUN}-codenames`, matchMode: 'caseInsensitive', active: true },
+		})
+		expect(dict.status(), `create dictionary (${await dict.text().catch(() => '')})`).toBe(201)
+		dictionaryId = (await dict.json()).id
+
+		const term = await req.post(`${API}/custom-dictionaries/${dictionaryId}/terms`, {
+			headers: jsonHeaders(token),
+			data: { value: TERM },
+		})
+		expect(term.status(), `create term (${await term.text().catch(() => '')})`).toBe(201)
+
+		// 2. A document containing it, in the folder My Documents lists.
+		// MKCOL is allowed to 405 — the folder normally already exists.
+		await dav(req, token, 'MKCOL', DAV_DIR).catch(() => null)
+		const put = await dav(
+			req, token, 'PUT', `${DAV_DIR}/${FILE_NAME}`,
+			`Interne notitie.\n\nHet dossier vermeldt ${TERM} als codenaam voor het traject.\n`,
+		)
+		expect([201, 204], `PUT ${DAV_DIR}/${FILE_NAME} -> ${put.status()}`).toContain(put.status())
+
+		// Resolve the numeric fileId — needed to drive extraction, and to prove
+		// the file landed rather than assuming it.
+		const propfind = await req.fetch(`/remote.php/dav/files/admin${DAV_DIR}/${FILE_NAME}`, {
+			method: 'PROPFIND',
+			headers: { requesttoken: token, Depth: '0' },
+			data: '<?xml version="1.0"?><d:propfind xmlns:d="DAV:" '
+				+ 'xmlns:oc="http://owncloud.org/ns"><d:prop><oc:fileid/></d:prop></d:propfind>',
+		})
+		expect(propfind.status(), 'PROPFIND for the seeded file').toBe(207)
+		fileId = Number((await propfind.text()).match(/<oc:fileid>(\d+)/)?.[1] ?? 0)
+		expect(fileId, 'seeded file must resolve to a numeric fileId').toBeGreaterThan(0)
+
+		// 3. Extraction + detection. Asserted here rather than in the test so a
+		// backend failure is not reported as a missing DOM node later.
+		const extract = await req.post(`${API}/anonymization/extract/${fileId}`, {
+			headers: jsonHeaders(token),
+		})
+		expect(extract.status(), `extract ${fileId} (${await extract.text().catch(() => '')})`).toBe(200)
+		const body = await extract.json()
+		expect(
+			(body.entities ?? []).map((e: { type: string, value: string }) => `${e.type}:${e.value}`),
+			'the detection pass must produce a CUSTOM_DICTIONARY occurrence for the seeded term',
+		).toContain(`CUSTOM_DICTIONARY:${TERM}`)
+
+		await ctx.close()
+	})
+
+	test.afterAll(async ({ browser }) => {
+		if (!dictionaryId) return
+		const ctx = await browser.newContext()
+		const page = await ctx.newPage()
+		const token = await harvestToken(page)
+		const res = await ctx.request
+			.delete(`${API}/custom-dictionaries/${dictionaryId}`, { headers: jsonHeaders(token) })
+			.catch(() => null)
+		if (res && res.status() >= 400) {
+			// eslint-disable-next-line no-console
+			console.warn(`[teardown] dictionary ${dictionaryId} -> ${res.status()} (leaked)`)
+		}
+		// The seeded document is deliberately left in place: every identifier in
+		// this file is stamped with `Date.now()`, so a leftover cannot satisfy or
+		// break a later run's assertions, and deleting a file mid-anonymisation
+		// is a worse failure mode than a stray fixture.
+		await ctx.close()
+	})
+
+	test('the dictionary hit appears in the review workbench as a CUSTOM_DICTIONARY occurrence', async ({ page }) => {
+		// @e2e openspec/specs/custom-dictionary-recognition/spec.md#a-dictionary-hit-is-detected-reviewable-and-redacted
+		await go(page, 'my-documents')
+		await expect(page).toHaveURL(/\/apps\/docudesk\/my-documents/)
+
+		// Opening the document is what sets `fileViewerStore.currentFile`, which
+		// is what mounts FileViewerPage and its sidebar (MyDocumentsIndex.vue:8).
+		const row = page.locator('#content tr, .app-content tr').filter({ hasText: FILE_BASE }).first()
+		await expect(row, 'the seeded document must be listed in /DocuDesk').toBeVisible()
+		await row.click()
+		await waitForAppReady(page)
+
+		// The workbench: DdEntityCard renders the raw type token in
+		// `.dd-entity-card__type` (entityTypeLabel() falls through to the
+		// uppercase token when untranslated) and the matched text in
+		// `.dd-entity-card__value`. Assert BOTH on the SAME card — asserting them
+		// separately would pass if any card carried the type and any other card
+		// carried the value.
+		const card = page.locator('.dd-entity-card').filter({ hasText: TERM }).first()
+		await expect(card, 'a review card for the seeded term must render').toBeVisible()
+		await expect(
+			card.locator('.dd-entity-card__type'),
+			'the occurrence must be typed CUSTOM_DICTIONARY, not a generic NER type',
+		).toHaveText('CUSTOM_DICTIONARY')
+		await expect(card.locator('.dd-entity-card__value').first()).toContainText(TERM)
+	})
+})

--- a/tests/e2e/spec-coverage/custom-dictionary-recognition.spec.ts
+++ b/tests/e2e/spec-coverage/custom-dictionary-recognition.spec.ts
@@ -2,129 +2,275 @@
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
  * SPDX-License-Identifier: EUPL-1.2
  *
- * Gate-19 e2e spec-coverage tests — custom-dictionary-recognition spec
+ * Gate-19 e2e spec-coverage — openspec/specs/custom-dictionary-recognition/spec.md
  *
- * Covers UI-observable scenarios from
- * openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md.
- * Backend-only scenarios (organisation gate, matcher semantics, import
- * dedupe, idempotent re-run) carry @e2e exclude annotations in the spec and
- * are covered by PHPUnit instead (see tests/unit/Service/).
+ * ⚠️ WHY THIS FILE WAS REWRITTEN, NOT JUST RE-ANCHORED
+ * ----------------------------------------------------
+ * Two independent problems, and fixing only the first would have bought a
+ * green with a false statement.
  *
- * NOT YET RUN against a live instance in this apply pass (worktree-only
- * implementation; no seeded/deployed NC instance available in this
- * session) — authored per the codebase's established spec-coverage
- * conventions (consent-management.spec.ts) but unverified end-to-end.
+ * 1. EVERY ANCHOR WAS INERT. They pointed at
+ *    `openspec/changes/custom-dictionary-recognition/specs/.../spec.md#…`.
+ *    Gate-19's ref parser only matches `openspec/specs/<spec>/…#<slug>`, so a
+ *    `changes/` path constructs no ref at all — not a dangling anchor that gets
+ *    reported, just silently invisible. All anchors now point at the canonical
+ *    archived spec.
+ *
+ * 2. THE TESTS COULD NOT FAIL. Every assertion sat behind
+ *    `if (await x.isVisible().catch(() => false))` with an `else` branch that
+ *    asserted `body` is visible, or with no `else` at all. A missing table, a
+ *    missing Add button and a missing row all produced a PASS. Re-anchoring
+ *    those would have credited five scenarios to tests that assert nothing —
+ *    the same failure mode as the six self-skipping tests documented at length
+ *    in orphaned-surface-restoration.spec.ts. The conditionals are gone; the
+ *    fixtures each test needs are created up front so the data is a
+ *    precondition rather than a hope.
+ *
+ * TWO SCENARIOS ARE DELIBERATELY NOT CLAIMED HERE — see the notes at the
+ * bottom of this file. Their anchors have been removed rather than repointed.
  */
 
-// @e2e openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md#match-mode-defaults-to-case-insensitive
-// @e2e openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md#a-dictionary-hit-is-detected-reviewable-and-redacted
-// @e2e openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md#a-permitted-manager-creates-a-dictionary
-// @e2e openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md#import-through-the-admin-page
-// @e2e openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md#the-dictionaries-page-lists-dictionaries-with-their-term-counts
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test'
+import { appUrl, go, waitForAppReady } from './_helpers'
+import { harvestToken, jsonHeaders, API } from '../workflows/_fixtures'
 
-import { test, expect, type Page } from '@playwright/test'
-import { waitForAppReady } from './_helpers'
+const P = `g19cdr-${Date.now()}`
+const SEEDED_LABEL = 'Projectnamen' // shipped by lib/Settings/docudesk_register.json
+const FIXTURE_LABEL = `${P}-Straatnamen`
 
-// `index.php`-prefixed — see the APP constant in ./_helpers.ts for why the
-// prefix is required on CI (`php -S` does not rewrite, so `/apps/...` hits
-// PHP's own 404 page instead of Nextcloud).
-const APP = '/index.php/apps/docudesk'
+let fixtureId = ''
 
-async function dismissOverlays(page: Page): Promise<void> {
-	const wizard = page.locator('#firstrunwizard')
-	if (await wizard.isVisible().catch(() => false)) {
-		await page.keyboard.press('Escape').catch(() => {})
-		await wizard.waitFor({ state: 'hidden', timeout: 4000 }).catch(() => {})
-	}
+/**
+ * The content region — never the page title / host chrome.
+ *
+ * A locator rather than a `innerText()` snapshot on purpose: an
+ * `expect(locator).toContainText()` retries until the store's fetch has
+ * resolved, whereas a one-shot string read races it. That race bit this suite
+ * once already (see `expectListedNotListed` in
+ * entity-publication-policies.spec.ts) and it is especially treacherous for
+ * NEGATIVE assertions, which an unloaded page satisfies for free.
+ *
+ * @param page A page navigated to an in-app route.
+ * @return A locator for the content region.
+ */
+const content = (page: Page) => page.locator('#content, .app-content, main').first()
+
+async function createDictionary(
+	req: APIRequestContext,
+	token: string,
+	data: Record<string, unknown>,
+): Promise<string> {
+	const res = await req.post(`${API}/custom-dictionaries`, {
+		headers: jsonHeaders(token),
+		data,
+	})
+	expect(res.status(), `create dictionary (${await res.text().catch(() => '')})`).toBe(201)
+	return (await res.json()).id
 }
 
-async function go(page: Page, route: string): Promise<void> {
-	const url = `${APP}/${route}`
-	// `domcontentloaded`, not the default `load` — NC's long-lived polling
-	// connections can delay `load` past any sane timeout. See _helpers.ts.
-	await page.goto(url, { waitUntil: 'domcontentloaded' })
-	// Not `networkidle` — Nextcloud's long-lived polling means it never fires,
-	// so the old swallowed wait burned its timeout and then proceeded anyway.
-	// See waitForAppReady in ./_helpers (ADR-074 rule 4 / gate-58).
-	await waitForAppReady(page)
-	await dismissOverlays(page)
-	await page.waitForTimeout(800)
-}
+test.describe('custom-dictionary-recognition — dictionaries admin UI', () => {
+	test.beforeAll(async ({ browser }) => {
+		const ctx = await browser.newContext()
+		const page = await ctx.newPage()
+		const token = await harvestToken(page)
 
-// ---------------------------------------------------------------------------
-// REQ-DDCDR-006: Custom-dictionary admin UI
-// ---------------------------------------------------------------------------
-
-test.describe('custom-dictionary-recognition — dictionaries list UI', () => {
-	test('custom dictionaries list view loads without error', async ({ page }) => {
-		// @e2e openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md#the-dictionaries-page-lists-dictionaries-with-their-term-counts
-		await go(page, 'custom-dictionaries')
-		await expect(page).toHaveURL(/\/apps\/docudesk/)
-		await expect(page.locator('body')).toBeVisible()
-		await expect(page).not.toHaveURL(/\/login/)
-		const title = await page.title()
-		expect(title).not.toMatch(/server error|500/i)
+		// The listing scenario says "GIVEN TWO dictionaries". One ships with the
+		// register seed; this is the second. Created with an explicit
+		// wordBoundary so the match-mode column has something to distinguish it
+		// from the seeded caseInsensitive row — a column that renders the same
+		// string for every row proves nothing about the column.
+		fixtureId = await createDictionary(ctx.request, token, {
+			label: FIXTURE_LABEL,
+			description: 'gate-19 e2e fixture',
+			matchMode: 'wordBoundary',
+			active: true,
+		})
+		await ctx.close()
 	})
 
-	test('the seeded demo dictionary is listed with a term count and match mode', async ({ page }) => {
-		// @e2e openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md#the-dictionaries-page-lists-dictionaries-with-their-term-counts
-		// @e2e openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md#match-mode-defaults-to-case-insensitive
+	test.afterAll(async ({ browser }) => {
+		const ctx = await browser.newContext()
+		const page = await ctx.newPage()
+		const token = await harvestToken(page)
+		if (fixtureId) {
+			const res = await ctx.request.delete(`${API}/custom-dictionaries/${fixtureId}`, {
+				headers: jsonHeaders(token),
+			}).catch(() => null)
+			if (res && res.status() >= 400) {
+				// eslint-disable-next-line no-console
+				console.warn(`[teardown] dictionary ${fixtureId} -> ${res.status()} (leaked)`)
+			}
+		}
+		await ctx.close()
+	})
+
+	test('both dictionaries are listed with label, term count, match mode and active state', async ({ page }) => {
+		// @e2e openspec/specs/custom-dictionary-recognition/spec.md#the-dictionaries-page-lists-dictionaries-with-their-term-counts
 		await go(page, 'custom-dictionaries')
-		const row = page.getByText('Projectnamen', { exact: false }).first()
-		const rowVisible = await row.isVisible().catch(() => false)
-		if (rowVisible) {
-			await expect(row).toBeVisible()
-		} else {
-			// Empty-state fallback (seed data not present on this instance) —
-			// the page must still render without crashing.
-			await expect(page.locator('body')).toBeVisible()
+		await expect(page).toHaveURL(/\/apps\/docudesk\/custom-dictionaries/)
+
+		const table = page.locator('#content table, .app-content table').first()
+		await expect(table, 'the index must render a table, not an empty state').toBeVisible()
+
+		// The seeded dictionary, and the four columns the scenario names. Its
+		// term count is 2 in the shipped register seed — asserting the NUMBER
+		// (not merely that a cell exists) is what makes this a term-count test.
+		const seededRow = table.locator('tr').filter({ hasText: SEEDED_LABEL }).first()
+		await expect(seededRow, `the seeded "${SEEDED_LABEL}" dictionary must be listed`).toBeVisible()
+		await expect(seededRow, 'term count column').toContainText('2')
+		await expect(seededRow, 'match mode column').toContainText('Case-insensitive')
+		await expect(seededRow, 'active state column').toContainText(/Active/i)
+
+		// The second dictionary, with a DIFFERENT match mode — so a column that
+		// renders a constant cannot satisfy both rows.
+		const fixtureRow = table.locator('tr').filter({ hasText: FIXTURE_LABEL }).first()
+		await expect(fixtureRow, 'the second dictionary must be listed too').toBeVisible()
+		await expect(fixtureRow, 'match mode column must reflect THIS row, not a constant')
+			.toContainText('Word boundary')
+		await expect(fixtureRow, 'a dictionary with no terms shows 0').toContainText('0')
+	})
+
+	test('a manager creates a word-boundary dictionary through the Add dialog and it is listed', async ({ page }) => {
+		// @e2e openspec/specs/custom-dictionary-recognition/spec.md#a-permitted-manager-creates-a-dictionary
+		const uiLabel = `${P}-ui-Straatnamen`
+		await go(page, 'custom-dictionaries')
+
+		// CnActionsBar resolves the CTA label to "Add <schema title>", never the
+		// bare "Add", so target the stable testid with a name-prefix fallback.
+		const addCta = page.locator('[data-testid="cn-cta-primary"]')
+			.or(page.getByRole('button', { name: /^Add\b/ }))
+			.first()
+		await expect(addCta, 'CustomDictionaryIndex declares :show-add="true"').toBeVisible()
+		await addCta.click()
+
+		const dialog = page.getByRole('dialog').first()
+		await expect(dialog).toBeVisible()
+		await dialog.getByLabel('Label').first().fill(uiLabel)
+
+		// Choosing a match mode, and PROVING the choice landed before submitting.
+		//
+		// Two earlier attempts failed differently and both were informative:
+		// clicking `getByRole('option', …)` timed out (with `{value, label}`
+		// options this nc-vue build does not put `role="option"` on the node,
+		// unlike the plain-string options in entity-publication-policies.spec.ts),
+		// and a looser text-matched click "succeeded" while leaving the select on
+		// its `caseInsensitive` default — the dictionary was created, listed, and
+		// carried the wrong mode. A create-then-assert test cannot tell those two
+		// apart, so the selection is asserted here, separately: a failure now
+		// means the FORM did not take the choice, a failure at the listing
+		// assertion below means it did not PERSIST.
+		const matchMode = dialog.getByLabel('Match mode')
+		await matchMode.click()
+		await matchMode.fill('Word boundary')
+		await page.keyboard.press('Enter')
+		await expect(
+			dialog.locator('.vs__selected').filter({ hasText: 'Word boundary' }),
+			'the form must show the chosen match mode before submit',
+		).toBeVisible()
+		await dialog.getByRole('button', { name: /^(Create|Save)$/ }).first().click()
+
+		// "THEN it is persisted under organisation A and listed for them" — the
+		// listing is the observable half, and it must survive a RELOAD, which is
+		// what separates "persisted" from "optimistically added to a local array".
+		await expect(page.getByText(uiLabel).first()).toBeVisible()
+		await go(page, 'custom-dictionaries')
+		const row = page.locator('#content table tr, .app-content table tr').filter({ hasText: uiLabel }).first()
+		await expect(row, 'the new dictionary must still be listed after a full reload').toBeVisible()
+		await expect(row, 'the chosen match mode must round-trip').toContainText('Word boundary')
+
+		// Clean up through the UI's own data path so a rerun's negative
+		// assertions are not poisoned by a leftover row.
+		const ctx = page.context()
+		const token = await harvestToken(page)
+		const list = await ctx.request.get(`${API}/custom-dictionaries`, { headers: jsonHeaders(token) })
+		const created = (await list.json()).find(
+			(d: { label?: unknown, id?: string }) => JSON.stringify(d.label ?? '').includes(uiLabel),
+		)
+		if (created?.id) {
+			await ctx.request.delete(`${API}/custom-dictionaries/${created.id}`, { headers: jsonHeaders(token) })
 		}
 	})
 
-	test('Add opens the create-dictionary dialog', async ({ page }) => {
-		// @e2e openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md#a-permitted-manager-creates-a-dictionary
-		await go(page, 'custom-dictionaries')
-		const addButton = page.getByRole('button', { name: /add/i }).first()
-		const addVisible = await addButton.isVisible().catch(() => false)
-		if (addVisible) {
-			await addButton.click()
-			await page.waitForTimeout(400)
-			await expect(page.getByText(/add custom dictionary/i)).toBeVisible()
-		}
+	test('a CSV upload on the detail page adds the terms and reports the added count', async ({ page }) => {
+		// @e2e openspec/specs/custom-dictionary-recognition/spec.md#import-through-the-admin-page
+		// `appUrl`, not a hardcoded `/index.php/...` — the router base differs
+		// between a rewriting Apache and CI's `php -S`. See `resolveAppBase`.
+		await page.goto(await appUrl(page, `custom-dictionaries/${fixtureId}`), {
+			waitUntil: 'domcontentloaded',
+		})
+		await waitForAppReady(page)
+		await expect(page).toHaveURL(new RegExp(`/custom-dictionaries/${fixtureId}`))
+
+		// Precondition, asserted rather than assumed: this dictionary starts
+		// empty, so "the new terms appear" cannot be satisfied by pre-existing
+		// rows. Ordered positive-then-negative for the reason spelled out in
+		// entity-publication-policies.spec.ts — wait for something that proves
+		// the page has rendered before asserting anything is absent from it,
+		// or an unloaded page satisfies the absence for free.
+		await expect(content(page), 'the detail page must have rendered')
+			.toContainText(FIXTURE_LABEL)
+		await expect(content(page), 'fixture dictionary must start with no terms')
+			.not.toContainText(`${P}-alpha`)
+
+		await page.getByRole('button', { name: /Import/i }).first().click()
+		const dialog = page.getByRole('dialog').filter({ hasText: 'Import terms' }).first()
+		await expect(dialog).toBeVisible()
+
+		// Parsing MUST NOT be delegated to the browser (REQ-DDCDR-005), so this
+		// hands the server a real file rather than pasting into the textarea.
+		await dialog.locator('#custom-dictionary-import-file').setInputFiles({
+			name: 'terms.csv',
+			mimeType: 'text/csv',
+			// EXACTLY three data rows and no blank line. The third row is a
+			// case-differing duplicate of the first, so the expected result
+			// isolates ONE behaviour: case-insensitive de-duplication.
+			//
+			// The first version of this test also put a blank line in the file
+			// and expected "1 skipped". The server answered "2 added, 2 skipped,
+			// 4 total" — it counts a blank line in BOTH `skipped` and `total`.
+			// That is arguably a separate question about what "total terms"
+			// means; it is not this scenario's question, so the blank line is
+			// gone rather than the assertion loosened.
+			buffer: Buffer.from(`${P}-alpha,Alpha label\n${P}-beta,Beta label\n${P}-ALPHA,duplicate\n`),
+		})
+		await dialog.getByRole('button', { name: /^Import$/ }).click()
+
+		// "THEN the new terms appear in the term table with the reported added
+		// count". Both halves, and the exact triple — a bare "some terms were
+		// added" would pass even if de-duplication did nothing.
+		await expect(dialog.getByText('2 added, 1 skipped, 3 total.')).toBeVisible()
+
+		await dialog.getByRole('button', { name: /Close|Cancel/i }).first().click().catch(() => {})
+		await expect(content(page), 'imported term must appear in the term table')
+			.toContainText(`${P}-alpha`)
+		await expect(content(page), 'the second imported term too')
+			.toContainText(`${P}-beta`)
 	})
 })
 
-test.describe('custom-dictionary-recognition — dictionary detail UI', () => {
-	test('clicking a dictionary row navigates to its detail page (term management)', async ({ page }) => {
-		// @e2e openspec/changes/custom-dictionary-recognition/specs/custom-dictionary-recognition/spec.md#import-through-the-admin-page
-		await go(page, 'custom-dictionaries')
-		const row = page.locator('tr[data-id], .index-page-table tbody tr').first()
-		const rowVisible = await row.isVisible().catch(() => false)
-		if (rowVisible) {
-			await row.click()
-			// Wait for exactly the transition this test then asserts: the
-			// in-app route moving from the index (`/custom-dictionaries`) to a
-			// detail (`/custom-dictionaries/<id>`). The previous
-			// `waitForLoadState('networkidle').catch(() => {})` waited for a
-			// state Nextcloud never reaches, then swallowed its own timeout —
-			// so the assertions ran against a page that might not have routed
-			// at all (ADR-074 rule 4 / gate-58).
-			await page.waitForURL(/\/custom-dictionaries\/.+/, { timeout: 15_000 })
-			await waitForAppReady(page)
-			await page.waitForTimeout(500)
-			await expect(page).toHaveURL(/\/custom-dictionaries\//)
-			await expect(page.getByText(/terms/i).first()).toBeVisible()
-		}
-	})
-})
-
-// ---------------------------------------------------------------------------
-// REQ-DDCDR-003: dictionary hits flow through detection → review → anonymise.
-//
-// Full pipeline exercise (upload a fixture document containing a seeded
-// term, run detection, assert a CUSTOM_DICTIONARY hit in the review
-// workbench, anonymise, assert the placeholder replaced it) needs a fixture
-// file + an authenticated upload flow already exercised by
-// anonymization.spec.ts. Left as a follow-up wired into that existing flow
-// rather than duplicated here — see the change's tasks.md task 5.2.
-// ---------------------------------------------------------------------------
+/*
+ * NOT CLAIMED BY THIS FILE — and why an `@e2e exclude` is right for one and
+ * wrong for the other.
+ *
+ * `match-mode-defaults-to-case-insensitive`
+ *   EXCLUDED in the spec. A browser genuinely cannot observe this: BOTH
+ *   rendering paths substitute the default themselves. `matchModeLabel()` in
+ *   CustomDictionaryIndex.vue:204 and in CustomDictionaryDetail.vue:222 are
+ *   identical and both end `|| t('docudesk', 'Case-insensitive')`. So a
+ *   dictionary persisted with a NULL match mode renders exactly the same string
+ *   as one persisted with `caseInsensitive`, and any browser assertion here
+ *   would pass whether or not the backend defaulted anything. The persisted
+ *   value is asserted where it is visible — at the service boundary, in
+ *   tests/unit/Service/CustomDictionaryServiceTest.php::testCreateDictionaryDefaultsMatchMode,
+ *   which asserts `saveObject` received `matchMode === 'caseInsensitive'`.
+ *
+ * `a-dictionary-hit-is-detected-reviewable-and-redacted`
+ *   NOT excluded, and NOT claimed. It is browser-observable in principle — the
+ *   review workbench is a real surface — but it needs a document containing the
+ *   seeded term to be extracted and detected end to end, and on a CI instance
+ *   entity recognition runs in regex-only mode with no anonymiser backend
+ *   installed. That is a MISSING TEST, not an unobservable scenario, so it stays
+ *   in gate-19's finding list where it is visible. The previous version of this
+ *   file claimed it from a file-level anchor while its own closing comment
+ *   admitted no such test existed.
+ */

--- a/tests/e2e/spec-coverage/document-comparison.spec.ts
+++ b/tests/e2e/spec-coverage/document-comparison.spec.ts
@@ -20,7 +20,17 @@ import { attachConsoleGuard, go } from './_helpers'
 
 test.describe('document-comparison — side-by-side view', () => {
 	test('comparison view renders its heading, pickers and Compare action', async ({ page }) => {
-		// @e2e openspec/specs/document-comparison/spec.md#the-ui-must-provide-a-side-by-side-comparison-view
+		// @e2e openspec/specs/document-comparison/spec.md#operator-picks-two-versions
+		//
+		// ANCHOR REPAIR: this used to name
+		// `#the-ui-must-provide-a-side-by-side-comparison-view`, which is a
+		// REQUIREMENT title, not a scenario — there is no such ref. Gate-19
+		// parses a dangling anchor and then silently drops it, so the mismatch
+		// was invisible. The scenario named above is what this test actually
+		// asserts (the two version pickers and the Compare action), and it is
+		// already claimed by the file-level anchors, so the count does not
+		// move; what changes is that the file no longer traces to something
+		// that is not there.
 		const guard = attachConsoleGuard(page)
 		// History-mode (manifest) router: deep-link the path, not a hash.
 		await go(page, 'comparison')
@@ -38,7 +48,17 @@ test.describe('document-comparison — side-by-side view', () => {
 	})
 
 	test('operator picks two files and triggers a comparison', async ({ page }) => {
-		// @e2e openspec/specs/document-comparison/spec.md#the-ui-must-provide-a-side-by-side-comparison-view
+		// @e2e openspec/specs/document-comparison/spec.md#operator-picks-two-versions
+		//
+		// ANCHOR REPAIR: this used to name
+		// `#the-ui-must-provide-a-side-by-side-comparison-view`, which is a
+		// REQUIREMENT title, not a scenario — there is no such ref. Gate-19
+		// parses a dangling anchor and then silently drops it, so the mismatch
+		// was invisible. The scenario named above is what this test actually
+		// asserts (the two version pickers and the Compare action), and it is
+		// already claimed by the file-level anchors, so the count does not
+		// move; what changes is that the file no longer traces to something
+		// that is not there.
 		const guard = attachConsoleGuard(page)
 		await go(page, 'comparison?left=1&right=2')
 

--- a/tests/e2e/spec-coverage/entity-publication-policies.spec.ts
+++ b/tests/e2e/spec-coverage/entity-publication-policies.spec.ts
@@ -1,0 +1,304 @@
+/*
+ * SPDX-FileCopyrightText: 2026 DocuDesk Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Gate-19 e2e spec-coverage — the "Three separate admin surfaces MUST exist"
+ * requirement of openspec/specs/entity-publication-policies/spec.md.
+ *
+ * This spec had ZERO `@e2e` anchors and ZERO `@e2e exclude` markers before this
+ * file: all 34 of its scenarios were raw gate-19 findings. Most of the other 30
+ * are match-rule semantics, cache behaviour and retroactive resolution — none
+ * browser-observable. This requirement is the part that is defined as *what an
+ * administrator sees*, so it is the part an e2e test can honestly prove.
+ *
+ * WHAT MAKES THESE FALSIFIABLE
+ * ----------------------------
+ * Each scenario is a NEGATIVE as much as a positive: "only records with
+ * scope=entity are listed" is worthless without a scope=document record in the
+ * store to be excluded. So `beforeAll` seeds one record of EACH kind through
+ * the real controllers, and every test asserts both halves — the record that
+ * must appear AND the record that must not. Drop the filter at
+ * `src/views/consent/ConsentIndex.vue:194` (`workflowConsents`) or at
+ * `lib/Service/PolicyCrudService.php:153` and these go red immediately; that
+ * is the check.
+ *
+ * A NOTE ON WHERE THE FILTER LIVES (do not "fix" this by moving the assertion)
+ * ---------------------------------------------------------------------------
+ * The two surfaces filter in DIFFERENT layers, and it matters for reading a
+ * failure:
+ *   - Standing consents filter SERVER-side. `GET /api/policy/standing-consents`
+ *     returns only `scope: "entity"` (PolicyCrudService::listStandingConsents).
+ *   - The consent workflow filters CLIENT-side. `GET /api/consents` returns
+ *     BOTH scopes — measured on a seeded instance: 13 entity + 1 document —
+ *     and `ConsentIndex.vue` narrows to `scope === 'document'` in a computed.
+ * So a regression on the workflow page shows up ONLY in the browser. An API
+ * assertion would pass straight through it, which is precisely why this
+ * scenario belongs in gate-19 and not in Newman.
+ *
+ * Fixtures are prefixed and removed in `afterAll` so a crashed run cannot
+ * poison the next one's negative assertions.
+ */
+
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test'
+import { go, waitForAppReady } from './_helpers'
+import { harvestToken, jsonHeaders, API } from '../workflows/_fixtures'
+
+/** Unique per run — the negative assertions depend on no stale twin existing. */
+const P = `g19epp-${Date.now()}`
+
+const STANDING_NAME = `${P}-standing-acme`
+const DOCUMENT_NAME = `${P}-workflow-pietersen`
+const PROHIBITION_NAME = `${P}-prohibited-jansen`
+
+const created = { standing: '', document: '', prohibition: '' }
+
+async function seed(req: APIRequestContext, token: string): Promise<void> {
+	// scope=entity — belongs on "Publish always" only.
+	const standing = await req.post(`${API}/policy/standing-consents`, {
+		headers: jsonHeaders(token),
+		data: {
+			entityText: STANDING_NAME,
+			entityType: 'ORGANIZATION',
+			consentMethod: 'paper',
+			matchRules: [{ type: 'exact', value: STANDING_NAME }],
+		},
+	})
+	expect(standing.status(), `seed standing consent (${await standing.text().catch(() => '')})`).toBe(201)
+	created.standing = (await standing.json()).id
+
+	// scope=document — belongs on the Consent Workflow page only.
+	const document = await req.post(`${API}/consents`, {
+		headers: jsonHeaders(token),
+		data: {
+			documentId: `${P}-doc`,
+			entityKey: `${P}-key`,
+			entityText: DOCUMENT_NAME,
+			entityType: 'PERSON',
+			scope: 'document',
+		},
+	})
+	expect(document.status(), `seed document consent (${await document.text().catch(() => '')})`).toBe(201)
+	created.document = (await document.json()).id
+
+	// publicationProhibition — a DIFFERENT schema, and belongs on
+	// "Publish never" only. `primaryName` and `reason` are schema-required;
+	// omitting them answers 500, not 422 (worth knowing when this seed breaks).
+	const prohibition = await req.post(`${API}/policy/prohibitions`, {
+		headers: jsonHeaders(token),
+		data: {
+			primaryName: PROHIBITION_NAME,
+			reason: 'gate-19 e2e fixture',
+			entityType: 'PERSON',
+			matchRules: [{ type: 'exact', value: PROHIBITION_NAME }],
+			active: true,
+		},
+	})
+	expect(prohibition.status(), `seed prohibition (${await prohibition.text().catch(() => '')})`).toBe(201)
+	created.prohibition = (await prohibition.json()).id
+}
+
+/**
+ * The content region — never the page title or the stats block.
+ *
+ * A page heading is host chrome: it renders from the manifest even when the
+ * body never does, so asserting on it tests the manifest rather than the
+ * render.
+ *
+ * @param page A page navigated to an index route.
+ * @return A locator for the content region.
+ */
+const content = (page: Page) => page.locator('#content, .app-content, main').first()
+
+/**
+ * Assert that a list page shows `present` and does NOT show `absent`.
+ *
+ * ⚠️ THE ORDER IS THE WHOLE POINT, and it is not stylistic.
+ *
+ * An absence assertion is satisfied for free by a page that has not finished
+ * loading — an empty table contains nothing, so `not.toContainText(absent)`
+ * passes instantly and the test proves precisely zero. The first version of
+ * this file read `innerText()` once into a string and asserted against it; the
+ * snapshot was taken before the consent store's fetch resolved, and the run
+ * failed on the POSITIVE half with a content region holding only the page
+ * heading and a "Refresh" button. That is the same race that would have made
+ * the negative half a silent no-op on any run where it happened to win.
+ *
+ * So: assert `present` FIRST with a retrying expectation (which is what
+ * establishes that the list is populated at all), and only then assert
+ * `absent`. A dead selector cannot produce that difference.
+ *
+ * @param page    A page navigated to an index route.
+ * @param present Text that MUST appear (the positive control).
+ * @param absent  Text that must NOT appear once the list has rendered.
+ * @param why     Message for the absence assertion.
+ */
+async function expectListedNotListed(
+	page: Page,
+	present: string,
+	absent: string,
+	why: string,
+): Promise<void> {
+	await expect(content(page), `positive control — ${present} must be listed`).toContainText(present)
+	await expect(content(page), why).not.toContainText(absent)
+}
+
+test.describe('entity-publication-policies — three separate admin surfaces', () => {
+	test.beforeAll(async ({ browser }) => {
+		const ctx = await browser.newContext()
+		const page = await ctx.newPage()
+		const token = await harvestToken(page)
+		await seed(ctx.request, token)
+		await ctx.close()
+	})
+
+	/*
+	 * TEARDOWN — and why it only removes ONE of the three fixtures.
+	 *
+	 * Measured, not assumed (first version of this file tried all three):
+	 *   DELETE api/policy/standing-consents/{id}  -> 200. Route exists.
+	 *   DELETE api/consents/{id}                  -> 405. There IS no delete
+	 *       route: appinfo/routes.php declares consent# index/create/show/
+	 *       update/byDocument and nothing else. A workflow consent record is
+	 *       not deletable over HTTP by design.
+	 *   DELETE api/policy/prohibitions/{id}       -> 409. PolicyController::
+	 *       deleteProhibition maps ArchivalImmutableException to 409 —
+	 *       prohibitions are retention-protected.
+	 *
+	 * So two of the three fixtures are PERMANENT, and that is correct app
+	 * behaviour rather than a teardown bug. It is safe here only because every
+	 * fixture name is stamped with `Date.now()`: the negative assertions
+	 * ("must NOT contain X") name THIS run's strings, so yesterday's leftovers
+	 * cannot satisfy or break them. Do not "fix" this by reusing a fixed name.
+	 */
+	test.afterAll(async ({ browser }) => {
+		if (!created.standing) return
+		const ctx = await browser.newContext()
+		const page = await ctx.newPage()
+		const token = await harvestToken(page)
+		const res = await ctx.request
+			.delete(`${API}/policy/standing-consents/${created.standing}`, { headers: jsonHeaders(token) })
+			.catch(() => null)
+		if (res && res.status() >= 400) {
+			// eslint-disable-next-line no-console
+			console.warn(`[teardown] standing consent ${created.standing} -> ${res.status()} (leaked)`)
+		}
+		await ctx.close()
+	})
+
+	test('"Publish always" lists the scope=entity record and NOT the scope=document one', async ({ page }) => {
+		// @e2e openspec/specs/entity-publication-policies/spec.md#standing-publication-consents-page-filters-by-scope
+		await go(page, 'policy/standing-consents')
+		await expect(page).toHaveURL(/\/apps\/docudesk\/policy\/standing-consents/)
+		await expect(page.getByRole('heading', { name: 'Publish always' })).toBeVisible()
+
+		await expectListedNotListed(
+			page,
+			STANDING_NAME,
+			DOCUMENT_NAME,
+			'a scope=document workflow record must NOT appear here',
+		)
+	})
+
+	test('the Consent Workflow page lists the scope=document record and NOT the scope=entity one', async ({ page }) => {
+		// @e2e openspec/specs/entity-publication-policies/spec.md#consent-workflow-page-filters-by-scope
+		//
+		// This is the surface whose filter is CLIENT-side: `GET /api/consents`
+		// hands the page both scopes and `ConsentIndex.vue`'s `workflowConsents`
+		// computed narrows them. An API-level test of this scenario would pass
+		// over a broken page, so it has to be a browser assertion.
+		await go(page, 'consent')
+		await expect(page).toHaveURL(/\/apps\/docudesk\/consent/)
+
+		await expectListedNotListed(
+			page,
+			DOCUMENT_NAME,
+			STANDING_NAME,
+			'a scope=entity standing consent must NOT leak onto the workflow page',
+		)
+	})
+
+	test('a prohibition appears on "Publish never" and on neither consent surface', async ({ page }) => {
+		// @e2e openspec/specs/entity-publication-policies/spec.md#publication-prohibitions-page-is-the-only-surface-for-prohibition-records
+		await go(page, 'policy/prohibitions')
+		await expect(page).toHaveURL(/\/apps\/docudesk\/policy\/prohibitions/)
+		await expect(page.getByRole('heading', { name: 'Publish never' })).toBeVisible()
+		await expect(
+			content(page),
+			'the seeded prohibition must be listed on its own page',
+		).toContainText(PROHIBITION_NAME)
+
+		// "AND they do not appear on either of the consent pages" — the whole
+		// point of the scenario, and the half a single-page test would miss.
+		// Each absence is paired with the positive control for THAT page, so an
+		// unloaded list cannot satisfy it for free (see expectListedNotListed).
+		await go(page, 'policy/standing-consents')
+		await expectListedNotListed(
+			page,
+			STANDING_NAME,
+			PROHIBITION_NAME,
+			'a prohibition must not appear on "Publish always"',
+		)
+
+		await go(page, 'consent')
+		await expectListedNotListed(
+			page,
+			DOCUMENT_NAME,
+			PROHIBITION_NAME,
+			'a prohibition must not appear on the Consent Workflow page',
+		)
+	})
+
+	test('the standing-consent create form blocks submit until consentMethod is set, and warns on a blank validUntil', async ({ page }) => {
+		// @e2e openspec/specs/entity-publication-policies/spec.md#standing-consent-create-form-requires-consentmethod
+		await go(page, 'policy/standing-consents')
+
+		// CnActionsBar renders the primary CTA with a resolved label of
+		// "Add <schema title>" — never the bare string "Add" — so target the
+		// stable testid, with a name-prefix fallback for older shells.
+		const addCta = page.locator('[data-testid="cn-cta-primary"]')
+			.or(page.getByRole('button', { name: /^Add\b/ }))
+			.first()
+		await expect(addCta, 'StandingConsentIndex declares :show-add="true"').toBeVisible()
+		await addCta.click()
+
+		const dialog = page.getByRole('dialog').filter({ hasText: 'Add standing consent' }).first()
+		await expect(dialog).toBeVisible()
+
+		const submit = dialog.getByRole('button', { name: /^(Create|Save)$/ }).first()
+
+		// Satisfy EVERY other precondition of `canSubmit` (entityText + one
+		// complete match rule) so the only thing still missing is
+		// consentMethod. Without this the assertion below would pass for the
+		// wrong reason — the button is disabled on a blank form regardless.
+		await dialog.getByLabel('Entity text (display name)').fill(`${P}-form-probe`)
+		await dialog.getByRole('button', { name: 'Add match rule' }).click()
+		await dialog.getByLabel('Match value').first().fill(`${P}-form-probe`)
+
+		await expect(
+			submit,
+			'consentMethod is still unset, so submission must remain blocked',
+		).toBeDisabled()
+
+		// "AND when validUntil is left blank, the form surfaces a non-blocking
+		// warning recommending an explicit term" — non-blocking, so it must be
+		// present while the form is still unsubmittable.
+		await expect(
+			dialog.locator('.form-warning').filter({ hasText: 'No expiry set' }),
+			'blank validUntil must surface the non-blocking expiry warning',
+		).toBeVisible()
+
+		// The positive control for the assertion above: setting consentMethod —
+		// and nothing else — must unblock submission. If it does not, the
+		// "blocked" assertion was passing for some other missing field.
+		await dialog.getByLabel('Consent method').click()
+		await page.getByRole('option', { name: 'paper' }).first().click()
+		await expect(
+			submit,
+			'with consentMethod set and every other requirement satisfied, submit must unblock',
+		).toBeEnabled()
+
+		// Leave no record behind: this form is never submitted.
+		await dialog.getByRole('button', { name: 'Cancel' }).click()
+		await waitForAppReady(page)
+	})
+})

--- a/tests/e2e/spec-coverage/folder-analysis.spec.ts
+++ b/tests/e2e/spec-coverage/folder-analysis.spec.ts
@@ -9,9 +9,19 @@
  * enable-on-input behaviour, and the optional dossier-binding sub-form.
  * Background extraction / NER pipeline scenarios are backend and carry
  * @e2e exclude in the spec.
+ *
+ * ANCHOR REPAIR: the anchors below used to name
+ * `#initiate-folder-analysis-on-a-folder-with-5-documents`, a scenario that
+ * does not exist in this spec (it was renamed to
+ * `initiate-folder-analysis-by-folder-path-existing-behavior`). Gate-19 does
+ * not report a dangling anchor — it parses the ref, finds no scenario with
+ * that name, and moves on — so the mismatch was invisible for as long as it
+ * existed. The count is unchanged by this repair (every scenario in this spec
+ * carries an `@e2e exclude`); what changes is that the file no longer claims
+ * to trace to something that is not there.
  */
 
-// @e2e openspec/specs/folder-batch-analysis/spec.md#initiate-folder-analysis-on-a-folder-with-5-documents
+// @e2e openspec/specs/folder-batch-analysis/spec.md#initiate-folder-analysis-by-folder-path-existing-behavior
 // @e2e openspec/specs/folder-batch-analysis/spec.md#folder-path-does-not-exist
 
 import { test, expect } from '@playwright/test'
@@ -19,7 +29,7 @@ import { attachConsoleGuard, dismissOverlays, go, navClick } from './_helpers'
 
 test.describe('folder-batch-analysis — folder analysis UI', () => {
 	test('Folder Analysis page renders heading, path input and Analyze action', async ({ page }) => {
-		// @e2e openspec/specs/folder-batch-analysis/spec.md#initiate-folder-analysis-on-a-folder-with-5-documents
+		// @e2e openspec/specs/folder-batch-analysis/spec.md#initiate-folder-analysis-by-folder-path-existing-behavior
 		const guard = attachConsoleGuard(page)
 		await go(page, 'folder-anonymization')
 		await expect(page).toHaveURL(/\/apps\/docudesk\/folder-anonymization/)
@@ -48,7 +58,7 @@ test.describe('folder-batch-analysis — folder analysis UI', () => {
 	})
 
 	test('initial step shows the folder-path instruction text', async ({ page }) => {
-		// @e2e openspec/specs/folder-batch-analysis/spec.md#initiate-folder-analysis-on-a-folder-with-5-documents
+		// @e2e openspec/specs/folder-batch-analysis/spec.md#initiate-folder-analysis-by-folder-path-existing-behavior
 		// Step 1 (store.isActive === false) renders the instruction paragraph.
 		// The optional dossier-binding sub-form is intentionally only mounted
 		// once analysis has started (store.batchStatus === extracting|review),
@@ -59,7 +69,7 @@ test.describe('folder-batch-analysis — folder analysis UI', () => {
 	})
 
 	test('Folder Analysis is reachable via the left navigation', async ({ page }) => {
-		// @e2e openspec/specs/folder-batch-analysis/spec.md#initiate-folder-analysis-on-a-folder-with-5-documents
+		// @e2e openspec/specs/folder-batch-analysis/spec.md#initiate-folder-analysis-by-folder-path-existing-behavior
 		await go(page, '')
 		await navClick(page, 'Folder Analysis')
 		await expect(page).toHaveURL(/\/apps\/docudesk\/folder-anonymization/)

--- a/tests/e2e/spec-coverage/orphaned-surface-restoration.spec.ts
+++ b/tests/e2e/spec-coverage/orphaned-surface-restoration.spec.ts
@@ -14,24 +14,43 @@
  * pages via deep link. Also asserts no policy menu entry exists yet
  * (menu ownership is deferred to publication-policy-labels-and-nav).
  *
- * NOTE: written against the existing spec-coverage helper conventions
- * (tests/e2e/spec-coverage/_helpers.ts) but not executed against a live
- * Nextcloud instance as part of this change — no dev instance was
- * provisioned for this task. Run `npm run test:e2e -- orphaned-surface-restoration`
- * against a running docudesk instance before relying on it in CI.
+ * ⚠️ WHY EVERY `@e2e` ANCHOR IN THIS FILE MOVED (and nothing else did)
+ * --------------------------------------------------------------------
+ * These tests were authored while the change still lived in
+ * `openspec/changes/orphaned-surface-restoration/`, and their anchors still
+ * pointed there after the change was archived to `openspec/specs/`. Gate-19's
+ * ref parser is
+ *
+ *     @e2e\s+openspec/specs/(?P<spec>[^/]+)/[^\s#]*#(?P<slug>[A-Za-z0-9_-]+)
+ *
+ * so a `openspec/changes/...` path matches NEITHER of its two regexes: the gate
+ * never constructs a ref at all. It is not a dangling anchor that gets reported
+ * — it is silently invisible. Result: five real, running, asserting tests were
+ * scored as ZERO coverage, and their five scenarios sat in gate-19's finding
+ * list looking untested.
+ *
+ * The archived slugs also carried a `scenario-` prefix that the canonical slug
+ * does not have, so repointing the directory alone would still have produced a
+ * dangling anchor — which gate-19 also does not report. Both halves are fixed
+ * below.
+ *
+ * The four file-level anchors that used to sit here have been REMOVED rather
+ * than repointed. They named REQUIREMENTS, not scenarios (no such ref exists),
+ * and a file-level anchor is credited by gate-19 without checking that anything
+ * in the file exercises it (.github#343). Every anchor now sits inside the body
+ * of the test that actually asserts the scenario.
+ *
+ * NOTE ON PROVENANCE: this file's original header said it had "not [been]
+ * executed against a live Nextcloud instance". It has now — see the run notes
+ * on the individual `test.fixme` blocks below.
  */
-
-// @e2e openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#requirement-the-correspondence-surface-is-reachable-req-ddosr-003
-// @e2e openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#requirement-signing-authoring-and-verify-are-reachable-with-trust-actions-gated-req-ddosr-004
-// @e2e openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#requirement-policy-surfaces-are-reachable-menu-ownership-deferred-req-ddosr-005
-// @e2e openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#requirement-the-dead-legacy-router-is-deleted-req-ddosr-001
 
 import { test, expect, type Page } from '@playwright/test'
 import { attachConsoleGuard, dismissOverlays, go, navClick } from './_helpers'
 
 test.describe('orphaned-surface-restoration — correspondence', () => {
 	test('Correspondence is reachable via the left navigation and renders its form', async ({ page }) => {
-		// @e2e openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#scenario-correspondence-opens-from-the-menu
+		// @e2e openspec/specs/orphaned-surface-restoration/spec.md#correspondence-opens-from-the-menu
 		const guard = attachConsoleGuard(page)
 		await go(page, '')
 		await navClick(page, 'Letters & correspondence')
@@ -54,7 +73,7 @@ test.describe('orphaned-surface-restoration — correspondence', () => {
 
 test.describe('orphaned-surface-restoration — signing authoring + verify', () => {
 	test('"New signing request" primary action opens the signer-chain create form, not the generic Add', async ({ page }) => {
-		// @e2e openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#scenario-signer-chain-create-form-opens-from-the-signing-index
+		// @e2e openspec/specs/orphaned-surface-restoration/spec.md#signer-chain-create-form-opens-from-the-signing-index
 		const guard = attachConsoleGuard(page)
 		await go(page, 'signing')
 		await dismissOverlays(page)
@@ -93,7 +112,7 @@ test.describe('orphaned-surface-restoration — signing authoring + verify', () 
 	})
 
 	test('SignatureVerification renders the engine-attributed verdict at a deep link', async ({ page }) => {
-		// @e2e openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#scenario-verify-page-renders-the-backend-verdict-verbatim
+		// @e2e openspec/specs/orphaned-surface-restoration/spec.md#verify-page-renders-the-backend-verdict-verbatim
 		const guard = attachConsoleGuard(page)
 		await go(page, 'signing/verify/1')
 		await expect(page).toHaveURL(/\/apps\/docudesk\/signing\/verify\/1/)
@@ -105,7 +124,7 @@ test.describe('orphaned-surface-restoration — signing authoring + verify', () 
 	})
 
 	test('a signing request detail with a document file id shows a Verify action', async ({ page }) => {
-		// @e2e openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#scenario-verify-page-renders-the-backend-verdict-verbatim
+		// @e2e openspec/specs/orphaned-surface-restoration/spec.md#verify-page-renders-the-backend-verdict-verbatim
 		// KNOWN FAILURE — ConductionNL/docudesk#339: rows on the Signing Requests
 		// index are not clickable. Clicking one neither routes to /signing/{id}
 		// nor opens the configured sidebar (0px wide, checkVisibility() false),
@@ -144,15 +163,26 @@ test.describe('orphaned-surface-restoration — signing authoring + verify', () 
 
 test.describe('orphaned-surface-restoration — publication policy', () => {
 	test('Prohibitions ("Publish never") deep-links and renders its list', async ({ page }) => {
-		// @e2e openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#scenario-policy-pages-are-deep-link-reachable
-		// KNOWN FAILURE — ConductionNL/docudesk#333: the `publicationProhibition`
-		// schema is declared in docudesk_register.json but is never imported into
-		// OpenRegister, so the list cannot load and the page renders an error note
-		// instead of a table or an empty state. The restoration this spec covers
-		// (the page is reachable and titled) is asserted above and does pass; the
-		// list assertion below is the part blocked by the missing schema.
-		// Remove this fixme once #333 lands — do NOT weaken the assertion.
-		test.fixme(true, 'blocked by #333 — publicationProhibition schema never imported')
+		// @e2e openspec/specs/orphaned-surface-restoration/spec.md#policy-pages-are-deep-link-reachable
+		// The `test.fixme(true, 'blocked by #333 …')` that used to sit here has
+		// been REMOVED, and the assertions below are untouched.
+		//
+		// #333 ("publicationProhibition schema is never imported") is still open,
+		// and correctly so: it is about DocuDesk's boot-time import path failing
+		// silently. But it is not true of the environment this suite runs in.
+		// `tests/e2e/ci-seed.sh` — the workflow's own `playwright-seed-command` —
+		// imports the register through OpenRegister's admin HTTP importer with
+		// `force=true` precisely because the boot-time path is unreliable, and it
+		// then VERIFIES the result. Measured on a seeded instance:
+		// `publicationProhibition` is present in `GET /api/schemas`, and the two
+		// sibling tests that read this very page (the Add-modal test below and
+		// entity-publication-policies.spec.ts's prohibition test) both pass.
+		//
+		// So the skip was suppressing a test that passes. A `fixme` whose stated
+		// blocker does not hold in the environment under test is indistinguishable
+		// from a healthy run in the summary line — the same failure mode this file
+		// already documents at length for its six self-skipping tests. If #333
+		// regresses INTO this environment, this test goes red, which is the point.
 		const guard = attachConsoleGuard(page)
 		await go(page, 'policy/prohibitions')
 		await expect(page).toHaveURL(/\/apps\/docudesk\/policy\/prohibitions/)
@@ -167,7 +197,7 @@ test.describe('orphaned-surface-restoration — publication policy', () => {
 	})
 
 	test('StandingConsents ("Publish always") deep-links and renders its list', async ({ page }) => {
-		// @e2e openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#scenario-policy-pages-are-deep-link-reachable
+		// @e2e openspec/specs/orphaned-surface-restoration/spec.md#policy-pages-are-deep-link-reachable
 		const guard = attachConsoleGuard(page)
 		await go(page, 'policy/standing-consents')
 		await expect(page).toHaveURL(/\/apps\/docudesk\/policy\/standing-consents/)
@@ -234,7 +264,7 @@ test.describe('orphaned-surface-restoration — publication policy', () => {
 	})
 
 	test('no policy menu entry is introduced by this change', async ({ page }) => {
-		// @e2e openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#scenario-no-policy-menu-label-is-introduced-here
+		// @e2e openspec/specs/orphaned-surface-restoration/spec.md#no-policy-menu-label-is-introduced-here
 		await go(page, '')
 		const prohibitionsLink = page.locator('#app-navigation a[title="Publish never"], .app-navigation a[title="Publish never"]')
 		const standingConsentsLink = page.locator('#app-navigation a[title="Publish always"], .app-navigation a[title="Publish always"]')
@@ -245,7 +275,7 @@ test.describe('orphaned-surface-restoration — publication policy', () => {
 
 test.describe('orphaned-surface-restoration — dead router removal is inert', () => {
 	test('previously-existing pages still route identically after the dead router removal', async ({ page }) => {
-		// @e2e openspec/changes/orphaned-surface-restoration/specs/orphaned-surface-restoration/spec.md#scenario-existing-pages-still-route-after-deletion
+		// @e2e openspec/specs/orphaned-surface-restoration/spec.md#existing-pages-still-route-after-deletion
 		// What this scenario actually guards is ROUTING: after deleting the dead
 		// vue-router, each previously-reachable route still resolves and renders
 		// its page. It must not assert a visible heading as the proxy for that:

--- a/tests/e2e/workflows/anonymization-workflow.spec.ts
+++ b/tests/e2e/workflows/anonymization-workflow.spec.ts
@@ -37,7 +37,7 @@
  */
 
 import { test, expect } from '@playwright/test'
-import { APP, dismissOverlays, waitForAppReady } from '../spec-coverage/_helpers'
+import { APP, appUrl, dismissOverlays, waitForAppReady } from '../spec-coverage/_helpers'
 import {
 	harvestToken, jsonHeaders, API, TEST_PREFIX, TEST_FAMILY,
 	createDavFolder, createDavFile,
@@ -82,7 +82,16 @@ async function goRoute(page, route: string): Promise<void> {
 	await page.goto(APP, { waitUntil: 'domcontentloaded' })
 	await waitForAppReady(page)
 	await dismissOverlays(page)
-	await page.goto(`${APP}/${route}`, { waitUntil: 'domcontentloaded' })
+	// `appUrl`, not `${APP}/${route}`. The SPA router's base is
+	// `generateUrl('/apps/docudesk')`, which includes the `index.php` segment
+	// only when `OC.config.modRewriteWorking` is false — true on CI's `php -S`,
+	// FALSE on any Apache with mod_rewrite. On a rewriting server the hardcoded
+	// form addressed a path the router does not recognise, so it fell back to
+	// the app root: this file's first test failed with
+	// `getByRole('heading', { name: /Folder Analysis/ })` not found while
+	// sitting on the dashboard, and took the four tests after it with it
+	// ("3 did not run"). See `resolveAppBase` in ../spec-coverage/_helpers.
+	await page.goto(await appUrl(page, route), { waitUntil: 'domcontentloaded' })
 	await waitForAppReady(page)
 	await dismissOverlays(page)
 	await page.waitForTimeout(1200)


### PR DESCRIPTION
## gate-19: 375 → 358

**Scope of every number here** — the canonical checker
(`ConductionNL/.github@main`, `hydra-gates/scripts/lib/check_e2e_coverage.py`,
1735 lines) run **UNSCOPED** (no `HYDRA_GATE_BASE_REF`) over the whole
`openspec/specs/` tree, from a worktree of `origin/development` (c5dec1dc).

⚠️ **The gate-19 cell on this PR is not evidence of the improvement.** Gate-19
is diff-scoped, and this PR touches exactly one spec file, so its scope here is
almost empty and it will report green trivially. The scope-independent evidence
is the negative control:

```
remove tests/e2e/spec-coverage/entity-publication-policies.spec.ts
    358 → 362      (+4, exactly the four scenarios it anchors)
restore it
    362 → 358
```

### Where the 17 come from

| | scenarios |
|---|---|
| real new Playwright tests (11 tests) | 11 |
| existing real tests whose `@e2e` anchors were **inert** — repointed | 5 |
| `@e2e exclude` — **1 scenario, 1 distinct reason** | 1 |

Reported per ConductionNL/.github#356: the one exclusion is written at
**scenario** level, not requirement level, so it exempts no sibling (verified —
the count moved by exactly 1), and its reason names a **test artifact**
(`tests/unit/Service/CustomDictionaryServiceTest.php::testCreateDictionaryDefaultsMatchMode`),
not a state of the world.

No baselines, no deleted tests, no new skips, no widened timeouts, no
`mode:'serial'`, no `networkidle`. One **stale** `test.fixme` was removed.

### 1. Five scenarios were already covered and the gate could not see it

Gate-19's ref parser only matches `openspec/specs/<spec>/…#<slug>`. An anchor
written as `openspec/changes/<change>/specs/<spec>/spec.md#<slug>` — the normal
shape for a test authored before its change was archived — matches **neither**
of its two regexes, so no ref is constructed at all: not reported as dangling,
not reported as dead, not reported. There were **22** such anchors across two
files, and both files contain real, running, asserting tests.

The archived slugs also carry a `scenario-` prefix the canonical slug lacks, so
repointing the directory alone would have produced a *dangling* anchor — which
gate-19 also does not report. Both halves fixed; filed at source as
ConductionNL/.github#357.

The four **file-level** anchors were removed rather than repointed: they named
requirements, not scenarios, and a file-level anchor is credited without
checking the body (#343). Every anchor now sits inside the test that asserts it.

### 2. Eleven new tests

- **`anonymiser-backend-warning.spec.ts` (4)** — the one requirement in the
  78-scenario `anonymization` spec defined purely in terms of what an admin
  sees. Asserts the banner is **above** the dashboard body (a banner below the
  fold satisfies "is shown" and fails the requirement), and that the App Store
  CTA triggers **no install** — via a request recorder, because `toHaveURL`
  cannot see a side effect.
- **`entity-publication-policies.spec.ts` (4)** — this spec had **zero** anchors
  and **zero** excludes; all 34 scenarios were raw findings. Each test seeds one
  record of *each* kind, because "only scope=entity records are listed" is
  worthless without a scope=document record present to be excluded. Note the two
  surfaces filter in different **layers**: standing consents server-side, the
  consent workflow **client-side** (`GET /api/consents` returns both scopes and
  `ConsentIndex.vue` narrows them). A regression there is invisible to an API
  test — which is exactly why it belongs in gate-19 and not Newman.
- **`custom-dictionary-recognition.spec.ts` (3, rewritten)** — re-anchoring
  alone would have bought green with a false statement. Every assertion sat
  behind `if (await x.isVisible().catch(() => false))` with an `else` asserting
  `<body>` is visible: a missing table, a missing Add button and a missing row
  all produced a **PASS**.

### 3. A defect the tests found, fixed here

`CustomDictionaryFormDialog.vue` bound its match-mode `NcSelect` with the Vue 2
contract (`:value` + `@input`). `@nextcloud/vue` 9.9.0's NcSelect declares a
`modelValue` prop, declares **no** `value` prop, and emits only
`update:modelValue`. The control was **inert** — every dictionary was written
with the `caseInsensitive` default whatever the operator picked, silently.
Positive control in the same run: the same dictionary created via the API with
`matchMode:"wordBoundary"` lists correctly, so backend and column are fine.
Also filed as #429 because the class fails silently and open.

### 4. A shared-helper repair affecting every spec

`_helpers.ts` hardcoded `/index.php/apps/docudesk`. The router's base is
`generateUrl('/apps/docudesk')`, which carries the `index.php` segment only when
`OC.config.modRewriteWorking` is **false** — true on CI's `php -S`, false on any
Apache. On a rewriting server every deep link fell back to the app root, and the
near-universal `expect(page).toHaveURL(/\/apps\/docudesk/)` then **passes on the
dashboard**. `go()` now reads the base from the running app; it throws rather
than falling back if `window.OC` is absent. **No-op on CI.**

That bug also caused the full suite's one real failure, in a file this branch
did not otherwise touch (`workflows/anonymization-workflow.spec.ts`), which took
four tests with it as "did not run". Those four now run and pass.

### 5. Verification — every test proven able to fail

| plant | effect | reverted |
|---|---|---|
| `POST api/admin/anonymiser-warning/dismiss` | all **4** banner tests red | `…/reset` |
| neutered `scope === 'entity'` in `PolicyCrudService` | "Publish always" test red **on its own message** | `git checkout --` |
| `$key = $value` instead of `mb_strtolower($value)` | CSV test read back `3 added, 0 skipped, 3 total.` | `git checkout --` |
| the NcSelect fix | its own control — red before, green after | n/a |

That exercise also caught a defect **in my own tests**: the first version read
`innerText()` once into a string, which raced the store's fetch. An **absence**
assertion is satisfied for free by a page that has not loaded, so the negative
halves would have been silent no-ops. Both files now assert the positive first
with a retrying expectation, then the absence.

### 6. A stale skip removed

The `test.fixme` citing #333 is gone. #333 is still open and still correct about
DocuDesk's boot-time import path — but `tests/e2e/ci-seed.sh`, the workflow's
own `playwright-seed-command`, force-imports the register through OpenRegister's
admin importer *precisely because* that path is unreliable, and verifies it. The
schema is present in the environment the suite runs in and the test passes. The
remaining skips (#339, and the NER-sidecar `fixme`) are untouched.

### Suite state

Full CI-config run against a seeded NC 34 instance: **every previously-failing
and every verdict-less test now passes**; the two remaining skips are
pre-existing `test.fixme`s this branch does not touch.

### Issues filed

- #428 — `prohibitionOverrideAudit` schema does not exist and `writeAudit()` is
  fail-closed (proven with a positive control: sibling schema 200, this one 404).
  **Not excluded** — a browser can observe those scenarios fine; the code path
  cannot run.
- #429 — the NcSelect binding (fixed here).
- #430 — one scenario left deliberately **uncovered** rather than excluded
  (needs a real anonymiser backend).
- #431 — 23 exclusions resting on a reason that expired at v0.0.34; the review
  table they call "unbuilt" ships and renders.
- ConductionNL/.github#357 — gate-19 silently ignores unparseable and dangling
  anchors.

Repo-wide, this branch leaves **zero** unparseable and **zero** dangling `@e2e`
anchors.
