### PR TITLE
fix(security): brute-force throttle the portal signing receiver

### DIFF
--- a/lib/Controller/PortalSigningReceiverController.php
+++ b/lib/Controller/PortalSigningReceiverController.php
@@ -46,10 +46,13 @@ use OCA\DocuDesk\Service\SettingsService;
 use OCA\DocuDesk\Service\SigningService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\Security\Bruteforce\IThrottler;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -59,6 +62,17 @@ use Throwable;
  * @spec openspec/specs/portal-signing-actions/spec.md
  */
 class PortalSigningReceiverController extends Controller {
+	/**
+	 * Brute-force throttler action for rejected portal signing assertions.
+	 *
+	 * One action across sign / decline / viewDocument: they share
+	 * `authoriseAct()`, so a caller must not be able to spread guesses over
+	 * three endpoints to stay under a per-endpoint ceiling.
+	 *
+	 * @var string
+	 */
+	private const THROTTLE_ACTION = 'docudesk_portal_signing_assertion';
+
 	/**
 	 * Minimum eIDAS-aligned portal trust required to act (mirrors
 	 * `PortalContributionProvider::SIGNING_MIN_TRUST` — re-checked here as
@@ -101,6 +115,7 @@ class PortalSigningReceiverController extends Controller {
 		private readonly OpenRegisterResolver $registerResolver,
 		private readonly LoggerInterface $logger,
 		private readonly PortalSigningDocumentResolver $documentResolver,
+		private readonly IThrottler $throttler,
 	) {
 		parent::__construct(appName: $appName, request: $request);
 
@@ -122,6 +137,8 @@ class PortalSigningReceiverController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 20, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function signDocument(): JSONResponse {
 		$context = $this->authoriseAct();
 		if ($context instanceof JSONResponse) {
@@ -172,6 +189,8 @@ class PortalSigningReceiverController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 20, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function declineDocument(): JSONResponse {
 		$context = $this->authoriseAct();
 		if ($context instanceof JSONResponse) {
@@ -217,6 +236,8 @@ class PortalSigningReceiverController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 60, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function viewDocument(): JSONResponse {
 		$context = $this->authoriseAct();
 		if ($context instanceof JSONResponse) {
@@ -270,6 +291,9 @@ class PortalSigningReceiverController extends Controller {
 		// 1. Verify — the assertion is the ONLY credential (fail-closed 401).
 		$claims = $this->verifier->verify((string)$this->request->getHeader(PortalAssertionVerifier::HEADER));
 		if ($claims === null) {
+			// The assertion is the only credential, so a failed verify is a
+			// presented-secret failure -- exactly what the counter is for.
+			$this->registerRejectedAssertion();
 			return new JSONResponse(['error' => 'unauthorized'], Http::STATUS_UNAUTHORIZED);
 		}
 
@@ -478,8 +502,39 @@ class PortalSigningReceiverController extends Controller {
 	 * @return JSONResponse
 	 */
 	private function forbidden(): JSONResponse {
+		// A verified assertion that fails the audience or trust check is still
+		// a rejected credential presentation: the signature held but the claims
+		// did not authorise this act. Counted with the 401s, since an attacker
+		// probing for a usable assertion sees both.
+		$this->registerRejectedAssertion();
 		return new JSONResponse(['error' => 'forbidden'], Http::STATUS_FORBIDDEN);
 	}//end forbidden()
+
+	/**
+	 * Record a rejected assertion with the brute-force throttler.
+	 *
+	 * This is the half that COUNTS. The half that ENFORCES is the
+	 * `#[BruteForceProtection]` attribute on sign / decline / viewDocument —
+	 * `BruteForceMiddleware` only calls `sleepDelayOrThrowOnMax()` when that
+	 * attribute is present, so registering without it writes a counter nothing
+	 * ever reads. Both are required; see ADR-082.
+	 *
+	 * @return void
+	 */
+	private function registerRejectedAssertion(): void {
+		try {
+			$this->throttler->registerAttempt(
+				action: self::THROTTLE_ACTION,
+				ip: $this->request->getRemoteAddress()
+			);
+		} catch (\Throwable $throttlerFailure) {
+			// Never let throttler bookkeeping change a fail-closed 401/403 into
+			// a 500 — the fail-closed answer is the security-relevant one.
+			$this->logger->warning(
+				'PortalSigningReceiverController: registerAttempt failed: ' . $throttlerFailure->getMessage()
+			);
+		}
+	}//end registerRejectedAssertion()
 
 	/**
 	 * Relay a downstream/OpenRegister failure as 502 — never leaking

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -72,6 +72,21 @@ if (is_dir($ocpSystemTagDir) === true) {
 	}
 }
 
+// Load OCP's brute-force throttler contract (PortalSigningReceiverController
+// registers rejected portal assertions against it) — same "real file, not
+// classmapped" situation as the EventDispatcher/AppFramework\Db/SystemTag
+// contracts above. Without this, createMock(IThrottler::class) raises
+// UnknownTypeException and every test in that class errors out.
+$ocpBruteforceDir = __DIR__ . '/../vendor/nextcloud/ocp/OCP/Security/Bruteforce';
+if (is_dir($ocpBruteforceDir) === true) {
+	foreach (['MaxDelayReached.php', 'IThrottler.php'] as $ocpBruteforceFile) {
+		$ocpBruteforcePath = $ocpBruteforceDir . '/' . $ocpBruteforceFile;
+		if (is_file($ocpBruteforcePath) === true) {
+			require_once $ocpBruteforcePath;
+		}
+	}
+}
+
 // Load OpenRegister stubs for mocking.
 require_once __DIR__ . '/stubs/OpenRegisterStubs.php';
 

--- a/tests/unit/Controller/PortalSigningReceiverControllerTest.php
+++ b/tests/unit/Controller/PortalSigningReceiverControllerTest.php
@@ -50,6 +50,7 @@ use OCP\IAppConfig;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use OCP\Security\Bruteforce\IThrottler;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -162,7 +163,8 @@ class PortalSigningReceiverControllerTest extends TestCase {
 			// away would remove exactly the behaviour under test.
 			registerResolver: new OpenRegisterResolver(settingsService: $this->mockSettingsService),
 			logger: $this->mockLogger,
-			documentResolver: new PortalSigningDocumentResolver(rootFolder: $this->mockRootFolder)
+			documentResolver: new PortalSigningDocumentResolver(rootFolder: $this->mockRootFolder),
+			throttler: $this->createMock(IThrottler::class)
 		);
 
 	}//end controller()


### PR DESCRIPTION
`sign`, `decline` and `viewDocument` are `#[PublicPage]` and the `X-Portal-Subject` assertion is the **only** credential. There was no throttle of any kind — an attacker could grind assertions at line rate against an endpoint that produces a **legally significant signature**.

Registration sits in the two fail-closed exits of `authoriseAct()`: the 401 when the assertion doesn't verify, and `forbidden()` when it verifies but the audience/trust claim doesn't authorise the act. Both are rejected credential presentations and an attacker probing for a usable assertion sees both, so they share one counter — one action across all three endpoints, so guesses can't be spread over three surfaces to stay under a ceiling.

Both halves are present: `#[BruteForceProtection]` is what makes `BruteForceMiddleware` call `sleepDelayOrThrowOnMax`; the registration feeds it. Either alone is inert — see ADR-082 (ConductionNL/hydra#554).

Limits: 20/60 on the two acts, 60/60 on the read.

### A test-harness fix rides along

`tests/bootstrap-unit.php` needed one too. The suite runs standalone against `vendor/nextcloud/ocp`, which **ships** `IThrottler` but doesn't classmap-autoload it, so `createMock(IThrottler::class)` raised `UnknownTypeException` and **all 15 tests errored**. Added the explicit require alongside the existing EventDispatcher / `AppFramework\\Db` / SystemTag ones, which exist for exactly this reason.

**15/15 pass.**

**Not verified behaviourally.** The 429 control was run against openregister federation; same mechanism, not exercised live here.