### PR TITLE
docs(document-editing): Phase 0.1 measured — paraId does not survive Collabora

### DIFF
--- a/openspec/changes/document-editing-tools/design.md
+++ b/openspec/changes/document-editing-tools/design.md
@@ -114,10 +114,40 @@ with no error.
 
 Preference order, resolved at Phase 0 (see §Verification):
 
-1. **Native persistent ids** — OOXML `w14:paraId`, ODF `xml:id`. Purpose-built
-   for exactly this, *if* the suite preserves them.
-2. **Content-hash anchors** with a re-anchoring pass on every `open` — the
-   fallback if (1) does not survive a save.
+1. ~~**Native persistent ids** — OOXML `w14:paraId`, ODF `xml:id`.~~ **RULED OUT
+   BY MEASUREMENT, 2026-08-15.**
+2. **Content-hash anchors** with a re-anchoring pass on every `open` — now the
+   only option, not the fallback.
+
+### 🔴 Phase 0.1 result: `paraId` does NOT survive Collabora
+
+Measured, not inferred. A `.docx` carrying three known `w14:paraId` values was
+round-tripped through Collabora's own LibreOffice core (the `soffice` binary
+inside `richdocumentscode`'s `Collabora_Online.AppImage`, i.e. exactly the filter
+a save goes through):
+
+```
+BEFORE: ['1A2B3C4D', '5E6F7A8B', '9C0D1E2F']
+AFTER : []
+```
+
+All three paragraphs survived; **zero** `w14:` attributes did. The `w14`
+namespace is still *declared* in the output — which is the trap: a reader
+checking for the namespace would conclude the extension round-trips. It does not.
+Collabora's OOXML export drops Microsoft's extension attributes wholesale.
+
+**Consequences for the implementation:**
+
+- The codec MUST use content-hash anchors, and `open` MUST re-anchor every time.
+  There is no native id to fall back to.
+- An anchor computed before a Collabora save is void after it, so an edit session
+  cannot span a save it did not perform.
+- ODF `xml:id` is untested and cannot be assumed to behave differently — but it
+  does not rescue the `.docx` path either way, so it changes nothing about the
+  design.
+
+This is precisely why the gate existed: discovering it after the codec was built
+would have meant rewriting the addressing model rather than choosing it.
 
 This is the single largest unknown in the change and it is measured before any
 codec code is written. It is recorded as a known unknown in ADR-087.

--- a/openspec/changes/document-editing-tools/tasks.md
+++ b/openspec/changes/document-editing-tools/tasks.md
@@ -2,7 +2,7 @@
 
 ## 0. Phase 0 — measure before building (hard gate)
 
-- [ ] 0.1 Measure `w14:paraId` survival: author a `.docx` with known ids, round-trip it through Collabora (open, edit elsewhere in the doc, save), diff the attributes. Repeat for ODF `xml:id`. Record the result in design.md §Anchors and select native-id or content-hash anchoring accordingly.
+- [x] 0.1 ~~Measure `w14:paraId` survival.~~ **DONE 2026-08-15 — NEGATIVE.** Round-tripped a `.docx` with three known ids through Collabora's own `soffice` (inside `richdocumentscode`'s AppImage): all three paragraphs survived, **zero** `w14:` attributes did, while the `w14` namespace is still declared in the output. Native-id anchoring is ruled out; the codec MUST use content-hash anchors with a re-anchor on every `open`. See design.md §Phase 0.1 result.
 - [ ] 0.2 Determine from richdocuments' WOPI token issuance whether a background job can obtain a file-scoped token for its initiating user. If the only route is a service user with broad file access, STOP and raise an ADR before writing editing code.
 - [ ] 0.3 Stand up a WOPI host in the dev environment (richdocuments + an office app profile in `.github/docker-compose.yml`) — nothing below is testable without one.
 


### PR DESCRIPTION
The `document-editing-tools` Phase 0 gate is answered, and the answer is **negative**.

## What was measured

A `.docx` carrying three known `w14:paraId` values, round-tripped through **Collabora's own LibreOffice core** — the `soffice` binary inside `richdocumentscode`'s `Collabora_Online.AppImage`, i.e. exactly the filter a save goes through.

```
BEFORE: ['1A2B3C4D', '5E6F7A8B', '9C0D1E2F']
AFTER : []
```

All three paragraphs survived. **Zero** `w14:` attributes did.

## The trap worth recording

The `w14` **namespace is still declared** in the output. Anyone checking for the namespace rather than the attributes would conclude the extension round-trips. It does not — Collabora's OOXML export drops Microsoft's extension attributes wholesale.

## Consequences for the implementation

- The codec **must** use content-hash anchors, and `open` must re-anchor every time. There is no native id to fall back to.
- An anchor computed before a Collabora save is void after it, so an edit session cannot span a save it did not perform.
- ODF `xml:id` is untested, but it cannot rescue the `.docx` path either way, so it changes nothing about the design.

This is precisely what the gate existed for: finding it after the codec was built would have meant rewriting the addressing model rather than choosing it.

Doc-only — updates `design.md` §Anchors and ticks task 0.1.