### PR TITLE
fix(icons): register ClipboardCheckOutline — the prohibition-override audit entry ships with no icon (gate-60 1 → 0)

### DIFF
--- a/src/icons.js
+++ b/src/icons.js
@@ -17,6 +17,7 @@ import AccountEdit from 'vue-material-design-icons/AccountEdit.vue'
 import BookAlphabet from 'vue-material-design-icons/BookAlphabet.vue'
 import BookOpenVariant from 'vue-material-design-icons/BookOpenVariant.vue'
 import BookOpenVariantOutline from 'vue-material-design-icons/BookOpenVariantOutline.vue'
+import ClipboardCheckOutline from 'vue-material-design-icons/ClipboardCheckOutline.vue'
 import Domain from 'vue-material-design-icons/Domain.vue'
 import EmailMultipleOutline from 'vue-material-design-icons/EmailMultipleOutline.vue'
 import EmailOutline from 'vue-material-design-icons/EmailOutline.vue'
@@ -48,6 +49,7 @@ export default {
 	BookAlphabet,
 	BookOpenVariant,
 	BookOpenVariantOutline,
+	ClipboardCheckOutline,
 	Domain,
 	EmailMultipleOutline,
 	EmailOutline,


### PR DESCRIPTION
## What

`lib/Settings/docudesk_register.json:3304` — the `prohibitionOverrideAudit` schema — names the icon `ClipboardCheckOutline`, but `src/icons.js` never imported or exported it.

`CnAppNav` / `CnIcon` / `CnIndexPage` resolve an `icon` by PascalCase name through the registry `registerIcons()` populates. **An unregistered name renders no icon at all — not a fallback glyph** (ADR-077 rule 3). That entry has been shipping blank.

gate-60 icon-vocabulary: **1 → 0**.

## Measurement (A/B, same tree, same run)

`ConductionNL/.github@923f57d` `scripts/lib/check_icon_vocabulary.py`, with `vue-material-design-icons` present so the upstream-existence half could actually execute — without it the checker skips as *wiring* and proves nothing:

```
fix reverted -> FAIL  src/icons.js: 1 icon name(s) used by the manifests are NOT
                      registered ... : ClipboardCheckOutline (ADR-077 rule 3).
                      checked 2 manifest(s): 1 failure(s), 0 warning(s)

fix applied  -> checked 2 manifest(s): 0 failure(s), 0 warning(s)
```

## Why the name is safe

- `ClipboardCheckOutline.vue` is verified present in the installed `vue-material-design-icons`.
- The name is **inside** the ADR-077 canonical vocabulary — it is absent from the checker's own list of the 13 out-of-vocabulary names this app uses (`AccountCheck`, `AccountEdit`, `BookAlphabet`, `BookOpenVariant`, `EmailMultipleOutline`, `FileDocument`, `FileDocumentCheck`, `FileLinkOutline`, `FolderAccount`, `FormatListBulleted`, `Palette`, `ShieldCheck`, `TagMultiple`), which is a separate, non-blocking note.

## Layer this covers

One import plus one export-map entry. No behaviour outside icon resolution can change.
