### PR TITLE
fix(prohibition-gate): declare the prohibitionOverrideAudit schema — every acknowledged override 500s without it

### DIFF
--- a/lib/Settings/docudesk_register.json
+++ b/lib/Settings/docudesk_register.json
@@ -2,8 +2,8 @@
     "openapi": "3.0.0",
     "info": {
         "title": "DocuDesk Register",
-        "description": "DocuDesk register v7.6.4 — standing-consent-documentid-not-required: `publicationConsent` listed `documentId` in the schema-level `required` array, so OpenRegister created the backing column NOT NULL. Every scope=entity (standing consent) record is document-less by definition, so all 12 seeded standing consents failed to insert with 'null value in column \"document_id\" violates not-null constraint', and the same constraint blocks PolicyController::createStandingConsent at runtime — the entire \"Publish always\" surface. The condition is PER RECORD, not per schema, and openspec/specs/consent-management/spec.md already states it: 'documentId MUST be required only for scope=document records'. It is enforced where it can be — ConsentScopeValidator::assertValid(), which rejects a scope=document record without a documentId AND a scope=entity record WITH one. Removing it from the schema's `required` array restores what the spec mandates; nothing is left unvalidated. Previous v7.6.3 — archival-retention-object-shape: fixes six schemas that OpenRegister REJECTED on import, so they never existed on any fresh install. Five (correspondence, signingRequest, signerRecord, signingAuditEntry, batchCorrespondenceJob) declared `x-openregister-archival.retention` as a bare ISO-8601 STRING; OpenRegister's ArchivalAnnotationValidator requires an object `{ default: <duration>, rules?: [] }` and threw 'retention is required and must be an object'. The sixth (publicationProhibition) declared an authorization action `write`, which is not in OpenRegister's CRUD vocabulary (create, read, update, delete) — expanded to create/update/delete, preserving the intent that docudesk-policy-admins may write. ImportHandler catches a per-schema exception, logs it and continues, so the import still answered HTTP 200 'Import successful' while writing only 14 of 20 schemas — which left signing entirely non-functional (signingRequest/signerRecord/signingAuditEntry absent). anonymizationLink and financialExtraction already used the object form; this aligns the rest. No property, slug or retention DURATION changed. Previous v7.6.2 — schema-level-titles-en: re-authored the remaining Dutch schema-level `title` values to English — base 'Grondslag' -> 'Legal Basis', huisstijl 'Huisstijl Configuration' -> 'Branding Configuration' (schema slugs, property keys/titles, enums, descriptions unchanged). Dutch labels now live in l10n/nl.json for the display layer. See openspec/changes (fleet-wide schema-i18n titles rule). Previous v7.6.1 — schema-titles-en: re-authored all Dutch schema property `title` values to English (property names/keys unchanged); Dutch labels now live in l10n/nl.json for the display layer. See openspec/changes (fleet-wide schema-i18n titles rule). Previous v7.6.0 — document-output-destinations-and-bulk-retention: generatedDocument gains additive, nullable fileId/filePath properties, populated when a generation is stored to Files via the new DocumentStorageService (options.output.mode 'files'/'both' on generate, or the now-persisted async bulk job). hardValidation:false, so existing rows remain valid unchanged. See openspec/changes/document-output-destinations-and-bulk-retention/. Previous v7.5.0 — unified-search-provider: corrects the searchable opt-in so only navigable schemas (template, signingRequest) stay searchable and every other schema is searchable:false, keeping DocuDesk's contribution to OpenRegister's shared Unified Search provider free of dead/unnavigable results. Deep-link routing for template + signingRequest lives in src/manifest.json deepLinks[]. No bespoke OCP\\Search\\IProvider — org scoping inherited from openregister_objects. See openspec/changes/unified-search-provider/. Previous v7.4.0 — adds customDictionary + customDictionaryTerm to the document register per custom-dictionary-recognition: organisation-scoped, register-i18n-tagged term lists (label, description, colour, matchMode exact/caseInsensitive/wordBoundary, deferred fuzzy flag, active, calculated termCount) matched by CustomDictionaryMatchService and written into OpenRegister's shared entity catalogue as CUSTOM_DICTIONARY occurrences alongside Presidio/regex detections. Seeds one demo dictionary (\"Projectnamen\") with two demo terms. See openspec/changes/custom-dictionary-recognition/. Previous v7.3.0 — MERGE of Robert's anonimiseren-bij-de-bron work onto development: Woo Art. 5 grondslagen legenda A–S seed (base schema), standing-consent generic-term seeds (publicationConsent, entityType OTHER, notificationStatus skipped), entityType OTHER enum on publicationConsent/publicationProhibition, and EML→PDF assembly. Development schemas + dialect/RBAC fixes are preserved. Previous v5.10.0 — adds glAccountBooking (opaque per-tenant GL-account booking history, keyed by supplierIdentity, fed by the financial-extraction corrections endpoint) and glAccountMappingRule (admin-editable cold-start keyword/category → account rules, no seeded rows — DocuDesk ships no chart of accounts) to the document register, per ai-gl-account-suggestion. Both hardValidation:true. See openspec/changes/ai-gl-account-suggestion/. Previous v5.9.0 adds the financialExtraction schema to the document register: structured financial field-extraction results (supplier/IBAN/KvK/BTW, invoice number, dates, currency, totals + VAT breakdown, line items) with per-field confidence and an additive corrections[] tuning corpus, per financial-document-field-extraction. hardValidation:true; x-openregister-archival category shipped as an explicit placeholder pending selectielijst-manager sign-off (same pattern as anonymizationLink). See openspec/changes/financial-document-field-extraction/. Previous v5.8.0 declares validationStatus + validationFindings as x-openregister-calculations on generatedDocument (computation backend docudesk.validation = DocumentValidationService) per document-validation-checks; the event-listener fallback dispatches the same service until OR's ADR-031 calculation runtime ships. Previous v5.7.0 declared the four AVG Art. 30 processing activities (anonymisation, OCR, metadata-enrichment, signing) as x-openregister-processing catalogue annotations on anonymizationLink, generatedDocument, base, and signingAuditEntry: each carries purpose (doelbinding), legal basis, NER data categories, backend identifier, retention reference taken from the existing x-openregister-archival annotations (\"not declared\" where absent), and opts the schema into OpenRegister's per-access read-logging (logReads:true, attribution.default referencing the activity code). Requires OpenRegister >= 0.2.14. See openspec/changes/processing-activity-export/. Previous v5.5.0 extended OR register-i18n adoption to the remaining user-facing string fields across templateVersion (name/description/changelog), huisstijl (name), base (name/description), correspondence (templateName), signingRequest (documentName), signingSession (documentName), signerRecord (displayName/declineReason), publicationConsent (notes/objectionReason/publicationDecision), publicationProhibition (primaryName/reason/notes), and batchCorrespondenceJob (templateName). OpenRegister TranslationHandler picks these up automatically and stores per-language variants under the existing object JSON column; no DB migration required. See openspec/changes/register-i18n/. Previous v5.4.0 tagged template (name/description/content/category) + dossier (name/description) per register-i18n. Previous v5.3.0 adopted OR abstractions per docudesk-adopt-or-abstractions, added batchCorrespondenceJob schema with x-openregister-lifecycle + archival + notifications + calculations, added x-openregister-archival to signingAuditEntry (P10Y), signingRequest (P10Y), signerRecord (P10Y), correspondence (P7Y), added x-openregister-lifecycle to signingSession, and added anonymizationLink schema for source↔anonymised file mapping.",
-        "version": "7.6.4"
+        "description": "DocuDesk register v7.7.0 — prohibition-override-audit-schema: adds the `prohibitionOverrideAudit` schema to the `consent` register. `ProhibitionOverrideCommitter::writeAudit()` has always written to `register: consent, schema: prohibitionOverrideAudit`, and that schema was declared NOWHERE — `GET /apps/openregister/api/objects/consent/prohibitionOverrideAudit` answered 404 `Schema not found` while its sibling `publicationProhibition` answered 200 on the same freshly-seeded instance. The write is explicitly fail-closed ('If the audit write fails we MUST NOT proceed to the OR PATCH'), so every acknowledged override raised RuntimeException 500 and NO override could ever be committed. openspec/specs/anonymisation-prohibition-gate/spec.md mandates the schema by name: 'Implementations MUST use a `prohibitionOverrideAudit` schema in `docudesk_register.json` for this entry'. Properties are exactly the six the committer writes {ruleId, entityRelationId, fileId, reason, acknowledgedBy, acknowledgedAt}; retention P10Y because an override audit must outlive the P10Y prohibition it released. `authorization: null` matches publicationConsent/anonymizationLink — restricting `create` to policy admins would re-break the same fail-closed path for the ordinary operator who performs the anonymise. See ConductionNL/docudesk#428. Previous v7.6.4 — standing-consent-documentid-not-required: `publicationConsent` listed `documentId` in the schema-level `required` array, so OpenRegister created the backing column NOT NULL. Every scope=entity (standing consent) record is document-less by definition, so all 12 seeded standing consents failed to insert with 'null value in column \"document_id\" violates not-null constraint', and the same constraint blocks PolicyController::createStandingConsent at runtime — the entire \"Publish always\" surface. The condition is PER RECORD, not per schema, and openspec/specs/consent-management/spec.md already states it: 'documentId MUST be required only for scope=document records'. It is enforced where it can be — ConsentScopeValidator::assertValid(), which rejects a scope=document record without a documentId AND a scope=entity record WITH one. Removing it from the schema's `required` array restores what the spec mandates; nothing is left unvalidated. Previous v7.6.3 — archival-retention-object-shape: fixes six schemas that OpenRegister REJECTED on import, so they never existed on any fresh install. Five (correspondence, signingRequest, signerRecord, signingAuditEntry, batchCorrespondenceJob) declared `x-openregister-archival.retention` as a bare ISO-8601 STRING; OpenRegister's ArchivalAnnotationValidator requires an object `{ default: <duration>, rules?: [] }` and threw 'retention is required and must be an object'. The sixth (publicationProhibition) declared an authorization action `write`, which is not in OpenRegister's CRUD vocabulary (create, read, update, delete) — expanded to create/update/delete, preserving the intent that docudesk-policy-admins may write. ImportHandler catches a per-schema exception, logs it and continues, so the import still answered HTTP 200 'Import successful' while writing only 14 of 20 schemas — which left signing entirely non-functional (signingRequest/signerRecord/signingAuditEntry absent). anonymizationLink and financialExtraction already used the object form; this aligns the rest. No property, slug or retention DURATION changed. Previous v7.6.2 — schema-level-titles-en: re-authored the remaining Dutch schema-level `title` values to English — base 'Grondslag' -> 'Legal Basis', huisstijl 'Huisstijl Configuration' -> 'Branding Configuration' (schema slugs, property keys/titles, enums, descriptions unchanged). Dutch labels now live in l10n/nl.json for the display layer. See openspec/changes (fleet-wide schema-i18n titles rule). Previous v7.6.1 — schema-titles-en: re-authored all Dutch schema property `title` values to English (property names/keys unchanged); Dutch labels now live in l10n/nl.json for the display layer. See openspec/changes (fleet-wide schema-i18n titles rule). Previous v7.6.0 — document-output-destinations-and-bulk-retention: generatedDocument gains additive, nullable fileId/filePath properties, populated when a generation is stored to Files via the new DocumentStorageService (options.output.mode 'files'/'both' on generate, or the now-persisted async bulk job). hardValidation:false, so existing rows remain valid unchanged. See openspec/changes/document-output-destinations-and-bulk-retention/. Previous v7.5.0 — unified-search-provider: corrects the searchable opt-in so only navigable schemas (template, signingRequest) stay searchable and every other schema is searchable:false, keeping DocuDesk's contribution to OpenRegister's shared Unified Search provider free of dead/unnavigable results. Deep-link routing for template + signingRequest lives in src/manifest.json deepLinks[]. No bespoke OCP\\Search\\IProvider — org scoping inherited from openregister_objects. See openspec/changes/unified-search-provider/. Previous v7.4.0 — adds customDictionary + customDictionaryTerm to the document register per custom-dictionary-recognition: organisation-scoped, register-i18n-tagged term lists (label, description, colour, matchMode exact/caseInsensitive/wordBoundary, deferred fuzzy flag, active, calculated termCount) matched by CustomDictionaryMatchService and written into OpenRegister's shared entity catalogue as CUSTOM_DICTIONARY occurrences alongside Presidio/regex detections. Seeds one demo dictionary (\"Projectnamen\") with two demo terms. See openspec/changes/custom-dictionary-recognition/. Previous v7.3.0 — MERGE of Robert's anonimiseren-bij-de-bron work onto development: Woo Art. 5 grondslagen legenda A–S seed (base schema), standing-consent generic-term seeds (publicationConsent, entityType OTHER, notificationStatus skipped), entityType OTHER enum on publicationConsent/publicationProhibition, and EML→PDF assembly. Development schemas + dialect/RBAC fixes are preserved. Previous v5.10.0 — adds glAccountBooking (opaque per-tenant GL-account booking history, keyed by supplierIdentity, fed by the financial-extraction corrections endpoint) and glAccountMappingRule (admin-editable cold-start keyword/category → account rules, no seeded rows — DocuDesk ships no chart of accounts) to the document register, per ai-gl-account-suggestion. Both hardValidation:true. See openspec/changes/ai-gl-account-suggestion/. Previous v5.9.0 adds the financialExtraction schema to the document register: structured financial field-extraction results (supplier/IBAN/KvK/BTW, invoice number, dates, currency, totals + VAT breakdown, line items) with per-field confidence and an additive corrections[] tuning corpus, per financial-document-field-extraction. hardValidation:true; x-openregister-archival category shipped as an explicit placeholder pending selectielijst-manager sign-off (same pattern as anonymizationLink). See openspec/changes/financial-document-field-extraction/. Previous v5.8.0 declares validationStatus + validationFindings as x-openregister-calculations on generatedDocument (computation backend docudesk.validation = DocumentValidationService) per document-validation-checks; the event-listener fallback dispatches the same service until OR's ADR-031 calculation runtime ships. Previous v5.7.0 declared the four AVG Art. 30 processing activities (anonymisation, OCR, metadata-enrichment, signing) as x-openregister-processing catalogue annotations on anonymizationLink, generatedDocument, base, and signingAuditEntry: each carries purpose (doelbinding), legal basis, NER data categories, backend identifier, retention reference taken from the existing x-openregister-archival annotations (\"not declared\" where absent), and opts the schema into OpenRegister's per-access read-logging (logReads:true, attribution.default referencing the activity code). Requires OpenRegister >= 0.2.14. See openspec/changes/processing-activity-export/. Previous v5.5.0 extended OR register-i18n adoption to the remaining user-facing string fields across templateVersion (name/description/changelog), huisstijl (name), base (name/description), correspondence (templateName), signingRequest (documentName), signingSession (documentName), signerRecord (displayName/declineReason), publicationConsent (notes/objectionReason/publicationDecision), publicationProhibition (primaryName/reason/notes), and batchCorrespondenceJob (templateName). OpenRegister TranslationHandler picks these up automatically and stores per-language variants under the existing object JSON column; no DB migration required. See openspec/changes/register-i18n/. Previous v5.4.0 tagged template (name/description/content/category) + dossier (name/description) per register-i18n. Previous v5.3.0 adopted OR abstractions per docudesk-adopt-or-abstractions, added batchCorrespondenceJob schema with x-openregister-lifecycle + archival + notifications + calculations, added x-openregister-archival to signingAuditEntry (P10Y), signingRequest (P10Y), signerRecord (P10Y), correspondence (P7Y), added x-openregister-lifecycle to signingSession, and added anonymizationLink schema for source↔anonymised file mapping.",
+        "version": "7.7.0"
     },
     "x-openregister": {
         "type": "application",
@@ -22,11 +22,12 @@
             "consent": {
                 "slug": "consent",
                 "title": "Consent Register",
-                "version": "2.0.0",
+                "version": "2.1.0",
                 "description": "Register voor GDPR publicatie toestemmingen",
                 "schemas": [
                     "publicationConsent",
-                    "publicationProhibition"
+                    "publicationProhibition",
+                    "prohibitionOverrideAudit"
                 ]
             },
             "signing": {
@@ -3292,6 +3293,111 @@
                         "docudesk-policy-admins"
                     ]
                 }
+            },
+            "prohibitionOverrideAudit": {
+                "uri": null,
+                "slug": "prohibitionOverrideAudit",
+                "title": "Prohibition Override Audit",
+                "description": "Records why an operator released a low-confidence publication-prohibition match from anonymisation. Written by ProhibitionOverrideCommitter BEFORE the OpenRegister EntityRelation is PATCHed with skipAnonymization=true, so an override can never reach OpenRegister unrecorded on the DocuDesk side. Carries the operator commentary that OpenRegister's own audit trail does not (its PATCH whitelist is decision-only).",
+                "version": "1.0.0",
+                "summary": "",
+                "icon": "ClipboardCheckOutline",
+                "required": [
+                    "ruleId",
+                    "fileId",
+                    "reason",
+                    "acknowledgedBy",
+                    "acknowledgedAt"
+                ],
+                "properties": {
+                    "ruleId": {
+                        "description": "Identifier of the publication-prohibition rule whose match was released.",
+                        "type": "string",
+                        "required": true,
+                        "visible": true,
+                        "order": 1,
+                        "facetable": true,
+                        "title": "Rule ID",
+                        "maxLength": 255
+                    },
+                    "entityRelationId": {
+                        "description": "OpenRegister EntityRelation row that was flagged skipAnonymization=true. Zero when the released match carried no relation id.",
+                        "type": "integer",
+                        "required": false,
+                        "visible": true,
+                        "order": 2,
+                        "facetable": true,
+                        "title": "Entity relation ID"
+                    },
+                    "fileId": {
+                        "description": "Nextcloud file ID the anonymisation request was made against.",
+                        "type": "integer",
+                        "required": true,
+                        "visible": true,
+                        "order": 3,
+                        "facetable": true,
+                        "title": "File ID"
+                    },
+                    "reason": {
+                        "description": "Operator's stated justification for releasing the flagged entity from redaction.",
+                        "type": "string",
+                        "required": true,
+                        "visible": true,
+                        "order": 4,
+                        "facetable": false,
+                        "title": "Reason",
+                        "maxLength": 1024,
+                        "translatable": true
+                    },
+                    "acknowledgedBy": {
+                        "description": "Nextcloud UID of the user who acknowledged the override.",
+                        "type": "string",
+                        "required": true,
+                        "visible": true,
+                        "order": 5,
+                        "facetable": true,
+                        "title": "Acknowledged by",
+                        "maxLength": 64
+                    },
+                    "acknowledgedAt": {
+                        "description": "Moment the override was acknowledged (ISO 8601).",
+                        "type": "string",
+                        "format": "date-time",
+                        "required": true,
+                        "visible": true,
+                        "order": 6,
+                        "facetable": false,
+                        "title": "Acknowledged at"
+                    }
+                },
+                "archive": [],
+                "source": "internal",
+                "hardValidation": true,
+                "immutable": false,
+                "updated": "2026-08-11T00:00:00+00:00",
+                "created": "2026-08-11T00:00:00+00:00",
+                "maxDepth": 0,
+                "owner": null,
+                "application": null,
+                "organisation": null,
+                "groups": null,
+                "deleted": null,
+                "configuration": {
+                    "objectNameField": "ruleId",
+                    "objectDescriptionField": "reason",
+                    "autoPublish": false
+                },
+                "searchable": false,
+                "x-openregister-archival": {
+                    "retention": {
+                        "default": "P10Y"
+                    },
+                    "reason": "An override audit entry is the only record of a deliberate decision NOT to redact a legally protected entity; it must outlive the prohibition it released, which is itself retained P10Y.",
+                    "category": "TODO: confirm Archiefwet 1995 selectielijst category with selectielijst manager",
+                    "action": "destroy",
+                    "responsibleParty": "docudesk-privacy-officer"
+                },
+                "authorization": null
             }
         },
         "objects": [

--- a/tests/e2e/workflows/prohibition-override-audit-schema.spec.ts
+++ b/tests/e2e/workflows/prohibition-override-audit-schema.spec.ts
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: 2026 DocuDesk Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Regression test for ConductionNL/docudesk#428.
+ *
+ * `ProhibitionOverrideCommitter` writes its AVG Art. 30 override-audit entry to
+ * `register: consent, schema: prohibitionOverrideAudit` and is explicitly
+ * fail-closed — "If the audit write fails we MUST NOT proceed to the OR PATCH"
+ * — rethrowing as `RuntimeException(…, 500)`. That schema was declared NOWHERE:
+ * `lib/Settings/docudesk_register.json` listed 20 schemas and this was not one
+ * of them, so the store answered
+ *
+ *     404 {"message":"Schema not found: 'prohibitionOverrideAudit'"}
+ *
+ * and every acknowledged prohibition override 500'd. The spec mandates the
+ * schema by name:
+ *
+ *   "Implementations MUST use a `prohibitionOverrideAudit` schema in
+ *    `docudesk_register.json` for this entry, alongside the existing schemas."
+ *   — openspec/specs/anonymisation-prohibition-gate/spec.md
+ *
+ * ⚠️ DELIBERATELY CARRIES NO `@e2e` ANCHOR, and that is not an oversight.
+ * The nearest scenario is `#override-acknowledgement-writes-both-audit-and-skip-flag`,
+ * which requires the CONTROLLER to write the entry while releasing a
+ * LOW-confidence match. An override is only valid below the high-confidence
+ * threshold (default 0.85, `docudesk.prohibition.high_confidence_threshold`,
+ * which is NOT in `SettingsService::WRITABLE_KEYS` so a test cannot move it),
+ * and the regex-only backend this instance and CI run emits `CUSTOM_DICTIONARY`
+ * at confidence 1.00 and nothing else — so no overridable match can be
+ * produced here. This test proves the STORE half only. Anchoring it to that
+ * scenario would credit a clause it never evaluates, which is the exact defect
+ * `.github#345` describes.
+ */
+
+import { test, expect } from '@playwright/test'
+import { harvestToken, jsonHeaders, TEST_PREFIX } from './_fixtures'
+
+const OR = '/index.php/apps/openregister/api/objects/consent'
+
+test('the prohibition-override audit schema resolves and accepts the committer\'s payload', async ({ page, request }) => {
+	const token = await harvestToken(page)
+
+	// POSITIVE CONTROL FIRST. If the consent register itself were missing or
+	// the seed had not run, the assertion below would fail for a reason that
+	// has nothing to do with #428 — and a bare 404 cannot tell the two apart.
+	const sibling = await request.get(`${OR}/publicationProhibition`, { headers: jsonHeaders(token) })
+	expect(sibling.status(),
+		`positive control — GET ${OR}/publicationProhibition must answer 200 before the `
+		+ 'assertion below means anything').toBe(200)
+
+	const res = await request.get(`${OR}/prohibitionOverrideAudit`, { headers: jsonHeaders(token) })
+	expect(res.status(),
+		`GET ${OR}/prohibitionOverrideAudit must answer 200. A 404 here means the schema `
+		+ 'is undeclared again and ProhibitionOverrideCommitter::writeAudit() is fail-closed '
+		+ `on it, so EVERY acknowledged override 500s. Body: ${(await res.text()).slice(0, 200)}`)
+		.toBe(200)
+
+	// The store resolving is necessary but not sufficient: the committer writes
+	// a specific six-field shape, and a schema that rejects it is the same
+	// outage with a different status code.
+	const write = await request.post(`${OR}/prohibitionOverrideAudit`, {
+		headers: jsonHeaders(token),
+		data: {
+			ruleId: `${TEST_PREFIX}-rule`,
+			entityRelationId: 7,
+			fileId: 123,
+			reason: `${TEST_PREFIX} — regression fixture for #428`,
+			acknowledgedBy: 'admin',
+			acknowledgedAt: new Date().toISOString(),
+		},
+	})
+	expect(write.status(),
+		`POST ${OR}/prohibitionOverrideAudit with the exact payload writeAudit() sends must be `
+		+ `accepted. Body: ${(await write.text()).slice(0, 300)}`).toBe(201)
+
+	const created = await write.json()
+	expect(created.ruleId, 'the audit entry must round-trip its ruleId').toBe(`${TEST_PREFIX}-rule`)
+	expect(created.acknowledgedBy, 'the audit entry must round-trip the acting user').toBe('admin')
+})


### PR DESCRIPTION
Closes #428.

## The defect

`ProhibitionOverrideCommitter` writes the AVG Art. 30 override-audit entry to
`register: consent, schema: prohibitionOverrideAudit`, and **that schema was
declared nowhere.** `lib/Settings/docudesk_register.json` listed 20 schemas and
this was not one of them.

The write is explicitly fail-closed — *"If the audit write fails we MUST NOT
proceed to the OR PATCH"* — and rethrows as `RuntimeException(…, 500)`. So
**every acknowledged prohibition override 500'd, and no override has ever been
committable**, on the one code path whose entire purpose is to record why an
operator released a legally protected entity from redaction.

## Measured, positive control first

Freshly seeded NC 34 rig (docudesk 0.0.46, openregister 0.2.17-unstable.36),
printing the status code on every probe:

| request | before | after |
|---|---|---|
| `GET /apps/openregister/api/objects/consent/publicationProhibition` | 200 | 200 |
| `GET /apps/openregister/api/objects/consent/publicationConsent` | 200 | 200 |
| `GET /apps/openregister/api/objects/consent/prohibitionOverrideAudit` | **404** `{"message":"Schema not found: 'prohibitionOverrideAudit'"}` | **200** |
| `POST …/prohibitionOverrideAudit` with the exact six-field payload `writeAudit()` sends | — | **201** |

The sibling schemas are the control: they answer 200 in both states, so the 404
was the schema and not the register, the seed, or the session.

`tests/e2e/ci-seed.sh` independently corroborates it — its own inventory line
went from `20 schemas` to `21 schemas` with `prohibitionOverrideAudit` appearing
in the sorted list.

## The spec mandated this by name

`openspec/specs/anonymisation-prohibition-gate/spec.md`:

> Implementations **MUST use a `prohibitionOverrideAudit` schema in
> `docudesk_register.json`** for this entry, alongside the existing schemas.

Nothing type-checks a schema-slug constant against the register, and nothing
checks a spec sentence against the file it names. Both claims were false for as
long as they existed.

## The change

`lib/Settings/docudesk_register.json` v7.6.4 → **v7.7.0**:

- new `prohibitionOverrideAudit` schema with exactly the six properties the
  committer writes — `ruleId`, `entityRelationId`, `fileId`, `reason`,
  `acknowledgedBy`, `acknowledgedAt`;
- added to the `consent` register (v2.0.0 → v2.1.0);
- retention **P10Y** — an override audit must outlive the P10Y prohibition it
  released;
- ⚠️ **`authorization: null`**, matching `publicationConsent` and
  `anonymizationLink`. Copying the sibling `publicationProhibition`'s
  `create: [docudesk-policy-admins]` is the obvious move and would have
  **re-broken the same fail-closed path** for the ordinary operator who performs
  the anonymise. Prohibitions are admin-authored; their override audits are
  written by whoever anonymises.

## Test

`tests/e2e/workflows/prohibition-override-audit-schema.spec.ts` — resolves the
schema (with the sibling as an explicit positive control) and writes the
committer's exact payload. It fails on the pre-fix tree with the 404 and passes
after, so it is a true-positive control that ships.

⚠️ It **deliberately carries no `@e2e` anchor.** The nearest scenario,
`#override-acknowledgement-writes-both-audit-and-skip-flag`, needs the
*controller* to write the entry while releasing a **low-confidence** match. An
override is only valid below `docudesk.prohibition.high_confidence_threshold`
(default 0.85, and not in `SettingsService::WRITABLE_KEYS`, so a test cannot
move it), while the regex-only backend CI runs emits `CUSTOM_DICTIONARY` at
confidence 1.00 and nothing else — no overridable match is producible. Anchoring
would credit a clause the test never evaluates, which is exactly the
false-coverage shape `ConductionNL/.github#345` describes.

## Scope

No spec file is touched, so gate-19's diff scope is unchanged by this PR.

Full suite on the rig before and after: **103 passed, 3 skipped, 0 failed** —
identical to CI's own tally on run 31516066468.
