### PR TITLE
refactor(docudesk): GrondslagenSummaryService → LegalBasesSummaryService

### DIFF
--- a/lib/Controller/DossierController.php
+++ b/lib/Controller/DossierController.php
@@ -6,7 +6,7 @@
  * single endpoint — `POST /api/anonymization/dossier/{dossierId}/grondslagen-pdf`
  * — which (re)generates the per-dossier grondslagen summary PDF aggregating
  * every redacted entity under the dossier's folder. See
- * `GrondslagenSummaryService::renderDossierSummary` for the render itself.
+ * `LegalBasesSummaryService::renderDossierSummary` for the render itself.
  *
  * Authentication is required (the route is `@NoAdminRequired` but
  * non-anonymous). Authorisation: the caller MUST be able to read the
@@ -33,7 +33,7 @@ declare(strict_types=1);
 namespace OCA\DocuDesk\Controller;
 
 use Exception;
-use OCA\DocuDesk\Service\GrondslagenSummaryService;
+use OCA\DocuDesk\Service\LegalBasesSummaryService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -59,7 +59,7 @@ class DossierController extends Controller
      * @param string                    $appName            The application name.
      * @param IRequest                  $request            The current HTTP request.
      * @param LoggerInterface           $logger             Logger for error reporting.
-     * @param GrondslagenSummaryService $grondslagenSummary Per-dossier renderer.
+     * @param LegalBasesSummaryService $grondslagenSummary Per-dossier renderer.
      * @param IL10N                     $l10n               Localisation service.
      * @param IUserSession              $userSession        User session for auth check.
      */
@@ -67,7 +67,7 @@ class DossierController extends Controller
         string $appName,
         IRequest $request,
         private readonly LoggerInterface $logger,
-        private readonly GrondslagenSummaryService $grondslagenSummary,
+        private readonly LegalBasesSummaryService $grondslagenSummary,
         private readonly IL10N $l10n,
         private readonly IUserSession $userSession
     ) {

--- a/lib/Controller/DossierController.php
+++ b/lib/Controller/DossierController.php
@@ -56,12 +56,12 @@ class DossierController extends Controller
     /**
      * Constructor for DossierController.
      *
-     * @param string                    $appName            The application name.
-     * @param IRequest                  $request            The current HTTP request.
-     * @param LoggerInterface           $logger             Logger for error reporting.
+     * @param string                   $appName            The application name.
+     * @param IRequest                 $request            The current HTTP request.
+     * @param LoggerInterface          $logger             Logger for error reporting.
      * @param LegalBasesSummaryService $grondslagenSummary Per-dossier renderer.
-     * @param IL10N                     $l10n               Localisation service.
-     * @param IUserSession              $userSession        User session for auth check.
+     * @param IL10N                    $l10n               Localisation service.
+     * @param IUserSession             $userSession        User session for auth check.
      */
     public function __construct(
         string $appName,

--- a/lib/EventListener/DocuDeskEventHandler.php
+++ b/lib/EventListener/DocuDeskEventHandler.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 
 namespace OCA\DocuDesk\EventListener;
 
-use OCA\DocuDesk\Service\GrondslagenSummaryService;
+use OCA\DocuDesk\Service\LegalBasesSummaryService;
 use OCA\DocuDesk\Service\MetadataService;
 use OCA\DocuDesk\Service\PolicyRetroactiveService;
 use OCA\DocuDesk\Service\SettingsService;
@@ -223,7 +223,7 @@ class DocuDeskEventHandler
         }
 
         try {
-            $service = \OC::$server->get(GrondslagenSummaryService::class);
+            $service = \OC::$server->get(LegalBasesSummaryService::class);
             $service->renderDossierSummary(dossierUuid: $dossierUuid);
         } catch (\Throwable $e) {
             $logger->warning(

--- a/lib/EventListener/DossierCheckedOnListener.php
+++ b/lib/EventListener/DossierCheckedOnListener.php
@@ -30,7 +30,7 @@ declare(strict_types=1);
 
 namespace OCA\DocuDesk\EventListener;
 
-use OCA\DocuDesk\Service\GrondslagenSummaryService;
+use OCA\DocuDesk\Service\LegalBasesSummaryService;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -71,7 +71,7 @@ class DossierCheckedOnListener implements IEventListener
      * Constructor for DossierCheckedOnListener.
      *
      * @param LoggerInterface           $logger         Logger for diagnostics
-     * @param GrondslagenSummaryService $summaryService Dossier grondslagen summary renderer
+     * @param LegalBasesSummaryService $summaryService Dossier grondslagen summary renderer
      *
      * @return void
      *
@@ -79,7 +79,7 @@ class DossierCheckedOnListener implements IEventListener
      */
     public function __construct(
         private readonly LoggerInterface $logger,
-        private readonly GrondslagenSummaryService $summaryService,
+        private readonly LegalBasesSummaryService $summaryService,
     ) {
 
     }//end __construct()
@@ -168,7 +168,7 @@ class DossierCheckedOnListener implements IEventListener
             // Log but do NOT rethrow — the dossier update must succeed.
             $this->logError(
                 exception: $e,
-                context: 'GrondslagenSummaryService::renderDossierSummary (auto-regen)',
+                context: 'LegalBasesSummaryService::renderDossierSummary (auto-regen)',
                 extra: ['dossierId' => $dossierId]
             );
         }//end try

--- a/lib/EventListener/DossierCheckedOnListener.php
+++ b/lib/EventListener/DossierCheckedOnListener.php
@@ -70,7 +70,7 @@ class DossierCheckedOnListener implements IEventListener
     /**
      * Constructor for DossierCheckedOnListener.
      *
-     * @param LoggerInterface           $logger         Logger for diagnostics
+     * @param LoggerInterface          $logger         Logger for diagnostics
      * @param LegalBasesSummaryService $summaryService Dossier grondslagen summary renderer
      *
      * @return void

--- a/lib/Service/AnonymizationService.php
+++ b/lib/Service/AnonymizationService.php
@@ -501,7 +501,7 @@ class AnonymizationService
     /**
      * Anonymize entities in a document AND append the grondslagen summary.
      *
-     * Identical to {@see anonymizeDocument()} except that GrondslagenSummaryService
+     * Identical to {@see anonymizeDocument()} except that LegalBasesSummaryService
      * is invoked after the anonymised file has been written. For PDF output the
      * summary is appended as an extra page; otherwise a separate
      * `<base>_grondslagen.pdf` is written alongside. Summary failure is non-fatal:

--- a/lib/Service/BaseLabelResolver.php
+++ b/lib/Service/BaseLabelResolver.php
@@ -6,7 +6,7 @@
  * Resolves Woo Art. 5 `base` (grondslag) references — slugs or UUIDs — to the
  * human-readable name plus toelichting the grondslagen report renders.
  *
- * Extracted from {@see GrondslagenSummaryService}: the lookup, the
+ * Extracted from {@see LegalBasesSummaryService}: the lookup, the
  * ObjectService result normalisation and the "unresolved reference" fallback
  * are one concern, and the renderer no longer needs to know any of it.
  *
@@ -207,7 +207,7 @@ class BaseLabelResolver
             }
         } catch (Exception $e) {
             $this->logger->warning(
-                'GrondslagenSummaryService: failed to load `base` objects for label resolution',
+                'LegalBasesSummaryService: failed to load `base` objects for label resolution',
                 ['error' => $e->getMessage()]
             );
         }//end try

--- a/lib/Service/DossierEntityCollector.php
+++ b/lib/Service/DossierEntityCollector.php
@@ -8,7 +8,7 @@
  * `(entity_type, entity_id)`, carrying its scope-local placeholder, occurrence
  * count and the union of its grondslagen.
  *
- * Extracted from {@see GrondslagenSummaryService}. The privacy rule lives here:
+ * Extracted from {@see LegalBasesSummaryService}. The privacy rule lives here:
  * an entity for which no SCOPE-LOCAL placeholder can be established is OMITTED
  * rather than rendered with its global id, because a global id is a relatable
  * cross-disclosure handle.
@@ -173,7 +173,7 @@ class DossierEntityCollector
         $mapper = $this->repository->entityRelationMapper();
         if ($mapper === null) {
             $this->logger->warning(
-                'GrondslagenSummaryService: EntityRelationMapper unavailable; producing empty entity set',
+                'LegalBasesSummaryService: EntityRelationMapper unavailable; producing empty entity set',
                 ['fileId' => $fileId]
             );
             return [];
@@ -183,7 +183,7 @@ class DossierEntityCollector
             $rawRows = $mapper->findAnonymisedEntitiesWithBasesForFile($fileId);
         } catch (Exception $e) {
             $this->logger->error(
-                'GrondslagenSummaryService: findAnonymisedEntitiesWithBasesForFile failed',
+                'LegalBasesSummaryService: findAnonymisedEntitiesWithBasesForFile failed',
                 ['fileId' => $fileId, 'error' => $e->getMessage()]
             );
             return [];
@@ -280,7 +280,7 @@ class DossierEntityCollector
             // PII-free: count only. Surfaces stale relations with no recoverable
             // scope-local placeholder, deliberately left out of the summary.
             $this->logger->info(
-                'GrondslagenSummaryService: omitted entities with no scope-local placeholder (no global-id fallback)',
+                'LegalBasesSummaryService: omitted entities with no scope-local placeholder (no global-id fallback)',
                 ['fileId' => $fileId, 'omitted' => $omitted]
             );
         }

--- a/lib/Service/DossierObjectRepository.php
+++ b/lib/Service/DossierObjectRepository.php
@@ -7,7 +7,7 @@
  * resolving OR's optional services, loading a dossier's context, and writing
  * back the `configuration.grondslagen` freshness metadata.
  *
- * Extracted from {@see GrondslagenSummaryService} so that knowledge of OR's
+ * Extracted from {@see LegalBasesSummaryService} so that knowledge of OR's
  * object shape — the `getObject()` payload, the entity-level `folder` column
  * that lives OUTSIDE that payload, and the save-path folder-preservation
  * dance — sits in one place instead of being spread through the renderer.
@@ -141,7 +141,7 @@ class DossierObjectRepository
             return $this->container->get('OCA\OpenRegister\Service\ObjectService');
         } catch (Exception $e) {
             $this->logger->warning(
-                'GrondslagenSummaryService: ObjectService unavailable',
+                'LegalBasesSummaryService: ObjectService unavailable',
                 ['error' => $e->getMessage()]
             );
             return null;
@@ -164,7 +164,7 @@ class DossierObjectRepository
             return $this->container->get('OCA\OpenRegister\Db\EntityRelationMapper');
         } catch (Exception $e) {
             $this->logger->warning(
-                'GrondslagenSummaryService: EntityRelationMapper unavailable',
+                'LegalBasesSummaryService: EntityRelationMapper unavailable',
                 ['error' => $e->getMessage()]
             );
             return null;
@@ -213,7 +213,7 @@ class DossierObjectRepository
         $objectService = $this->objectService();
         if ($objectService === null) {
             $this->logger->warning(
-                'GrondslagenSummaryService: cannot update dossier configuration — ObjectService unavailable',
+                'LegalBasesSummaryService: cannot update dossier configuration — ObjectService unavailable',
                 ['dossierUuid' => $dossierUuid]
             );
             return;
@@ -250,7 +250,7 @@ class DossierObjectRepository
             );
         } catch (Exception $e) {
             $this->logger->warning(
-                'GrondslagenSummaryService: failed to update dossier configuration.grondslagen',
+                'LegalBasesSummaryService: failed to update dossier configuration.grondslagen',
                 ['dossierUuid' => $dossierUuid, 'error' => $e->getMessage()]
             );
         }//end try
@@ -441,7 +441,7 @@ class DossierObjectRepository
             // log and proceed with the save (the user-visible PDF is already
             // on disk).
             $this->logger->warning(
-                'GrondslagenSummaryService: could not read existing folder ref before save',
+                'LegalBasesSummaryService: could not read existing folder ref before save',
                 ['dossierUuid' => $dossierUuid, 'error' => $e->getMessage()]
             );
             return $payload;

--- a/lib/Service/DossierPlaceholderRanker.php
+++ b/lib/Service/DossierPlaceholderRanker.php
@@ -8,7 +8,7 @@
  * a live anonymise run shows the SAME scope-local number the documents carry
  * (e.g. `[DATUM: 6]`) rather than the global entity id.
  *
- * Extracted from {@see GrondslagenSummaryService}. It is also the single seam
+ * Extracted from {@see LegalBasesSummaryService}. It is also the single seam
  * through which DocuDesk reaches OpenRegister's ranking helper: that helper is
  * a static API on an OPTIONAL app, so — like every other OR reference in this
  * codebase — it is named by string and probed with `class_exists()` before
@@ -117,7 +117,7 @@ class DossierPlaceholderRanker
             $rows = $mapper->findEntityIdsByValueForFiles(fileIds: $fileIds);
         } catch (Exception $e) {
             $this->logger->warning(
-                'GrondslagenSummaryService: dossier placeholder recompute failed; falling back to global ids',
+                'LegalBasesSummaryService: dossier placeholder recompute failed; falling back to global ids',
                 ['error' => $e->getMessage()]
             );
             return $empty;
@@ -189,7 +189,7 @@ class DossierPlaceholderRanker
             }
         } catch (Exception $e) {
             $this->logger->warning(
-                'GrondslagenSummaryService: dossier file enumeration failed',
+                'LegalBasesSummaryService: dossier file enumeration failed',
                 ['error' => $e->getMessage()]
             );
         }//end try

--- a/lib/Service/DossierSummaryDataService.php
+++ b/lib/Service/DossierSummaryDataService.php
@@ -7,7 +7,7 @@
  * *know* — the dossier's context and folder, the placeholder ranking, the
  * anonymised entity rows, and the resolved grondslag labels — behind one seam.
  *
- * Extracted from {@see GrondslagenSummaryService} together with the four
+ * Extracted from {@see LegalBasesSummaryService} together with the four
  * collaborators it composes ({@see DossierObjectRepository},
  * {@see BaseLabelResolver}, {@see DossierPlaceholderRanker},
  * {@see DossierEntityCollector}), leaving the summary service to do only what

--- a/lib/Service/GrondslagProposalService.php
+++ b/lib/Service/GrondslagProposalService.php
@@ -14,7 +14,7 @@
  *     (`docudesk.grondslagen.entity_type_bases`), value
  *     `{ "<TYPE>": ["<base-slug>", ...] }`.
  *   - Bases are stored as plain slug strings, matching the existing
- *     `EntityRelation.bases` shape and `GrondslagenSummaryService` resolver.
+ *     `EntityRelation.bases` shape and `LegalBasesSummaryService` resolver.
  *   - Selectable entity types come from a curated in-DocuDesk list (v1).
  *     Sourcing them live from the anonymiser backend is deferred until that
  *     backend exposes a supported-types endpoint; {@see getSelectableEntityTypes}

--- a/lib/Service/GrondslagenPdfWriter.php
+++ b/lib/Service/GrondslagenPdfWriter.php
@@ -8,7 +8,7 @@
  * into an already-anonymised PDF with FPDI, and persists the result to
  * Nextcloud Files.
  *
- * Extracted from {@see GrondslagenSummaryService} so that the summary service
+ * Extracted from {@see LegalBasesSummaryService} so that the summary service
  * decides WHAT to report while this class owns HOW it reaches disk.
  *
  * @category  Service

--- a/lib/Service/GrondslagenSummaryAttacher.php
+++ b/lib/Service/GrondslagenSummaryAttacher.php
@@ -48,14 +48,14 @@ class GrondslagenSummaryAttacher
      * Constructor for GrondslagenSummaryAttacher
      *
      * @param LoggerInterface           $logger             Logger for the non-fatal failure warning.
-     * @param GrondslagenSummaryService $grondslagenSummary Renderer for the per-document grondslagen
+     * @param LegalBasesSummaryService $grondslagenSummary Renderer for the per-document grondslagen
      *                                                      summary page.
      *
      * @return void
      */
     public function __construct(
         private readonly LoggerInterface $logger,
-        private readonly GrondslagenSummaryService $grondslagenSummary
+        private readonly LegalBasesSummaryService $grondslagenSummary
     ) {
 
     }//end __construct()

--- a/lib/Service/GrondslagenSummaryAttacher.php
+++ b/lib/Service/GrondslagenSummaryAttacher.php
@@ -47,9 +47,9 @@ class GrondslagenSummaryAttacher
     /**
      * Constructor for GrondslagenSummaryAttacher
      *
-     * @param LoggerInterface           $logger             Logger for the non-fatal failure warning.
+     * @param LoggerInterface          $logger             Logger for the non-fatal failure warning.
      * @param LegalBasesSummaryService $grondslagenSummary Renderer for the per-document grondslagen
-     *                                                      summary page.
+     *                                                     summary page.
      *
      * @return void
      */

--- a/lib/Service/LegalBasesSummaryService.php
+++ b/lib/Service/LegalBasesSummaryService.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Grondslagen Summary Service
+ * Legal Bases Summary Service
  *
  * Renders per-document and per-dossier grondslagen summary PDFs. Reads
  * EntityRelation.bases (OpenRegister, Wave 1.3 — entity-relation-grondslagen)
@@ -62,7 +62,7 @@ use Psr\Log\LoggerInterface;
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.app
  */
-class GrondslagenSummaryService
+class LegalBasesSummaryService
 {
 
     /**
@@ -191,7 +191,7 @@ class GrondslagenSummaryService
         $this->pdfWriter->appendToPdf(anonymisedFile: $anonymisedFile, summaryBytes: $summaryBytes);
 
         $this->logger->info(
-            'GrondslagenSummaryService: appended summary to anonymised PDF',
+            'LegalBasesSummaryService: appended summary to anonymised PDF',
             [
                 'fileId'       => $anonymisedFile->getId(),
                 'sourceFileId' => $sourceFileId,
@@ -234,9 +234,9 @@ class GrondslagenSummaryService
             summaryBytes: $summaryBytes
         );
 
-        $message = 'GrondslagenSummaryService: wrote beside-file summary';
+        $message = 'LegalBasesSummaryService: wrote beside-file summary';
         if ($written['refreshed'] === true) {
-            $message = 'GrondslagenSummaryService: refreshed beside-file summary';
+            $message = 'LegalBasesSummaryService: refreshed beside-file summary';
         }
 
         $this->logger->info(
@@ -343,7 +343,7 @@ class GrondslagenSummaryService
         );
 
         $this->logger->info(
-            'GrondslagenSummaryService: rendered per-dossier summary',
+            'LegalBasesSummaryService: rendered per-dossier summary',
             [
                 'dossierUuid'   => $dossierUuid,
                 'summaryFileId' => $summaryFile->getId(),

--- a/src/services/entityTypes.js
+++ b/src/services/entityTypes.js
@@ -73,7 +73,7 @@ export function entityTypeColor(type) {
  * and only produces the string shown to the user.
  *
  * The raw uppercase token IS the translation msgid — deliberately the same
- * scheme the DocuDesk backend uses (`GrondslagenSummaryService::localizeEntityType`
+ * scheme the DocuDesk backend uses (`LegalBasesSummaryService::localizeEntityType`
  * → `IL10N::t($entityType)`) and that OpenRegister writes into redacted
  * documents (`DocumentProcessingHandler::LOCALIZABLE_ENTITY_TYPES`). Translating
  * by the raw token means the sidebar label, the summary legend and the redacted

--- a/tests/unit/Controller/DossierControllerTest.php
+++ b/tests/unit/Controller/DossierControllerTest.php
@@ -21,7 +21,7 @@ namespace OCA\DocuDesk\Tests\Unit\Controller;
 
 use Exception;
 use OCA\DocuDesk\Controller\DossierController;
-use OCA\DocuDesk\Service\GrondslagenSummaryService;
+use OCA\DocuDesk\Service\LegalBasesSummaryService;
 use OCP\Files\File;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -60,9 +60,9 @@ class DossierControllerTest extends TestCase
     private LoggerInterface|MockObject $mockLogger;
 
     /**
-     * @var GrondslagenSummaryService|MockObject
+     * @var LegalBasesSummaryService|MockObject
      */
-    private GrondslagenSummaryService|MockObject $mockSummaryService;
+    private LegalBasesSummaryService|MockObject $mockSummaryService;
 
     /**
      * @var IL10N|MockObject
@@ -90,7 +90,7 @@ class DossierControllerTest extends TestCase
 
         $this->mockRequest        = $this->createMock(IRequest::class);
         $this->mockLogger         = $this->createMock(LoggerInterface::class);
-        $this->mockSummaryService = $this->createMock(GrondslagenSummaryService::class);
+        $this->mockSummaryService = $this->createMock(LegalBasesSummaryService::class);
         $this->mockL10n           = $this->createMock(IL10N::class);
         $this->mockUserSession    = $this->createMock(IUserSession::class);
 

--- a/tests/unit/EventListener/DossierCheckedOnListenerTest.php
+++ b/tests/unit/EventListener/DossierCheckedOnListenerTest.php
@@ -23,7 +23,7 @@
 namespace OCA\DocuDesk\Tests\Unit\EventListener;
 
 use OCA\DocuDesk\EventListener\DossierCheckedOnListener;
-use OCA\DocuDesk\Service\GrondslagenSummaryService;
+use OCA\DocuDesk\Service\LegalBasesSummaryService;
 use OCP\EventDispatcher\Event;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -60,7 +60,7 @@ class DossierCheckedOnListenerTest extends TestCase
     /**
      * Mock grondslagen summary service.
      *
-     * @var MockObject&GrondslagenSummaryService
+     * @var MockObject&LegalBasesSummaryService
      */
     private MockObject $grondslagenSummaryService;
 
@@ -74,7 +74,7 @@ class DossierCheckedOnListenerTest extends TestCase
         parent::setUp();
 
         $this->logger                    = $this->createMock(originalClassName: LoggerInterface::class);
-        $this->grondslagenSummaryService = $this->createMock(originalClassName: GrondslagenSummaryService::class);
+        $this->grondslagenSummaryService = $this->createMock(originalClassName: LegalBasesSummaryService::class);
 
         $this->listener = new DossierCheckedOnListener(
             logger: $this->logger,

--- a/tests/unit/Service/AnonymizationLinkServiceTest.php
+++ b/tests/unit/Service/AnonymizationLinkServiceTest.php
@@ -29,7 +29,7 @@ use OCA\DocuDesk\Service\CustomDictionaryService;
 use OCA\DocuDesk\Service\EmlPdfAssemblyService;
 use OCA\DocuDesk\Service\EntityDetectionService;
 use OCA\DocuDesk\Service\FileEntityStatsService;
-use OCA\DocuDesk\Service\GrondslagenSummaryService;
+use OCA\DocuDesk\Service\LegalBasesSummaryService;
 use OCA\DocuDesk\Service\PdfConversionService;
 use OCP\App\IAppManager;
 use OCP\IAppConfig;

--- a/tests/unit/Service/AnonymizationServiceConfidentialityTest.php
+++ b/tests/unit/Service/AnonymizationServiceConfidentialityTest.php
@@ -31,7 +31,7 @@ use OCA\DocuDesk\Service\ConsentService;
 use OCA\DocuDesk\Service\CustomDictionaryMatchService;
 use OCA\DocuDesk\Service\CustomDictionaryService;
 use OCA\DocuDesk\Service\EntityDetectionService;
-use OCA\DocuDesk\Service\GrondslagenSummaryService;
+use OCA\DocuDesk\Service\LegalBasesSummaryService;
 use OCP\App\IAppManager;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/unit/Service/AnonymizationServiceCustomDictionaryTest.php
+++ b/tests/unit/Service/AnonymizationServiceCustomDictionaryTest.php
@@ -31,7 +31,7 @@ use OCA\DocuDesk\Service\CustomDictionaryMatchService;
 use OCA\DocuDesk\Service\CustomDictionaryService;
 use OCA\DocuDesk\Service\EntityDetectionService;
 use OCA\DocuDesk\Service\FileEntityStatsService;
-use OCA\DocuDesk\Service\GrondslagenSummaryService;
+use OCA\DocuDesk\Service\LegalBasesSummaryService;
 use OCA\DocuDesk\Service\GrondslagProposalService;
 use OCA\OpenRegister\Db\Chunk;
 use OCA\OpenRegister\Db\ChunkMapper;

--- a/tests/unit/Service/AnonymizationServiceProhibitionTest.php
+++ b/tests/unit/Service/AnonymizationServiceProhibitionTest.php
@@ -27,7 +27,7 @@ use OCA\DocuDesk\Service\ConsentService;
 use OCA\DocuDesk\Service\CustomDictionaryMatchService;
 use OCA\DocuDesk\Service\CustomDictionaryService;
 use OCA\DocuDesk\Service\EntityDetectionService;
-use OCA\DocuDesk\Service\GrondslagenSummaryService;
+use OCA\DocuDesk\Service\LegalBasesSummaryService;
 use OCA\DocuDesk\Service\PolicyMatchService;
 use OCP\App\IAppManager;
 use OCP\IAppConfig;

--- a/tests/unit/Service/AnonymizationServicePublicationClearanceTest.php
+++ b/tests/unit/Service/AnonymizationServicePublicationClearanceTest.php
@@ -31,7 +31,7 @@ use OCA\DocuDesk\Service\CustomDictionaryMatchService;
 use OCA\DocuDesk\Service\CustomDictionaryService;
 use OCA\DocuDesk\Service\EntityDetectionService;
 use OCA\DocuDesk\Service\FileEntityStatsService;
-use OCA\DocuDesk\Service\GrondslagenSummaryService;
+use OCA\DocuDesk\Service\LegalBasesSummaryService;
 use OCP\App\IAppManager;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/unit/Service/AnonymizationServiceTest.php
+++ b/tests/unit/Service/AnonymizationServiceTest.php
@@ -31,7 +31,7 @@ use OCA\DocuDesk\Service\EmlAnonymizationService;
 use OCA\DocuDesk\Service\EmlPdfAssemblyService;
 use OCA\DocuDesk\Service\EntityDetectionService;
 use OCA\DocuDesk\Service\GrondslagenSummaryAttacher;
-use OCA\DocuDesk\Service\GrondslagenSummaryService;
+use OCA\DocuDesk\Service\LegalBasesSummaryService;
 use OCA\DocuDesk\Service\OpenRegisterServiceLocator;
 use OCA\DocuDesk\Service\PdfConversionService;
 use OCA\DocuDesk\Service\PolicyMatchService;
@@ -386,7 +386,7 @@ class AnonymizationServiceTest extends TestCase
      */
     public function testWarningFieldDefinedOnSummaryFailure(): void
     {
-        $summary = $this->createMock(GrondslagenSummaryService::class);
+        $summary = $this->createMock(LegalBasesSummaryService::class);
         $summary->method('appendSummaryToPdf')->willThrowException(new \Exception('renderer down'));
 
         $result = $this->summaryAttacher($summary)->attachGrondslagenSummary(
@@ -415,7 +415,7 @@ class AnonymizationServiceTest extends TestCase
         $summaryFile->method('getId')->willReturn(321);
         $summaryFile->method('getPath')->willReturn('/u/doc_grondslagen.pdf');
 
-        $summary = $this->createMock(GrondslagenSummaryService::class);
+        $summary = $this->createMock(LegalBasesSummaryService::class);
         $summary->method('renderSummaryBesideFile')->willReturn($summaryFile);
 
         $result = $this->summaryAttacher($summary)->attachGrondslagenSummary(
@@ -956,11 +956,11 @@ class AnonymizationServiceTest extends TestCase
     /**
      * Build the grondslagen summary attacher around a renderer double.
      *
-     * @param GrondslagenSummaryService $summary The renderer double.
+     * @param LegalBasesSummaryService $summary The renderer double.
      *
      * @return GrondslagenSummaryAttacher The attacher under test.
      */
-    private function summaryAttacher(GrondslagenSummaryService $summary): GrondslagenSummaryAttacher
+    private function summaryAttacher(LegalBasesSummaryService $summary): GrondslagenSummaryAttacher
     {
         return new GrondslagenSummaryAttacher(logger: new NullLogger(), grondslagenSummary: $summary);
 
@@ -1114,7 +1114,7 @@ class AnonymizationServiceTest extends TestCase
             ),
             summaryAttacher: new GrondslagenSummaryAttacher(
                 logger: $logger,
-                grondslagenSummary: $this->createMock(GrondslagenSummaryService::class)
+                grondslagenSummary: $this->createMock(LegalBasesSummaryService::class)
             )
         );
 

--- a/tests/unit/Service/BuildsAnonymizationService.php
+++ b/tests/unit/Service/BuildsAnonymizationService.php
@@ -42,7 +42,7 @@ use OCA\DocuDesk\Service\EmlPdfAssemblyService;
 use OCA\DocuDesk\Service\EntityDetectionService;
 use OCA\DocuDesk\Service\FileEntityStatsService;
 use OCA\DocuDesk\Service\GrondslagenSummaryAttacher;
-use OCA\DocuDesk\Service\GrondslagenSummaryService;
+use OCA\DocuDesk\Service\LegalBasesSummaryService;
 use OCA\DocuDesk\Service\OpenRegisterServiceLocator;
 use OCA\DocuDesk\Service\PdfConversionService;
 use OCA\DocuDesk\Service\ProhibitionGateService;
@@ -131,7 +131,7 @@ trait BuildsAnonymizationService
             ),
             summaryAttacher: new GrondslagenSummaryAttacher(
                 logger: $logger,
-                grondslagenSummary: ($deps['grondslagenSummary'] ?? $this->createMock(GrondslagenSummaryService::class))
+                grondslagenSummary: ($deps['grondslagenSummary'] ?? $this->createMock(LegalBasesSummaryService::class))
             )
         );
 

--- a/tests/unit/Service/LegalBasesSummaryServiceTest.php
+++ b/tests/unit/Service/LegalBasesSummaryServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Unit tests for GrondslagenSummaryService
+ * Unit tests for LegalBasesSummaryService
  *
  * @category Tests
  * @package  OCA\DocuDesk\Tests\Unit\Service
@@ -17,7 +17,7 @@
 
 namespace OCA\DocuDesk\Tests\Unit\Service;
 
-use OCA\DocuDesk\Service\GrondslagenSummaryService;
+use OCA\DocuDesk\Service\LegalBasesSummaryService;
 use OCA\DocuDesk\Service\PdfService;
 use OCP\App\IAppManager;
 use OCP\Files\IRootFolder;
@@ -30,7 +30,7 @@ use Psr\Log\LoggerInterface;
 use ReflectionMethod;
 
 /**
- * Cover the deterministic helpers of GrondslagenSummaryService.
+ * Cover the deterministic helpers of LegalBasesSummaryService.
  *
  * The public methods touch OpenRegister via the container and the
  * Nextcloud filesystem, which are out of scope for unit tests; Newman
@@ -47,15 +47,15 @@ use ReflectionMethod;
  *
  * @psalm-suppress PropertyNotSetInConstructor
  */
-class GrondslagenSummaryServiceTest extends TestCase
+class LegalBasesSummaryServiceTest extends TestCase
 {
 
     /**
      * Service under test.
      *
-     * @var GrondslagenSummaryService
+     * @var LegalBasesSummaryService
      */
-    private GrondslagenSummaryService $service;
+    private LegalBasesSummaryService $service;
 
     /**
      * Mock logger.
@@ -115,7 +115,7 @@ class GrondslagenSummaryServiceTest extends TestCase
         $this->mockAppManager  = $this->createMock(originalClassName: IAppManager::class);
         $this->mockContainer   = $this->createMock(originalClassName: ContainerInterface::class);
 
-        $this->service = new GrondslagenSummaryService(
+        $this->service = new LegalBasesSummaryService(
             logger: $this->mockLogger,
             pdfService: $this->mockPdfService,
             rootFolder: $this->mockRootFolder,
@@ -134,7 +134,7 @@ class GrondslagenSummaryServiceTest extends TestCase
     public function testServiceCanBeInstantiated(): void
     {
         $this->assertInstanceOf(
-            expected: GrondslagenSummaryService::class,
+            expected: LegalBasesSummaryService::class,
             actual: $this->service
         );
 
@@ -153,7 +153,7 @@ class GrondslagenSummaryServiceTest extends TestCase
     public function testResolveBaseLabelsFallsBackToRawRef(): void
     {
         $method = new ReflectionMethod(
-            objectOrMethod: GrondslagenSummaryService::class,
+            objectOrMethod: LegalBasesSummaryService::class,
             method: 'resolveBaseLabels'
         );
         $method->setAccessible(accessible: true);
@@ -177,7 +177,7 @@ class GrondslagenSummaryServiceTest extends TestCase
     public function testCountDistinctBases(): void
     {
         $method = new ReflectionMethod(
-            objectOrMethod: GrondslagenSummaryService::class,
+            objectOrMethod: LegalBasesSummaryService::class,
             method: 'countDistinctBases'
         );
         $method->setAccessible(accessible: true);
@@ -207,7 +207,7 @@ class GrondslagenSummaryServiceTest extends TestCase
     public function testAggregateForDossier(): void
     {
         $method = new ReflectionMethod(
-            objectOrMethod: GrondslagenSummaryService::class,
+            objectOrMethod: LegalBasesSummaryService::class,
             method: 'aggregateForDossier'
         );
         $method->setAccessible(accessible: true);
@@ -301,7 +301,7 @@ class GrondslagenSummaryServiceTest extends TestCase
             }
         );
 
-        $service = new GrondslagenSummaryService(
+        $service = new LegalBasesSummaryService(
             logger: $this->mockLogger,
             pdfService: $this->mockPdfService,
             rootFolder: $this->mockRootFolder,
@@ -312,7 +312,7 @@ class GrondslagenSummaryServiceTest extends TestCase
         );
 
         $method = new ReflectionMethod(
-            objectOrMethod: GrondslagenSummaryService::class,
+            objectOrMethod: LegalBasesSummaryService::class,
             method: 'localizeEntityType'
         );
         $method->setAccessible(accessible: true);
@@ -334,7 +334,7 @@ class GrondslagenSummaryServiceTest extends TestCase
     {
         // $this->service was constructed without an IL10N (l10n defaults null).
         $method = new ReflectionMethod(
-            objectOrMethod: GrondslagenSummaryService::class,
+            objectOrMethod: LegalBasesSummaryService::class,
             method: 'localizeEntityType'
         );
         $method->setAccessible(accessible: true);


### PR DESCRIPTION
A **code-only** slice of `openspec/changes/english-vocabulary`, separable from the rest because it carries no data risk.

docudesk already stores the legal bases under the English property `bases` — `grondslagen` survives purely as a code identifier. **No migration required**, and that was verified against the register rather than assumed.

Renames the class, its file, its test file, and all 22 referencing files. Per the ratified Woo rule, freedom-of-information concepts are internationalised rather than preserved with a statute marker.

## ⚠️ A scoping mistake worth recording

My first `grep -rl` for the class name listed 17 files. It **missed seven**, because I ran it in the shared checkout (on `development`, 306 files dirty) and then built the worktree from `origin/development` — different content, different file list.

One of the missed files matters: `GrondslagenSummaryAttacher` holds a real typed dependency,

```php
private readonly GrondslagenSummaryService $grondslagenSummary
```

which would have been a **fatal on instantiation**, not a lint error. Same shape as scoping against one revision and editing another.

I also renamed the six `{@see GrondslagenSummaryService}` docblock references in the services extracted from it — those resolve to a class, so a stale one is a broken reference rather than stale prose.

## Deliberately not here
The `dossier` → `RedactionDossier` schema rename. It holds **7 live objects** and needs the migration first, per this app's own spec.

## Verification
`php -l` clean on all 22 changed files; class name matches file name; no residual reference anywhere in `lib/`, `src/`, `tests/` or `appinfo/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)