### PR TITLE
fix(lint): clear all 6 tranche-A suppressions — every one a disable for a rule that does not exist

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -67,9 +67,6 @@
     }
   },
   "src/components/viewers/PdfViewer.vue": {
-    "import/no-unresolved": {
-      "count": 1
-    },
     "no-console": {
       "count": 1
     }
@@ -80,9 +77,6 @@
     }
   },
   "src/components/viewers/WordViewer.vue": {
-    "import/no-unresolved": {
-      "count": 1
-    },
     "no-console": {
       "count": 1
     }
@@ -113,12 +107,6 @@
     }
   },
   "src/entities/index.js": {
-    "import/export": {
-      "count": 1
-    },
-    "import/no-unresolved": {
-      "count": 1
-    },
     "n/no-missing-import": {
       "count": 1
     }
@@ -136,11 +124,6 @@
   "src/services/bases.js": {
     "no-unused-vars": {
       "count": 1
-    }
-  },
-  "src/services/fileViewerService.js": {
-    "import/no-unresolved": {
-      "count": 2
     }
   },
   "src/sidebars/FileViewerSidebar.vue": {

--- a/src/components/viewers/PdfViewer.vue
+++ b/src/components/viewers/PdfViewer.vue
@@ -41,7 +41,6 @@ let pdfjsLibPromise = null
 async function loadPdfjs() {
 	if (!pdfjsLibPromise) {
 		pdfjsLibPromise = (async () => {
-			// eslint-disable-next-line import/no-unresolved
 			const pdfjsLib = await import('pdfjs-dist/build/pdf.mjs')
 			const workerUrl = new URL(
 				'pdfjs-dist/build/pdf.worker.min.mjs',

--- a/src/components/viewers/WordViewer.vue
+++ b/src/components/viewers/WordViewer.vue
@@ -38,7 +38,6 @@ let mammothPromise = null
  */
 async function loadMammoth() {
 	if (!mammothPromise) {
-		// eslint-disable-next-line import/no-unresolved
 		mammothPromise = import('mammoth/mammoth.browser.js')
 	}
 	return mammothPromise

--- a/src/entities/index.js
+++ b/src/entities/index.js
@@ -1,4 +1,7 @@
-/* eslint-disable import/export, import/no-unresolved, n/no-missing-import */
+/* eslint-disable n/no-missing-import */
+// `import/export` and `import/no-unresolved` are NOT disabled here: the flat
+// config does not register either, so naming them made the comment itself an
+// error ('Definition for rule ... was not found').
 export * from './anonymization/index.js'
 export * from './report/index.js'
 export * from './template/index.js'

--- a/src/services/fileViewerService.js
+++ b/src/services/fileViewerService.js
@@ -113,7 +113,6 @@ let jsZipPromise = null
 async function loadPdfjs() {
 	if (!pdfjsLibPromise) {
 		pdfjsLibPromise = (async () => {
-			// eslint-disable-next-line import/no-unresolved
 			const pdfjsLib = await import('pdfjs-dist/build/pdf.mjs')
 			const workerUrl = new URL(
 				'pdfjs-dist/build/pdf.worker.min.mjs',
@@ -133,7 +132,6 @@ async function loadPdfjs() {
  */
 async function loadMammoth() {
 	if (!mammothPromise) {
-		// eslint-disable-next-line import/no-unresolved
 		mammothPromise = import('mammoth/mammoth.browser.js')
 	}
 	return mammothPromise


### PR DESCRIPTION
## What

Clears **all 6** of this repo's tranche-A eslint suppressions.

Every one was a disable comment for a rule the flat config does not register — `import/no-unresolved` or `import/export`. So each comment was **itself** the error:

```
Definition for rule 'import/no-unresolved' was not found
```

Six suppressions existed to silence six comments that existed to silence rules that are not there.

## Where they were

Four sat on deliberate dynamic imports the bundler resolves at runtime:

```js
const pdfjsLib = await import('pdfjs-dist/build/pdf.mjs')
mammothPromise = import('mammoth/mammoth.browser.js')
```

Removing the comments changes nothing about those imports.

The other two were part of a combined header in `entities/index.js`:

```js
/* eslint-disable import/export, import/no-unresolved, n/no-missing-import */
```

`n/no-missing-import` **is** registered and is kept — only the two dead names are dropped.

## Verification

| check | result |
|---|---|
| `npx eslint src` | **0 errors** (160 pre-existing warnings, unchanged) |
| `npm run build` | exit 0 |
| `npm test` | **77 passed**, 7 suites |
| suppressions | 180 → **174** |
