### PR TITLE
ci(stylelint): cover css/ — a file that had never been linted

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -106,6 +106,7 @@
 .publishedIcon > svg {
 	fill: var(--color-success);
 }
+
 .warningIcon > svg {
 	fill: var(--color-warning);
 }
@@ -131,6 +132,7 @@
 .successMessage {
 	color: var(--color-success);
 }
+
 .errorMessage {
 	color: var(--color-error);
 }

--- a/css/main.css
+++ b/css/main.css
@@ -165,9 +165,6 @@
 
 .filesListDragDropNoticeTitle {
 	margin: 12px 0;
-}
-
-.filesListDragDropNoticeTitle {
 	margin-left: 16px;
 	color: inherit;
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "check:manifest": "node tests/validate-manifest.js",
     "test:e2e": "playwright test",
     "test:e2e:docs": "playwright test --project docs-capture",
-    "stylelint": "stylelint \"src/**/*.{vue,scss,css}\"",
+    "stylelint": "stylelint \"{src,css}/**/*.{vue,scss,css}\"",
+    "stylelint:fix": "stylelint \"{src,css}/**/*.{vue,scss,css}\" --fix",
     "format": "prettier --check \"**/*.{js,ts,vue,css,scss}\"",
     "format:fix": "prettier --write \"**/*.{js,ts,vue,css,scss}\"",
     "prepare": "git config core.hooksPath .githooks || true"

--- a/src/components/viewers/PdfViewer.vue
+++ b/src/components/viewers/PdfViewer.vue
@@ -336,7 +336,7 @@ export default {
  * anchored on `.pdf-viewer__page` — which IS a template element and does carry
  * the hash — and wrapped in `:deep()`.
  *
- * This block used to live in a second, unscoped <style> tag. That leaked every
+ * This block used to live in a second, unscoped `style` tag. That leaked every
  * rule below into the whole page: `.pdf-viewer__text-layer ::selection` in
  * particular is not namespaced by anything Vue enforces, and an unscoped
  * `::selection` rule applies wherever a matching ancestor exists. Scoping it


### PR DESCRIPTION
## What

`stylelint` ran `src/**` only. `css/main.css` (173 lines), loaded directly by Nextcloud, had **never been linted**.

The rules were fine. The file was outside the glob.

```
before:  stylelint "src/**/*.{vue,scss,css}"
after:   stylelint "{src,css}/**/*.{vue,scss,css}"
```

**74 files checked before → 75 after**, both from stylelint itself (`-f json`, array length), not counted by hand.

Also adds `stylelint:fix`, which did not exist here. Where it does exist elsewhere in the fleet it has drifted *narrower* than `stylelint` itself — a fix script that reports "done" while leaving violations the check then flags. Defining it with the identical glob forecloses that.

The glob stays **quoted** so stylelint expands it, not the shell. Unquoted, and without `globstar`, `src/**/` matches exactly one directory level.

## What the new coverage found

### Manual — `6ab171e`

`.filesListDragDropNoticeTitle` declared twice, four lines apart. Merged in source order — identical cascade result.

### Auto-fixable — `30b42bc`

Two `rule-empty-line-before`, produced mechanically by `stylelint --fix`. The diff is two blank lines; no hand edits in that commit.

`npm run stylelint` now exits **0** across all 75 files.

## The one thing here that is not about `css/` — `d63dc17`

Running `stylelint --fix` for the first time turned up something unrelated to the glob, and it is the most interesting finding in this PR.

`src/components/viewers/PdfViewer.vue` carries a prose comment inside its scoped `<style>` block containing a literal `<style>`. `--fix` rewrites it:

```diff
- * This block used to live in a second, unscoped <style> tag. That leaked every
+ * This block used to live in a second, unscoped \3c style> tag. That leaked every
```

That is postcss-html escaping a sequence which would otherwise close the tag early. It is **not a lint finding** — the file reports zero warnings both before and after. `--fix` was silently rewriting a file it had nothing to say about, and the damage lands in committed source.

Two things worth being precise about:

- **It is pre-existing.** `src/**` was already in the glob, so any earlier `stylelint --fix` would have done the same. It is not caused by widening to `css/`.
- **This PR is what makes it reachable.** Before this branch there was no `stylelint:fix` script in this repo. Adding one and leaving the mangling in place would ship a documented command that corrupts a file when you run it.

Fixed by swapping the angle brackets for backticks — comment text only, no behaviour. `--fix` is now **idempotent across two consecutive passes** (verified: second pass produces no further diff).

## Proof the glob actually reaches `css/`

A glob that silently matches nothing looks exactly like a clean directory — the very defect being fixed — so this was tested, not assumed.

The obvious probe, a **space-indented rule**, reported **nothing**. Not because the glob missed: this repo's `.stylelintrc.js` sets `indentation: null`, having handed indentation to prettier in an earlier round. A probe against a disabled rule proves nothing and would have read as a passing test.

| plant | file | result |
|---|---|---|
| 4-space-indented rule | `css/main.css` | ⚪ silent — `indentation` is off in this repo |
| same, vs `npm run format` | `css/main.css` | ✅ prettier flags it, exit 1 — the gate that *does* own indentation reaches the file |
| `color: #zzz` | `css/main.css` | ✅ `175:9 color-no-invalid-hex`, exit 2 |
| same plant, **old** glob | `css/main.css` | exit **0** — invisible. The negative control. |

All plants removed; `git status` clean apart from `package.json`.

## On the indentation class

`css/main.css` measures **79 tab-indented lines and zero space-indented**. The repo's own stylelint config records this file as having sat at 78 space-indented lines when the handover was written; prettier's fleet-wide `**/*.{js,ts,vue,css,scss}` gate has since reached `css/` and cleared all of them. That is why this PR is three findings rather than eighty.

## Verification

- `npm run stylelint` — exit 0, 75 files
- `npm run format` — exit 0, "All matched files use Prettier code style"
- `npm run lint` — exit 0 (165 pre-existing warnings, 0 errors, unchanged)
- `phpmetrics/` vendored third-party CSS is untouched — it is outside `{src,css}` and already carries a `.prettierignore` entry

Pre-existing red on `development` (Hydra Gates, Quality Report) is not from this branch; compare the same job on `development` before attributing.
