### PR TITLE
docs(security): state that gates scan the whole tree, not the diff

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -86,3 +86,10 @@ A 90-day workflow artifact named `sbom-<app>` is also produced on every successf
 ### Reporting SBOM-related issues
 
 If you spot a missing dependency, an incorrect version, or a CVE we should be alerted to, email `security@conduction.nl` per the disclosure process at the top of this document.
+
+### Gate scope
+
+Hydra Gates scan the **whole tree** on every event, not the diff (`.github#378`, `#416`). A
+one-file pull request therefore inherits the repository's entire outstanding finding count.
+That is deliberate: adding or tightening a gate is meant to block the next release until the
+existing code meets the new standard, rather than applying only to newly-touched lines.


### PR DESCRIPTION
A one-line docs change, deliberately.

This PR is also the **confirming observation for `.github#416`**. That fix landed as `fa555a2` and was proven only locally: gates 19/25/26/51/52/54/55 read their base from an ambient `HYDRA_GATE_BASE_REF`, which is exported on `pull_request` but not on `push`, so they **diff-scoped on PRs and swept on pushes while both printed `SCOPE-MODE: full`**. On docudesk that hid **396 gate-19 findings on every pull request** — the event that gates a merge.

The prediction, written before the run: this one-file PR should now report gate-19 in the hundreds rather than `NOT APPLICABLE`. If it reports `NOT APPLICABLE`, the fix did not reach CI and `#416` is not closed.

Expect this PR to be red. That is the point.