### PR TITLE
fix(security): rate-limit the health probe

### DIFF
--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -42,6 +42,7 @@ namespace OCA\DocuDesk\Controller;
 use OCA\DocuDesk\AppInfo\Application;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -115,6 +116,8 @@ class HealthController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// Liveness probe — no credential, so a ceiling rather than a counter.
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(): JSONResponse {
 		$body = $this->engineBody();
 		if ($body === null) {


### PR DESCRIPTION
Closes this app's public surface — it now reports **zero unthrottled $#[PublicPage]$ endpoints**. Ceiling only, no brute-force counter: the endpoint takes no guessable credential. Suite identical to baseline. Part of the ADR-081/082 sweep (ConductionNL/hydra#554).