### PR TITLE
fix(build): make local-lib opt-in and validate the sibling by semver

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,24 +66,49 @@ webpackConfig.entry = {
 // is present — without it a local build can never reproduce what CI and production
 // build (they have no sibling, so they always resolve the npm dist).
 //
-// ⚠️ USE_LOCAL_LIB is opt-OUT, and the shared apps-extra checkout of
-// nextcloud-vue sits on the Vue 2 (beta.*) line. Defaulting to "on" therefore
-// compiles Vue 2 library sources into this Vue 3 app, silently, with a clean
-// build. Guard on the sibling's MAJOR version instead of trusting the default:
-// a v1.x sibling is the Vue 2 line and must be ignored.
+// ⚠️ USE_LOCAL_LIB is opt-IN (ADR-090). Building against a developer's working
+// checkout is the wrong default for a build that can ship.
+//
+// The sibling is validated against THIS app's own declared range. The previous
+// test was `major < 2`, on the premise that a bad sibling would be 1.x. The
+// sibling today is 2.0.5 while this app declares 2.2.0-vue3.16 — both major 2 —
+// so the test waved through a version the app never asked for.
+//
+// The failure that skew produces is not obvious from the version alone. Building
+// against the sibling also pulls packages out of the SIBLING's node_modules, and
+// a stale vue-demi shim there (its postinstall picks v2/v2.7/v3 and does not
+// re-run on `npm install`) yields errors of the form
+//   export 'default' (imported as 'Vue') was not found in 'vue'
+// — a Vue-2-shaped failure from a library that is itself Vue 3.
+//
+// Fail CLOSED: if the check cannot run, the sibling is refused. A guard that
+// degrades to "allow" is not a guard.
 const localLib = path.resolve(__dirname, '../nextcloud-vue/src')
 const localLibPkg = path.resolve(__dirname, '../nextcloud-vue/package.json')
-let useLocalLib = process.env.USE_LOCAL_LIB !== 'false' && fs.existsSync(localLib)
-if (useLocalLib && fs.existsSync(localLibPkg)) {
-	const localVersion = String(
-		JSON.parse(fs.readFileSync(localLibPkg, 'utf8')).version || '',
-	)
-	const localMajor = parseInt(localVersion, 10)
-	if (!Number.isNaN(localMajor) && localMajor < 2) {
+let useLocalLib = process.env.USE_LOCAL_LIB === 'true' && fs.existsSync(localLib)
+if (useLocalLib) {
+	let localVersion = 'unreadable'
+	let satisfied = false
+	try {
+		// eslint-disable-next-line n/no-extraneous-require
+		const semver = require('semver')
+		const required =
+			require('./package.json').dependencies['@conduction/nextcloud-vue']
+		localVersion = String(
+			JSON.parse(fs.readFileSync(localLibPkg, 'utf8')).version || '',
+		)
+		satisfied = semver.satisfies(localVersion, required, {
+			includePrerelease: true,
+		})
+	} catch (e) {
+		satisfied = false
+	}
+
+	if (!satisfied) {
 		// eslint-disable-next-line no-console
 		console.warn(
 			`[docudesk] IGNORING sibling @conduction/nextcloud-vue@${localVersion} — `
-				+ 'that is the Vue 2 line and this app is Vue 3. Building against the npm dist.',
+				+ 'it does not satisfy this app\'s declared range. Building against the npm dist.',
 		)
 		useLocalLib = false
 	}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,7 +108,7 @@ if (useLocalLib) {
 		// eslint-disable-next-line no-console
 		console.warn(
 			`[docudesk] IGNORING sibling @conduction/nextcloud-vue@${localVersion} — `
-				+ 'it does not satisfy this app\'s declared range. Building against the npm dist.',
+				+ "it does not satisfy this app's declared range. Building against the npm dist.",
 		)
 		useLocalLib = false
 	}


### PR DESCRIPTION
## Two defects in the sibling-checkout guard

### 1. Polarity

`USE_LOCAL_LIB` was **opt-OUT** (`!== 'false'`), so with the variable unset — its normal state — the build used the sibling `../nextcloud-vue` checkout instead of the published package. Defaulting to a developer's working checkout is the wrong default for a build that can ship. Now opt-in.

Fleet context: this flag is opt-in in 3 apps and opt-out in 8 — the same name means opposite things depending on the repo.

### 2. The version test could not do its job

It keyed on the semver **major**, on the premise that a bad sibling would be `1.x`. The sibling today is `2.0.5` while this app declares `2.2.0-vue3.16` — **both major 2** — so it waved through a version the app never asked for.

## A correction worth reading

The earlier diagnosis was that the sibling is "the Vue 2 line" and that these apps were compiling Vue 2 sources into a Vue 3 app. **That was wrong.**

`../nextcloud-vue@2.0.5` declares `peerDependencies.vue: ^3.5.0` and its source uses `defineComponent` / `createApp` / `<script setup>`. **It is a Vue 3 library.**

The real cause of the 13 build errors is a **stale `vue-demi` shim inside the sibling's own `node_modules`** — vue-demi selects `v2`/`v2.7`/`v3` in a postinstall that does not re-run on `npm install`, and that checkout still has the **v2** shim (its `index.mjs` opens with `import Vue from 'vue'`; Vue 3 has no default export). Building from the sibling's *source* also resolves packages out of the *sibling's* `node_modules`, so the bad shim travels with it — a Vue-2-shaped error from a Vue 3 library.

## Why the fix is unaffected

That is the argument for validating against the **declared range** rather than a hand-rolled notion of which "line" a sibling is on: `2.0.5` does not satisfy `2.2.0-vue3.16`, so the sibling is refused regardless of *why* it would have broken.

**Fails closed.** An unrunnable check (semver unresolvable, package unreadable) refuses the sibling.

## Verification

- sibling `2.0.5` vs declared `2.2.0-vue3.16` → **refused**; `semver` resolvable in this app
- `npm run build` with no environment set compiles clean, exit 0, 0 errors

See ADR-090 ([hydra#582](https://github.com/ConductionNL/hydra/pull/582)). Sister PRs: [openregister#2505](https://github.com/ConductionNL/openregister/pull/2505), [softwarecatalog#517](https://github.com/ConductionNL/softwarecatalog/pull/517).
