### PR TITLE
chore(security): bump phpcsstandards/phpcsutils to 1.2.3 — CVE-2026-65954 is failing every open PR

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3864,16 +3864,16 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -3953,7 +3953,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",


### PR DESCRIPTION
`composer audit` fails on **every open PR in this repo right now**:

```
Package:  phpcsstandards/phpcsutils
CVE:      CVE-2026-65954
Title:    Arbitrary code execution
Affected: >=1.0.0-alpha1,<1.2.3
```

## Not caused by any diff — controlled two ways before touching anything

1. It reproduces on **two branches with disjoint diffs** — #435 (a register JSON + a test file) and #436 (a spec file + a test file) — neither of which touches `composer.json` or `composer.lock`.
2. `composer.lock` on both branches is **byte-identical to `origin/development`**, and running `composer audit` locally against that unchanged lock reproduces the advisory. So the dependency set development already ships is the one being flagged; what moved is the advisory database, not this repository.

The `Security (composer)` job passed on development's own run 31516066468 earlier today, which is the same fact from the other side: **a green `composer audit` is a statement about the advisory DB at the moment it ran, not a durable property of the lock.**

## Change

`composer update phpcsstandards/phpcsutils` — one transitive dev dependency, **five lines** of `composer.lock`, no other package moved:

```
phpcsstandards/phpcsutils: 1.2.2 -> 1.2.3
```

`composer audit` afterwards: **No security vulnerability advisories found.**

## What I could NOT verify locally, stated so it is not mistaken for verified

PHPCS could not be exercised here: this box runs PHP 8.2.22 and the project requires >= 8.3.0, so `vendor/bin/phpcs` dies in `platform_check.php` before it lints anything. **The PHPCS / PHPCBF jobs in CI are the verification for that half.** The bump is a patch release of a PHPCS utility library, so the risk is low, but low is not zero and it has not been measured here.

Merging this unblocks #435 and #436.