### PR TITLE
fix: clear the gate-16 red, and delete four docblocks asserting an RBAC guard that never runs

### DIFF
--- a/lib/Controller/CorrespondenceController.php
+++ b/lib/Controller/CorrespondenceController.php
@@ -342,10 +342,23 @@ class CorrespondenceController extends Controller
             // ownerUserId is stored at the top level of the status payload (persisted
             // by dispatchBatchJob and every storeJobStatus call in the background job).
             // The old check read options.userId which was NEVER persisted — SB1 fix.
+            //
+            // This test FAILS CLOSED. It previously read
+            // `$jobUserId !== '' && $jobUserId !== $uid`, which let a status
+            // payload carrying no owner through to any authenticated caller —
+            // i.e. the one input an attacker benefits from was the one that
+            // skipped the check. Every writer sets the key today
+            // (CorrespondenceService::dispatchBatchJob and all three
+            // BatchCorrespondenceJob::storeJobStatus calls, seeded from
+            // `$options['userId']`, which this controller sets from the session
+            // before dispatch), so refusing an empty owner costs nothing that
+            // works — it only removes the fallback. Same shape as
+            // PrintJobController::authorizeJobAccess(), which already compares
+            // for equality rather than for inequality-when-present.
             $jobUserId = (string) ($status['ownerUserId'] ?? '');
-            if ($jobUserId !== '' && $jobUserId !== $user->getUID()) {
+            if ($jobUserId !== $user->getUID()) {
                 return new JSONResponse(
-                    data: ['error' => $this->l10n->t('Access denied')],
+                    data: ['error' => $this->l10n->t('This job belongs to another user')],
                     statusCode: Http::STATUS_FORBIDDEN
                 );
             }

--- a/lib/Controller/DossierController.php
+++ b/lib/Controller/DossierController.php
@@ -9,10 +9,23 @@
  * `LegalBasesSummaryService::renderDossierSummary` for the render itself.
  *
  * Authentication is required (the route is `@NoAdminRequired` but
- * non-anonymous). Authorisation: the caller MUST be able to read the
- * dossier object via OpenRegister's standard RBAC + the file listing
- * uses the session user's view, so visibility of files under the
- * dossier folder mirrors the operator's permissions.
+ * non-anonymous).
+ *
+ * ⚠️ Authorisation, stated accurately. This header used to say the caller
+ * "MUST be able to read the dossier object via OpenRegister's standard RBAC".
+ * Half of that sentence is enforced and half is not:
+ *
+ *  - The FILE half is real. `renderDossierSummary` walks the dossier folder
+ *    through the session user's view, so a file the operator cannot see does
+ *    not enter the summary.
+ *  - The OBJECT half is not. The pre-render check resolves to an existence
+ *    test only, because the `dossier` schema declares `"authorization": null`
+ *    and OpenRegister treats an unconfigured cascade as open. See
+ *    `DossierSummaryDataService::assertDossierReadable()`.
+ *
+ * So any authenticated user in the organisation can trigger a regen for any
+ * dossier uuid they can name; what they get back is scoped to the files they
+ * can already see. Tracked in ConductionNL/docudesk#441.
  *
  * @category  Controller
  * @package   OCA\DocuDesk\Controller

--- a/lib/Service/ConsentCrudService.php
+++ b/lib/Service/ConsentCrudService.php
@@ -147,9 +147,22 @@ class ConsentCrudService
      */
     public function getConsent(string $consentId, string $register, string $schema): ?array
     {
-        // Let OpenRegister enforce per-object RBAC and multitenancy access.
-        // Bypassing these (security finding #283) allowed any authenticated
-        // user to read consent records owned by other users.
+        // Do NOT pass `_rbac: false` / `_multitenancy: false` here — bypassing
+        // them (security finding #283) is a regression and the multitenancy
+        // half is genuinely load-bearing.
+        //
+        // ⚠️ But this is NOT what stops one user reading another's consent
+        // record, and this comment used to imply that it was. The
+        // `publicationConsent` schema declares `"authorization": null` in
+        // `lib/Settings/docudesk_register.json`, and OpenRegister treats an
+        // unconfigured authorization cascade as OPEN — so the per-object RBAC
+        // half permits the read for any authenticated caller in the org.
+        //
+        // The control that actually closes #283 is
+        // `ConsentController::canAccessConsent()`, which compares
+        // `@self.owner` against the session uid with an admin bypass, and the
+        // server-side owner filter on the list paths. Do not delete either as
+        // "redundant with OpenRegister RBAC" — measured, it is not redundant.
         $objectService = $this->settingsService->getObjectService();
         $object        = $objectService->find(
             id: $consentId,

--- a/lib/Service/ConsentRecordWriter.php
+++ b/lib/Service/ConsentRecordWriter.php
@@ -383,8 +383,15 @@ class ConsentRecordWriter
         // controller surfaces as HTTP 400.
         $this->scopeValidator->assertValid($consentData);
 
-        // Let OpenRegister enforce RBAC and multitenancy so the consent
-        // record is owned by the creating user (security finding #283).
+        // Save WITHOUT the bypass flags so OpenRegister stamps `@self.owner`
+        // from the session user — that ownership stamp is what the read guard
+        // in `ConsentController::canAccessConsent()` later compares against,
+        // and it is the half of #283 that this call really delivers.
+        //
+        // ⚠️ The word "RBAC" was in this comment and has been removed: the
+        // `publicationConsent` schema declares `"authorization": null`, so
+        // OpenRegister's per-object RBAC permits this write for anyone
+        // authenticated. Ownership is RECORDED here, not ENFORCED here.
         $savedObject = $this->getObjectService()->saveObject(
             object: $consentData,
             register: $register,

--- a/lib/Service/DossierObjectRepository.php
+++ b/lib/Service/DossierObjectRepository.php
@@ -130,6 +130,8 @@ class DossierObjectRepository
      * Get the OpenRegister ObjectService, or null when unavailable.
      *
      * @return object|null The ObjectService instance, or null.
+     *
+     * @spec openspec/specs/anonymisation-grondslagen-summary/spec.md#requirement-a-per-dossier-summary-endpoint-must-exist
      */
     public function objectService(): ?object
     {
@@ -153,6 +155,8 @@ class DossierObjectRepository
      * Get the OpenRegister EntityRelationMapper, or null when unavailable.
      *
      * @return object|null The EntityRelationMapper instance, or null.
+     *
+     * @spec openspec/specs/anonymisation-grondslagen-summary/spec.md#requirement-a-per-dossier-summary-endpoint-must-exist
      */
     public function entityRelationMapper(): ?object
     {
@@ -207,6 +211,8 @@ class DossierObjectRepository
      * @param int    $summaryFileId The newly-written summary file's NC node id.
      *
      * @return void
+     *
+     * @spec openspec/specs/anonymisation-grondslagen-summary/spec.md#requirement-a-per-dossier-summary-endpoint-must-exist
      */
     public function updateDossierConfiguration(string $dossierUuid, int $summaryFileId): void
     {

--- a/lib/Service/DossierPlaceholderRanker.php
+++ b/lib/Service/DossierPlaceholderRanker.php
@@ -99,6 +99,8 @@ class DossierPlaceholderRanker
      * @return array{ranks: array<array-key, int>, types: array<string, string>} Ranks per entity
      *                                                                           id, and each id's
      *                                                                           entity TYPE.
+     *
+     * @spec openspec/specs/anonymisation-grondslagen-summary/spec.md#requirement-the-per-dossier-summary-must-aggregate-per-document-and-per-grondslag
      */
     public function rank(Folder $folder): array
     {
@@ -165,6 +167,8 @@ class DossierPlaceholderRanker
      * @param Folder $folder The dossier folder.
      *
      * @return array<int, int> Distinct descendant source file ids.
+     *
+     * @spec openspec/specs/anonymisation-grondslagen-summary/spec.md#requirement-the-per-dossier-summary-must-aggregate-per-document-and-per-grondslag
      */
     public function collectFileIds(Folder $folder): array
     {

--- a/lib/Service/DossierSummaryDataService.php
+++ b/lib/Service/DossierSummaryDataService.php
@@ -146,17 +146,36 @@ class DossierSummaryDataService
     }//end loadDossier()
 
     /**
-     * Assert that the acting user may read a dossier.
+     * Assert that the dossier EXISTS and is resolvable to the acting user.
      *
-     * Resolves the dossier through OpenRegister's ObjectService under the
-     * session user's view, so OR's standard RBAC governs visibility: a dossier
-     * the caller may not read resolves to null and we deny by throwing.
+     * ⚠️ This is an EXISTENCE check, not an ownership check. The previous
+     * docblock claimed the opposite — "OR's standard RBAC governs visibility:
+     * a dossier the caller may not read resolves to null and we deny by
+     * throwing" — and that claim is false as the app is configured.
+     *
+     * The call below genuinely omits `_rbac: false`, so OpenRegister's RBAC
+     * cascade is consulted. But the cascade resolves to "configured nowhere",
+     * which OpenRegister treats as OPEN: the `dossier` schema in
+     * `lib/Settings/docudesk_register.json` declares `"authorization": null`,
+     * and no register declares the key at all. `find()` therefore returns the
+     * object for any authenticated caller in the same organisation, so the
+     * `null` branch below can only ever fire for a dossier that does not
+     * exist — never for one the caller merely has no business reading.
+     *
+     * What IS still enforced: organisation scoping (multitenancy is not
+     * bypassed here), and the existence check itself.
+     *
+     * Do not read a green result from this method as "the caller owns this
+     * dossier". Closing that gap needs an agreed ownership model for dossiers
+     * — a dossier is a shared work object and it is NOT obvious that only its
+     * creator may regenerate its summary — so it is deliberately not invented
+     * here. Tracked in ConductionNL/docudesk#441.
      *
      * @param string $dossierId The OR dossier object UUID.
      *
      * @return void
      *
-     * @throws RuntimeException 403 when the dossier is not readable / not found.
+     * @throws RuntimeException 403 when the dossier cannot be resolved at all.
      */
     public function assertDossierReadable(string $dossierId): void
     {

--- a/lib/Service/LegalBasesSummaryService.php
+++ b/lib/Service/LegalBasesSummaryService.php
@@ -179,6 +179,8 @@ class LegalBasesSummaryService
      * @return File The same anonymised file, with the summary page appended.
      *
      * @throws \RuntimeException When template rendering, PDF merging, or file write fails.
+     *
+     * @spec openspec/specs/anonymisation-grondslagen-summary/spec.md#requirement-the-per-document-anonymise-endpoint-must-accept-an-optional-appendbasissummary-field
      */
     public function appendSummaryToPdf(File $anonymisedFile, int $sourceFileId, array $placeholderMap=[]): File
     {
@@ -218,6 +220,8 @@ class LegalBasesSummaryService
      * @return File The newly-written summary PDF.
      *
      * @throws \RuntimeException When rendering or write fails.
+     *
+     * @spec openspec/specs/anonymisation-grondslagen-summary/spec.md#requirement-the-per-document-anonymise-endpoint-must-accept-an-optional-appendbasissummary-field
      */
     public function renderSummaryBesideFile(File $anonymisedFile, int $sourceFileId, array $placeholderMap=[]): File
     {
@@ -289,6 +293,8 @@ class LegalBasesSummaryService
      *
      * @throws \RuntimeException When the dossier can't be loaded, the folder
      *                           isn't accessible, or rendering fails.
+     *
+     * @spec openspec/specs/anonymisation-grondslagen-summary/spec.md#requirement-a-per-dossier-summary-endpoint-must-exist
      */
     public function renderDossierSummary(string $dossierUuid): File
     {

--- a/lib/Service/LegalBasesSummaryService.php
+++ b/lib/Service/LegalBasesSummaryService.php
@@ -253,20 +253,27 @@ class LegalBasesSummaryService
     }//end renderSummaryBesideFile()
 
     /**
-     * Authorize the acting user to (re)generate a dossier's summary.
+     * Assert the dossier exists before (re)generating its summary.
      *
-     * Resolves the dossier through OpenRegister's ObjectService under the
-     * session user's view, so OR's standard RBAC governs visibility: a dossier
-     * the caller may not read resolves to null and we deny by throwing. A
-     * successful resolution means the operator is permitted. The HTTP layer
-     * (`DossierController`) calls this before `renderDossierSummary` (which
-     * itself runs the render as a system operation with RBAC disabled).
+     * ⚠️ The name of this method overstates what it does, and the docblock it
+     * replaces overstated it further ("a successful resolution means the
+     * operator is permitted"). It is an EXISTENCE check. See
+     * `DossierSummaryDataService::assertDossierReadable()` for the measured
+     * reason: OpenRegister's RBAC cascade resolves to "configured nowhere" for
+     * the `dossier` schema, which OpenRegister treats as open, so the refusal
+     * this method relies on cannot fire for an existing dossier.
+     *
+     * What remains true: the HTTP layer (`DossierController`) does call this
+     * before `renderDossierSummary`, and the render itself deliberately runs
+     * as a system operation with RBAC disabled — so this call is the ONLY
+     * pre-render check there is, which is exactly why its real strength
+     * matters. Tracked in ConductionNL/docudesk#441.
      *
      * @param string $dossierId The OR dossier object UUID.
      *
      * @return void
      *
-     * @throws \RuntimeException 403 when the dossier is not readable / not found.
+     * @throws \RuntimeException 403 when the dossier cannot be resolved at all.
      */
     public function authorizeAccess(string $dossierId): void
     {

--- a/lib/Service/MetadataService.php
+++ b/lib/Service/MetadataService.php
@@ -266,10 +266,26 @@ class MetadataService
      * Read the object, merge the metadata into it and save it back.
      *
      * Security (C2): `_rbac:false` / `_multitenancy:false` are deliberately not
-     * passed — OpenRegister's per-object RBAC and multitenancy guards must apply
-     * so callers cannot read or overwrite objects in other tenants/users.
-     * System-context callers elevate via `runAsSystem()` instead of disabling
-     * the guards wholesale.
+     * passed, and system-context callers elevate via `runAsSystem()` instead of
+     * disabling the guards wholesale. That much is real and worth keeping.
+     *
+     * ⚠️ But read what each half actually buys, because this comment used to
+     * claim more than the code delivers:
+     *
+     *  - The MULTITENANCY half is live. Organisation scoping still applies.
+     *  - The per-object RBAC half currently enforces NOTHING for this app.
+     *    OpenRegister resolves authorization through a register/schema cascade
+     *    and treats "configured nowhere" as OPEN. Every schema in
+     *    `lib/Settings/docudesk_register.json` declares `"authorization": null`
+     *    except `publicationProhibition`, and no register declares the key at
+     *    all — so for the schemas this method writes, OR permits the read and
+     *    the write regardless of who is asking.
+     *
+     * So this is NOT a per-user boundary today. Do not treat the absence of the
+     * bypass flags as an ownership check, and do not delete a caller-side
+     * ownership guard on the strength of it. Making the RBAC half real means
+     * declaring `authorization` on the schemas (ConductionNL/openregister#2011),
+     * not changing anything here.
      *
      * @param \OCA\OpenRegister\Service\ObjectService $objectService The resolved OpenRegister object service
      * @param string                                  $objectId      The object UUID in OpenRegister

--- a/tests/unit/Wave12SecurityRegressionTest.php
+++ b/tests/unit/Wave12SecurityRegressionTest.php
@@ -255,13 +255,33 @@ class Wave12SecurityRegressionTest extends TestCase
     }//end testJobStatusReturns200ForOwner()
 
     /**
-     * SB1: when ownerUserId is empty (e.g. sync batch — no ownerUserId stored)
-     * the check is skipped and any authenticated user can query it.
-     * (Backward-compat: sync results were never gated by this field.)
+     * SB1, CORRECTED: an empty ownerUserId must be REFUSED, not waved through.
+     *
+     * This test previously asserted the opposite — that an empty ownerUserId
+     * skipped the check so any authenticated user could query the job — on the
+     * stated grounds that a "sync batch" stores no ownerUserId and sync results
+     * "were never gated by this field". That reason names a state of the world,
+     * and the state does not exist:
+     *
+     *  - The only writer of a correspondence job-status record is
+     *    `CorrespondenceService::dispatchBatchJob()` plus the three
+     *    `storeJobStatus()` calls in `BatchCorrespondenceJob`, and every one of
+     *    them seeds `ownerUserId` from `$options['userId']`.
+     *  - `$options['userId']` is set in exactly two places, both in
+     *    `CorrespondenceController`, both from the session, and both behind a
+     *    `$user === null` 401 preamble — so it cannot be empty.
+     *  - The sync path is `generate()`, which returns the document directly and
+     *    writes no job-status record at all. There is nothing for the
+     *    backward-compat clause to protect.
+     *
+     * So the old assertion pinned a fail-open: the single input an attacker
+     * benefits from was the one input that skipped the ownership check, in the
+     * file whose whole purpose is to stop that. A test asserting the call the
+     * code happens to make cannot tell you the call is wrong.
      *
      * @return void
      */
-    public function testJobStatusAllowsAccessWhenOwnerUserIdIsEmpty(): void
+    public function testJobStatusDeniesAccessWhenOwnerUserIdIsEmpty(): void
     {
         $corrSvc = $this->createMock(CorrespondenceService::class);
         $corrSvc->method('getJobStatus')->willReturn(
@@ -284,9 +304,14 @@ class Wave12SecurityRegressionTest extends TestCase
         $response = $controller->jobStatus('some-job-id');
 
         $this->assertInstanceOf(JSONResponse::class, $response);
-        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(
+            Http::STATUS_FORBIDDEN,
+            $response->getStatus(),
+            'a job-status record carrying no ownerUserId must be refused, not '
+            .'handed to whichever authenticated caller guessed the jobId'
+        );
 
-    }//end testJobStatusAllowsAccessWhenOwnerUserIdIsEmpty()
+    }//end testJobStatusDeniesAccessWhenOwnerUserIdIsEmpty()
 
     // ─────────────────────────────────────────────────────────────────────────
     // WF1 — cancelRequest requires initiator-or-admin


### PR DESCRIPTION
Two commits. Read them separately — the first clears the red, the second is a
security correction that happens to live in the same files' neighbourhood.

---

## Commit 1 — clear the actual CI red

The `Code Quality` push run on `development` at `67d5201b` is RED. Read job by
job, exactly one job failed for a reason of its own: `Hydra Gates`. `Quality
Report` also shows failure, but it is a pure aggregator over the other jobs and
is not independent debt. All 24 remaining jobs succeeded.

The failing gate is spec-coverage, with eight findings, and its coverage line
for that run reads 43 of 64 declared gates reporting a result.

All eight findings are a side effect of the `Grondslag` to `LegalBases` rename
that landed in #433: that PR modified three services, which pulls every modified
method into the gate's diff scope. All three files carried only a FILE-level
spec tag, and the gate requires the tag in the docblock directly above each
changed method.

Eight docblocks, one tag each. No exclusion added, no threshold moved, no test
touched, no gate weakened. Each method is anchored to the requirement it
actually implements — the two per-document render paths to the requirement whose
prose names both of them, the four dossier-summary methods to the requirement
that mandates the configuration writeback and names `EntityRelationMapper`
explicitly, and the two ranking methods to the per-dossier aggregation
requirement.

## Commit 2 — four docblocks asserted a guard that does not run

Written up in full in #441. The short version:

`lib/Settings/docudesk_register.json` declares twenty schemas and nineteen carry
a null authorization block, with no register-level key at all. OpenRegister
documents that a cascade configured nowhere resolves to null and that callers
treat that as open. So four comments saying "let OpenRegister enforce per-object
RBAC" describe a boundary that does not exist for these schemas.

These are worth more attention than their diff size suggests, because a comment
of that kind is what a reviewer reads before marking an endpoint done. One of
them — in `MetadataService` — reads as a considered security decision, which
makes it the worst of the four. Another claimed to BE the fix for a numbered
security finding when the real control lives in a controller guard elsewhere;
the danger there was that someone deletes the real guard as redundant.

Each comment now states what IS enforced rather than merely dropping the claim,
so the next reader gets the organisation scoping and the ownership stamp that
are real, and does not get the per-object boundary that is not.

**No guard is invented.** Dossiers are shared work objects and there is no fact
in the data saying who may regenerate one, so guessing at an ownership predicate
would ship a security control nobody has agreed. Both candidate directions are
recorded in #441 for a decision.

One genuine fail-open IS closed, because it needed no new model:
`CorrespondenceController::jobStatus` tested for inequality-when-present, so a
status payload carrying no owner was handed to any authenticated caller — the
one input an attacker benefits from was the one that skipped the check. It now
compares for equality, the shape `PrintJobController::authorizeJobAccess`
already had. Every writer sets the key today, seeded from the session uid this
same controller sets before dispatch, so this removes a fallback rather than a
working path.

**Direction of change, stated deliberately:** nothing in this PR causes a
request that previously errored to now succeed. The only behavioural change
refuses more than before.

## How this was verified

Gate reproduced against a fresh clone of the canonical gate package from
`ConductionNL/.github@main`, not the checkout sitting next to the app. Against
the same base commit CI used, the checker returned the same count of eight that
CI reported, then zero after the change.

The anchor-existence gate was positive-controlled before its clean result was
believed: rewriting one anchor to name a requirement that does not exist moved
it from no findings to exactly one, naming that file and that fragment. Plant
reverted with an editor rather than a script; tree byte-identical to the commit
afterwards. A separate full-scope run of that gate over every PHP file in `lib/`
also comes back clean, and that zero is real rather than an argv accident — the
checker resolves tags pointing into archived change directories by de-dating
them, which I confirmed by finding the dated archive directory for a change
whose original path no longer exists.

Line length was measured rather than assumed. The ruleset caps lines at 150 and
two new tags exceed it, so I checked the base tree: every over-length line under
`lib/` at `67d5201b` is itself a spec tag, up to 188 characters, on the exact
commit where the phpcs job passed.

The register-JSON claim behind commit 2 was checked per schema with the line
number for each, and cross-checked against OpenRegister's own permission
handler, rather than inferred from one example.

## What I could not verify here

PHPCS itself. This box is PHP 8.2 and the project requires 8.3, so the linter
exits in its platform check before reading a file. CI's phpcs job is the
verification for that half — committed without complaint is not the same as
linted when the linter never started.

The fail-open fix is reasoned from every writer of the key, not from a live
two-account probe; I had no rig for this app.

Closes nothing on its own. Refs #441, #438.
