### PR TITLE
chore(deps): resolve conduction/hydra-gates v1.7.3 in composer.lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2084,16 +2084,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.7.1",
+            "version": "v1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "487e8d235b650a211328d5dfd1dbf90531b26436"
+                "reference": "9b9896abf87167e97b821d8ee86c5422f0b32e80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/487e8d235b650a211328d5dfd1dbf90531b26436",
-                "reference": "487e8d235b650a211328d5dfd1dbf90531b26436",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/9b9896abf87167e97b821d8ee86c5422f0b32e80",
+                "reference": "9b9896abf87167e97b821d8ee86c5422f0b32e80",
                 "shasum": ""
             },
             "require": {
@@ -2132,9 +2132,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.7.1"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.7.3"
             },
-            "time": "2026-08-12T12:57:31+00:00"
+            "time": "2026-08-12T22:32:31+00:00"
         },
         {
             "name": "consolidation/annotated-command",


### PR DESCRIPTION
## What

Lock-only bump of `conduction/hydra-gates` to **v1.7.3**. `composer.json` is untouched — the `^1.0` constraint is correct and stays floating. No other file changes.

## Why

v1.7.3 removes two **conditional paths** from the shared `quality-config/phpstan-base.neon`:

- `%currentWorkingDirectory%/vendor-bin`
- `%currentWorkingDirectory%/lib/Resources/template`

Measured against real apps on 2026-08-13, a conditional path in a shared base has **no spelling that is safe on both PHPStan majors**:

| spelling | PHPStan 1.x | PHPStan 2.x |
| --- | --- | --- |
| plain `%cwd%/vendor-bin` | accepted silently | **validates the entry and ABORTS** — zero files analysed |
| `%cwd%/vendor-bin (?)` (v1.7.2's attempted fix) | ok | **dies**: NEON reads `… (?)` after a `%…%` expansion as an *entity* → `isAbsolutePath(): … Nette\DI\Definitions\Statement given` |
| `'%cwd%/vendor-bin (?)'` | **stops stripping the marker** — the exclusion silently matches nothing | ok |

So the conditional paths move out of the shared base and into the individual apps that actually have those directories (`vendor-bin` → openregister; `lib/Resources/template` → portaliq, openbuild, hermiq), where they need no marker and work on both majors.

## Impact on this app

This app is on **PHPStan 1.12.x**, so it is **not broken today** — it is carrying a landmine that fires the moment it moves to PHPStan 2. That is exactly how the fleet's only 2.x app came to analyse **zero files** while every other app stayed green.

This app has **neither** `vendor-bin` **nor** `lib/Resources/template`, so **no `phpstan.neon` change is needed** — the removed exclusions matched nothing here. `PHP Quality (phpstan)` must stay green with an unchanged finding count.

## Verification

- resolved version in `composer.lock`: **v1.7.1 → v1.7.3**
- `composer update` reported `Upgrading conduction/hydra-gates (v1.7.1 => v1.7.3)`
- `composer.lock` diff touches **hydra-gates and nothing else** (version, source/dist reference, support URL, time)
- `platform-overrides` preserved: ``{"php": "8.3"}``
- resolved with composer 2.10.2 (the local 2.7.7 rewrites unrelated lock keys)

## Expected red

Gates scan the whole tree now, so this app carries pre-existing red gates that are not from this change. `Quality Report` is only an aggregator. The job that matters is **`PHP Quality (phpstan)`**, compared against the same job's conclusion on `development`.
