### PR TITLE
feat(office): probe WOPI instead of trusting that a suite is installed

### DIFF
--- a/docker-compose.office.yml
+++ b/docker-compose.office.yml
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: EUPL-1.2
+# SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+#
+##############################################################################
+# DocuDesk — office suite overlay
+#
+# Neither suite runs by default. Each sits behind its own profile:
+#
+#   docker compose -f docker-compose.office.yml --profile onlyoffice up -d
+#   docker compose -f docker-compose.office.yml --profile collabora up -d
+#
+# Why this file lives HERE and not in .github/docker-compose.yml:
+# `.github` is a separate repository shared by the whole fleet, and an office
+# suite is a DocuDesk concern. Putting it there would split one change across
+# two review surfaces and start a 3 GB image for apps that never touch a
+# document.
+#
+# DocuDesk does NOT require either suite. Reading and editing documents goes
+# through the in-package codec with no suite in the call path (ADR-087 §2).
+# These exist to (a) exercise the conversion cascade against a real provider
+# and (b) measure anchor stability across a real save round-trip, which
+# ADR-087 lists as a known unknown.
+#
+# See docs/office-suite-setup.md for the full walkthrough.
+##############################################################################
+
+networks:
+  default:
+    # The shared development stack's network, so `nextcloud` resolves by name
+    # from inside these containers and vice versa. Verified with
+    # `docker inspect nextcloud --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}'`
+    # rather than assumed — the compose project name does not determine it here.
+    name: conduction-network
+    external: true
+
+services:
+
+  # ===========================================================================
+  # Euro-Office / ONLYOFFICE Document Server
+  #
+  # Euro-Office is the ONLYOFFICE fork from the nine-company European
+  # consortium (GA 2026-06-09) and is now the engine behind Nextcloud Office.
+  # It is API-compatible with ONLYOFFICE Document Server, which is what runs
+  # here — the upstream image is public and the consortium build is not
+  # separately published for local development.
+  #
+  # ⚠️  WOPI IS DISABLED BY DEFAULT in Euro-Office's local.json. That is the
+  #     single most important fact in this file: the container starts, the
+  #     port answers, the Nextcloud admin page goes green, and WOPI serves
+  #     nothing. "The app is installed" is NOT the probe — a successful
+  #     CheckFileInfo is (ADR-087 §3).
+  # ===========================================================================
+  onlyoffice:
+    profiles:
+      - onlyoffice
+    container_name: docudesk-onlyoffice
+    image: onlyoffice/documentserver:latest
+    restart: unless-stopped
+    ports:
+      - "8092:80"
+    environment:
+      # No JWT in local development so the connector can be wired without
+      # sharing a secret. NEVER do this off a development host: with JWT off,
+      # anyone who can reach the port can ask the server to open any document
+      # it can fetch.
+      - JWT_ENABLED=false
+      - ALLOW_PRIVATE_IP_ADDRESS=true
+      - USE_UNAUTHORIZED_STORAGE=true
+      # WITHOUT THIS THE SERVER SERVES NO WOPI AT ALL.
+      # Measured on this image 2026-08-16: with it unset, the container is
+      # healthy, /healthcheck returns `true`, the welcome page 302s — and
+      # /hosting/discovery, /hosting/wopi/discovery and /hosting/capabilities
+      # all return 404, because default.json ships `"wopi": {"enable": false}`.
+      # That is the exact "installed, running, reachable, serves nothing"
+      # state ADR-087 §3 warns about, and it is why the capability is probed
+      # with a CheckFileInfo rather than by asking whether the app is enabled.
+      - WOPI_ENABLED=true
+    volumes:
+      - onlyoffice-data:/var/www/onlyoffice/Data
+      - onlyoffice-logs:/var/log/onlyoffice
+    healthcheck:
+      # /healthcheck returns the literal string `true` when the server is up.
+      # A 200 alone is not enough — the server answers the port well before
+      # its converters are ready.
+      test: ["CMD-SHELL", "curl -fsS http://localhost/healthcheck | grep -q true"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 90s
+
+  # ===========================================================================
+  # Collabora Online (CODE)
+  #
+  # LibreOffice-based, the incumbent Nextcloud Office engine, WOPI client.
+  # Unlike Euro-Office it serves WOPI out of the box.
+  # ===========================================================================
+  collabora:
+    profiles:
+      - collabora
+    container_name: docudesk-collabora
+    image: collabora/code:latest
+    restart: unless-stopped
+    ports:
+      - "9980:9980"
+    environment:
+      # The host Collabora will accept WOPI callbacks from. Regex, and the
+      # dots must be escaped or it will match far more than intended.
+      - aliasgroup1=http://nextcloud:80
+      - username=admin
+      - password=admin
+      - DONT_GEN_SSL_CERT=true
+      - extra_params=--o:ssl.enable=false --o:ssl.termination=true
+    cap_add:
+      - MKNOD
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9980/hosting/discovery | grep -q wopi"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+
+volumes:
+  onlyoffice-data:
+  onlyoffice-logs:

--- a/docs/office-suite-setup.md
+++ b/docs/office-suite-setup.md
@@ -1,0 +1,209 @@
+<!--
+SPDX-License-Identifier: EUPL-1.2
+SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+-->
+
+# Setting up an office suite for DocuDesk
+
+## Read this first: DocuDesk does not need one
+
+Reading a document, editing a paragraph, changing style, writing metadata and
+embedding a chart all go through DocuDesk's in-package codec. No office suite is in
+that call path (ADR-087 §2). If you install nothing from this document, those
+capabilities still work.
+
+An office suite adds two things:
+
+1. **Format conversion providers.** Each suite registers with Nextcloud's
+   `IConversionManager`, and DocuDesk's cascade picks up whatever is registered
+   (ADR-087 §1). Adding a suite is zero code.
+2. **Editing sessions over WOPI**, plus a realistic target for measuring what a real
+   save does to a document.
+
+A feature that only works when one named suite is present would be lock-in we
+authored ourselves, which is the thing Euro-Office exists to escape. If you find
+one, it is a bug — see the conformance test in
+`tests/Unit/Office/SuiteIndependenceTest.php`.
+
+---
+
+## The one thing that will waste your afternoon
+
+> **Euro-Office ships with WOPI disabled.**
+
+`wopi.enable` is `false` by default in Euro-Office's `local.json`. This means:
+
+- the container starts,
+- the port answers,
+- Nextcloud's admin page shows the server connected and **green**,
+- and WOPI serves nothing at all.
+
+Every "is it working?" check you would reach for by instinct — is the app enabled,
+is the container up, does the URL load — returns **yes** in exactly this state.
+That is why ADR-087 §3 says the probe is a successful `CheckFileInfo` and not
+anything else, and why DocuDesk's capability resolves **absent** unless it gets one.
+
+Verify with the probe (below), not with the admin page.
+
+---
+
+## Quick start
+
+Both suites live in `docker-compose.office.yml` in this repository, each behind its
+own profile. Neither starts by default.
+
+```bash
+# Euro-Office / ONLYOFFICE
+docker compose -f docker-compose.office.yml --profile onlyoffice up -d
+
+# Collabora
+docker compose -f docker-compose.office.yml --profile collabora up -d
+
+# Stop either
+docker compose -f docker-compose.office.yml --profile onlyoffice down
+```
+
+Both services join `conduction-network`, so `nextcloud` resolves by name from inside
+them and vice versa. If your stack uses a different network, change it in the
+overlay — check yours rather than assuming:
+
+```bash
+docker inspect nextcloud --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}'
+```
+
+---
+
+## Euro-Office / ONLYOFFICE
+
+Euro-Office is the ONLYOFFICE fork announced 2026-03-27 by a nine-company European
+consortium (IONOS, Nextcloud, Proton, XWiki, OpenProject, EuroStack, Soverin,
+Abilian, BTactic), GA 2026-06-09, and is now the engine behind Nextcloud Office. It
+is API-compatible with ONLYOFFICE Document Server, which is what the overlay runs —
+the upstream image is public, the consortium build is not separately published for
+local development.
+
+### 1. Start it
+
+```bash
+docker compose -f docker-compose.office.yml --profile onlyoffice up -d
+docker inspect docudesk-onlyoffice --format '{{.State.Health.Status}}'   # want: healthy
+```
+
+First boot takes 1–3 minutes. The port answers well before the converters are ready,
+which is why the healthcheck greps for the literal `true` from `/healthcheck` rather
+than accepting a 200.
+
+### 2. Connect Nextcloud
+
+```bash
+docker exec nextcloud php occ app:install onlyoffice
+docker exec nextcloud php occ app:enable onlyoffice
+docker exec nextcloud php occ config:app:set onlyoffice DocumentServerUrl \
+    --value="http://docudesk-onlyoffice/"
+```
+
+`DocumentServerUrl` is resolved **from inside the Nextcloud container**, so it is the
+container name — not `localhost:8092`, which from Nextcloud's perspective is
+Nextcloud itself. This is the same class of mistake as the Hermiq
+`mcp_run_base_url` trap: a browser-facing origin used where a container-internal one
+is needed, failing silently.
+
+### 3. Enable WOPI — the step that is not optional
+
+```bash
+docker exec nextcloud php occ config:app:set onlyoffice enableSharing --value="true"
+```
+
+For a Euro-Office deployment proper, set `wopi.enable` to `true` in the server's
+`local.json` and restart it. On the ONLYOFFICE image used here, WOPI is served at
+`/hosting/wopi` once the app is connected.
+
+### 4. Verify with the probe
+
+```bash
+docker exec nextcloud php occ docudesk:office:probe
+```
+
+Expected when it works:
+
+```
+WOPI: available (suite reported: ONLYOFFICE/Euro-Office)
+```
+
+Expected when the suite is installed but WOPI is off — the state this document
+exists to warn about:
+
+```
+WOPI: absent (probe failed: CheckFileInfo returned 404)
+```
+
+Note the second is a **success** of the probe, not a failure of it. Absent is the
+correct answer and the feature degrades visibly rather than failing in a user's
+hands.
+
+---
+
+## Collabora Online
+
+LibreOffice-based, the incumbent Nextcloud Office engine, and unlike Euro-Office it
+serves WOPI out of the box.
+
+### 1. Start it
+
+```bash
+docker compose -f docker-compose.office.yml --profile collabora up -d
+docker inspect docudesk-collabora --format '{{.State.Health.Status}}'    # want: healthy
+```
+
+### 2. Connect Nextcloud
+
+```bash
+docker exec nextcloud php occ app:install richdocuments
+docker exec nextcloud php occ app:enable richdocuments
+docker exec nextcloud php occ config:app:set richdocuments wopi_url \
+    --value="http://docudesk-collabora:9980"
+docker exec nextcloud php occ richdocuments:activate-config
+```
+
+### 3. The `aliasgroup1` regex
+
+`aliasgroup1` in the overlay tells Collabora which host it will accept WOPI
+callbacks from. It is a **regular expression**, so dots are wildcards unless
+escaped. An unescaped `aliasgroup1=http://nextcloud.local` also matches
+`http://nextcloudXlocal`. Escape them.
+
+### 4. Verify
+
+```bash
+docker exec nextcloud php occ docudesk:office:probe
+curl -s http://localhost:9980/hosting/discovery | head -5     # should be WOPI XML
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| Admin page green, editing fails | WOPI disabled. Euro-Office's default. Run the probe. |
+| Probe says absent, container healthy | `DocumentServerUrl` / `wopi_url` points at a browser origin. From inside Nextcloud, `localhost` is Nextcloud. |
+| Probe times out | The suite is on a different docker network. Check with `docker inspect`. |
+| Conversion works, sessions do not | Expected and fine. Conversion goes through `IConversionManager`; sessions need WOPI. |
+| `healthcheck` never goes healthy | First boot can take 3 minutes. After that, check `docker logs docudesk-onlyoffice`. |
+
+---
+
+## What is measured, and what is not
+
+DocuDesk carries a round-trip test that opens a document, has a real suite save it,
+re-reads it through `PackageCodec` and asserts which content-hash anchors still
+resolve. ADR-087 lists anchor stability as a **known unknown** and says to measure it
+before building on §2.
+
+That test reports three outcomes: `passed`, `failed`, and **`not run`**. The third is
+deliberate. A test that silently skips when no suite is present reports green, and a
+green "anchors survive" that never opened a document is worse than no test — it
+converts an open question into a false answer.
+
+If you are reading this because you want the measurement, start a suite first and
+check the test output says it ran.

--- a/lib/Service/Office/OfficeSuiteCapabilityService.php
+++ b/lib/Service/Office/OfficeSuiteCapabilityService.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * DocuDesk OfficeSuiteCapabilityService
+ *
+ * Determines whether a WOPI host is actually usable on this instance, by asking
+ * it rather than by asking whether an app is installed.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service\Office
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service\Office;
+
+use OCP\Http\Client\IClientService;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Probes WOPI availability with a real CheckFileInfo.
+ *
+ * ADR-087 §3: availability is capability-probed per instance, never assumed, and
+ * "the app is installed" is explicitly NOT the probe.
+ *
+ * That is not a theoretical caution. Measured against onlyoffice/documentserver on
+ * 2026-08-16, with WOPI left at its shipped default:
+ *
+ *   container health .......... healthy
+ *   GET /healthcheck .......... 200, body `true`
+ *   GET / ..................... 302 (serving)
+ *   GET /hosting/discovery .... 404
+ *   GET /hosting/wopi/discovery 404
+ *   GET /hosting/capabilities . 404
+ *   default.json .............. "wopi": { "enable": false }
+ *
+ * Every check a person reaches for by instinct — is it up, does the port answer,
+ * is the admin page green — returns YES in that state, and WOPI serves nothing.
+ * Only asking WOPI a WOPI question separates the two.
+ *
+ * The probe therefore fails CLOSED. A wrong "absent" hides a feature that would
+ * have worked; a wrong "available" ships a control that fails in a user's hands,
+ * and the second is much the more expensive mistake.
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service\Office
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ *
+ * @spec openspec/specs/office-suite-portability/spec.md
+ */
+class OfficeSuiteCapabilityService {
+
+	/**
+	 * Fields a CheckFileInfo response must carry to be usable.
+	 *
+	 * WOPI defines both as required. A 2xx body lacking either cannot support a
+	 * session, so treating the status alone as success would report available for
+	 * a host that cannot serve one.
+	 *
+	 * @var string[]
+	 */
+	private const REQUIRED_FIELDS = ['BaseFileName', 'Size'];
+
+	/**
+	 * Probe timeout in seconds.
+	 *
+	 * Bounded because the probe can run inside a user-facing request. An
+	 * unreachable host must cost a bounded wait and then resolve absent, never
+	 * hang the response.
+	 *
+	 * @var int
+	 */
+	private const TIMEOUT_SECONDS = 5;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IClientService  $clientService The HTTP client factory.
+	 * @param LoggerInterface $logger        The logger.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly IClientService $clientService,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Probe a WOPI host.
+	 *
+	 * @param string $checkFileInfoUrl Absolute CheckFileInfo URL to probe.
+	 *
+	 * @return array{available:bool, reason:string, suite:string|null} The verdict.
+	 *
+	 * @spec openspec/specs/office-suite-portability/spec.md
+	 */
+	public function probe(string $checkFileInfoUrl): array {
+		if (trim($checkFileInfoUrl) === '') {
+			return $this->absent(reason: 'no WOPI endpoint configured');
+		}
+
+		try {
+			$response = $this->clientService->newClient()->get(
+				$checkFileInfoUrl,
+				[
+					'timeout'         => self::TIMEOUT_SECONDS,
+					'connect_timeout' => self::TIMEOUT_SECONDS,
+					// A redirect to a login page is not a CheckFileInfo response.
+					'allow_redirects' => false,
+					// Handle the status ourselves so a 404 is a verdict, not an
+					// exception indistinguishable from a network failure.
+					'http_errors'     => false,
+				]
+			);
+		} catch (Throwable $e) {
+			// Refused, DNS failure, TLS failure, timeout. All absent.
+			return $this->absent(reason: 'probe could not complete: ' . $e->getMessage());
+		}
+
+		$status = $response->getStatusCode();
+		if ($status < 200 || $status >= 300) {
+			// The measured Euro-Office default lands exactly here, with 404.
+			return $this->absent(reason: sprintf('CheckFileInfo returned %d', $status));
+		}
+
+		$decoded = json_decode((string)$response->getBody(), true);
+		if (is_array($decoded) === false) {
+			// A 200 can be an error page or a login redirect body.
+			return $this->absent(reason: 'CheckFileInfo returned a non-JSON body');
+		}
+
+		foreach (self::REQUIRED_FIELDS as $field) {
+			if (array_key_exists($field, $decoded) === false) {
+				return $this->absent(
+					reason: sprintf('CheckFileInfo response is missing the required field "%s"', $field)
+				);
+			}
+		}
+
+		return [
+			'available' => true,
+			'reason'    => 'CheckFileInfo succeeded',
+			'suite'     => $this->identifySuite(payload: $decoded),
+		];
+	}//end probe()
+
+	/**
+	 * Build an absent verdict and record why.
+	 *
+	 * The reason is retained rather than collapsed to a boolean because "no suite
+	 * installed" and "suite installed with WOPI disabled" need different actions
+	 * from an operator, and the second is invisible from every other angle.
+	 *
+	 * @param string $reason Why the probe resolved absent.
+	 *
+	 * @return array{available:bool, reason:string, suite:string|null} The verdict.
+	 */
+	private function absent(string $reason): array {
+		$this->logger->debug(
+			'[DocuDesk] WOPI capability resolved absent: ' . $reason,
+			['app' => 'docudesk']
+		);
+
+		return [
+			'available' => false,
+			'reason'    => $reason,
+			'suite'     => null,
+		];
+	}//end absent()
+
+	/**
+	 * Name the responding suite when it identifies itself.
+	 *
+	 * Reporting only. Nothing in DocuDesk branches on which suite answered — a
+	 * capability that behaved differently per suite would be the per-suite driver
+	 * set ADR-087 §5 bans.
+	 *
+	 * @param array $payload The decoded CheckFileInfo response.
+	 *
+	 * @return string|null The suite name, or null when it did not say.
+	 */
+	private function identifySuite(array $payload): ?string {
+		$claimed = ($payload['BreadcrumbBrandName'] ?? ($payload['HostEditUrl'] ?? null));
+		if (is_string($claimed) === false || $claimed === '') {
+			return null;
+		}
+
+		return $claimed;
+	}//end identifySuite()
+}//end class

--- a/openspec/changes/office-suite-portability/.openspec.yaml
+++ b/openspec/changes/office-suite-portability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/openspec/changes/office-suite-portability/design.md
+++ b/openspec/changes/office-suite-portability/design.md
@@ -1,0 +1,145 @@
+## Context
+
+DocuDesk's document path does not use an office suite. `PackageCodec` opens the
+ODF/OOXML package, rewrites the targeted paragraph's byte range, and leaves every
+other part byte-identical. Nothing in that path talks to Collabora, ONLYOFFICE or
+LibreOffice. Conversion is the only place a suite participates, and it participates
+through `IConversionManager`, which Nextcloud brokers.
+
+That means portability is mostly a property the code *already has* — and an
+unguarded, unmeasured one. Three concrete gaps:
+
+1. **No probe exists.** `grep -rl 'CheckFileInfo\|wopi' lib/` returns nothing, so
+   there is no code that could tell an installed-but-disabled suite from a working
+   one.
+2. **Nothing prevents regression.** `richdocuments` appears in `lib/` only in
+   comments today. That is a fact about HEAD, not a constraint.
+3. **The round-trip has never happened.** ADR-087 lists anchor stability as a known
+   unknown and says to measure it. Content-hash anchors were chosen *because*
+   `w14:paraId` was expected to be regenerated on save — but "expected" is the
+   operative word.
+
+One further constraint shapes where things go: `.github/` is a **separate
+repository**, mounted here as a submodule. Adding office-suite services to the fleet
+compose would put a DocuDesk concern into a shared repo and split this change across
+two review surfaces.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A capability that is honest about whether WOPI actually works on this instance.
+- A guard that keeps §5 true rather than merely observing that it is true.
+- A reproducible environment for both suites, opt-in.
+- The anchor-stability measurement ADR-087 asked for, reported honestly either way.
+
+**Non-Goals:**
+
+- Building a WOPI client. DocuDesk edits packages directly; it does not need a WOPI
+  session, and ADR-087 §3 governs sessions we do not currently open. The probe
+  reports availability for the *feature-gating* purpose ADR-075 §4 describes.
+- Live in-editor manipulation (Collabora `postMessage` / ONLYOFFICE plugin API).
+  ADR-087 §4 permits it as a non-portable enhancement; it is not required, and
+  building it would create the lock-in the ADR exists to avoid.
+- Supporting a fourth suite explicitly. Under §1 that is no work: a suite that
+  registers with `IConversionManager` is picked up by the cascade.
+- Changing `PackageCodec` or the conversion cascade.
+
+## Decisions
+
+### D1 — The probe is `CheckFileInfo`, and everything short of it is "absent"
+
+Availability is the conjunction of: the endpoint answers, the status is 2xx, the
+body parses as JSON, and the body carries the fields `CheckFileInfo` is defined to
+return (`BaseFileName`, `Size`).
+
+Each weaker check was considered and rejected:
+
+- *App id enabled* — Euro-Office ships `wopi.enable: false`; installed proves nothing.
+- *Port reachable* — a running document server with WOPI off answers the port.
+- *Any 2xx* — an error page or a login redirect can be a 200.
+
+Failing to absent rather than to available is deliberate. A wrong "absent" hides a
+feature that would have worked; a wrong "available" ships a control that fails in a
+user's hands. This project has met the second failure repeatedly and it is the more
+expensive one.
+
+### D2 — The §5 guard is a test, not a gate
+
+A hydra gate would live in `.github`, a separate repo, and would apply fleet-wide to
+apps that legitimately *are* an office integration. The constraint is DocuDesk's, so
+it lives in DocuDesk's suite.
+
+The check must ignore comments. A file explaining *why* it does not depend on
+`richdocuments` — which `EditSessionService` does at length, because the WOPI lock
+reasoning is not obvious — must not be flagged. A naive `grep richdocuments lib/`
+would fail today against correct code, and the natural response to that would be to
+delete the explanation, making the codebase worse.
+
+### D3 — Compose overlay in this repo, both suites, neither by default
+
+`docker-compose.office.yml` here rather than in `.github/`. Two profiles,
+`collabora` and `onlyoffice`, so a developer opts into one, the other, or neither.
+Nothing changes for anyone who does not ask for it — which matters because
+ONLYOFFICE is ~1.5 GB and this host runs 30 containers already.
+
+### D4 — The round-trip test reports three outcomes, not two
+
+`passed` / `failed` / **`not run`**. The third is the point.
+
+A test that silently skips when no suite is present reports green, and a green
+"anchors survive the round-trip" that never opened a document is worse than no test:
+it converts an open question into a false answer. The distinction must survive into
+the output a human reads, not only into an internal state.
+
+This is the same shape as the E2E session gate already in this repo, which skips
+only on a specific, named cause and throws on every other.
+
+### D5 — Measure, then report, including a negative result
+
+If content-hash anchors do **not** survive an ONLYOFFICE round-trip, that is a
+finding about `PackageCodec`'s anchoring strategy and it gets written down as one.
+The purpose of the measurement is to replace an assumption, and an assumption is
+equally replaced by a disappointing answer.
+
+If ONLYOFFICE cannot be brought up on this host at all — a real possibility, since
+Docker-on-WSL has silently emptied bind mounts here before — the arm is recorded as
+unmeasured. ADR-087's own instruction for an unverified portability claim is to drop
+the claim, not to ship it.
+
+## Seed Data (ADR-001)
+
+**None.** This change introduces and modifies no OpenRegister schemas. Its fixtures
+are a single `.docx` used by the round-trip test, already present in the E2E suite.
+
+## Declarative-vs-imperative decision (ADR-031)
+
+| Behaviour | Path | Rationale |
+|---|---|---|
+| WOPI capability probe | **Imperative** | A side-effecting call across an instance boundary — the ADR-031 external-integration exception, named explicitly in ADR-087's own closing note. |
+| §5 conformance check | **Imperative** | A test over source files; not a runtime behaviour at all. |
+
+No behaviour here matches a declarative category (lifecycle, aggregation, derived
+field, notification, relation, widget), so no `lib/Settings/docudesk_register.json`
+patch is appropriate.
+
+## Risks / Trade-offs
+
+**ONLYOFFICE may not come up on this host.** ~1.5 GB image, 30 containers already
+running, and a Docker-on-WSL history of silently emptying bind mounts. Mitigation is
+D4: the test distinguishes *not run* from *passed*, so a failure to launch produces
+an honest gap rather than a false green.
+
+**The probe adds a network call to a capability resolution.** Bounded by an explicit
+timeout and resolving absent on expiry. It must never sit on a hot path
+uncached — and note that no app in this fleet resolves configuration on app load, so
+the probe must not either.
+
+**A negative anchor-stability result would be expensive.** If anchors do not survive,
+the anchored-edit design needs a re-anchoring pass. That cost is real, but it is
+already owed — ADR-087 has been carrying it as a known unknown, and discovering it
+in a test is far cheaper than discovering it in a user's document.
+
+**Two suites doubles the setup surface to keep current.** Accepted: the alternative
+is documenting one and claiming portability to the other, which is the claim this
+change exists to stop making.

--- a/openspec/changes/office-suite-portability/proposal.md
+++ b/openspec/changes/office-suite-portability/proposal.md
@@ -1,0 +1,156 @@
+---
+kind: code
+---
+
+## Why
+
+ADR-087 decides that office-suite divergence is **brokered, not driven**: conversion
+goes through `IConversionManager`, format manipulation is suite-independent, editing
+sessions use WOPI and only WOPI, and availability is *capability-probed per instance,
+never assumed*. DocuDesk was built to that decision. None of it has been measured
+against a second suite.
+
+Two of the four clauses already hold, and were verified rather than assumed:
+
+| ADR-087 clause | State at HEAD |
+|---|---|
+| §1 conversion brokers through `IConversionManager` | **Holds.** `Service/Conversion/OfficeAppBackend.php` dispatches through it, with a declared cascade behind it. |
+| §2 manipulation is suite-independent | **Holds.** `Service/Editing/PackageCodec.php` edits package XML in place; no suite is in the call path. |
+| §3 availability is capability-probed | **Absent.** There is no probe of any kind. `grep -rl 'CheckFileInfo\|wopi' lib/` returns nothing. |
+| §5 no hard dependency on a suite's app id | **Holds, unguarded.** Verified across `lib/` **and** `src/` by a tokeniser-based scan, not a grep. Nothing stops the next change reintroducing it. |
+
+> The §5 row originally said "verified in `lib/`". That was an incomplete check — the
+> conformance test, once written, immediately flagged `src/views/settings/Settings.vue`,
+> which `lib/`-only grepping never looked at. The flag turned out to be a false positive
+> (a translated `t()` label listing which suites give the best fidelity), but the
+> narrower evidence would have supported the claim for the wrong reason.
+
+So the gap is not the architecture. It is that **the portability claim has never been
+exercised**, and that ADR-087 §3 names the exact trap: *"Euro-Office ships WOPI
+disabled, so 'the app is installed' is not the probe — a successful `CheckFileInfo`
+is."* A codebase with no probe at all cannot make that distinction, and the failure
+mode is the one this project keeps meeting — a capability that reports available and
+then does nothing.
+
+ADR-087 also records anchor stability as a **known unknown**: whether a suite
+preserves paragraph identity across a save round-trip *"has not been measured.
+Measure before building on §2."* DocuDesk already builds on §2, using content-hash
+anchors rather than `w14:paraId` precisely because the latter was expected not to
+survive. That expectation is still an expectation.
+
+Finally, neither suite has any setup documentation in this repo, so a developer
+cannot reproduce the environment the claim is about.
+
+## What Changes
+
+- **`OfficeSuiteCapabilityService`** probing WOPI by issuing a real `CheckFileInfo`
+  and treating anything short of a well-formed success as *absent*. Installed-but-
+  disabled resolves absent, which is Euro-Office's shipped default.
+- The probe result is surfaced as a capability so the feature degrades **visibly**
+  per ADR-075 §4, rather than failing at use time.
+- **A conformance test locking §5**: no `lib/` or `src/` path may name a suite's app
+  id outside a comment. This currently passes; the test is what keeps it passing.
+- **`docker-compose.office.yml`** in this repo — an overlay adding both
+  `onlyoffice/documentserver` and `collabora/code`, each behind its own profile.
+  Deliberately NOT added to the fleet `.github/docker-compose.yml`: an office suite
+  is a DocuDesk concern, and `.github` is a separate repository.
+- **`docs/office-suite-setup.md`** covering Collabora **and** Euro-Office/ONLYOFFICE
+  end to end — bring-up, connector configuration, the `wopi.enable` default that
+  makes Euro-Office look installed-but-inert, and how to verify with the probe rather
+  than by eye.
+- **The measurement ADR-087 asks for**: open a `.docx` in a non-Collabora suite, save
+  it through that suite, re-read it with `PackageCodec`, and record whether
+  content-hash anchors survive. The result is reported whichever way it lands.
+
+## What was measured (2026-08-16, live ONLYOFFICE 3.32 GB image)
+
+### ADR-087 §3 is correct, and the failure mode is exactly as described
+
+Same container, same health, same port. The only variable is `wopi.enable`:
+
+| Signal | `WOPI_ENABLED` unset (shipped default) | `WOPI_ENABLED=true` |
+|---|---|---|
+| container health | `healthy` | `healthy` |
+| `GET /healthcheck` from Nextcloud | `200`, body `true` | `200`, body `true` |
+| `GET /` | `302` (serving) | `302` (serving) |
+| `GET /hosting/discovery` | **404** | **200** |
+| `GET /hosting/capabilities` | **404** | **200** |
+| `default.json` | `"wopi": {"enable": false}` | `"enable": true` |
+
+Every instinctive "is it working?" check returns yes in the left-hand column while
+WOPI serves nothing. That is the case for probing with a `CheckFileInfo`, now
+demonstrated rather than argued.
+
+### Anchor stability: content-hash anchors SURVIVE a real re-serialisation
+
+ADR-087's known unknown, measured.
+
+**First attempt was vacuous and is reported because it is the more useful half.** A
+`docx → docx` conversion returned a file 1172 → 1394 bytes, which looks like a
+rewrite. Comparing every package part by md5 showed **all four identical** — the
+size delta was ZIP container overhead. ONLYOFFICE had passed the file through
+without parsing it. "Anchors survived" was true and meaningless.
+
+A `docx → odt → docx` round-trip forces the engine to parse and re-serialise:
+
+```
+word/document.xml before: 1599 bytes  md5 9a714c548b
+word/document.xml after : 2590 bytes  md5 bfbd74955b     REWRITTEN
+package parts: 14 -> 17
+```
+
+Against that genuinely-rewritten document, read back through the real
+`PackageCodec`:
+
+```
+before                              after
+b9f931ca9-1  Subsidiebesluit 2026   b9f931ca9-1  Subsidiebesluit 2026
+b1a7a4f16-1  ...eight weeks.        b1a7a4f16-1  ...eight weeks.
+bd36e1657-1  ...bold run...         bd36e1657-1  ...bold run...
+b94c4021b-1  Kind regards,          b94c4021b-1  Kind regards,
+b1a7a4f16-2  ...eight weeks.        b1a7a4f16-2  ...eight weeks.
+```
+
+All five identical, **including the occurrence ordinal** on the deliberately
+duplicated paragraph. The bold run survived.
+
+### `w14:paraId` is not merely unstable — it is often absent
+
+Neither the input nor the output carried a single `w14:paraId`. PhpWord does not
+emit them and ONLYOFFICE did not add them. So this run does **not** answer "does
+`paraId` survive a save"; it answers something more decisive for the design — an
+anchor scheme built on `paraId` would have had **nothing to anchor to at all** on an
+ordinarily-generated document.
+
+### The honest limits of this measurement
+
+- It used the **conversion service**, not a WOPI `PutFile` from an editing session.
+  That is the engine genuinely parsing and re-serialising, which is the strongest
+  proxy available without minting per-file WOPI tokens — but it is not literally a
+  user pressing save.
+- One document, one suite, one format pair. Collabora is **not** measured here.
+
+## Capabilities
+
+### New Capabilities
+- `office-suite-portability`: how DocuDesk detects an office suite, what it refuses
+  to assume, and what is guaranteed to work without any suite present.
+
+### Modified Capabilities
+
+None. ADR-087 §1/§2 already hold in code, and this change adds their guard rather
+than changing their behaviour.
+
+## Impact
+
+- **Code**: new `lib/Service/Office/OfficeSuiteCapabilityService.php`; capability
+  registration in the existing bootstrap; no change to `PackageCodec` or the
+  conversion cascade.
+- **Infra**: new `docker-compose.office.yml` in this repo. ~1.5 GB image for
+  ONLYOFFICE, opt-in behind a profile, off by default.
+- **Docs**: new `docs/office-suite-setup.md`.
+- **Risk carried explicitly**: the round-trip measurement depends on the ONLYOFFICE
+  container running on this host. If it cannot be brought up, the anchor-stability
+  result MUST be recorded as *unmeasured* — ADR-087's own instruction is to drop an
+  unverified claim rather than ship it, and an unmeasured arm reported as passing is
+  the failure this change exists to prevent.

--- a/openspec/changes/office-suite-portability/specs/office-suite-portability/spec.md
+++ b/openspec/changes/office-suite-portability/specs/office-suite-portability/spec.md
@@ -1,0 +1,137 @@
+## ADDED Requirements
+
+### Requirement: WOPI availability MUST be probed, never inferred from installation
+
+The system MUST determine WOPI availability by issuing a real `CheckFileInfo`
+request and treating only a well-formed success as *available*. The presence of an
+office app — its app id being enabled, its container running, its port answering —
+MUST NOT be accepted as evidence.
+
+This is not a hypothetical distinction. Euro-Office ships `wopi.enable` **false** in
+`local.json`, so an installed, running, reachable Euro-Office serves no WOPI at all.
+An "is the app installed" check reports available and every subsequent editing
+session fails at use time.
+
+A probe that cannot complete — connection refused, timeout, non-2xx, unparseable
+body, or a 2xx body missing the required `BaseFileName` / `Size` fields — MUST
+resolve **absent**. Absent is the safe answer: it degrades the feature visibly per
+ADR-075 §4, whereas a wrong "available" produces a capability that exists in the UI
+and fails in the hands of a user.
+
+#### Scenario: An installed suite with WOPI disabled resolves absent
+
+- **GIVEN** an office suite app is installed and enabled
+- **AND** its WOPI endpoint is disabled, as Euro-Office ships by default
+- **WHEN** the capability is probed
+- **THEN** the capability MUST resolve absent
+- **AND** the reason MUST record that the probe failed, not that the app was missing
+
+#### Scenario: A reachable endpoint returning a malformed body resolves absent
+
+- **GIVEN** the WOPI endpoint answers `200 OK` with a body that is not valid JSON
+- **WHEN** the capability is probed
+- **THEN** the capability MUST resolve absent
+- **AND** the system MUST NOT treat the 2xx status alone as success
+
+#### Scenario: A 2xx body missing required fields resolves absent
+
+- **GIVEN** the WOPI endpoint returns valid JSON lacking `BaseFileName`
+- **WHEN** the capability is probed
+- **THEN** the capability MUST resolve absent, because a `CheckFileInfo` response without the fields the protocol requires cannot support a session
+
+#### Scenario: A genuine CheckFileInfo success resolves available
+
+- **GIVEN** the WOPI endpoint returns `200 OK` with a JSON body carrying `BaseFileName` and `Size`
+- **WHEN** the capability is probed
+- **THEN** the capability MUST resolve available
+- **AND** the probe MUST record which suite answered, when the suite identifies itself
+
+#### Scenario: The probe never blocks the request that triggered it
+
+- **GIVEN** a WOPI endpoint that does not answer
+- **WHEN** the capability is probed during a user-facing request
+- **THEN** the probe MUST time out within a bounded interval and resolve absent
+- **AND** MUST NOT propagate the failure as an error to the caller
+
+### Requirement: No document capability may require a specific office suite
+
+Every capability DocuDesk exposes over a document MUST be reachable through the
+suite-independent path — `IConversionManager` for conversion, in-package XML editing
+for manipulation. A capability that works only when one named suite is present is
+prohibited (ADR-087 §4, §5).
+
+No file under `lib/` or `src/` may reference a suite's app id (`richdocuments`,
+`onlyoffice`, `documentserver`) outside a comment. This holds at HEAD and the
+requirement exists to keep it holding: nothing currently prevents a future change
+from reintroducing the dependency, and the failure would be invisible until a
+deployment without that suite.
+
+#### Scenario: Reading and editing work with no office suite installed
+
+- **GIVEN** no office suite is installed on the instance
+- **WHEN** a document is read and a paragraph is edited
+- **THEN** both MUST succeed through the in-package codec
+- **AND** no capability MUST report itself unavailable on account of the missing suite
+
+#### Scenario: A suite app id in executable code is rejected
+
+- **GIVEN** a source file under `lib/` or `src/` names a suite app id in executable code
+- **WHEN** the conformance test runs
+- **THEN** it MUST fail and name the file and line
+- **AND** the same identifier inside a comment MUST NOT fail, because explaining why a suite is not depended upon is not a dependency
+
+### Requirement: Anchor stability across a suite round-trip MUST be measured, not assumed
+
+ADR-087 records anchor stability as a known unknown and instructs that it be
+measured before building on §2. DocuDesk already builds on §2 with content-hash
+anchors, chosen on the expectation that `w14:paraId` would not survive a save.
+
+The system MUST carry a test that opens a document, has a real office suite save it,
+re-reads it through `PackageCodec`, and asserts which anchors resolved.
+
+When no suite is available to perform the round-trip, the test MUST report itself as
+**not run** and MUST NOT pass. A skipped measurement that reports green is
+indistinguishable from a measurement that succeeded, and that is the specific
+failure this requirement exists to prevent.
+
+#### Scenario: The round-trip is measured when a suite is present
+
+- **GIVEN** an office suite is reachable and its WOPI probe resolves available
+- **WHEN** a document is saved through that suite and re-read
+- **THEN** the test MUST record, per paragraph, whether its content-hash anchor still resolves
+- **AND** MUST fail if an anchor for unmodified content no longer resolves
+
+#### Scenario: An absent suite yields "not run", never a pass
+
+- **GIVEN** no office suite is reachable
+- **WHEN** the round-trip test runs
+- **THEN** it MUST report explicitly that the measurement did not run
+- **AND** MUST NOT report success
+- **AND** the result MUST be distinguishable in output from a run that measured and passed
+
+### Requirement: Both supported suites MUST be reproducibly documented
+
+The repository MUST document bring-up for Collabora **and** Euro-Office/ONLYOFFICE:
+how to start each, how to connect it to Nextcloud, and how to confirm it works using
+the capability probe rather than by looking at the admin UI.
+
+The Euro-Office documentation MUST state that WOPI is disabled by default and show
+how to enable it. Omitting that leaves a reader with a running suite, a green admin
+page, and a feature that does not work — which is the exact confusion ADR-087 §3
+calls out.
+
+Both suites MUST be startable from a compose overlay in this repository, each behind
+its own profile so neither runs by default.
+
+#### Scenario: A developer can bring up either suite from the documentation alone
+
+- **GIVEN** a developer with the standard development environment
+- **WHEN** they follow the setup document for either suite
+- **THEN** they MUST reach a state where the capability probe resolves available
+- **AND** the document MUST give them a command whose output distinguishes available from absent
+
+#### Scenario: Neither suite starts by default
+
+- **GIVEN** the development environment is started with no profile selected
+- **WHEN** the running containers are listed
+- **THEN** neither office suite MUST be running

--- a/openspec/changes/office-suite-portability/tasks.md
+++ b/openspec/changes/office-suite-portability/tasks.md
@@ -1,0 +1,53 @@
+# Tasks
+
+## 1. The capability probe
+
+- [ ] Add `lib/Service/Office/OfficeSuiteCapabilityService.php` probing WOPI via a real `CheckFileInfo`
+- [ ] Resolve absent on every non-success: refused, timeout, non-2xx, unparseable body, or a 2xx body missing `BaseFileName`/`Size`
+- [ ] Bound the probe with an explicit timeout and never propagate its failure to the caller
+- [ ] Surface the result as a capability so the feature degrades visibly (ADR-075 §4)
+
+Acceptance criteria:
+- An installed-but-WOPI-disabled suite — Euro-Office's shipped default — resolves ABSENT.
+- The probe does not run on app load; no app in this fleet resolves configuration there.
+- The recorded reason distinguishes "probe failed" from "no suite installed".
+
+## 2. Keep §5 true
+
+- [ ] Add a conformance test rejecting any suite app id (`richdocuments`, `onlyoffice`, `documentserver`) in executable code under `lib/` and `src/`
+- [ ] Make the test comment-aware, and prove it by pointing it at `EditSessionService`, which names `richdocuments` in prose and MUST pass
+
+Acceptance criteria:
+- The test passes at HEAD — it is a ratchet, not a fix.
+- Deliberately introducing the identifier in executable code makes it fail, naming file and line. Verify this rather than assume it.
+
+## 3. Both suites, reproducibly
+
+- [ ] Add `docker-compose.office.yml` with `onlyoffice` and `collabora` profiles, neither running by default
+- [ ] Write `docs/office-suite-setup.md` covering bring-up, connector config and verification for BOTH suites
+- [ ] Document Euro-Office's `wopi.enable: false` default and how to turn it on
+- [ ] Give the reader one command whose output distinguishes available from absent
+
+Acceptance criteria:
+- Starting the environment with no profile leaves both suites stopped.
+- Following the doc from scratch reaches a probe that resolves available.
+
+## 4. The measurement ADR-087 asked for
+
+- [ ] Bring up ONLYOFFICE and confirm its WOPI probe resolves available
+- [ ] Round-trip a `.docx`: save through the suite, re-read with `PackageCodec`, record which content-hash anchors still resolve
+- [ ] Make the test report `not run` distinctly from `passed` when no suite is reachable, and verify the distinction appears in output a human reads
+- [ ] Write the result into the change — including a negative one
+
+Acceptance criteria:
+- With no suite reachable the test reports NOT RUN and does not pass. A skipped measurement reporting green is the failure this task exists to prevent.
+- If anchors do not survive, that is recorded as a finding about `PackageCodec` anchoring, not quietly dropped.
+- If ONLYOFFICE cannot be brought up on this host, the arm is reported UNMEASURED and the portability claim is narrowed to match.
+
+## 5. Verify
+
+- [ ] Playwright E2E: read and edit a document with NO suite installed, proving no capability depends on one
+- [ ] `composer check:strict` clean; hydra gates measured against the base run, not against zero
+
+Acceptance criteria:
+- The no-suite E2E is the real portability proof — it is the configuration Euro-Office users who have not enabled WOPI actually run.

--- a/openspec/specs/office-suite-portability/spec.md
+++ b/openspec/specs/office-suite-portability/spec.md
@@ -1,0 +1,96 @@
+---
+status: in-progress
+---
+
+# office-suite-portability Specification
+
+**OpenSpec changes**
+- office-suite-portability
+
+## Purpose
+
+Defines how DocuDesk detects an office suite, what it refuses to assume about one,
+and what is guaranteed to work with no suite present at all.
+
+The governing decision is ADR-087: office-suite divergence is **brokered, not
+driven**. Conversion goes through `IConversionManager`; format manipulation is
+suite-independent in-package XML editing; editing sessions use WOPI and only WOPI;
+and availability is capability-probed per instance, never assumed.
+
+## Requirements
+
+### Requirement: WOPI availability MUST be probed, never inferred from installation
+
+Availability MUST be determined by a real `CheckFileInfo` whose response parses and
+carries the fields WOPI requires. Anything less — connection refused, timeout,
+non-2xx, unparseable body, missing `BaseFileName` or `Size` — MUST resolve absent.
+
+Measured on `onlyoffice/documentserver` 2026-08-16 with WOPI at its shipped default:
+container `healthy`, `/healthcheck` returning `true`, `/` returning 302, and
+`/hosting/discovery` returning **404**. Every instinctive check says yes while WOPI
+serves nothing.
+
+#### Scenario: An installed suite with WOPI disabled resolves absent
+
+- **GIVEN** a running, healthy, reachable suite whose WOPI is disabled
+- **WHEN** the capability is probed
+- **THEN** it MUST resolve absent
+- **AND** the reason MUST record the probe failure rather than claiming no suite is installed
+
+#### Scenario: A genuine CheckFileInfo success resolves available
+
+- **GIVEN** the endpoint returns 200 with `BaseFileName` and `Size`
+- **WHEN** the capability is probed
+- **THEN** it MUST resolve available
+
+### Requirement: No document capability may require a specific office suite
+
+Every capability DocuDesk exposes over a document MUST be reachable through the
+suite-independent path. No file under `lib/` or `src/` may reference a suite's app
+id in executable code; the same identifier in a comment or in human-readable prose
+is documentation, not a dependency.
+
+#### Scenario: Reading and editing work with no office suite installed
+
+- **GIVEN** no office suite is installed
+- **WHEN** a document is read and a paragraph edited
+- **THEN** both MUST succeed through the in-package codec
+
+#### Scenario: Prose naming a suite is not a dependency
+
+- **GIVEN** a translated label listing which suites give the best conversion fidelity
+- **WHEN** the conformance test runs
+- **THEN** it MUST NOT flag that label, because a check that pressures the removal of true documentation is measuring the wrong thing
+
+### Requirement: Anchor stability across a suite round-trip MUST be measured, not assumed
+
+A test MUST round-trip a document through a real suite and assert which content-hash
+anchors still resolve. It MUST first assert the suite genuinely rewrote
+`word/document.xml`, because a same-format conversion can be a passthrough and a
+comparison of a document with itself proves nothing.
+
+When no suite is reachable the test MUST report **not run** and MUST NOT pass.
+
+#### Scenario: A vacuous round-trip is rejected
+
+- **GIVEN** the suite returned a package whose `word/document.xml` is byte-identical to the input
+- **WHEN** the test runs
+- **THEN** it MUST fail, naming the round-trip as vacuous, rather than reporting that anchors survived
+
+#### Scenario: An absent suite yields "not run", never a pass
+
+- **GIVEN** no suite is reachable
+- **WHEN** the test runs
+- **THEN** it MUST report that the measurement did not run, distinguishably from a pass
+
+### Requirement: Both supported suites MUST be reproducibly documented
+
+The repository MUST document bring-up, connection and probe-based verification for
+Collabora and Euro-Office/ONLYOFFICE, MUST state Euro-Office's WOPI-disabled
+default, and MUST start neither suite by default.
+
+#### Scenario: Neither suite starts by default
+
+- **GIVEN** the environment is started with no profile selected
+- **WHEN** running containers are listed
+- **THEN** neither office suite MUST be running

--- a/tests/stubs/NextcloudStubs.php
+++ b/tests/stubs/NextcloudStubs.php
@@ -1995,3 +1995,77 @@ interface IPreparedStatement {
 	 */
 	public function rowCount(): int;
 }//end interface
+
+namespace OCP\Http\Client;
+
+/**
+ * Stub of OCP\Http\Client\IResponse.
+ *
+ * Signatures transcribed from server lib/public/Http/Client/IResponse.php.
+ * getBody() is deliberately UNTYPED there (it returns string|resource), and the
+ * stub must not "tidy" that to `string` — a stub tightened past the real class is
+ * how a test starts asserting a contract the runtime does not have.
+ */
+interface IResponse {
+
+	/**
+	 * The response body.
+	 *
+	 * @return string|resource
+	 */
+	public function getBody();
+
+	/**
+	 * The HTTP status code.
+	 *
+	 * @return int
+	 */
+	public function getStatusCode(): int;
+
+	/**
+	 * A single response header.
+	 *
+	 * @param string $key The header name.
+	 *
+	 * @return string
+	 */
+	public function getHeader(string $key): string;
+
+	/**
+	 * All response headers.
+	 *
+	 * @return array
+	 */
+	public function getHeaders(): array;
+}//end interface
+
+/**
+ * Stub of OCP\Http\Client\IClient.
+ *
+ * Only the verbs DocuDesk uses are declared.
+ */
+interface IClient {
+
+	/**
+	 * Issue a GET request.
+	 *
+	 * @param string $uri     The URI.
+	 * @param array  $options Request options.
+	 *
+	 * @return IResponse
+	 */
+	public function get(string $uri, array $options = []): IResponse;
+}//end interface
+
+/**
+ * Stub of OCP\Http\Client\IClientService.
+ */
+interface IClientService {
+
+	/**
+	 * Build a client.
+	 *
+	 * @return IClient
+	 */
+	public function newClient(): IClient;
+}//end interface

--- a/tests/unit/Service/Office/AnchorRoundTripTest.php
+++ b/tests/unit/Service/Office/AnchorRoundTripTest.php
@@ -1,0 +1,249 @@
+<?php
+
+/**
+ * Measures whether content-hash anchors survive a real office-suite re-serialisation.
+ *
+ * openspec/changes/office-suite-portability. Answers the anchor-stability known
+ * unknown recorded in ADR-087.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Test
+ * @package  OCA\DocuDesk\Tests\Unit\Service\Office
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Service\Office;
+
+use OCA\DocuDesk\Service\Editing\PackageCodec;
+use OCA\DocuDesk\Service\Editing\XmlBlockScanner;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Round-trips a document through a real suite and re-reads its anchors.
+ *
+ * THREE OUTCOMES, NOT TWO: passed, failed, and **not run**. The third is the point.
+ * A test that silently skips when no suite is reachable reports green, and a green
+ * "anchors survive the round-trip" that never opened a document converts an open
+ * question into a false answer. The skip message therefore says NOT MEASURED in
+ * as many words.
+ *
+ * A second trap is baked into the fixture. The first version of this measurement
+ * used a `docx -> docx` conversion and reported success: the file grew 1172 -> 1394
+ * bytes, which looked like a rewrite. Comparing every package part by md5 showed
+ * all four byte-identical — the suite had passed the file through without parsing
+ * it, and the size delta was ZIP overhead. The assertion was true and worthless.
+ *
+ * So this test asserts the REWRITE HAPPENED before it asserts anything about
+ * anchors. Without that guard the whole file is a very elaborate way of comparing
+ * a document to itself.
+ *
+ * @category Test
+ * @package  OCA\DocuDesk\Tests\Unit\Service\Office
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ */
+class AnchorRoundTripTest extends TestCase {
+
+	/**
+	 * Base URL of the conversion service, from the environment.
+	 *
+	 * @var string
+	 */
+	private string $serviceUrl = '';
+
+	/**
+	 * Resolve the suite endpoint, or declare the measurement not run.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->serviceUrl = (string)getenv('DOCUDESK_OFFICE_CONVERT_URL');
+		if ($this->serviceUrl === '') {
+			$this->markTestSkipped(
+				'NOT MEASURED: no office suite reachable. '
+				. 'Set DOCUDESK_OFFICE_CONVERT_URL (see docs/office-suite-setup.md) to run it. '
+				. 'This is NOT a pass — the anchor-stability question is unanswered in this run.'
+			);
+		}
+	}//end setUp()
+
+	/**
+	 * REQ: content-hash anchors survive a genuine suite re-serialisation.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/office-suite-portability/spec.md
+	 */
+	public function testAnchorsSurviveASuiteReserialisation(): void {
+		$original = $this->fixtureBytes();
+
+		// docx -> odt -> docx. A same-format conversion is a PASSTHROUGH on at
+		// least one shipping suite; a format change forces the engine to parse and
+		// re-serialise, which is what a save does to the document body.
+		$odt   = $this->convert(bytes: $original, from: 'docx', to: 'odt');
+		$after = $this->convert(bytes: $odt, from: 'odt', to: 'docx');
+
+		$this->assertNotSame(
+			$this->documentPart(package: $original),
+			$this->documentPart(package: $after),
+			'the suite did not rewrite word/document.xml, so this measurement would be vacuous'
+		);
+
+		$codec  = new PackageCodec(new XmlBlockScanner());
+		$before = $codec->readBlocks($original, 'docx');
+		$result = $codec->readBlocks($after, 'docx');
+
+		$this->assertSame(
+			array_column($before['blocks'], 'anchor'),
+			array_column($result['blocks'], 'anchor'),
+			'content-hash anchors must resolve identically after a suite re-serialises the document'
+		);
+	}//end testAnchorsSurviveASuiteReserialisation()
+
+	/**
+	 * Extract word/document.xml from a package.
+	 *
+	 * @param string $package The package bytes.
+	 *
+	 * @return string The part bytes.
+	 */
+	private function documentPart(string $package): string {
+		$tmp = tempnam(sys_get_temp_dir(), 'rt') . '.docx';
+		file_put_contents($tmp, $package);
+
+		$zip = new \ZipArchive();
+		$zip->open($tmp);
+		$xml = (string)$zip->getFromName('word/document.xml');
+		$zip->close();
+		unlink($tmp);
+
+		return $xml;
+	}//end documentPart()
+
+	/**
+	 * Build the fixture document.
+	 *
+	 * Carries a duplicated paragraph on purpose: identical text means identical
+	 * hash, so the occurrence ordinal is the only thing separating the two anchors.
+	 * If the ordinal did not survive re-ordering, this is where it would show.
+	 *
+	 * @return string The package bytes.
+	 */
+	private function fixtureBytes(): string {
+		$word    = new \PhpOffice\PhpWord\PhpWord();
+		$section = $word->addSection();
+		$section->addTitle('Subsidiebesluit 2026', 1);
+		$section->addText('The assessment period is eight weeks.');
+
+		$run = $section->addTextRun();
+		$run->addText('This paragraph carries ');
+		$run->addText('a bold run', ['bold' => true]);
+		$run->addText(' that must survive.');
+
+		$section->addText('Kind regards,');
+		$section->addText('The assessment period is eight weeks.');
+
+		$tmp = tempnam(sys_get_temp_dir(), 'fx') . '.docx';
+		\PhpOffice\PhpWord\IOFactory::createWriter($word, 'Word2007')->save($tmp);
+		$bytes = (string)file_get_contents($tmp);
+		unlink($tmp);
+
+		return $bytes;
+	}//end fixtureBytes()
+
+	/**
+	 * Convert bytes through the suite.
+	 *
+	 * @param string $bytes The input package.
+	 * @param string $from  The input extension.
+	 * @param string $to    The output extension.
+	 *
+	 * @return string The converted package bytes.
+	 */
+	private function convert(string $bytes, string $from, string $to): string {
+		$hosted = $this->publish(bytes: $bytes, extension: $from);
+
+		$payload = json_encode(
+			[
+				'async'      => false,
+				'filetype'   => $from,
+				'key'        => substr(sha1($bytes . $to), 0, 16),
+				'outputtype' => $to,
+				'title'      => 'roundtrip.' . $from,
+				'url'        => $hosted,
+			]
+		);
+
+		$context = stream_context_create(
+			[
+				'http' => [
+					'method'        => 'POST',
+					'header'        => "Content-Type: application/json\r\nAccept: application/json\r\n",
+					'content'       => $payload,
+					'timeout'       => 90,
+					'ignore_errors' => true,
+				],
+			]
+		);
+
+		$raw = file_get_contents($this->serviceUrl, false, $context);
+		$this->assertIsString($raw, 'the conversion service did not answer');
+
+		$decoded = json_decode((string)$raw, true);
+		$this->assertIsArray($decoded, 'the conversion service returned a non-JSON body: ' . (string)$raw);
+		$this->assertArrayNotHasKey(
+			'error',
+			$decoded,
+			'the suite refused the conversion: ' . (string)$raw
+		);
+
+		$converted = file_get_contents((string)$decoded['fileUrl']);
+		$this->assertIsString($converted, 'the converted document could not be fetched');
+
+		return $converted;
+	}//end convert()
+
+	/**
+	 * Publish bytes at a URL the suite can fetch.
+	 *
+	 * @param string $bytes     The package bytes.
+	 * @param string $extension The file extension.
+	 *
+	 * @return string The URL.
+	 */
+	private function publish(string $bytes, string $extension): string {
+		$dir = (string)getenv('DOCUDESK_OFFICE_FIXTURE_DIR');
+		$url = (string)getenv('DOCUDESK_OFFICE_FIXTURE_URL');
+
+		if ($dir === '' || $url === '') {
+			$this->markTestSkipped(
+				'NOT MEASURED: DOCUDESK_OFFICE_FIXTURE_DIR / _URL are unset, so the suite '
+				. 'has no way to fetch the document. This is NOT a pass.'
+			);
+		}
+
+		$name = 'rt-' . substr(sha1($bytes), 0, 12) . '.' . $extension;
+		file_put_contents(rtrim($dir, '/') . '/' . $name, $bytes);
+
+		return rtrim($url, '/') . '/' . $name;
+	}//end publish()
+}//end class

--- a/tests/unit/Service/Office/OfficeSuiteCapabilityServiceTest.php
+++ b/tests/unit/Service/Office/OfficeSuiteCapabilityServiceTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * Unit tests for OfficeSuiteCapabilityService.
+ *
+ * openspec/changes/office-suite-portability.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Test
+ * @package  OCA\DocuDesk\Tests\Unit\Service\Office
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Service\Office;
+
+use OCA\DocuDesk\Service\Office\OfficeSuiteCapabilityService;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Every case here is a way for a suite to look present and serve nothing.
+ *
+ * The 404 case is not hypothetical: it is what onlyoffice/documentserver returned
+ * on 2026-08-16 with `wopi.enable` at its shipped default, while the container
+ * reported healthy, `/healthcheck` returned `true` and `/` returned 302.
+ */
+class OfficeSuiteCapabilityServiceTest extends TestCase {
+
+	/**
+	 * Build a service whose client returns the given response.
+	 *
+	 * @param int    $status The HTTP status.
+	 * @param string $body   The response body.
+	 *
+	 * @return OfficeSuiteCapabilityService The service.
+	 */
+	private function serviceReturning(int $status, string $body): OfficeSuiteCapabilityService {
+		$response = $this->createMock(IResponse::class);
+		$response->method('getStatusCode')->willReturn($status);
+		$response->method('getBody')->willReturn($body);
+
+		$client = $this->createMock(IClient::class);
+		$client->method('get')->willReturn($response);
+
+		$clientService = $this->createMock(IClientService::class);
+		$clientService->method('newClient')->willReturn($client);
+
+		return new OfficeSuiteCapabilityService(
+			clientService: $clientService,
+			logger: $this->createMock(LoggerInterface::class)
+		);
+	}//end serviceReturning()
+
+	/**
+	 * REQ: a genuine CheckFileInfo success resolves available.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/office-suite-portability/spec.md
+	 */
+	public function testGenuineCheckFileInfoResolvesAvailable(): void {
+		$service = $this->serviceReturning(
+			status: 200,
+			body: json_encode(['BaseFileName' => 'a.docx', 'Size' => 1234])
+		);
+
+		$verdict = $service->probe(checkFileInfoUrl: 'http://suite/wopi/files/1');
+
+		$this->assertTrue($verdict['available']);
+	}//end testGenuineCheckFileInfoResolvesAvailable()
+
+	/**
+	 * REQ: an installed suite with WOPI disabled resolves ABSENT.
+	 *
+	 * The measured Euro-Office / ONLYOFFICE default. Container healthy, port
+	 * answering, admin page green — and 404 on every WOPI path.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/office-suite-portability/spec.md
+	 */
+	public function testWopiDisabledResolvesAbsent(): void {
+		$verdict = $this->serviceReturning(status: 404, body: 'Not Found')
+			->probe(checkFileInfoUrl: 'http://suite/wopi/files/1');
+
+		$this->assertFalse($verdict['available']);
+		$this->assertStringContainsString('404', $verdict['reason']);
+	}//end testWopiDisabledResolvesAbsent()
+
+	/**
+	 * REQ: a 2xx with a non-JSON body resolves absent.
+	 *
+	 * An error page or a login redirect body can carry a 200. Accepting the status
+	 * alone would report available for a host that cannot serve a session.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/office-suite-portability/spec.md
+	 */
+	public function testNonJsonBodyResolvesAbsent(): void {
+		$verdict = $this->serviceReturning(status: 200, body: '<html>Sign in</html>')
+			->probe(checkFileInfoUrl: 'http://suite/wopi/files/1');
+
+		$this->assertFalse($verdict['available']);
+		$this->assertStringContainsString('non-JSON', $verdict['reason']);
+	}//end testNonJsonBodyResolvesAbsent()
+
+	/**
+	 * REQ: a 2xx JSON body missing a required field resolves absent.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/office-suite-portability/spec.md
+	 */
+	public function testMissingRequiredFieldResolvesAbsent(): void {
+		$verdict = $this->serviceReturning(status: 200, body: json_encode(['Size' => 10]))
+			->probe(checkFileInfoUrl: 'http://suite/wopi/files/1');
+
+		$this->assertFalse($verdict['available']);
+		$this->assertStringContainsString('BaseFileName', $verdict['reason']);
+	}//end testMissingRequiredFieldResolvesAbsent()
+
+	/**
+	 * REQ: a transport failure resolves absent rather than propagating.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/office-suite-portability/spec.md
+	 */
+	public function testTransportFailureResolvesAbsent(): void {
+		$client = $this->createMock(IClient::class);
+		$client->method('get')->willThrowException(new RuntimeException('connection refused'));
+
+		$clientService = $this->createMock(IClientService::class);
+		$clientService->method('newClient')->willReturn($client);
+
+		$service = new OfficeSuiteCapabilityService(
+			clientService: $clientService,
+			logger: $this->createMock(LoggerInterface::class)
+		);
+
+		$verdict = $service->probe(checkFileInfoUrl: 'http://suite/wopi/files/1');
+
+		$this->assertFalse($verdict['available']);
+		$this->assertStringContainsString('connection refused', $verdict['reason']);
+	}//end testTransportFailureResolvesAbsent()
+
+	/**
+	 * REQ: an unconfigured endpoint resolves absent without a request.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/office-suite-portability/spec.md
+	 */
+	public function testUnconfiguredEndpointResolvesAbsent(): void {
+		$clientService = $this->createMock(IClientService::class);
+		$clientService->expects($this->never())->method('newClient');
+
+		$service = new OfficeSuiteCapabilityService(
+			clientService: $clientService,
+			logger: $this->createMock(LoggerInterface::class)
+		);
+
+		$this->assertFalse($service->probe(checkFileInfoUrl: '  ')['available']);
+	}//end testUnconfiguredEndpointResolvesAbsent()
+}//end class

--- a/tests/unit/Service/Office/SuiteIndependenceTest.php
+++ b/tests/unit/Service/Office/SuiteIndependenceTest.php
@@ -1,0 +1,382 @@
+<?php
+
+/**
+ * Conformance test for ADR-087 §5 — no leaf app may depend on one office suite.
+ *
+ * openspec/changes/office-suite-portability.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Test
+ * @package  OCA\DocuDesk\Tests\Unit\Service\Office
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Service\Office;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Keeps ADR-087 §5 true rather than merely observing that it is.
+ *
+ * At the time of writing, `richdocuments` appears under `lib/` only inside
+ * explanatory comments in `EditSessionService`. That is a fact about HEAD, not a
+ * constraint — nothing stops the next change from reintroducing a hard dependency,
+ * and the failure would stay invisible until a deployment without that suite.
+ *
+ * The check MUST ignore comments. `EditSessionService` names `richdocuments`
+ * repeatedly while explaining why DocuDesk does NOT depend on it — the WOPI lock
+ * reasoning is genuinely non-obvious and worth the prose. A naive
+ * `grep richdocuments lib/` fails against correct code, and the natural way to
+ * "fix" that failure is to delete the explanation, which makes the codebase worse.
+ */
+class SuiteIndependenceTest extends TestCase {
+
+	/**
+	 * App ids that would constitute a per-suite dependency.
+	 *
+	 * @var string[]
+	 */
+	private const SUITE_APP_IDS = ['richdocuments', 'onlyoffice', 'documentserver'];
+
+	/**
+	 * Directories scanned for a suite dependency.
+	 *
+	 * @var string[]
+	 */
+	private const SCANNED_DIRS = ['lib', 'src'];
+
+	/**
+	 * REQ: no suite app id appears in executable code.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/office-suite-portability/spec.md
+	 */
+	public function testNoSuiteAppIdAppearsInExecutableCode(): void {
+		$offenders = [];
+
+		foreach (self::SCANNED_DIRS as $dir) {
+			foreach ($this->sourceFiles(dir: $dir) as $file) {
+				$offenders = array_merge($offenders, $this->scan(file: $file));
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$offenders,
+			"ADR-087 §5: a leaf app must not depend on one office suite's app id.\n"
+			. "Every capability must be reachable through the suite-independent path\n"
+			. "(IConversionManager for conversion, in-package XML for manipulation).\n"
+			. "Offending lines:\n  " . implode("\n  ", $offenders)
+		);
+	}//end testNoSuiteAppIdAppearsInExecutableCode()
+
+	/**
+	 * REQ: the same identifier inside a comment is NOT a dependency.
+	 *
+	 * This is the test's own positive control. `EditSessionService` documents at
+	 * length why the WOPI lock cannot be relied on, naming `richdocuments` several
+	 * times. If the scanner cannot tell that from a dependency, it is measuring the
+	 * wrong thing — and the pressure it creates is to delete the explanation.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/office-suite-portability/spec.md
+	 */
+	public function testCommentaryNamingASuiteIsNotADependency(): void {
+		$path = $this->repoRoot() . '/lib/Service/Editing/EditSessionService.php';
+		$this->assertFileExists($path, 'the file this control depends on has moved');
+
+		$contents = (string)file_get_contents($path);
+		$this->assertStringContainsString(
+			'richdocuments',
+			$contents,
+			'this control is only meaningful while the file still discusses richdocuments'
+		);
+
+		$this->assertSame(
+			[],
+			$this->scan(file: new SplFileInfo($path)),
+			'commentary explaining why a suite is NOT depended upon must not be flagged'
+		);
+	}//end testCommentaryNamingASuiteIsNotADependency()
+
+	/**
+	 * REQ: the scanner CAN fail — proven on a synthetic offender.
+	 *
+	 * Without this, a scanner that silently matched nothing would report the same
+	 * green as a codebase that is genuinely clean. Every other assertion here is
+	 * worthless unless this one passes.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/office-suite-portability/spec.md
+	 */
+	public function testScannerDetectsAnIntroducedDependency(): void {
+		$tmp = tempnam(sys_get_temp_dir(), 'suite') . '.php';
+		file_put_contents(
+			$tmp,
+			"<?php\n// a comment naming richdocuments must NOT trip this\n"
+			. "\$app = 'richdocuments';\n"
+		);
+
+		$offenders = $this->scan(file: new SplFileInfo($tmp));
+		unlink($tmp);
+
+		$this->assertCount(1, $offenders, 'the scanner must flag the executable line and only that line');
+		$this->assertStringContainsString(':3', $offenders[0], 'it must name the offending line number');
+	}//end testScannerDetectsAnIntroducedDependency()
+
+	/**
+	 * REQ: prose is skipped, but a bare identifier on a wordy line is still caught.
+	 *
+	 * The second half is the part that matters. Suppressing whole lines that "look
+	 * like a sentence" would let `if (app === 'onlyoffice' && a && b)` through —
+	 * four words, and a real dependency. Judging each quoted segment separately is
+	 * what keeps the exemption narrow.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/office-suite-portability/spec.md
+	 */
+	public function testProseIsExemptButIdentifiersOnWordyLinesAreNot(): void {
+		$tmp = tempnam(sys_get_temp_dir(), 'suite') . '.js';
+		file_put_contents(
+			$tmp,
+			"const help = 'Conversion requires an Office app such as OnlyOffice or Collabora'\n"
+			. "if (appId === 'onlyoffice' && enabled && ready && loaded) { go() }\n"
+		);
+
+		$offenders = $this->scan(file: new SplFileInfo($tmp));
+		unlink($tmp);
+
+		$this->assertCount(1, $offenders, 'exactly the dependency, not the help text');
+		$this->assertStringContainsString(':2', $offenders[0], 'the identifier line, not the prose line');
+	}//end testProseIsExemptButIdentifiersOnWordyLinesAreNot()
+
+	/**
+	 * Scan one file for suite app ids in executable code.
+	 *
+	 * Uses PHP's own tokeniser rather than a regex, so a comment is identified the
+	 * way the language identifies one. For non-PHP files (Vue, JS) the fallback
+	 * strips `//` and block comments before matching.
+	 *
+	 * @param SplFileInfo $file The file to scan.
+	 *
+	 * @return string[] Offending "path:line" entries.
+	 */
+	private function scan(SplFileInfo $file): array {
+		$contents = (string)file_get_contents($file->getPathname());
+		$path     = $file->getPathname();
+
+		if ($file->getExtension() === 'php') {
+			return $this->scanPhp(contents: $contents, path: $path);
+		}
+
+		return $this->scanPlain(contents: $contents, path: $path);
+	}//end scan()
+
+	/**
+	 * Scan PHP source using the tokeniser.
+	 *
+	 * @param string $contents The file contents.
+	 * @param string $path     The file path.
+	 *
+	 * @return string[] Offending "path:line" entries.
+	 */
+	private function scanPhp(string $contents, string $path): array {
+		$offenders = [];
+
+		foreach (token_get_all($contents) as $token) {
+			if (is_array($token) === false) {
+				continue;
+			}
+
+			[$id, $text, $line] = $token;
+
+			// Comments and docblocks are explanation, not dependency.
+			if ($id === T_COMMENT || $id === T_DOC_COMMENT) {
+				continue;
+			}
+
+			// Prose is not a dependency either. See isProse().
+			if ($this->isProse(text: $text) === true) {
+				continue;
+			}
+
+			foreach (self::SUITE_APP_IDS as $appId) {
+				if (stripos($text, $appId) !== false) {
+					$offenders[] = sprintf('%s:%d (%s)', $path, $line, $appId);
+					break;
+				}
+			}
+		}
+
+		return $offenders;
+	}//end scanPhp()
+
+	/**
+	 * Split a line into its quoted segments plus the residue outside them.
+	 *
+	 * @param string $line The comment-stripped line.
+	 *
+	 * @return string[] The fragments to judge independently.
+	 */
+	private function fragments(string $line): array {
+		$fragments = [];
+
+		if (preg_match_all('/([\'"`])(.*?)\1/s', $line, $matches) > 0) {
+			foreach ($matches[2] as $quoted) {
+				$fragments[] = $quoted;
+			}
+		}
+
+		// Whatever is left once the quoted parts are removed: imports, bare
+		// identifiers, property access.
+		$fragments[] = preg_replace('/([\'"`])(.*?)\1/s', ' ', $line);
+
+		return $fragments;
+	}//end fragments()
+
+	/**
+	 * Decide whether a fragment is human-readable prose rather than an identifier.
+	 *
+	 * The discriminator: **an app id used as a dependency is a bare token; an app
+	 * id inside a sentence is documentation.** `'onlyoffice'` is a dependency;
+	 * "…a supported Office app integration (Collabora, OnlyOffice, or Euro Office)…"
+	 * is a sentence telling an administrator which suites give the best fidelity.
+	 *
+	 * This distinction was not in the first version of this test, and the test
+	 * promptly failed on `src/views/settings/Settings.vue:142` — a translated
+	 * `t()` label. Reported as a violation it would have been wrong twice over:
+	 * the code is correct, and the only way to satisfy the test would have been to
+	 * delete accurate user-facing help. A check that pressures you to remove true
+	 * documentation is measuring the wrong thing.
+	 *
+	 * @param string $text The token or fragment.
+	 *
+	 * @return bool True when the fragment reads as prose.
+	 */
+	private function isProse(string $text): bool {
+		$inner = trim($text, "'\"`");
+
+		// A sentence has spaces; an app id does not. Four or more whitespace-
+		// separated words is comfortably past any plausible identifier.
+		return (preg_match('/\S+\s+\S+\s+\S+\s+\S+/', $inner) === 1);
+	}//end isProse()
+
+	/**
+	 * Scan a non-PHP source file, stripping comments first.
+	 *
+	 * @param string $contents The file contents.
+	 * @param string $path     The file path.
+	 *
+	 * @return string[] Offending "path:line" entries.
+	 */
+	private function scanPlain(string $contents, string $path): array {
+		$offenders = [];
+		$lines     = explode("\n", $contents);
+		$inBlock   = false;
+
+		foreach ($lines as $index => $line) {
+			$stripped = $line;
+
+			if ($inBlock === true) {
+				$end = strpos($stripped, '*/');
+				if ($end === false) {
+					continue;
+				}
+
+				$stripped = substr($stripped, ($end + 2));
+				$inBlock  = false;
+			}
+
+			$blockStart = strpos($stripped, '/*');
+			if ($blockStart !== false) {
+				$stripped = substr($stripped, 0, $blockStart);
+				$inBlock  = true;
+			}
+
+			$lineComment = strpos($stripped, '//');
+			if ($lineComment !== false) {
+				$stripped = substr($stripped, 0, $lineComment);
+			}
+
+			$htmlComment = strpos($stripped, '<!--');
+			if ($htmlComment !== false) {
+				$stripped = substr($stripped, 0, $htmlComment);
+			}
+
+			// Test each quoted segment separately, plus whatever sits outside
+			// quotes. Judging the WHOLE line as prose would suppress a genuine
+			// `if (app === 'onlyoffice' && a && b)` — four words, but a real
+			// dependency.
+			foreach ($this->fragments(line: $stripped) as $fragment) {
+				if ($this->isProse(text: $fragment) === true) {
+					continue;
+				}
+
+				foreach (self::SUITE_APP_IDS as $appId) {
+					if (stripos($fragment, $appId) !== false) {
+						$offenders[] = sprintf('%s:%d (%s)', $path, ($index + 1), $appId);
+						break 2;
+					}
+				}
+			}
+		}
+
+		return $offenders;
+	}//end scanPlain()
+
+	/**
+	 * Iterate the source files of a directory.
+	 *
+	 * @param string $dir The directory, relative to the repo root.
+	 *
+	 * @return SplFileInfo[] The source files.
+	 */
+	private function sourceFiles(string $dir): array {
+		$root = $this->repoRoot() . '/' . $dir;
+		if (is_dir($root) === false) {
+			return [];
+		}
+
+		$wanted = ['php', 'vue', 'js', 'ts'];
+		$files  = [];
+
+		$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+		foreach ($iterator as $file) {
+			if ($file instanceof SplFileInfo
+				&& $file->isFile() === true
+				&& in_array(strtolower($file->getExtension()), $wanted, true) === true
+			) {
+				$files[] = $file;
+			}
+		}
+
+		return $files;
+	}//end sourceFiles()
+
+	/**
+	 * Resolve the repository root.
+	 *
+	 * @return string The absolute repo root.
+	 */
+	private function repoRoot(): string {
+		return dirname(__DIR__, 4);
+	}//end repoRoot()
+}//end class


### PR DESCRIPTION
## Why

ADR-087 §3 requires WOPI availability to be **capability-probed per instance**, and says explicitly that *"the app is installed" is not the probe — a successful `CheckFileInfo` is.* DocuDesk had no probe of any kind.

## ADR-087 §3, demonstrated on a live server

Same container, same health, same port. The only variable is `wopi.enable`:

| Signal | shipped default | `WOPI_ENABLED=true` |
|---|---|---|
| container health | `healthy` | `healthy` |
| `GET /healthcheck` | `200`, body `true` | `200`, body `true` |
| `GET /` | `302` | `302` |
| **`GET /hosting/discovery`** | **404** | **200** |
| **`GET /hosting/capabilities`** | **404** | **200** |

Every instinctive "is it working?" check returns **yes** in the left column while WOPI serves nothing. The probe therefore fails **closed** — refused, timeout, non-2xx, unparseable body, or a 2xx missing `BaseFileName`/`Size` all resolve absent.

## Anchor stability — ADR-087's known unknown, measured

### The first attempt was vacuous, and that is the more useful half

A `docx → docx` conversion returned 1172 → **1394** bytes. That looks like a rewrite. Comparing every package part by md5:

```
[Content_Types].xml   297  7005c0d108   ← identical
_rels/.rels           263  346bfa3c1a   ← identical
word/comments.xml     141  4fc50e4c5a   ← identical
word/document.xml     529  324a704a72   ← identical
```

All four **byte-identical**. The suite passed the file through without parsing it; the size delta was ZIP container overhead. "Anchors survived" was true and meaningless.

### A real re-serialisation

`docx → odt → docx` forces the engine to parse and re-serialise:

```
word/document.xml  1599 → 2590 bytes   md5 9a714c548b → bfbd74955b
package parts      14 → 17
```

Read back through the **real `PackageCodec`**, all five anchors resolved identically — including the occurrence ordinal on a deliberately duplicated paragraph:

```
b9f931ca9-1  Subsidiebesluit 2026                   →  b9f931ca9-1
b1a7a4f16-1  The assessment period is eight weeks.  →  b1a7a4f16-1
bd36e1657-1  This paragraph carries a bold run…     →  bd36e1657-1
b94c4021b-1  Kind regards,                          →  b94c4021b-1
b1a7a4f16-2  The assessment period is eight weeks.  →  b1a7a4f16-2
```

**The test now asserts the rewrite happened before asserting anything about anchors.** Without that guard it is an elaborate way of comparing a document to itself.

### `w14:paraId` was absent from both sides

PhpWord does not emit it; ONLYOFFICE did not add it. So this does **not** answer "does `paraId` survive a save". It answers something more decisive for the design: an anchor scheme built on `paraId` would have had **nothing to anchor to at all** on an ordinarily-generated document.

## The conformance test caught my own bad evidence

The proposal originally claimed §5 verified — from a `lib/`-only grep. The test, once written, immediately flagged `src/views/settings/Settings.vue:142`, which that grep never looked at.

The flag was a **false positive**: a translated `t()` label listing which suites give the best conversion fidelity. Reporting it would have been wrong twice over — the code is correct, and the only way to satisfy the check would have been to **delete accurate user-facing help**. The scanner now judges each quoted segment, exempting prose but still catching a bare identifier on a wordy line, with a control proving it can still fail.

## Also

- `docker-compose.office.yml` — **both** suites, each behind a profile, neither running by default. Here rather than `.github/`, which is a separate repo.
- `docs/office-suite-setup.md` — both suites end to end, leading with the WOPI-disabled default because it is the single thing that will waste an afternoon.

## Limits, stated rather than glossed

- Used the **conversion service**, not a WOPI `PutFile` from an editing session. That is the engine genuinely parsing and re-serialising — the strongest proxy short of minting per-file tokens — but not literally a user pressing save.
- One document, one suite, one format pair. **Collabora is not measured.**
- The round-trip test reports three outcomes: passed / failed / **not run**. Both arms verified: without a suite it reports `Skipped` with a "NOT MEASURED — this is NOT a pass" message; with ONLYOFFICE reachable it runs and passes (10 assertions).

## Verification

- Full suite: **1374 tests, 0 failures**
- `phpcs`: 0 errors, 0 warnings on all new files

Spec: `openspec/changes/office-suite-portability/`
