### PR TITLE
fix(ci): test the whole declared Nextcloud range, not only the ceiling

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -54,7 +54,15 @@ jobs:
     with:
       app-name: docudesk
       php-version: "8.3"
-      nextcloud-test-refs: '["stable34"]'
+      # THE LIST IS THE WHOLE DECLARED RANGE. appinfo/info.xml declares
+      # <nextcloud min-version="32" max-version="34"/>, so 32, 33 and 34 each get
+      # a leg. Adopting NC 34 by REPLACING the list left 32 and 33 advertised to
+      # the App Store with no job touching them — the declared floor became the
+      # untested end, which is the same drift as never testing 34, reversed.
+      # stable34 leads because newman, playwright and journeydoc-capture all read
+      # `fromJSON(inputs.nextcloud-test-refs)[0]` as their single server, and 34
+      # is the major this app had never been exercised on.
+      nextcloud-test-refs: '["stable34", "stable32", "stable33"]'
       enable-psalm: true
       enable-phpstan: true
       enable-phpmetrics: true


### PR DESCRIPTION
## What

`nextcloud-test-refs` becomes `'["stable34", "stable32", "stable33"]'` — every
major inside the range `appinfo/info.xml` declares.

## Why

`appinfo/info.xml` declares `<nextcloud min-version="32" max-version="34"/>`,
and `development` currently tests **stable34 only**. So 32 and 33 are
advertised to the App Store with no job touching either — not known-broken,
unmeasured.

This is the coding-standard migration's own defect. Its rollout script did:

```python
re.sub(r"nextcloud-test-refs: '\[[^\]]*\]'", '''nextcloud-test-refs: '["stable34"]'''', t)
```

which **replaces** the list instead of extending it. The programme opened by
reporting that nothing was tested on NC 34 and, in fixing that, made the
declared floor the untested end. Same defect, other direction.

Several apps' comments recorded the intent correctly while the value
contradicted them — larpingapp, decidesk and procest all said *"stable33 is
deliberately NOT added: this removes an impossible leg, it does not widen the
matrix"*, but the same change had also dropped **stable32**, which was not an
impossible leg, it was the floor. Those comments are corrected here too, along
with two that had simply rotted: scholiq claimed a min-version of 33 and
launchpad a floor of 29, where both files now declare 32.

## Evidence

Verified on portaliq, which already runs all three refs against
`nextcloud/ocp ^34` — run 31599055849, six PHPUnit legs green:

```
success  PHPUnit (PHP 8.3, NC stable32, pgsql)   success  PHPUnit (PHP 8.4, NC stable32, pgsql)
success  PHPUnit (PHP 8.3, NC stable33, pgsql)   success  PHPUnit (PHP 8.4, NC stable33, pgsql)
success  PHPUnit (PHP 8.3, NC stable34, pgsql)   success  PHPUnit (PHP 8.4, NC stable34, pgsql)
```

`stable34` stays **first**: newman, playwright and journeydoc-capture all read
`fromJSON(inputs.nextcloud-test-refs)[0]` as their single server.

## Reviewing this

The added legs are the point — **do not merge this on the strength of the diff.**
If a stable32 or stable33 leg goes red here, that is this app failing on a
version it already claims to support, and it is a finding, not noise.
