### PR TITLE
docs(openspec): document-editing-tools + multi-format-editing-tools specs

### DIFF
--- a/openspec/changes/document-editing-tools/design.md
+++ b/openspec/changes/document-editing-tools/design.md
@@ -1,0 +1,262 @@
+# Design — document-editing-tools
+
+Two curated agent-reachable operations on documents that already exist:
+convert one, and edit one. Both suite-independent per ADR-087; both write a new
+file rather than mutating the source.
+
+## Declarative-vs-imperative decision (ADR-031)
+
+| Behaviour | Path | Rationale |
+|---|---|---|
+| Format conversion | **Imperative** — `ConversionService` (existing cascade) | External integration: dispatches into Nextcloud's `IConversionManager` and, below it, into an office app or a headless `soffice` process. Owns no schema, no derived value, no lifecycle. Explicit ADR-031 external-integration exception, and the same one ADR-075 already grants document generation. |
+| WOPI editing session | **Imperative** — `Editing/WopiClient` + `Editing/EditSessionService` | External integration across an instance boundary (HTTP + a stateful lock protocol). Same exception. |
+| Document codec | **Imperative** — `Editing/PackageCodec` | Pure byte manipulation of ODF/OOXML packages. Not expressible declaratively at all. |
+| Record of what an agent produced | **Declarative** — reuse `generatedDocument` | A converted or edited output is a generated document. It gets a `generatedDocument` row through the existing declarative path; this change adds **no** new schema and **no** new lifecycle, aggregation, calculation, notification or relation. |
+
+No `x-openregister-{lifecycle,aggregations,calculations,notifications,relations,widgets}`
+block is added or modified by this change.
+
+## Where the office-suite divergence goes (ADR-087)
+
+It mostly does not exist. The layers, and who brokers each:
+
+| Layer | Brokered by | Per-suite code here? |
+|---|---|---|
+| Format conversion | `IConversionManager` (NC 31+) — Collabora, ONLYOFFICE and Euro Office all register as providers | **No.** `OfficeAppBackend` already dispatches uniformly. |
+| Package read/write (ODF, OOXML) | Nothing — they are file formats | **No.** One codec, no suite in the call path. |
+| Editing session (get bytes, lock, put bytes) | WOPI | **No.** One client. Availability probed by a real `CheckFileInfo`, never by an installed app id — Euro-Office ships `wopi.enable` false. |
+| Live in-editor insertion | Nothing. Collabora `Send_UNO_Command`; ONLYOFFICE a plugin API | **Not built in this change** (ADR-087 §4). |
+
+## The two curated tools
+
+### `docudesk.convertDocument`
+
+Wraps the existing cascade. Input: a file id the acting user can read, plus a
+target format. Output: a new file node plus a `generatedDocument` record.
+
+- `scope: 'create'`, `readOnlyHint: false`, `destructiveHint: false`,
+  `idempotentHint: false`.
+- Backend selection is **not** an agent-supplied argument. The cascade picks;
+  the response reports which backend claimed the conversion (`backend` field), so
+  an operator reading the invocation log can tell an `IConversionManager`
+  conversion from an mPDF fallback.
+- Refuses when no backend claims the source MIME → target pair, with a structured
+  error naming the source format. It never silently returns a lower-fidelity
+  result without saying so.
+
+### `docudesk.editDocument`
+
+Input: a file id, plus a list of anchored edits. Output: a **new document
+version**, never a mutation of the input.
+
+Session lifecycle, entirely inside `EditSessionService` — none of these steps is
+an agent-callable tool, and the model never sees a lock id:
+
+```
+CheckFileInfo   -> capability probe + user's permissions on this file
+Lock            -> X-WOPI-Lock held by the service
+GetFile         -> package bytes
+  codec: parse -> anchored blocks -> apply edits -> serialise in place
+PutRelativeFile -> the NEW version
+Unlock          -> in a finally, on every exit path
+```
+
+**Output mode: in-place by default, sibling on request.**
+
+| Mode | WOPI call | Undo | Default |
+|---|---|---|---|
+| In-place | `PutFile` on the source | Nextcloud file versioning | **yes** |
+| Sibling | `PutRelativeFile` | source never touched | on request |
+
+In-place keeps one document identity and one history, and puts the undo where
+users already look for it — the file's version list — rather than scattering
+near-duplicate files through a folder. Review still works: DocuDesk has
+`DocumentComparisonService`, and Collabora Online 26.04 renders version-to-version
+redlines natively, so "what did the agent change?" is answered by diffing versions.
+
+**`PutFile` has no merge semantics**, so in-place needs three guards, and all three
+are required — none of them substitutes for another:
+
+1. **The lock is held across the whole read-modify-write.** Not re-acquired for the
+   write. A gap between `GetFile` and `PutFile` is a window in which a human's
+   change is silently lost.
+2. **`CheckFileInfo`'s `Version` is re-read immediately before `PutFile` and the
+   write is refused if it moved.** This is optimistic concurrency using a field the
+   protocol already returns, and it is what closes the residual race the lock alone
+   does not: a change made outside a WOPI session. Refusing is correct here —
+   merging is not something this codec can do, and guessing would be worse than
+   stopping.
+3. **The ADR-088 tag makes the change visible in Files**, so an in-place edit is
+   something the user sees rather than something they must notice by reading the
+   document.
+
+**Configuration sets the ceiling; the tool argument may only narrow it.** An agent
+may request sibling output when configuration says in-place; it may never request
+in-place when configuration says sibling. An agent that can widen its own blast
+radius has no blast radius.
+
+**Verify versioning rather than assume it.** That a WOPI `PutFile` produces a
+Nextcloud file version is the entire recovery story for the default mode. It is
+asserted by test — a restorable prior version must exist after an agent edit —
+because a recovery path nobody has watched work is not a recovery path.
+
+**Lock contention is a refusal, not a wait.** If the document is open in an
+editor the lock is already held. The tool returns a structured error naming the
+condition. It does **not** poll, queue, retry, or use `UnlockAndRelock` to take a
+lock it did not create — an agent stealing a human's editing lock is a data-loss
+primitive.
+
+## Anchors
+
+Edits address **stable block anchors**, never array indexes: a human inserting a
+paragraph shifts every index, and an agent's edit would land in the wrong place
+with no error.
+
+Preference order, resolved at Phase 0 (see §Verification):
+
+1. **Native persistent ids** — OOXML `w14:paraId`, ODF `xml:id`. Purpose-built
+   for exactly this, *if* the suite preserves them.
+2. **Content-hash anchors** with a re-anchoring pass on every `open` — the
+   fallback if (1) does not survive a save.
+
+This is the single largest unknown in the change and it is measured before any
+codec code is written. It is recorded as a known unknown in ADR-087.
+
+## The codec edits in place
+
+Parse the package, mutate only the `w:p` / `text:p` nodes an edit targets,
+rewrite that one part, leave every other entry in the package byte-identical.
+
+The alternative — parse to a model and re-serialise — is what a general-purpose
+document library does, and it silently drops comments, tracked changes, styles,
+headers and embedded objects. Those losses are invisible in a diff of the visible
+text and no test asserts on them, which is precisely why they must be structurally
+impossible rather than guarded.
+
+## Refusals
+
+Extending the standing refusals in `docudesk-mcp-adoption` §Refusals, which
+remain in force unchanged:
+
+- **No unguarded in-place write.** `PutFile` is called only while the session's own
+  lock is held and only after `CheckFileInfo`'s `Version` has been re-confirmed
+  unchanged. A version that moved is a refusal, never a merge attempt.
+- **No escalation of output mode.** A tool argument may narrow to sibling output;
+  it may never widen to in-place against configuration.
+- **No lock stealing.** `UnlockAndRelock` is never used to acquire a lock the
+  service does not already hold.
+- **No editing a document under signature.** A file referenced by a
+  `signingRequest` in any state other than cancelled is refused — editing the
+  artefact behind a signature process invalidates the signature's meaning.
+- **No editing anonymisation output.** A redacted document is a deliberate
+  artefact; re-editing it risks re-identification.
+- **No bytes in responses.** No tool returns document bytes, attachment bytes, or
+  signature material. Responses carry file ids, metadata and structured status.
+- **No live in-editor streaming** in this change (ADR-087 §4 permits it later,
+  behind a probe, never as the only path).
+- **No backend override.** The agent cannot pick a conversion backend, so it
+  cannot be steered onto `soffice` as a process-execution primitive.
+
+## Marking and recording (ADR-088)
+
+Every file either tool produces is marked and recorded, in both directions:
+
+- **On the artefact** — a Nextcloud system tag applied via `ISystemTagManager` /
+  `ISystemTagObjectMapper` in the same code path that writes the file. Files is
+  where a user actually looks, and a system tag is visible and filterable there, so
+  "did an agent write this?" is answerable without opening an audit page.
+- **In the record** — the `generatedDocument` row carries the invoking agent, and
+  Hermiq's `tool` trace step for the invocation carries the produced **file id**.
+  Without that, the oversight surface says `docudesk.editDocument` succeeded and
+  cannot say on what.
+
+Two rules that are easy to get wrong:
+
+- **Tagging is not a follow-up job.** It happens at write time. An artefact that
+  exists untagged even briefly is one a user can mistake for their own, and a
+  background pass that fails leaves it that way permanently.
+- **A tagging failure is a failed operation.** If the file is written but the tag
+  cannot be applied, the tool reports failure. Returning success on an unmarked
+  file is the single outcome nothing downstream will ever re-examine.
+
+The mark is a **hint, not a guarantee** — a user can remove a system tag. Hermiq's
+record is the authoritative account; the tag is what makes that record discoverable
+from the file. Neither the spec nor the tool description claims tamper-resistance.
+
+No document content enters the record — file id, agent identity and outcome only,
+consistent with the no-bytes refusal below.
+
+## Grant-surface correctness
+
+Both tools are two-segment curated ids (`docudesk.convertDocument`,
+`docudesk.editDocument`), not three-segment derived ones. Per
+`hermiq-prefer-tool-hints`, classification **fails closed** on a hint-less
+non-3-segment id — a missing `scope` does not produce an unclassified tool, it
+produces a write/destructive one. Both are write-classified either way, so the
+hints are declared for *accuracy in the grant editor and the oversight log*, not
+to unlock anything.
+
+Consequence, which is intended: both tools are **default-denied**. An agent
+reaches them only through an explicit exact-id grant, and each invocation passes
+`FacadeToolInvoker`'s approval gate unless a grant waives it. They appear in the
+agent detail page's Tool governance grant editor automatically —
+`ToolOversightController::toolCatalog()` enumerates `ToolRegistryFacade::listTools([])`,
+so nothing needs adding to the UI, but it MUST be verified rather than assumed.
+
+## Verification
+
+Phase 0 gates the rest. Both are measurements, not reviews:
+
+1. **`w14:paraId` survival.** Author a `.docx` with known `paraId` values, open
+   it in Collabora, save, diff the attributes. Repeat for ODF `xml:id`. A negative
+   result selects content-hash anchors and adds a re-anchoring pass — it does not
+   block the change, but discovering it after the codec is written does.
+2. **Headless WOPI token issuance.** Determine, from richdocuments' token
+   issuance, whether a background job can obtain a file-scoped token for its
+   initiating user. If the only route is a service user with broad file access,
+   **stop and escalate to an ADR** — that is a privilege concentration, not an
+   implementation detail.
+
+Then: `CheckFileInfo` probe returns absent on an instance with no WOPI host and
+the capability degrades visibly; conversion verified against `IConversionManager`
+with an office app installed *and* with the cascade falling through to PhpWord;
+lock contention returns the structured refusal; both tool ids appear in the Tool
+governance grant editor with write classification; scoped `phpcs` clean; zero new
+PHPUnit failures against a self-measured baseline.
+
+Portability is verified, not asserted: the conversion path is exercised on an
+instance running Collabora **and** on one running Euro-Office (with
+`wopi.enable` explicitly set true in `local.json`). If Euro-Office is not
+available to test against, the portability claim is dropped from the spec rather
+than shipped unmeasured.
+
+## Seed data
+
+None. This change introduces and modifies no OpenRegister schema; outputs are
+recorded through the existing `generatedDocument` schema.
+
+## DEFERRED_QUESTIONS
+
+All three resolved 2026-08-15.
+
+1. ~~Ship `editDocument` before Phase 0 returns, or split?~~ **RESOLVED: one
+   change, Phase 0 as a hard gate inside it.** Splitting would cost a full review
+   cycle for ~80 lines around an existing cascade. Two consequences to watch, since
+   they are the price of not splitting: the conversion tool cannot merge until the
+   editing work clears Phase 0, and this change sits **exactly at the 20-task cap
+   with no headroom** — any further scope requires an ADR-032 split rather than an
+   extra checkbox.
+2. ~~**Where does the new version land?**~~
+   **RESOLVED (2026-08-15): into the source file by default, creating a Nextcloud
+   file version; sibling output selectable.** This reverses the original
+   never-overwrite position. It is defensible now for reasons that did not hold
+   when that position was written: the ADR-088 tag makes an in-place change visible
+   in Files, the lock refusal already blocks writing under a live editing session,
+   and the `Version` precondition closes the remaining out-of-session race. The
+   undo moves from "a second file the user must find" to Nextcloud's own version
+   list. Affects: proposal, design §Output mode, tasks 2.x/3.x, spec requirement.
+3. ~~**Does an agent-produced version need a distinguishing marker?**~~
+   **RESOLVED (2026-08-15): yes — a Nextcloud system tag applied at write time,
+   plus the file id in Hermiq's record.** Both directions are required, not one:
+   a tag with no log entry is unattributable, and a log entry with no file id is
+   unactionable. Generalised to the fleet as ADR-088. See §Marking and recording.

--- a/openspec/changes/document-editing-tools/proposal.md
+++ b/openspec/changes/document-editing-tools/proposal.md
@@ -1,0 +1,121 @@
+---
+kind: code
+depends_on:
+  - docudesk-mcp-adoption
+---
+
+# Proposal: document-editing-tools
+
+## Why
+
+`docudesk-mcp-adoption` gives an agent the ability to **find** a template and
+**generate** a new document from register data (`docudesk.generateCorrespondence`).
+`mcp-generation-tools` adds status and anonymisation. Nothing in either change —
+or anywhere in DocuDesk — lets an agent act on a document that **already
+exists**: convert it to another format, or change its content.
+
+Those are the two operations users actually ask an assistant for once the first
+document exists ("zet dit even om naar PDF", "werk de bedragen in deze brief
+bij"), and DocuDesk already owns most of the machinery for the first one:
+`lib/Service/Conversion/` holds a complete backend cascade behind
+`ConversionBackendInterface` — `OfficeAppBackend` (Nextcloud's
+`IConversionManager`, NC 31+) → `LibreOfficeHeadlessBackend` → `PhpWordBackend`
+→ `MpdfBackend`, plus an Eml slot. It is reachable from DocuDesk's own UI and
+from ADR-075's channel, but **not from an agent**.
+
+The second operation has no machinery at all, and it is where the fleet's
+office-suite problem actually lives. **ADR-087** settles the shape: conversion
+brokers through `IConversionManager` (no per-suite driver), format manipulation
+is one suite-independent codec, editing sessions use WOPI and only WOPI, and
+live in-editor streaming (Collabora's `postMessage` / `Send_UNO_Command`) is an
+explicitly non-portable enhancement that this change does **not** build.
+
+The governance posture is inherited, not reinvented: `docudesk-mcp-adoption`
+established a narrow, read-biased surface with standing refusals (no signing, no
+batch mail-merge, no entity values, no signature material). This change extends
+that surface with two curated tools and contradicts none of it.
+
+## What Changes
+
+- **One curated conversion tool** `docudesk.convertDocument` — a genuinely
+  non-CRUD action on a real service method wrapping the existing
+  `ConversionBackendInterface` cascade. Converts one file the acting user can
+  read into a requested target format, writing the **result as a new file**.
+  Annotated honestly: `scope: 'create'`, `readOnlyHint: false`,
+  `destructiveHint: false`, `idempotentHint: false`.
+
+- **One curated editing tool** `docudesk.editDocument` — opens a WOPI session
+  against the instance's WOPI host, applies anchored block edits to the document
+  package, and writes the result back into the source file (or to a sibling, on
+  request). Annotated honestly for what it now does: `scope: 'update'`,
+  `readOnlyHint: false`, **`destructiveHint: true`**, `idempotentHint: false` —
+  a tool that modifies a user's existing file in place is destructive, and
+  declaring it as such is what keeps it default-denied and approval-gated.
+
+- **Output mode is configurable, defaulting to in-place.** By default an edit
+  writes back into the source file via `PutFile`, so Nextcloud file versioning
+  holds the undo and the document keeps one identity and one history. A
+  sibling-file mode (`PutRelativeFile`, source untouched) is selectable for
+  callers who want the original guaranteed intact.
+
+- **In-place needs three guards, because `PutFile` has no merge semantics.** It
+  replaces the whole file, so an agent write would otherwise land on top of
+  anything changed since `GetFile`. Mitigated by: holding the WOPI lock across the
+  whole read-modify-write; **re-checking `CheckFileInfo`'s `Version` immediately
+  before `PutFile` and refusing if it moved** — optimistic concurrency using what
+  the protocol already offers; and the ADR-088 tag, which makes the change visible
+  in Files rather than something the user must notice by reading. Nextcloud file
+  versioning is the recovery path, and that it actually captures a version on a
+  WOPI `PutFile` is **verified, not assumed**.
+
+- **Configuration sets the ceiling; a tool argument may only be more
+  conservative.** An agent can request sibling output when the configuration says
+  in-place, but never the reverse — an agent cannot escalate its own blast radius.
+
+- **Both tools are suite-independent** per ADR-087. No
+  `{Collabora,LibreOffice,EuroOffice}` backend triad is added. WOPI availability
+  is probed with a real `CheckFileInfo`, never inferred from an installed app id
+  — Euro-Office ships `wopi.enable` false by default.
+
+- **The document codec edits XML in place inside the package**, leaving untouched
+  parts byte-identical, so comments, tracked changes, styles, headers and
+  embedded objects survive because they are never re-serialised.
+
+- **Every produced document is tagged and recorded** (ADR-088). A Nextcloud system
+  tag is applied at write time by the same code path that writes the file, so a
+  user sees in Files that an agent authored or changed it without consulting an
+  audit page; and the write is recorded by Hermiq with the file id, so an operator
+  reviewing the agent can follow the record to the artefact. If the tag cannot be
+  applied the operation reports failure rather than returning success — an unmarked
+  document reported as marked is the one outcome nothing downstream will question.
+
+- **Standing refusals extended** (design.md §Refusals): no editing of a document
+  with an open or completed `signingRequest`; no editing of anonymisation output;
+  no lock stealing; no attachment or signature bytes in any tool response; no
+  live in-editor streaming in this change.
+
+- **Grant-surface correctness**: both tools carry ADR-063 descriptor hints so
+  Hermiq's `ToolGrantResolver` classifies them correctly and they appear, with
+  the right write classification, in the agent detail page's Tool governance
+  grant editor. Per `hermiq-prefer-tool-hints`, a hint-less two-segment id fails
+  **closed** — so the hints are load-bearing, not documentation.
+
+## Capabilities
+
+**New Capabilities**
+- `document-editing` — DocuDesk's suite-independent conversion and editing of
+  existing documents.
+
+**Modified Capabilities**
+- `docudesk-mcp-surface` — extended with the two curated tools above, bound by
+  the standing refusals already declared there.
+
+## Impact
+
+- New: `lib/Service/Editing/` (WOPI client, session manager, document codec),
+  two `#[McpTool]` methods, `DocudeskScannableServices` extended.
+- Blocked on two unknowns recorded in ADR-087 and re-stated in design.md
+  §Verification: `w14:paraId` survival across a Collabora save, and headless WOPI
+  token issuance. Both are measured in Phase 0 tasks before any editing code is
+  written.
+- No new OpenRegister schema, therefore no seed data.

--- a/openspec/changes/document-editing-tools/specs/docudesk-mcp-surface/spec.md
+++ b/openspec/changes/document-editing-tools/specs/docudesk-mcp-surface/spec.md
@@ -1,0 +1,65 @@
+# docudesk-mcp-surface
+
+Delta: extends DocuDesk's curated MCP surface with two tools that act on
+documents which already exist. The schema allowlist declared by
+`docudesk-mcp-adoption` is unchanged — this change adds **no** schema and enables
+**no** derived write verb. Every standing refusal declared there remains in force.
+
+## ADDED Requirements
+
+### Requirement: Two curated tools act on existing documents
+DocuDesk MUST expose exactly two further curated `#[McpTool]` methods via the
+`IMcpScannableServices` path: `docudesk.convertDocument`, which MUST produce a new
+file and MUST NOT mutate its input; and `docudesk.editDocument`, which by default
+modifies the source file in place under the guards this change requires, and which
+MUST also support a mode that writes a sibling file and leaves the source
+untouched. No further curated tool is added by this change.
+
+#### Scenario: The extended curated surface is enumerated
+- **WHEN** an agent lists DocuDesk's tool surface
+- **THEN** `docudesk.convertDocument` and `docudesk.editDocument` MUST be present
+  in addition to `docudesk.generateCorrespondence`
+- **AND** the derived schema surface MUST be unchanged — still sixteen read-only
+  tools, and no tool name ending in `.create`, `.update` or `.delete`
+
+#### Scenario: A conversion is invoked
+- **WHEN** the conversion tool completes
+- **THEN** a new file MUST exist
+- **AND** the input file MUST be unchanged
+
+#### Scenario: An edit is invoked in the default mode
+- **WHEN** the editing tool completes in its default mode
+- **THEN** the source file MUST contain the edit
+- **AND** a restorable prior version of that file MUST exist
+
+### Requirement: Both curated tools declare honest ADR-063 descriptor hints
+`docudesk.convertDocument` MUST declare `scope: "create"`, `readOnlyHint: false`,
+`destructiveHint: false`. `docudesk.editDocument` MUST declare `scope: "update"`,
+`readOnlyHint: false`, and **`destructiveHint: true`**, because it modifies a
+user's existing file in place. Both MUST declare `idempotentHint: false` and an
+agent-facing `description`. The hints MUST describe what the tool does, not what
+would be convenient for grant resolution.
+
+#### Scenario: A curated tool is classified for grants
+- **WHEN** Hermiq's grant resolver classifies either tool
+- **THEN** it MUST resolve as write
+- **AND** it MUST be default-denied in the absence of an explicit exact-id grant
+
+#### Scenario: The tool appears in the agent oversight surface
+- **WHEN** the per-agent tool catalogue is requested
+- **THEN** both tool ids MUST appear with their write classification
+- **AND** an operator MUST be able to grant or withhold each one individually
+
+### Requirement: Signing and batch mail-merge remain unexposed
+This change MUST NOT add an `#[McpTool]` attribute to any signing service, and
+MUST NOT expose the batch correspondence path. The refusals declared by
+`docudesk-mcp-adoption` are extended, never relaxed.
+
+#### Scenario: The curated surface is audited for refused capabilities
+- **WHEN** the set of `#[McpTool]`-annotated methods is enumerated
+- **THEN** no signing service and no batch generation method MUST carry the attribute
+
+#### Scenario: An agent asks to edit a document awaiting signature
+- **WHEN** an edit targets a file in an active signature process
+- **THEN** the tool MUST refuse
+- **AND** the agent MUST report that editing a document under signature is not available

--- a/openspec/changes/document-editing-tools/specs/document-editing/spec.md
+++ b/openspec/changes/document-editing-tools/specs/document-editing/spec.md
@@ -1,0 +1,207 @@
+# document-editing
+
+DocuDesk's suite-independent handling of documents that already exist: format
+conversion through Nextcloud's conversion broker, and content editing through a
+WOPI session that always writes a new version. Governed by ADR-087
+(office-suite divergence is brokered, not driven) and ADR-075 (DocuDesk owns
+document generation, one channel).
+
+## ADDED Requirements
+
+### Requirement: Conversion routes through the Nextcloud conversion broker
+The system MUST perform format conversion through the existing
+`ConversionBackendInterface` cascade, whose highest-priority backend dispatches
+via `OCP\Files\Conversion\IConversionManager`. The system MUST NOT add a
+per-office-suite conversion backend for any conversion the conversion manager
+brokers, and MUST NOT branch on an office app's id to select a conversion path.
+
+#### Scenario: An office app is installed and claims the conversion
+- **GIVEN** an office app is registered as a conversion provider with `IConversionManager`
+- **WHEN** a document is converted
+- **THEN** the conversion MUST be dispatched through `IConversionManager`
+- **AND** the result MUST report which backend claimed the conversion
+
+#### Scenario: No conversion provider is registered
+- **GIVEN** no office app is registered as a conversion provider
+- **WHEN** a document is converted
+- **THEN** the cascade MUST fall through to the built-in backends
+- **AND** the result MUST report the backend that produced it, so a lower-fidelity
+  fallback is never reported as an office-app conversion
+
+#### Scenario: No backend claims the source format
+- **WHEN** no backend in the cascade claims the source MIME → target format pair
+- **THEN** the system MUST return a structured error naming the source format
+- **AND** the system MUST NOT return a partial or substituted result
+
+### Requirement: Editing session availability is probed, never inferred
+The system MUST determine WOPI availability by performing a real `CheckFileInfo`
+request against the configured WOPI host. The system MUST NOT infer availability
+from the presence of an installed office app, because a supported suite may ship
+with its WOPI interface disabled by default.
+
+#### Scenario: No WOPI host is reachable
+- **WHEN** the `CheckFileInfo` probe fails
+- **THEN** the editing capability MUST resolve as absent
+- **AND** the absence MUST be surfaced visibly to the caller
+- **AND** the system MUST NOT report a successful edit
+
+#### Scenario: An office app is installed but its WOPI interface is disabled
+- **GIVEN** an office app is installed whose WOPI interface is turned off
+- **WHEN** availability is determined
+- **THEN** the capability MUST resolve as absent, exactly as if no office app were installed
+
+### Requirement: Editing writes in place by default, with a recoverable prior version
+The system MUST support two output modes: writing back into the source file, which
+is the default, and writing a sibling file that leaves the source untouched. After
+an in-place edit a restorable prior version of the file MUST exist.
+
+#### Scenario: A document is edited in the default mode
+- **WHEN** an edit completes successfully in the default mode
+- **THEN** the source file MUST contain the edit
+- **AND** a prior version of the file MUST be restorable
+
+#### Scenario: A caller requests sibling output
+- **WHEN** an edit is requested in sibling mode
+- **THEN** a new file MUST be created
+- **AND** the source file's bytes MUST be unchanged
+
+### Requirement: An in-place write is guarded by the lock and a version precondition
+The system MUST hold its own WOPI lock across the whole read-modify-write, and MUST
+re-read `CheckFileInfo` immediately before writing and refuse the write if the
+file's version has changed since it was read. The system MUST NOT attempt to merge.
+
+#### Scenario: The document changed between read and write
+- **GIVEN** a document was read at the start of an edit
+- **AND** the document changed before the edit was written
+- **THEN** the system MUST refuse the write
+- **AND** the change made by the other writer MUST remain intact
+- **AND** the system MUST NOT attempt to merge the two versions
+
+#### Scenario: The lock was not held for the whole session
+- **WHEN** a write is attempted without the session's own lock held continuously
+  since the read
+- **THEN** the system MUST refuse the write
+
+### Requirement: Output mode may be narrowed by a caller but never widened
+Configuration MUST determine the most permissive output mode available. A tool
+argument MAY select the sibling mode when configuration permits in-place, and MUST
+NOT select in-place when configuration permits only sibling.
+
+#### Scenario: An agent requests in-place output against a sibling-only configuration
+- **WHEN** an edit requests in-place output on an instance configured for sibling output
+- **THEN** the system MUST refuse or produce sibling output
+- **AND** the source file MUST NOT be modified
+
+### Requirement: Lock contention is refused, not waited out
+The system MUST hold the WOPI lock inside the editing service for the whole
+session and MUST release it on every exit path, including timeout and error. When
+the document is already locked, the system MUST return a structured refusal. The
+system MUST NOT poll, queue, retry, or acquire a lock it does not already hold via
+`UnlockAndRelock`.
+
+#### Scenario: The document is open in an editor
+- **GIVEN** a document is locked by an active editing session
+- **WHEN** an edit is requested
+- **THEN** the system MUST return a structured refusal naming the condition
+- **AND** the system MUST NOT take over or break the existing lock
+
+#### Scenario: An edit fails partway through
+- **WHEN** an edit raises an error after the lock was acquired
+- **THEN** the lock MUST be released before the call returns
+- **AND** the document MUST NOT be left locked
+
+### Requirement: Edits address stable anchors, never positional indexes
+The system MUST address edits to stable block anchors. The system MUST NOT
+address edits by array index or byte offset into the document.
+
+#### Scenario: A paragraph was inserted before the targeted block
+- **GIVEN** an edit targets a block
+- **AND** a paragraph was inserted before that block since the anchors were computed
+- **THEN** the edit MUST still apply to the intended block, or MUST be refused
+- **AND** the edit MUST NOT be applied to a different block
+
+#### Scenario: An anchor can no longer be resolved
+- **WHEN** an edit's anchor cannot be resolved in the current document
+- **THEN** the system MUST refuse that edit with a structured error
+- **AND** the system MUST NOT guess a nearby block
+
+### Requirement: Untouched parts of a document package survive an edit unchanged
+The system MUST apply edits by mutating only the targeted nodes and rewriting only
+the affected package part, leaving every other entry in the document package
+byte-identical. The system MUST NOT parse a document to an intermediate model and
+re-serialise the whole package.
+
+#### Scenario: A document carrying comments and tracked changes is edited
+- **GIVEN** a document containing comments, tracked changes, a header and embedded objects
+- **WHEN** one paragraph is edited
+- **THEN** the comments, tracked changes, header and embedded objects MUST be present
+  and unchanged in the result
+
+### Requirement: Documents under signature or produced by anonymisation are not editable
+The system MUST refuse to edit a file referenced by a `signingRequest` in any state
+other than cancelled, and MUST refuse to edit anonymisation output.
+
+#### Scenario: An agent targets a document in a signature process
+- **WHEN** an edit targets a file referenced by an active or completed `signingRequest`
+- **THEN** the system MUST refuse the edit
+- **AND** the refusal MUST name the signature process as the reason
+
+#### Scenario: An agent targets a redacted document
+- **WHEN** an edit targets a document produced by the anonymisation pipeline
+- **THEN** the system MUST refuse the edit
+
+### Requirement: No document, attachment or signature bytes leave through this capability
+No response from the conversion or editing capability may contain document bytes,
+attachment bytes, or signature material. Responses MUST carry file identifiers,
+metadata and structured status only.
+
+#### Scenario: A conversion or edit completes
+- **WHEN** the operation returns
+- **THEN** the response MUST reference the produced file by identifier
+- **AND** the response MUST NOT embed the file's bytes
+
+### Requirement: Every produced file is marked as agent-authored at write time
+The system MUST apply a Nextcloud system tag identifying the file as agent-authored,
+in the same operation that writes the file. The system MUST NOT defer marking to a
+later pass. If the file is written but the mark cannot be applied, the operation
+MUST report failure.
+
+#### Scenario: A document is converted or edited
+- **WHEN** either tool produces a file
+- **THEN** the file MUST carry the agent-authored system tag from the moment it is
+  visible to the user
+- **AND** the tag MUST be visible in the Files interface
+
+#### Scenario: The mark cannot be applied
+- **GIVEN** the file was written
+- **WHEN** applying the tag fails
+- **THEN** the operation MUST report failure
+- **AND** the operation MUST NOT report success
+
+#### Scenario: A user removes the tag
+- **WHEN** a user removes the agent-authored tag from a file
+- **THEN** the system MUST NOT re-apply it
+- **AND** the authoritative record of the agent's write MUST remain in the
+  invocation record regardless
+
+### Requirement: Every produced file is recorded with its identity, and without its content
+The system MUST record each write with the identity of the produced file and the
+acting agent, so an operator reviewing an agent can locate what it changed. The
+record MUST NOT contain document content.
+
+#### Scenario: An operator reviews an agent's document activity
+- **WHEN** the agent's invocation records are reviewed
+- **THEN** each write MUST identify the file it produced and the agent that produced it
+- **AND** the record MUST NOT contain the document's contents
+
+### Requirement: Live in-editor manipulation is out of scope and non-portable when added
+The system MUST NOT make any capability reachable only through a single office
+suite's in-editor manipulation API. If live in-editor manipulation is added later,
+it MUST sit behind a capability probe, MUST be documented as suite-specific, and
+every capability it offers MUST also be reachable through the suite-independent
+path.
+
+#### Scenario: A capability is offered on one suite only
+- **WHEN** a capability is implemented against one office suite's in-editor API
+- **THEN** an equivalent capability MUST exist through the suite-independent path
+- **AND** an instance running a different supported suite MUST NOT lose the capability

--- a/openspec/changes/document-editing-tools/tasks.md
+++ b/openspec/changes/document-editing-tools/tasks.md
@@ -1,0 +1,44 @@
+# Tasks — document-editing-tools
+
+## 0. Phase 0 — measure before building (hard gate)
+
+- [ ] 0.1 Measure `w14:paraId` survival: author a `.docx` with known ids, round-trip it through Collabora (open, edit elsewhere in the doc, save), diff the attributes. Repeat for ODF `xml:id`. Record the result in design.md §Anchors and select native-id or content-hash anchoring accordingly.
+- [ ] 0.2 Determine from richdocuments' WOPI token issuance whether a background job can obtain a file-scoped token for its initiating user. If the only route is a service user with broad file access, STOP and raise an ADR before writing editing code.
+- [ ] 0.3 Stand up a WOPI host in the dev environment (richdocuments + an office app profile in `.github/docker-compose.yml`) — nothing below is testable without one.
+
+## 1. Conversion tool (no unknowns)
+
+- [ ] 1.1 Add `ConversionService::convertForAgent()` wrapping the existing `ConversionBackendInterface` cascade: resolve the file for the acting user, run the cascade, write the result as a new file, log a `generatedDocument` record. Report the claiming backend in the result.
+- [ ] 1.2 Annotate it `#[McpTool(name: 'convertDocument', scope: 'create', readOnlyHint: false, destructiveHint: false, idempotentHint: false, description: ...)]`; add the class to `DocudeskScannableServices`.
+- [ ] 1.3 Refuse with a structured error naming the source format when no backend claims the source→target pair. Never return a lower-fidelity result without reporting which backend produced it.
+
+## 2. WOPI editing session (gated on task 0)
+
+- [ ] 2.1 Add `lib/Service/Editing/WopiClient.php` — `CheckFileInfo`, `GetFile`, `PutFile`, `PutRelativeFile`, `Lock`, `RefreshLock`, `Unlock`. `UnlockAndRelock` is NOT implemented. `PutFile` MUST refuse unless the session's own lock is held AND `CheckFileInfo`'s `Version` is re-confirmed unchanged immediately before the write.
+- [ ] 2.2 Add `lib/Service/Editing/EditSessionService.php` owning lock lifetime with release in a `finally` on every exit path, including timeout and thrown-exception paths.
+- [ ] 2.3 Return a structured refusal on lock contention — no polling, no queueing, no retry loop.
+- [ ] 2.4 Add `lib/Service/Editing/PackageCodec.php` — parse the ODF/OOXML package, expose anchored blocks, apply edits by mutating only targeted nodes and rewriting only that package part, leaving every other entry byte-identical.
+- [ ] 2.5 Add `EditSessionService::editForAgent()` supporting both output modes — in-place (`PutFile`, default) and sibling (`PutRelativeFile`) — where configuration sets the ceiling and a tool argument may only narrow to sibling, never widen to in-place. Annotate `#[McpTool(name: 'editDocument', scope: 'update', readOnlyHint: false, destructiveHint: true, idempotentHint: false, description: ...)]`; extend `DocudeskScannableServices`.
+- [ ] 2.6 Enforce the refusals: reject a file referenced by a non-cancelled `signingRequest`; reject anonymisation output; return no document, attachment or signature bytes in any response.
+- [ ] 2.7 ADR-088 marking: apply a Nextcloud system tag via `ISystemTagManager` / `ISystemTagObjectMapper` in the SAME code path that writes the file (both tools), record the produced file id on the `generatedDocument` row and on Hermiq's `tool` trace step, and return FAILURE if the tag cannot be applied — never success on an unmarked file.
+
+## 3. Verify
+
+- [ ] 3.1 Probe test: on an instance with no reachable WOPI host, `CheckFileInfo` fails and the capability resolves absent with a visible degrade — not a silent success. Assert the probe is a real `CheckFileInfo`, not an installed-app-id check.
+- [ ] 3.2 Conversion verified twice: once with an office app registered in `IConversionManager`, once with the cascade falling through to PhpWord/mPDF. Assert the reported backend differs between the two runs.
+- [ ] 3.3 Portability run: exercise conversion against Collabora AND against Euro-Office with `wopi.enable` set true in `local.json`. If Euro-Office cannot be tested, remove the portability claim from the spec rather than ship it unmeasured.
+- [ ] 3.4 Assert both tool ids appear in the agent detail page's Tool governance grant editor (`ToolOversightController::toolCatalog()`) classified write, and that both are default-denied without an explicit exact-id grant.
+- [ ] 3.5 Concurrency + recovery controls for the in-place default, all three run: (a) a `Version` that moved between `GetFile` and `PutFile` REFUSES the write, proven with a forced mid-session change; (b) after an in-place edit a restorable prior Nextcloud file version exists — verified by restoring it, not by observing that versioning is enabled; (c) `grep -rn "UnlockAndRelock" lib/` returns nothing outside comments.
+- [ ] 3.6 Round-trip fidelity test: edit one paragraph of a document carrying comments, tracked changes and a header; assert all three survive byte-identical in the output package.
+- [ ] 3.7 Scoped `phpcs` clean on new/touched files; zero new PHPUnit failures vs a self-measured baseline; CHANGELOG entry.
+
+## Acceptance criteria
+
+- An agent can convert an existing document (producing a new file, source untouched) and edit an existing document (in place by default, with a restorable prior version; sibling output on request).
+- An in-place write is refused when the file changed between read and write, and the other writer's change survives intact.
+- Every produced file carries the agent-authored system tag at the moment it becomes visible, and a tagging failure surfaces as a failed operation rather than a silent success (verified by forcing the tag write to fail).
+- Every produced file's id appears in Hermiq's invocation record, so an operator can follow the record to the artefact; no document content appears there.
+- No per-suite backend class is added; conversion routes through `IConversionManager` and editing through one WOPI client (ADR-087).
+- Lock contention, missing WOPI host, unsupported format, signed document and anonymisation output each produce a distinct structured refusal.
+- Both tools are default-denied and approval-gated, and are visible with correct classification in Tool governance.
+- Comments, tracked changes and styles survive an edit round-trip.

--- a/openspec/changes/multi-format-editing-tools/design.md
+++ b/openspec/changes/multi-format-editing-tools/design.md
@@ -1,0 +1,154 @@
+# Design — multi-format-editing-tools
+
+Editing beyond text documents: spreadsheets, presentations, and whatever else the
+installed suite turns out to accept.
+
+## Declarative-vs-imperative decision (ADR-031)
+
+| Behaviour | Path | Rationale |
+|---|---|---|
+| Per-type codecs | **Imperative** — `Editing/Codec/*` | Byte manipulation of ODF/OOXML packages. Not expressible declaratively. |
+| WOPI session, locking, version precondition | **Imperative, REUSED** | Inherited unchanged from `document-editing-tools`. None of it is type-specific, and re-implementing it per type is how the two paths drift apart. |
+| Supported-type matrix | **Declarative** — a versioned declaration, re-measured per suite/version | A table of measured facts. Making it declarative is what makes it visibly stale when the suite changes. |
+| Record of what was produced | **Declarative** — existing `generatedDocument` | Unchanged. |
+
+No `x-openregister-{lifecycle,aggregations,calculations,notifications,relations,widgets}`
+block is added or modified.
+
+## One session, three codecs
+
+The layers `document-editing-tools` built are type-agnostic and are reused as-is:
+
+```
+CheckFileInfo → Lock → GetFile → [ codec ] → Version recheck → PutFile → Unlock
+                                     ↑
+              TextCodec | SpreadsheetCodec | PresentationCodec
+```
+
+Only the bracketed step varies. This matters more than it sounds: the lock
+discipline and the `Version` precondition are the controls that make an in-place
+write safe, and a per-type editing path that re-implemented them would eventually
+re-implement one of them wrongly.
+
+## Addressing, per type
+
+**Text** — block anchors, with the `w14:paraId` question that
+`document-editing-tools` Phase 0 answers.
+
+**Spreadsheet** — `Sheet!Cell`. This is the pleasant surprise of the change: a
+spreadsheet has no anchor problem. A cell address *is* a durable identity, and a
+human inserting a row above shifts the addresses of everything below in a way both
+the file format and the user's mental model already agree on. Nothing needs
+measuring.
+
+**Presentation** — slide id + shape id. Object ids are stable; **slide ORDER is
+not**. So an edit addresses a slide by id, never by "slide 4" — an agent told to
+fix the third slide must resolve that to an id at read time, and a reorder between
+read and write is caught by the same `Version` precondition that catches any other
+concurrent change.
+
+## The formula hazard
+
+This is the substance of the change.
+
+A cell holds either a literal or a formula, and a written literal replaces a
+formula with no visible difference. The sheet keeps rendering a number; it is
+simply a number that has stopped being computed. Worse, the loss propagates: every
+cell depending on it recalculates against the frozen literal, so a single
+careless write can shift a whole model while every individual cell still *looks*
+right.
+
+There is no equivalent in text editing, and it is not caught by any of the
+controls `document-editing-tools` established — the lock held, the version matched,
+the tag was applied, the trace recorded the file id. All of it green, and the
+budget is now wrong.
+
+So:
+
+- **Writing a literal into a formula cell is refused** unless the caller sets an
+  explicit `replaceFormula` intent for that cell. Not a global flag — per cell, so
+  a bulk write cannot quietly carry the permission along.
+- **Accepted writes report what recalculated.** The response names the cells whose
+  computed value changed as a consequence. "What else moved?" is the question a
+  spreadsheet edit raises, and an answer no other surface provides.
+- **A write that would produce an error value** (`#REF!`, `#DIV/0!`, `#VALUE!`) in
+  any dependent cell is reported, because an agent has no way to notice it and a
+  human reading a summary would not either.
+
+## The type matrix is measured
+
+The suites differ, and any table written here would be wrong by the next release:
+
+| | Collabora (LibreOffice lineage) | Euro-Office (ONLYOFFICE lineage) | LibreOffice desktop |
+|---|---|---|---|
+| Text / sheet / slides | ODF + OOXML | OOXML-native, ODF supported | all, but **no server seam** |
+| Legacy `.doc`/`.xls`/`.ppt` | strong | weaker | strong |
+| Draw (`.odg`) | yes | own diagram editor, different model | yes |
+| PDF | annotation / forms | dedicated PDF editor | — |
+
+Rather than encode that, the system **probes**: for each candidate type it asks the
+installed suite, through the same `CheckFileInfo` / `IConversionManager` seams
+ADR-087 already mandates, whether the type is actually editable here — and
+publishes the answer with the suite name and version it was measured against.
+
+The rule that follows is the one that keeps us honest: **an unprobed type is
+unsupported.** Not "probably fine because LibreOffice can open it".
+
+## ADR-087 §4 in practice
+
+Draw is the concrete case. If `.odg` editing works on Collabora and not on
+Euro-Office, then:
+
+- the capability is offered where it works and resolves **absent, visibly**, where
+  it does not;
+- no workflow, template or downstream feature may require it;
+- the spec says so, rather than leaving a Collabora-only capability to be
+  discovered by a Euro-Office tenant at the point of failure.
+
+## Refusals
+
+Extending the standing refusals in `document-editing-tools`, all still in force:
+
+- **No macro-bearing formats.** `.xlsm`, `.docm`, `.pptm` are refused on sight.
+  Writing into a file carrying VBA is a code-execution vector in document clothing.
+- **No formula overwrite without per-cell intent.**
+- **No PDF content editing.** Annotation and form-fill only — a PDF is a final-form
+  artefact, and silently rewriting its text produces something forgery-shaped.
+- **No database formats.** `.odb` is a database, not a document; it has no
+  meaningful "edit a cell" semantics and its backing store is not a package.
+- **No type inferred from extension.** Type is determined from content/MIME, since
+  a `.xlsx` that is actually a zip of something else is exactly the input that
+  should be refused rather than parsed.
+
+## Verification
+
+- Phase 0 is the **type-support probe**, run per suite, and its output is the
+  matrix. Until it runs, the supported set is empty rather than assumed.
+- The formula guard is proven with a **control pair**: a write to a formula cell
+  without intent is refused, and the same write with per-cell intent succeeds and
+  reports the recalculated cells. A guard nobody has watched refuse is a guard
+  nobody has tested.
+- Round-trip fidelity per type, on a file carrying the things a rebuild silently
+  drops: a spreadsheet with named ranges, conditional formatting and a pivot table;
+  a presentation with speaker notes, transitions and an embedded chart.
+- Portability: each type exercised against Collabora **and** Euro-Office. Any type
+  that cannot be exercised against both is published as suite-specific rather than
+  claimed as supported.
+
+## Seed data
+
+None. No OpenRegister schema is introduced or modified.
+
+## DEFERRED_QUESTIONS
+
+1. **Should CSV be editable, or convert-only?** CSV has no formulas, styles or
+   sheets, so "editing" it is line rewriting with none of this machinery.
+   Provisional decision: convert-only, not editable. Affects: the type matrix.
+2. **Does a presentation edit need to address speaker notes separately from slide
+   content?** They are different audiences on the same object. Provisional
+   decision: yes, as a distinct addressable region, since an agent asked to draft
+   talking points should never touch what is on screen. Affects: the presentation
+   addressing model.
+3. **How should a bulk spreadsheet write be bounded?** A single call could rewrite
+   ten thousand cells. Provisional decision: a per-call cell cap, refusing rather
+   than truncating. Affects: the tool's input schema and a spec requirement.

--- a/openspec/changes/multi-format-editing-tools/proposal.md
+++ b/openspec/changes/multi-format-editing-tools/proposal.md
@@ -1,0 +1,94 @@
+---
+kind: code
+depends_on:
+  - document-editing-tools
+---
+
+# Proposal: multi-format-editing-tools
+
+## Why
+
+`document-editing-tools` edits **text documents**. That is one third of what an
+office suite is for. The corpora these deployments actually hold are budgets,
+registers and calculations in spreadsheets, and council decks and briefings in
+presentations — and an assistant that can revise a letter but not correct a figure
+in the budget it refers to is a strange half-capability.
+
+Extending to those formats is **not** "the same codec with more MIME types", and
+that is the whole reason this is its own change. The addressing model — the thing
+`document-editing-tools` spent its Phase 0 measuring — is fundamentally different
+per type:
+
+| Type | How an edit is addressed | Anchor stability |
+|---|---|---|
+| Text | block anchors (`w14:paraId`, `xml:id`) | **the open question** — may not survive a save |
+| Spreadsheet | sheet name + cell address (`Budget!C14`) | **inherently stable** — an address is the identity |
+| Presentation | slide id + shape/placeholder id | stable per object, but slide *order* is not |
+
+Spreadsheets are therefore in one sense *easier* than text: there is no anchor
+problem to solve, because a cell address is already a durable identity that a
+human inserting a row updates for you. In another sense they are considerably more
+dangerous, for a reason that has no analogue in text:
+
+**A cell holds a formula, and a written value silently destroys it.** An agent
+asked to "correct the total to 41,200" that writes `41200` into a cell containing
+`=SUM(C2:C13)` has not corrected the total — it has removed the calculation, and
+the sheet now shows a number that will never update again. Nothing renders
+differently. Every dependent cell recalculates against the new literal, so the
+damage propagates silently through the model. This is the spreadsheet equivalent
+of the fluent-but-wrong transcript, and it needs the same treatment: make the
+failure impossible rather than unlikely.
+
+This change is **specified, not built**. It is written now so the format question
+is settled before `document-editing-tools` hardens a codec shape that only suits
+text.
+
+## What Changes
+
+- **Editing extends to spreadsheets and presentations**, addressed natively:
+  spreadsheets by sheet + cell address, presentations by slide + shape. The text
+  path's block anchors are not stretched to cover them.
+
+- **A formula is never overwritten by accident.** Writing a literal into a cell
+  that currently holds a formula is refused unless the caller states that intent
+  explicitly. The response reports which cells recalculated as a result of any
+  accepted write, because "what else changed?" is the question a spreadsheet edit
+  raises and nothing else answers.
+
+- **Macro-bearing formats are refused outright** — `.xlsm`, `.docm`, `.pptm`.
+  An agent writing into a file that carries VBA is a code-execution vector wearing
+  a document's clothes, and no use case here needs it.
+
+- **The supported-type matrix is MEASURED per suite, not declared.** The suites
+  genuinely differ — Collabora is LibreOffice, so it carries the full ODF set
+  including Draw (`.odg`) and legacy `.doc`/`.xls`/`.ppt`; Euro-Office's lineage is
+  OOXML-native with its own diagram and PDF editors; LibreOffice desktop has no
+  server seam at all. Rather than hard-code a table that will be wrong within a
+  release, the system probes what the *installed* suite actually accepts and
+  publishes the result, exactly as `document-editing-tools` probes WOPI with a real
+  `CheckFileInfo` rather than an app id.
+
+- **ADR-087 §4 is enforced, not assumed.** A type editable on only one suite MUST
+  NOT become the only path to a capability. If Draw editing works on Collabora and
+  not on Euro-Office, the feature is available there and *absent* — visibly — here,
+  and no workflow may depend on it.
+
+- **PDF is annotation and form-fill only**, never content rewriting. A PDF is a
+  final-form artefact; an agent editing its text is producing a forgery-shaped
+  object with no version history.
+
+## Capabilities
+
+**Modified Capabilities**
+- `document-editing` — extended from text documents to spreadsheets,
+  presentations and the measured remainder of the installed suite's type set.
+
+## Impact
+
+- Extends `lib/Service/Editing/` with per-type codecs behind one interface; the
+  WOPI session, lock discipline, `Version` precondition and ADR-088 marking from
+  `document-editing-tools` are reused unchanged, because none of them is
+  type-specific.
+- No new OpenRegister schema; no seed data.
+- **Not scheduled for implementation.** It depends on `document-editing-tools`
+  clearing its Phase 0 gate, and its own Phase 0 is the type-support probe.

--- a/openspec/changes/multi-format-editing-tools/specs/document-editing/spec.md
+++ b/openspec/changes/multi-format-editing-tools/specs/document-editing/spec.md
@@ -1,0 +1,142 @@
+# document-editing
+
+Delta: editing extends beyond text documents to spreadsheets, presentations and
+whatever else the installed office suite is measured to accept. The WOPI session,
+lock discipline, version precondition, ADR-088 marking and standing refusals
+declared by `document-editing-tools` are unchanged and apply to every type here.
+
+E2E note: every scenario below is a guard inside a codec or a session, reached
+only by an agent tool call. There is no page on which a refused formula overwrite
+or a rejected macro file becomes visible, so all carry a reason-bearing
+`@e2e exclude`. The browser-observable part of this capability — the grant surface
+and default-deny — is already covered by the tools change that introduced it.
+
+## ADDED Requirements
+
+### Requirement: Each document type is addressed by its own native identity
+The system MUST address spreadsheet edits by sheet name and cell address, and
+presentation edits by slide identifier and shape identifier. The system MUST NOT
+address a presentation slide by its ordinal position, because slide order is not
+stable across edits.
+
+#### Scenario: A spreadsheet cell is edited
+- **WHEN** an edit targets a spreadsheet cell
+- **THEN** it MUST be addressed by sheet name and cell address
+- **AND** a row inserted above it by a human MUST NOT cause the edit to land in a
+  different cell
+
+#### Scenario: A presentation slide is edited
+- **WHEN** an edit targets a slide
+- **THEN** it MUST be addressed by slide identifier
+- **AND** a slide reordered between read and write MUST NOT cause the edit to land
+  on a different slide
+
+@e2e exclude Addressing is internal to the codec and never rendered; a mis-addressed edit is observable only in the resulting package. Verified by round-trip codec tests.
+
+#### Scenario: Speaker notes are edited
+- **WHEN** an edit targets a slide's speaker notes
+- **THEN** the slide's visible content MUST be unchanged
+
+@e2e exclude Notes and content live in the same package and differ only by region; the assertion is a package diff, not a page observation.
+
+### Requirement: A formula is never replaced by a literal without explicit per-cell intent
+The system MUST refuse to write a literal value into a cell that currently holds a
+formula, unless the caller has declared that intent for that specific cell. A
+call-wide or global flag MUST NOT satisfy this requirement.
+
+#### Scenario: An agent writes a value into a formula cell
+- **GIVEN** a cell containing a formula
+- **WHEN** an edit writes a literal into it without per-cell intent
+- **THEN** the system MUST refuse the edit
+- **AND** the formula MUST remain intact
+
+#### Scenario: A bulk write includes one formula cell
+- **GIVEN** an edit writing to many cells, one of which holds a formula
+- **WHEN** intent was declared for a different cell
+- **THEN** the formula cell MUST still be refused
+- **AND** the intent declared elsewhere MUST NOT extend to it
+
+#### Scenario: Replacement is explicitly intended
+- **GIVEN** a cell containing a formula
+- **WHEN** an edit writes a literal into it WITH per-cell intent
+- **THEN** the write MUST proceed
+
+@e2e exclude A codec-level guard with no rendered surface. Verified by a control pair — the same write refused without intent and accepted with it — because a guard nobody has watched refuse is untested.
+
+### Requirement: A spreadsheet write reports what it caused to recalculate
+The system MUST report, for every accepted spreadsheet write, which cells' computed
+values changed as a consequence, and MUST report any dependent cell that became an
+error value.
+
+#### Scenario: A written value changes dependent cells
+- **WHEN** a spreadsheet write completes
+- **THEN** the response MUST identify the cells whose computed values changed
+
+#### Scenario: A write produces an error value downstream
+- **WHEN** a write causes a dependent cell to evaluate to an error
+- **THEN** the response MUST report that cell and its error
+- **AND** the system MUST NOT report the write as wholly successful without it
+
+@e2e exclude Recalculation is computed inside the codec/suite and reported in the tool response; there is no page that displays an agent's recalculation report.
+
+### Requirement: Supported types are measured per suite, never assumed
+The system MUST determine editability per type by probing the installed suite, and
+MUST publish the result with the suite name, suite version and probe date. A type
+that has not been probed MUST be treated as unsupported.
+
+#### Scenario: A type has not been probed
+- **WHEN** an edit targets a type absent from the measured declaration
+- **THEN** the system MUST refuse
+- **AND** the system MUST NOT infer support from the suite's documented format list
+
+#### Scenario: The suite is upgraded
+- **WHEN** the installed suite's version changes
+- **THEN** the existing declaration MUST NOT be presented as valid for the new version
+
+@e2e exclude The probe runs against a live suite at deploy/verify time and produces a declaration; asserting it in a browser would only re-read what the probe wrote.
+
+#### Scenario: A type is editable on one suite only
+- **GIVEN** a type the installed suite cannot edit but another supported suite can
+- **WHEN** the capability is resolved
+- **THEN** it MUST resolve as absent and be surfaced visibly
+- **AND** no other capability MUST require it
+
+@e2e exclude Requires two instances running different office suites; covered by the portability run in the change's verification rather than by a single-instance browser test.
+
+### Requirement: Macro-bearing, database and final-form documents are refused
+The system MUST refuse macro-bearing formats before parsing them, MUST refuse
+database formats, and MUST restrict PDF handling to annotation and form-fill. The
+system MUST determine a file's type from its content, never from its filename
+extension.
+
+#### Scenario: A macro-bearing file is targeted
+- **WHEN** an edit targets a file carrying macros
+- **THEN** the system MUST refuse before parsing the file
+
+#### Scenario: A file's extension misrepresents its content
+- **WHEN** a file's extension and actual content disagree
+- **THEN** the system MUST judge it on content
+- **AND** MUST NOT parse it as the type its extension claims
+
+#### Scenario: A PDF is targeted for content editing
+- **WHEN** an edit would rewrite a PDF's text content
+- **THEN** the system MUST refuse
+- **AND** annotation and form-fill MUST remain available
+
+@e2e exclude Refusals happen before any session opens, so nothing reaches a surface. Asserted directly against the refusal path.
+
+### Requirement: All types share one session, lock and marking path
+Spreadsheet and presentation edits MUST use the same WOPI session, lock discipline,
+version precondition and ADR-088 marking as text edits. A per-type editing path
+MUST NOT re-implement any of them.
+
+#### Scenario: A spreadsheet is edited in place
+- **WHEN** a spreadsheet edit completes in the default mode
+- **THEN** a restorable prior version MUST exist
+- **AND** the file MUST carry the agent-authored mark
+
+#### Scenario: The file changed between read and write
+- **WHEN** a spreadsheet or presentation changed since it was read
+- **THEN** the write MUST be refused on the same version precondition as a text edit
+
+@e2e exclude The session machinery is inherited unchanged from document-editing-tools and verified there; these scenarios assert that the new codecs reuse rather than replace it, which is a structural property asserted by test, not a browser observation.

--- a/openspec/changes/multi-format-editing-tools/tasks.md
+++ b/openspec/changes/multi-format-editing-tools/tasks.md
@@ -1,0 +1,48 @@
+# Tasks — multi-format-editing-tools
+
+> **Not scheduled for implementation.** This change is specified so the format
+> question is settled before `document-editing-tools` hardens a codec shape that
+> only suits text. It cannot start until that change clears its own Phase 0.
+
+## 0. Phase 0 — probe what the installed suite actually edits (hard gate)
+
+- [ ] 0.1 For each candidate type (odt/docx, ods/xlsx, odp/pptx, odg, csv, legacy doc/xls/ppt, pdf), probe the installed suite through `CheckFileInfo` and `IConversionManager` and record whether it is genuinely editable here — never inferred from the suite's marketing list.
+- [ ] 0.2 Publish the result as a versioned type-support declaration carrying the suite name, suite version and probe date. An unprobed type is UNSUPPORTED.
+- [ ] 0.3 Run the probe against Collabora AND Euro-Office. Any type editable on only one is published as suite-specific per ADR-087 §4, never as generally supported.
+
+## 1. Codec interface + spreadsheet
+
+- [ ] 1.1 Extract a `DocumentCodecInterface` (`supports(mime)`, `read(package)`, `applyEdits(package, edits)`) and move the existing text codec behind it, leaving the WOPI session, lock discipline, `Version` precondition and ADR-088 marking untouched and shared.
+- [ ] 1.2 Add `SpreadsheetCodec` addressing cells as `Sheet!Cell`. No block-anchor machinery — a cell address is already a durable identity.
+- [ ] 1.3 Refuse a literal write into a cell currently holding a formula unless the caller sets `replaceFormula` FOR THAT CELL. A per-call or global flag is not acceptable: a bulk write must not carry the permission along.
+- [ ] 1.4 Report, on every accepted spreadsheet write, which cells' computed values changed as a consequence, and flag any dependent cell that became an error value.
+- [ ] 1.5 Bound a single call's cell count, refusing rather than truncating when exceeded.
+
+## 2. Presentation
+
+- [ ] 2.1 Add `PresentationCodec` addressing slides by ID and shapes by ID — never by ordinal position, since slide order is not stable.
+- [ ] 2.2 Address speaker notes as a region distinct from slide content, so drafting talking points cannot alter what is on screen.
+
+## 3. Refusals
+
+- [ ] 3.1 Refuse macro-bearing formats (`.xlsm`, `.docm`, `.pptm`) on sight, before any parsing.
+- [ ] 3.2 Refuse `.odb`, and restrict PDF to annotation and form-fill — never content rewriting.
+- [ ] 3.3 Determine type from content/MIME, never from the filename extension.
+
+## 4. Verify
+
+- [ ] 4.1 Control pair on the formula guard: the same write is REFUSED without per-cell intent and SUCCEEDS with it, reporting the recalculated cells. Run both halves — a guard nobody has watched refuse is untested.
+- [ ] 4.2 Assert a dependent cell turning into `#REF!`/`#DIV/0!`/`#VALUE!` is reported rather than silently persisted.
+- [ ] 4.3 Spreadsheet round-trip fidelity on a file carrying named ranges, conditional formatting and a pivot table — all present and unchanged after a one-cell edit.
+- [ ] 4.4 Presentation round-trip fidelity on a deck carrying speaker notes, transitions and an embedded chart.
+- [ ] 4.5 Assert a macro-bearing file is refused before parsing, and that a mislabelled extension is judged on content.
+- [ ] 4.6 Assert a suite-specific type resolves ABSENT and visibly on a suite that lacks it, and that no other capability depends on it.
+- [ ] 4.7 Scoped `phpcs` clean; zero new PHPUnit failures vs a self-measured baseline; CHANGELOG entry recording the measured type matrix and the suite versions it was measured against.
+
+## Acceptance criteria
+
+- Spreadsheets and presentations are editable through the same WOPI session, lock discipline and ADR-088 marking as text documents — one session, three codecs, no duplicated safety machinery.
+- A formula cannot be destroyed by an agent writing a literal, and any write reports what recalculated.
+- Macro-bearing formats, `.odb`, and PDF content rewriting are all refused.
+- The supported-type set is a measured, dated, suite-pinned declaration; an unprobed type is unsupported.
+- A type editable on only one suite is published as suite-specific and is never the only path to a capability.


### PR DESCRIPTION
Two OpenSpec changes. **Spec-only** — no implementation in this PR.

## `document-editing-tools`

DocuDesk can generate documents (`docudesk-mcp-adoption`) but has nothing that acts on a document that **already exists**. Adds two curated tools:

- **`docudesk.convertDocument`** — wraps the `ConversionBackendInterface` cascade that already exists (`OfficeApp` → `LibreOfficeHeadless` → `PhpWord` → `mPDF`) and is reachable from the UI but not from an agent.
- **`docudesk.editDocument`** — WOPI session, anchored edits, writing **in place by default** so Nextcloud file versioning holds the undo and the document keeps one identity and one history. Sibling-file output is selectable.

### Why in-place needs three guards, not one

`PutFile` replaces the whole file and WOPI defines no merge semantics. So:

1. the lock is held across the **whole** read-modify-write, not re-acquired for the write;
2. `CheckFileInfo`'s `Version` is re-read immediately before `PutFile` and the write is **refused** if it moved — optimistic concurrency using a field the protocol already returns, closing the out-of-session race the lock alone does not;
3. the ADR-088 tag makes the change visible in Files rather than something the user must notice by reading.

That a WOPI `PutFile` actually produces a restorable Nextcloud version is **verified by restoring one**. It is the entire recovery story for the default mode, and a recovery path nobody has watched work is not a recovery path.

`editDocument` is classified `scope: update`, **`destructiveHint: true`** — it modifies a user's existing file, and declaring that honestly is what keeps it default-denied and approval-gated.

### Phase 0 is a hard gate

Two measurements, because finding either out after the codec is written is expensive:

- does Collabora preserve `w14:paraId` across a save? It decides native-id vs content-hash anchoring.
- can a headless agent obtain a file-scoped WOPI token at all? If the only route is a service user with broad file access, the change **stops and raises an ADR** — that is a privilege concentration, not an implementation detail.

## `multi-format-editing-tools`

Spreadsheets, presentations, and whatever else the installed suite is **measured** to accept. Written now so the format question is settled before a codec shape hardens around text alone. **Not scheduled to build.**

The point is that addressing differs fundamentally per type:

| Type | Addressed by | Anchor stability |
|---|---|---|
| Text | block anchors | the open Phase 0 question |
| Spreadsheet | `Sheet!Cell` | **inherently stable** — an address *is* the identity |
| Presentation | slide id + shape id | stable per object; slide *order* is not |

Spreadsheets have no anchor problem. They carry a different hazard instead, with no analogue in text:

> **A cell holds a formula, and a written literal silently destroys it.** An agent asked to "correct the total to 41,200" that writes `41200` over `=SUM(C2:C13)` has removed the calculation. Nothing renders differently, and every dependent cell now recalculates against a frozen number.

Every control from `document-editing-tools` would report green through that — lock held, version matched, tag applied, file id traced — and the budget would be wrong. So a formula is never replaced without **per-cell** intent (not a call-wide flag, which a bulk write would carry along), and every accepted write reports which cells recalculated and which became error values.

Also refused: macro-bearing formats (`.xlsm`/`.docm`/`.pptm` — writing into a file carrying VBA is a code-execution vector in document clothing), `.odb`, and PDF content rewriting (annotation and form-fill only).

## Shared discipline

Both changes take their capability sets from a **probe, not a vendor list**, per ADR-087 — a real `CheckFileInfo` rather than an installed app id, since Euro-Office ships WOPI disabled by default. An unprobed type is unsupported, and a type editable on only one suite is published as suite-specific and never becomes the only path to a capability.