### PR TITLE
chore(quality): adopt the central PHPStan base config

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2084,16 +2084,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.7.0",
+            "version": "v1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "b9c6520a648468ab2055ba4ce498348b31ab1f57"
+                "reference": "487e8d235b650a211328d5dfd1dbf90531b26436"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/b9c6520a648468ab2055ba4ce498348b31ab1f57",
-                "reference": "b9c6520a648468ab2055ba4ce498348b31ab1f57",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/487e8d235b650a211328d5dfd1dbf90531b26436",
+                "reference": "487e8d235b650a211328d5dfd1dbf90531b26436",
                 "shasum": ""
             },
             "require": {
@@ -2132,9 +2132,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.7.0"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.7.1"
             },
-            "time": "2026-08-12T09:38:06+00:00"
+            "time": "2026-08-12T12:57:31+00:00"
         },
         {
             "name": "consolidation/annotated-command",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,20 +1,18 @@
+# DocuDesk — Conduction PHPStan config.
+#
+# The shared base is the single source of truth. Everything here is either the
+# app's own tracked debt or an ignore naming a symbol that exists in no other
+# fleet app. Anything you are tempted to add that another app would also need
+# belongs in the base, not here.
 includes:
-    # Per-app tracked lint debt lives here (auto-generated via `phpstan --generate-baseline`).
-    # Apps without debt ship an empty baseline file; canonical includes are otherwise byte-identical
-    # across the fleet.
+    - vendor/conduction/hydra-gates/quality-config/phpstan-base.neon
+    # Per-app tracked lint debt (auto-generated via `phpstan --generate-baseline`).
     - phpstan-baseline.neon
 
 parameters:
-    level: 5
-    paths:
-        - lib
-    bootstrapFiles:
-        - phpstan-bootstrap.php
+    # App-specific only. The base already sets level, paths, bootstrapFiles,
+    # excludePaths, scanDirectories and every fleet-wide ignore.
     excludePaths:
-        - vendor
-        - vendor-bin
-        # Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt).
-        - lib/Resources/template
         # AppHost-delegator controllers: thin subclasses of OCA\OpenRegister\AppHost classes
         # that are absent during static analysis (OR is co-installed at runtime only).
         # PHPStan disallows ignoreErrors for "extends unknown class" — excludePaths is the
@@ -22,6 +20,7 @@ parameters:
         - lib/Controller/DashboardController.php
         - lib/Controller/HealthController.php
         - lib/Controller/MetricsController.php
+
     scanFiles:
         # AppHost generic preferences controller stub, so the thin
         # OCA\DocuDesk\Controller\PreferencesController subclass resolves its
@@ -33,58 +32,14 @@ parameters:
         # Application::register() passes to the engine constructor.
         # The real class lives in openregister/lib/AppHost/Controller/.
         - tests/stubs/openregister-apphost.stub.php
-    scanDirectories:
-        - vendor/nextcloud/ocp
-    reportUnmatchedIgnoredErrors: false
+
     ignoreErrors:
-        # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp
-        - '#Call to an undefined method OC::#'
-        - '#Class OC not found#'
-        - '#Access to static property \$server on an unknown class OC#'
-        - '#unknown class OC\\#'
-        - '#Caught class OC\\#'
-        - '#unknown class OC_App#'
-        - '#Class OC_App not found#'
-        # OCA\DAV is server-internal and not in nextcloud/ocp stubs
-        - '#unknown class OCA\\DAV\\#'
-        - '#Class OCA\\DAV\\#'
-        # OCA classes from other apps (OpenRegister) not available during static analysis
-        - '#unknown class OCA\\OpenRegister\\#'
-        - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'
-        - '#on an unknown class OCA\\OpenRegister\\#'
-        - '#has invalid return type OCA\\OpenRegister\\#'
-        - '#has invalid type OCA\\OpenRegister\\#'
-        - '#implements unknown interface OCA\\OpenRegister\\#'
         # @template-implements IEventListener<OCA\OpenRegister\Event\*> in listeners:
         # OR events are absent in static analysis — the generic bound check fails
         # and registerEventListener rejects the class-string as not matching
         # IEventListener<Event>. Both errors stem from the same missing OR type.
         - '#is not subtype of template type T of OCP\\\\EventDispatcher\\\\Event#'
         - '#expects class-string.OCP\\\\EventDispatcher\\\\IEventListener.OCP\\\\EventDispatcher\\\\Event..,.+DossierCheckedOnListener.+given#'
-        # OCA\DocuDesk controllers delegate via parent:: to OR AppHost classes absent here.
-        # Application.php constructs these with named args from the AppHost ctors —
-        # PHPStan cannot see the inherited constructor. These are OR-runtime-only.
-        - '#Class OCA\\DocuDesk\\Controller\\(HealthController|MetricsController) does not have a constructor#'
-        # GuzzleHttp is available at runtime via Nextcloud but not in composer require
-        - '#unknown class GuzzleHttp\\#'
-        - '#GuzzleHttp\\[a-zA-Z\\]+.*not found#'
-        - '#on an unknown class GuzzleHttp\\#'
-        - '#invalid type GuzzleHttp\\#'
-        - '#Caught class GuzzleHttp\\#'
-        # Doctrine\DBAL is shipped by Nextcloud server but not stubbed in nextcloud/ocp
-        - '#unknown class Doctrine\\DBAL\\#'
-        - '#Doctrine\\DBAL\\[a-zA-Z\\]+.*not found#'
-        - '#on an unknown class Doctrine\\DBAL\\#'
-        # Dynamic HTTP status codes from business rule validation results
-        # (matches both `Parameter $statusCode` and `Parameter #N $statusCode` forms emitted by phpstan)
-        - '#Parameter (\#\d+ )?\$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
-        # registerRepairStep exists on server; not yet in nextcloud/ocp stub used for analysis
-        - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerRepairStep#'
-        # OCP stub gaps for methods that exist at runtime
-        - '#Call to an undefined method OCP\\IRequest::getContent\(\)#'
-        - '#Call to an undefined method OCP\\IRequest::setParameter\(\)#'
-        - '#Call to an undefined method OCP\\Mail\\IMessage::attachFile\(\)#'
-        - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize#'
         # TesseractOCR uses __call magic methods for lang(), dpi() etc.
         - '#Call to an undefined method .+TesseractOCR::#'
         # DI-injected properties in scaffold classes not yet using them
@@ -94,14 +49,12 @@ parameters:
         # it; in CI / fresh-checkout phpstan runs without the package
         # vendored. The PhpWordBackend usages are guarded by
         # class_exists() in isAvailable(), so the runtime behaviour is
-        # safe. Same exemption pattern as the OpenRegister one above.
+        # safe. Same exemption pattern as the OpenRegister ignores in the base.
         - '#unknown class PhpOffice\\PhpWord\\#'
         - '#static method [^ ]+ on an unknown class PhpOffice\\PhpWord\\#'
         - '#Access to constant [^ ]+ on an unknown class PhpOffice\\PhpWord\\#'
-        # Defensive runtime guards (`is_string(...) === false`) on file-
-        # content reads. The docblock for File::getContent() promises
-        # `string`, so phpstan treats the negated check as unreachable.
-        # The guards stay — Nextcloud's File implementation can fail
-        # under quota / locked-file conditions and we'd rather emit a
-        # typed ConversionFailedException than crash the cascade.
+        # Defensive guards whose PHPDoc-narrowed types make phpstan treat the negated
+        # check as unreachable. The guards stay — Nextcloud's File implementation can
+        # fail under quota / locked-file conditions and we'd rather emit a typed
+        # ConversionFailedException than crash the cascade.
         - '#Strict comparison using === between true and false will always evaluate to false#'


### PR DESCRIPTION
## What

`phpstan.neon` now includes the shared base that ships in `conduction/hydra-gates`
(`quality-config/phpstan-base.neon`). Everything the base already provides — level,
paths, bootstrapFiles, excludePaths, scanDirectories and the fleet-wide ignore list —
is removed from the app file. What stays is only what is genuinely local:

- the app's own `phpstan-baseline.neon` include
- three `excludePaths` entries for the AppHost-delegating controllers
- the `tests/stubs/openregister-apphost.stub.php` entry under `scanFiles`
- eight ignores this app alone needs: the two OpenRegister event-generic wordings,
  `TesseractOCR`'s `__call` magic, the write-only DI properties, three
  `PhpOffice\PhpWord` shapes, and one PHPDoc-driven always-false comparison

This is step 2b of the Nextcloud CI/CD alignment programme.

## Why hydra-gates moves to v1.7.1

v1.7.0 shipped the base file with bare relative paths. PHPStan resolves a relative
path against the directory of the config that *declares* it, so `lib` there meant
`vendor/conduction/hydra-gates/quality-config/lib` and the run aborted before
analysing anything. v1.7.1 prefixes every path with `%currentWorkingDirectory%/`.
`composer.lock` is regenerated for that one package; nothing else moved.

## How it was verified

`phpstan dump-parameters` was captured on both sides in a PHP 8.3 container. The five
load-bearing keys — level, paths, excludePaths, bootstrapFiles, scanDirectories —
resolve byte-identically, same sha256 over the extracted block. The analysis ran over
228 files before and 228 files after, with 0 findings before and 0 after.
The remaining difference in the full parameter dump is the extra ignore patterns the
base contributes (ContextChat, SystemTag, Bookmarks), which can only suppress, never
add.

The method was positive-controlled on the first app migrated: dropping an app-local
ignore makes real errors appear, and adding an entry under `paths` moves the resolved
key — so a byte-identical comparison here is a result, not an instrument that reports
"same" whatever it is fed.

## Scope

Only PHPStan files. `phpmd.xml`, stylelint and prettier are untouched here; a
separate change covers those.
