### PR TITLE
feat(editing): style, layout and metadata, not just words

### DIFF
--- a/lib/Service/Editing/BlockStyleCodec.php
+++ b/lib/Service/Editing/BlockStyleCodec.php
@@ -1,0 +1,390 @@
+<?php
+
+/**
+ * DocuDesk BlockStyleCodec
+ *
+ * Applies style and layout properties to an anchored paragraph, in place.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service\Editing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service\Editing;
+
+use RuntimeException;
+
+/**
+ * Style and layout for one paragraph's markup.
+ *
+ * Operates on a single `<w:p>` span's markup and returns rewritten markup. It does
+ * not touch the package, does not know about anchors, and does not decide which
+ * paragraph is being styled — {@see PackageCodec} owns all of that. Keeping this
+ * class ignorant of the package is what lets it be tested against a string.
+ *
+ * ## Why OOXML only, said out loud
+ *
+ * OOXML carries direct formatting INSIDE the paragraph: `<w:pPr>` for paragraph
+ * properties, `<w:rPr>` inside each `<w:r>` for run properties. Rewriting the span
+ * is therefore sufficient and nothing outside it changes.
+ *
+ * ODF does not work that way. `text:p` carries only a `text:style-name` pointing at
+ * a `<style:style>` defined in `<office:automatic-styles>` — a different region of
+ * `content.xml` — and a heading is a different ELEMENT (`text:h`), not a styled
+ * paragraph. Supporting ODF properly means minting automatic styles, guaranteeing
+ * name uniqueness against existing ones, and in the heading case rewriting the
+ * element the anchor scanner keys on.
+ *
+ * That is real work and it is not done here. What matters is that it is REFUSED BY
+ * NAME rather than silently ignored: an ODF style request that returned the markup
+ * unchanged would report success and change nothing, which is the failure mode this
+ * codebase keeps meeting. `supports()` answers honestly and
+ * {@see applyStyle()} throws with the reason.
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service\Editing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ *
+ * @spec openspec/specs/document-rich-editing/spec.md
+ */
+class BlockStyleCodec {
+
+	/**
+	 * Paragraph alignment values, mapped to their OOXML `w:jc` value.
+	 *
+	 * @var array<string, string>
+	 */
+	private const ALIGNMENTS = [
+		'left'    => 'left',
+		'center'  => 'center',
+		'right'   => 'right',
+		'justify' => 'both',
+	];
+
+	/**
+	 * Style keys this codec understands.
+	 *
+	 * @var array<int, string>
+	 */
+	public const STYLE_KEYS = [
+		'bold',
+		'italic',
+		'underline',
+		'alignment',
+		'heading',
+		'list',
+		'pageBreakBefore',
+	];
+
+	/**
+	 * Whether style can be applied to this package family.
+	 *
+	 * @param string $format The package family constant.
+	 *
+	 * @return bool True when supported.
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function supports(string $format): bool {
+		return ($format === PackageCodec::FORMAT_OOXML);
+	}//end supports()
+
+	/**
+	 * Apply style properties to one paragraph's markup.
+	 *
+	 * @param string $markup The paragraph markup.
+	 * @param array  $style  The style properties.
+	 * @param string $format The package family constant.
+	 *
+	 * @return string The rewritten markup.
+	 *
+	 * @throws RuntimeException When the format is unsupported or a property is unknown.
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function applyStyle(string $markup, array $style, string $format): string {
+		if ($this->supports(format: $format) === false) {
+			throw new RuntimeException(
+				'Style and layout can only be applied to OOXML (.docx) documents. '
+				. 'ODF direct formatting needs an automatic style minted in content.xml, and an ODF '
+				. 'heading is a different element (text:h) rather than a styled paragraph; neither is '
+				. 'implemented. Text edits and metadata DO work on .odt.'
+			);
+		}
+
+		$this->assertKnownKeys(style: $style);
+
+		$markup = $this->applyParagraphProperties(markup: $markup, style: $style);
+
+		return $this->applyRunProperties(markup: $markup, style: $style);
+	}//end applyStyle()
+
+	/**
+	 * Reject unknown style keys.
+	 *
+	 * A misspelled key that was silently ignored would report success and change
+	 * nothing — and the caller here is a language model, which will misspell keys.
+	 *
+	 * @param array $style The style properties.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException When a key is not understood.
+	 */
+	private function assertKnownKeys(array $style): void {
+		if ($style === []) {
+			throw new RuntimeException('At least one style property is required.');
+		}
+
+		foreach (array_keys($style) as $key) {
+			if (in_array((string)$key, self::STYLE_KEYS, true) === false) {
+				throw new RuntimeException(
+					sprintf(
+						'Unknown style property "%s". Supported: %s.',
+						(string)$key,
+						implode(', ', self::STYLE_KEYS)
+					)
+				);
+			}
+		}
+
+		$alignment = ($style['alignment'] ?? null);
+		if ($alignment !== null && isset(self::ALIGNMENTS[(string)$alignment]) === false) {
+			throw new RuntimeException(
+				sprintf(
+					'Unknown alignment "%s". Supported: %s.',
+					(string)$alignment,
+					implode(', ', array_keys(self::ALIGNMENTS))
+				)
+			);
+		}
+
+		$heading = ($style['heading'] ?? null);
+		if ($heading !== null && (is_numeric($heading) === false || (int)$heading < 0 || (int)$heading > 9)) {
+			throw new RuntimeException('Heading level must be between 0 (body text) and 9.');
+		}
+	}//end assertKnownKeys()
+
+	/**
+	 * Apply the paragraph-level properties.
+	 *
+	 * @param string $markup The paragraph markup.
+	 * @param array  $style  The style properties.
+	 *
+	 * @return string The rewritten markup.
+	 */
+	private function applyParagraphProperties(string $markup, array $style): string {
+		$properties = '';
+		$removals   = [];
+
+		if (isset($style['heading']) === true) {
+			$level = (int)$style['heading'];
+			if ($level > 0) {
+				$properties .= sprintf('<w:pStyle w:val="Heading%d"/>', $level);
+			} else {
+				// Level 0 means body text. This is a REMOVAL, not an absence: an
+				// early return here would leave an existing <w:pStyle> in place and
+				// report the restyle as applied while changing nothing — which is
+				// precisely what the first version of this method did.
+				$removals[] = 'w:pStyle';
+			}
+		}
+
+		if (isset($style['list']) === true && (bool)$style['list'] === false) {
+			$removals[] = 'w:numPr';
+		}
+
+		if (isset($style['pageBreakBefore']) === true && (bool)$style['pageBreakBefore'] === false) {
+			$removals[] = 'w:pageBreakBefore';
+		}
+
+		if (isset($style['list']) === true && (bool)$style['list'] === true) {
+			$properties .= '<w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>';
+		}
+
+		if (isset($style['pageBreakBefore']) === true && (bool)$style['pageBreakBefore'] === true) {
+			$properties .= '<w:pageBreakBefore/>';
+		}
+
+		if (isset($style['alignment']) === true) {
+			$properties .= sprintf('<w:jc w:val="%s"/>', self::ALIGNMENTS[(string)$style['alignment']]);
+		}
+
+		if ($properties === '' && $removals === []) {
+			return $markup;
+		}
+
+		return $this->mergeParagraphProperties(
+			markup: $markup,
+			properties: $properties,
+			removals: $removals
+		);
+	}//end applyParagraphProperties()
+
+	/**
+	 * Merge properties into the paragraph's `<w:pPr>`, creating it when absent.
+	 *
+	 * Existing properties of the SAME name are replaced; unrelated ones survive.
+	 * Wholesale replacement of `<w:pPr>` would silently drop spacing, indentation
+	 * and numbering the user set by hand — the class of loss ADR-087 §2 warns
+	 * about, and one no test would notice.
+	 *
+	 * @param string        $markup     The paragraph markup.
+	 * @param string        $properties The properties to merge.
+	 * @param array<string> $removals   Element names to remove outright.
+	 *
+	 * @return string The rewritten markup.
+	 */
+	private function mergeParagraphProperties(string $markup, string $properties, array $removals = []): string {
+		if (preg_match('#<w:pPr>(.*?)</w:pPr>#s', $markup, $matches) === 1) {
+			$existing = $this->dropSameNamed(existing: $matches[1], incoming: $properties);
+			$existing = $this->dropNamed(existing: $existing, names: $removals);
+
+			return (string)preg_replace(
+				'#<w:pPr>.*?</w:pPr>#s',
+				'<w:pPr>' . $existing . $properties . '</w:pPr>',
+				$markup,
+				1
+			);
+		}
+
+		if ($properties === '') {
+			// Nothing to add and no <w:pPr> to clean: creating an empty one would
+			// be noise in the document.
+			return $markup;
+		}
+
+		// `<w:pPr>` must be the FIRST child of `<w:p>`; Word rejects it elsewhere.
+		return (string)preg_replace(
+			'#(<w:p(?:\s[^>]*)?>)#',
+			'$1<w:pPr>' . $properties . '</w:pPr>',
+			$markup,
+			1
+		);
+	}//end mergeParagraphProperties()
+
+	/**
+	 * Remove existing properties whose element name is being set again.
+	 *
+	 * @param string $existing The existing property markup.
+	 * @param string $incoming The incoming property markup.
+	 *
+	 * @return string The retained existing markup.
+	 */
+	private function dropSameNamed(string $existing, string $incoming): string {
+		preg_match_all('#<(w:[A-Za-z]+)#', $incoming, $matches);
+
+		return $this->dropNamed(existing: $existing, names: array_unique($matches[1]));
+	}//end dropSameNamed()
+
+	/**
+	 * Remove named elements from a property block.
+	 *
+	 * @param string        $existing The existing property markup.
+	 * @param array<string> $names    The element names to remove.
+	 *
+	 * @return string The retained markup.
+	 */
+	private function dropNamed(string $existing, array $names): string {
+		foreach ($names as $name) {
+			$quoted   = preg_quote($name, '#');
+			$existing = (string)preg_replace('#<' . $quoted . '(?:\s[^>]*)?/>#', '', $existing);
+			$existing = (string)preg_replace('#<' . $quoted . '(?:\s[^>]*)?>.*?</' . $quoted . '>#s', '', $existing);
+		}
+
+		return $existing;
+	}//end dropNamed()
+
+	/**
+	 * Apply the run-level properties to every run in the paragraph.
+	 *
+	 * @param string $markup The paragraph markup.
+	 * @param array  $style  The style properties.
+	 *
+	 * @return string The rewritten markup.
+	 */
+	private function applyRunProperties(string $markup, array $style): string {
+		$properties = '';
+
+		foreach (['bold' => 'w:b', 'italic' => 'w:i', 'underline' => 'w:u'] as $key => $element) {
+			if (isset($style[$key]) === false) {
+				continue;
+			}
+
+			if ((bool)$style[$key] === false) {
+				// Explicit off, not absent: `<w:b w:val="0"/>` overrides a style
+				// that turns it on, which simply omitting the element would not.
+				$properties .= sprintf('<%s w:val="0"/>', $element);
+				continue;
+			}
+
+			if ($element === 'w:u') {
+				// Underline is the odd one out: it carries a STYLE, not a flag, so
+				// a bare `<w:u/>` is not "underlined".
+				$properties .= '<w:u w:val="single"/>';
+				continue;
+			}
+
+			$properties .= sprintf('<%s/>', $element);
+		}
+
+		if ($properties === '') {
+			return $markup;
+		}
+
+		return (string)preg_replace_callback(
+			'#<w:r(?:\s[^>]*)?>(.*?)</w:r>#s',
+			function (array $match) use ($properties): string {
+				return $this->mergeRunProperties(run: $match[0], properties: $properties);
+			},
+			$markup
+		);
+	}//end applyRunProperties()
+
+	/**
+	 * Merge run properties into one `<w:r>`, creating `<w:rPr>` when absent.
+	 *
+	 * @param string $run        The run markup.
+	 * @param string $properties The properties to merge.
+	 *
+	 * @return string The rewritten run.
+	 */
+	private function mergeRunProperties(string $run, string $properties): string {
+		if (preg_match('#<w:rPr>(.*?)</w:rPr>#s', $run, $matches) === 1) {
+			$existing = $this->dropSameNamed(existing: $matches[1], incoming: $properties);
+
+			return (string)preg_replace(
+				'#<w:rPr>.*?</w:rPr>#s',
+				'<w:rPr>' . $existing . $properties . '</w:rPr>',
+				$run,
+				1
+			);
+		}
+
+		return (string)preg_replace(
+			'#(<w:r(?:\s[^>]*)?>)#',
+			'$1<w:rPr>' . $properties . '</w:rPr>',
+			$run,
+			1
+		);
+	}//end mergeRunProperties()
+}//end class

--- a/lib/Service/Editing/BlockStyleCodec.php
+++ b/lib/Service/Editing/BlockStyleCodec.php
@@ -167,6 +167,22 @@ class BlockStyleCodec {
 			}
 		}
 
+		$this->assertKnownValues(style: $style);
+	}//end assertKnownKeys()
+
+	/**
+	 * Reject values that name something the codec cannot express.
+	 *
+	 * Split from {@see assertKnownKeys()} to keep both under phpmd's complexity
+	 * threshold; the behaviour is unchanged.
+	 *
+	 * @param array $style The style properties.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException When a value is not understood.
+	 */
+	private function assertKnownValues(array $style): void {
 		$alignment = ($style['alignment'] ?? null);
 		if ($alignment !== null && isset(self::ALIGNMENTS[(string)$alignment]) === false) {
 			throw new RuntimeException(
@@ -179,10 +195,14 @@ class BlockStyleCodec {
 		}
 
 		$heading = ($style['heading'] ?? null);
-		if ($heading !== null && (is_numeric($heading) === false || (int)$heading < 0 || (int)$heading > 9)) {
+		if ($heading === null) {
+			return;
+		}
+
+		if (is_numeric($heading) === false || (int)$heading < 0 || (int)$heading > 9) {
 			throw new RuntimeException('Heading level must be between 0 (body text) and 9.');
 		}
-	}//end assertKnownKeys()
+	}//end assertKnownValues()
 
 	/**
 	 * Apply the paragraph-level properties.
@@ -193,41 +213,8 @@ class BlockStyleCodec {
 	 * @return string The rewritten markup.
 	 */
 	private function applyParagraphProperties(string $markup, array $style): string {
-		$properties = '';
-		$removals   = [];
-
-		if (isset($style['heading']) === true) {
-			$level = (int)$style['heading'];
-			if ($level > 0) {
-				$properties .= sprintf('<w:pStyle w:val="Heading%d"/>', $level);
-			} else {
-				// Level 0 means body text. This is a REMOVAL, not an absence: an
-				// early return here would leave an existing <w:pStyle> in place and
-				// report the restyle as applied while changing nothing — which is
-				// precisely what the first version of this method did.
-				$removals[] = 'w:pStyle';
-			}
-		}
-
-		if (isset($style['list']) === true && (bool)$style['list'] === false) {
-			$removals[] = 'w:numPr';
-		}
-
-		if (isset($style['pageBreakBefore']) === true && (bool)$style['pageBreakBefore'] === false) {
-			$removals[] = 'w:pageBreakBefore';
-		}
-
-		if (isset($style['list']) === true && (bool)$style['list'] === true) {
-			$properties .= '<w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>';
-		}
-
-		if (isset($style['pageBreakBefore']) === true && (bool)$style['pageBreakBefore'] === true) {
-			$properties .= '<w:pageBreakBefore/>';
-		}
-
-		if (isset($style['alignment']) === true) {
-			$properties .= sprintf('<w:jc w:val="%s"/>', self::ALIGNMENTS[(string)$style['alignment']]);
-		}
+		$properties = $this->paragraphAdditions(style: $style);
+		$removals   = $this->paragraphRemovals(style: $style);
 
 		if ($properties === '' && $removals === []) {
 			return $markup;
@@ -239,6 +226,66 @@ class BlockStyleCodec {
 			removals: $removals
 		);
 	}//end applyParagraphProperties()
+
+	/**
+	 * The paragraph properties this style adds.
+	 *
+	 * @param array $style The style properties.
+	 *
+	 * @return string The property markup.
+	 */
+	private function paragraphAdditions(array $style): string {
+		$properties = '';
+
+		$heading = (int)($style['heading'] ?? 0);
+		if ($heading > 0) {
+			$properties .= sprintf('<w:pStyle w:val="Heading%d"/>', $heading);
+		}
+
+		if (($style['list'] ?? false) === true) {
+			$properties .= '<w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>';
+		}
+
+		if (($style['pageBreakBefore'] ?? false) === true) {
+			$properties .= '<w:pageBreakBefore/>';
+		}
+
+		if (isset($style['alignment']) === true) {
+			$properties .= sprintf('<w:jc w:val="%s"/>', self::ALIGNMENTS[(string)$style['alignment']]);
+		}
+
+		return $properties;
+	}//end paragraphAdditions()
+
+	/**
+	 * The paragraph properties this style REMOVES.
+	 *
+	 * Switching a property off is a removal, not an absence. Treating it as
+	 * "nothing to add" leaves the existing element in place and reports the
+	 * restyle as applied while changing nothing — which is exactly what the first
+	 * version of this codec did with `heading: 0`.
+	 *
+	 * @param array $style The style properties.
+	 *
+	 * @return array<int, string> The element names to remove.
+	 */
+	private function paragraphRemovals(array $style): array {
+		$removals = [];
+
+		if (isset($style['heading']) === true && (int)$style['heading'] === 0) {
+			$removals[] = 'w:pStyle';
+		}
+
+		if (isset($style['list']) === true && (bool)$style['list'] === false) {
+			$removals[] = 'w:numPr';
+		}
+
+		if (isset($style['pageBreakBefore']) === true && (bool)$style['pageBreakBefore'] === false) {
+			$removals[] = 'w:pageBreakBefore';
+		}
+
+		return $removals;
+	}//end paragraphRemovals()
 
 	/**
 	 * Merge properties into the paragraph's `<w:pPr>`, creating it when absent.

--- a/lib/Service/Editing/DocumentAgentService.php
+++ b/lib/Service/Editing/DocumentAgentService.php
@@ -129,11 +129,15 @@ class DocumentAgentService {
 
 	#[McpTool(
 		name: 'editDocument',
-		description: 'Change the text of a Word (.docx) or OpenDocument (.odt) file by replacing, inserting '
-			. 'after, or deleting anchored paragraphs. Call readDocument first to get the anchors and version. '
-			. 'Writes into the file by default (restorable via Nextcloud file versions); pass outputMode '
-			. '"sibling" to write a new file instead. Refuses if the document changed since it was read, if it '
-			. 'is open in an editor, if it is under a signing request, or if it is anonymisation output.',
+		description: 'Change a Word (.docx) or OpenDocument (.odt) file by replacing, inserting after, or '
+			. 'deleting anchored paragraphs, or by restyling one with action "style". A style edit carries a '
+			. '"style" object instead of text: bold, italic, underline (true/false), alignment '
+			. '(left/center/right/justify), heading (0-9, where 0 means body text), list (true/false), '
+			. 'pageBreakBefore (true/false). Style edits need a .docx -- .odt is refused by name. Call '
+			. 'readDocument first to get the anchors and version. Writes into the file by default (restorable '
+			. 'via Nextcloud file versions); pass outputMode "sibling" to write a new file instead. Refuses if '
+			. 'the document changed since it was read, if it is open in an editor, if it is under a signing '
+			. 'request, or if it is anonymisation output.',
 		readOnlyHint: false,
 		destructiveHint: true,
 		idempotentHint: false,
@@ -194,6 +198,93 @@ class DocumentAgentService {
 		return ($result + ['artefact' => ['type' => 'file', 'id' => (string)$result['fileId']]]);
 
 	}//end editDocument()
+
+	#[McpTool(
+		name: 'readDocumentMetadata',
+		description: 'Read a Word (.docx) or OpenDocument (.odt) file\'s document properties: title, subject, '
+			. 'creator, keywords and description. Use this before setDocumentMetadata: it returns the version '
+			. 'that call requires. A property the document does not carry comes back as an empty string.',
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		scope: 'read'
+	)]
+	/**
+	 * Read a document's properties.
+	 *
+	 * Fields are named format-neutrally (`title`, `subject`, `creator`, `keywords`,
+	 * `description`). The caller never sees that OOXML stores keywords as
+	 * `cp:keywords` and ODF as `meta:keyword` -- a caller that had to know would be
+	 * writing per-format code, which ADR-087 §2 exists to prevent.
+	 *
+	 * @param int $fileId The Nextcloud file id of the document to read.
+	 *
+	 * @return array<string, mixed> The document's name, version and metadata fields.
+	 *
+	 * @throws RuntimeException When the file cannot be read or the format has no metadata part.
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function readDocumentMetadata(int $fileId): array {
+		return $this->editSession->readMetadataForAgent(uid: $this->requireUid(), fileId: $fileId);
+
+	}//end readDocumentMetadata()
+
+	#[McpTool(
+		name: 'setDocumentMetadata',
+		description: 'Set a Word (.docx) or OpenDocument (.odt) file\'s document properties. Supported fields: '
+			. 'title, subject, creator, keywords, description. Call readDocumentMetadata first and pass back '
+			. 'the version it returned. Fields you do not name are left unchanged. Created and modified '
+			. 'timestamps cannot be set. The file is tagged "Agent authored" and the previous version stays '
+			. 'restorable in Nextcloud.',
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: true,
+		scope: 'update'
+	)]
+	/**
+	 * Set a document's properties.
+	 *
+	 * Goes through the same editing session as a text change: same lock, same
+	 * version recheck immediately before the write, same agent-authored tag applied
+	 * before the bytes become visible. Metadata is a smaller change than a
+	 * paragraph rewrite, not a less accountable one.
+	 *
+	 * `created` and `modified` are deliberately not writable. They record what
+	 * happened to the document, and an agent that could set them would turn that
+	 * record from a fact into a claim.
+	 *
+	 * @param int $fileId The Nextcloud file id of the document to change.
+	 * @param array<string, string> $metadata Field name => new value.
+	 * @param string $version The version returned by readDocumentMetadata.
+	 * @param string $outputMode Empty for the configured default, or "sibling" to write a new file.
+	 *
+	 * @return array<string, mixed> The written file's id, name, path, version and the fields written.
+	 *
+	 * @throws RuntimeException When the version is stale, a field is unknown, or the write is refused.
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function setDocumentMetadata(
+		int $fileId,
+		array $metadata,
+		string $version,
+		string $outputMode = ''
+	): array {
+		$mode = null;
+		if ($outputMode !== '') {
+			$mode = $outputMode;
+		}
+
+		return $this->editSession->setMetadataForAgent(
+			uid: $this->requireUid(),
+			fileId: $fileId,
+			values: $metadata,
+			version: $version,
+			requestedMode: $mode
+		);
+
+	}//end setDocumentMetadata()
 
 	#[McpTool(
 		name: 'convertDocumentToPdf',

--- a/lib/Service/Editing/EditSessionService.php
+++ b/lib/Service/Editing/EditSessionService.php
@@ -126,6 +126,7 @@ class EditSessionService {
 	 * @param DocumentGuard $guard The standing refusals.
 	 * @param IAppConfig $appConfig App configuration.
 	 * @param LoggerInterface $logger Logger for diagnostics.
+	 * @param PackageMetadataCodec $metadata The document metadata codec.
 	 *
 	 * @return void
 	 */
@@ -137,6 +138,7 @@ class EditSessionService {
 		private readonly DocumentGuard $guard,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly PackageMetadataCodec $metadata = new PackageMetadataCodec(),
 	) {
 
 	}//end __construct()
@@ -227,7 +229,11 @@ class EditSessionService {
 		return $this->runSession(
 			uid: $uid,
 			file: $file,
-			edits: $edits,
+			transform: fn (string $bytes, string $extension): array => $this->codec->applyEdits(
+				packageBytes: $bytes,
+				extension: $extension,
+				edits: $edits
+			),
 			version: $version,
 			mode: $mode
 		);
@@ -235,11 +241,96 @@ class EditSessionService {
 	}//end editForAgent()
 
 	/**
+	 * Read a document's metadata.
+	 *
+	 * @param string $uid The acting user id.
+	 * @param int $fileId The Nextcloud file id.
+	 *
+	 * @return array<string, mixed> The document's name, format, version and metadata.
+	 *
+	 * @throws RuntimeException When the file cannot be read or the format is unsupported.
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function readMetadataForAgent(string $uid, int $fileId): array {
+		$file = $this->resolveFile(uid: $uid, fileId: $fileId);
+
+		return [
+			'fileId' => $file->getId(),
+			'name' => $file->getName(),
+			'path' => $this->userPath(uid: $uid, file: $file),
+			'version' => $file->getEtag(),
+			'editable' => ($file->isUpdateable() === true),
+			'metadata' => $this->metadata->readMetadata(
+				packageBytes: $this->readBytes(file: $file),
+				extension: $file->getExtension()
+			),
+		];
+
+	}//end readMetadataForAgent()
+
+	/**
+	 * Write a document's metadata.
+	 *
+	 * Runs through the same session as a body edit -- same lock, same version
+	 * recheck immediately before the write, same agent-authored tag applied before
+	 * the bytes become visible. Metadata is a smaller change than a paragraph
+	 * rewrite, not a less accountable one.
+	 *
+	 * @param string $uid The acting user id.
+	 * @param int $fileId The Nextcloud file id.
+	 * @param array<string, string> $values Field name => new value.
+	 * @param string $version The version returned by the preceding read.
+	 * @param string|null $requestedMode The requested output mode, or null for the configured default.
+	 *
+	 * @return array<string, mixed> The write result.
+	 *
+	 * @throws RuntimeException On any refusal or failure.
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function setMetadataForAgent(
+		string $uid,
+		int $fileId,
+		array $values,
+		string $version,
+		?string $requestedMode = null,
+	): array {
+		if (trim($version) === '') {
+			throw new RuntimeException(
+				'A version is required. Read the document metadata first and pass back the version it returned.'
+			);
+		}
+
+		$file = $this->resolveFile(uid: $uid, fileId: $fileId);
+		$mode = $this->resolveMode(requested: $requestedMode);
+
+		$this->refuseIfGuarded(file: $file);
+
+		if ($mode === self::MODE_IN_PLACE && $file->isUpdateable() === false) {
+			throw new RuntimeException('You do not have permission to change this file.');
+		}
+
+		return $this->runSession(
+			uid: $uid,
+			file: $file,
+			transform: fn (string $bytes, string $extension): array => $this->metadata->writeMetadata(
+				packageBytes: $bytes,
+				extension: $extension,
+				values: $values
+			),
+			version: $version,
+			mode: $mode
+		);
+
+	}//end setMetadataForAgent()
+
+	/**
 	 * Hold the lock across the whole read-modify-write, and release it on every exit path.
 	 *
 	 * @param string $uid The acting user id.
 	 * @param File $file The source file.
-	 * @param array<int, array<string, mixed>> $edits The edits.
+	 * @param callable $transform Given (bytes, extension), returns the rewritten package.
 	 * @param string $version The expected version.
 	 * @param string $mode The resolved output mode.
 	 *
@@ -247,7 +338,7 @@ class EditSessionService {
 	 *
 	 * @throws RuntimeException On any refusal or failure.
 	 */
-	private function runSession(string $uid, File $file, array $edits, string $version, string $mode): array {
+	private function runSession(string $uid, File $file, callable $transform, string $version, string $mode): array {
 		$lock = new LockContext($file, ILock::TYPE_APP, Application::APP_ID);
 		$held = $this->acquire(lock: $lock, file: $file);
 		$warnings = [];
@@ -258,12 +349,13 @@ class EditSessionService {
 		}
 
 		try {
+			// The transform is a parameter rather than a fixed call so that a
+			// metadata write gets the IDENTICAL lock, version-recheck, tag-then-write
+			// and unlock path as a body edit. Copying this method for metadata would
+			// have meant two copies of the only code that stops an agent clobbering
+			// a concurrent human edit — and the copy would drift.
 			$bytes = $this->readBytes(file: $file);
-			$edited = $this->codec->applyEdits(
-				packageBytes: $bytes,
-				extension: $file->getExtension(),
-				edits: $edits
-			);
+			$edited = $transform($bytes, $file->getExtension());
 
 			// Re-read the version immediately before the write. The lock excludes
 			// another editing SESSION; this closes the remaining window in which
@@ -284,7 +376,8 @@ class EditSessionService {
 				'name' => $written['name'],
 				'path' => $written['path'],
 				'outputMode' => $mode,
-				'appliedAnchors' => $edited['applied'],
+				'appliedAnchors' => ($edited['applied'] ?? []),
+				'metadataWritten' => ($edited['written'] ?? []),
 				'version' => $written['version'],
 				'agentAuthoredTag' => AgentArtefactMarker::TAG_NAME,
 				'warnings' => $warnings,

--- a/lib/Service/Editing/PackageCodec.php
+++ b/lib/Service/Editing/PackageCodec.php
@@ -34,7 +34,6 @@ declare(strict_types=1);
 namespace OCA\DocuDesk\Service\Editing;
 
 use RuntimeException;
-use ZipArchive;
 
 /**
  * Byte-surgical reader/editor for ODF and OOXML word-processing packages.
@@ -112,21 +111,42 @@ class PackageCodec {
 	public const ACTION_DELETE = 'delete';
 
 	/**
+	 * Edit action: change the anchored paragraph's style or layout, not its text.
+	 *
+	 * Separate from `replace` on purpose. Restyling and rewording are different
+	 * intentions, and folding them together would mean a caller that wanted bold
+	 * had to resend the text — which, when the caller is a language model, is an
+	 * invitation to paraphrase the paragraph while "only" making it bold.
+	 *
+	 * @var string
+	 */
+	public const ACTION_STYLE = 'style';
+
+	/**
 	 * Every action this codec understands.
 	 *
 	 * @var array<int, string>
 	 */
-	public const ACTIONS = [self::ACTION_REPLACE, self::ACTION_INSERT_AFTER, self::ACTION_DELETE];
+	public const ACTIONS = [
+		self::ACTION_REPLACE,
+		self::ACTION_INSERT_AFTER,
+		self::ACTION_DELETE,
+		self::ACTION_STYLE,
+	];
 
 	/**
 	 * Constructor.
 	 *
 	 * @param XmlBlockScanner $scanner The element-span scanner.
+	 * @param BlockStyleCodec $styles  The paragraph style/layout codec.
+	 * @param PackagePartIo   $io      The package part reader/writer.
 	 *
 	 * @return void
 	 */
 	public function __construct(
 		private readonly XmlBlockScanner $scanner = new XmlBlockScanner(),
+		private readonly BlockStyleCodec $styles = new BlockStyleCodec(),
+		private readonly PackagePartIo $io = new PackagePartIo(),
 	) {
 
 	}//end __construct()
@@ -177,7 +197,7 @@ class PackageCodec {
 	 */
 	public function readBlocks(string $packageBytes, string $extension): array {
 		$package = $this->packageFor(extension: $extension);
-		$xml = $this->readPart(packageBytes: $packageBytes, part: $package['part']);
+		$xml = $this->io->readPart(packageBytes: $packageBytes, part: $package['part']);
 
 		$blocks = [];
 		foreach ($this->scanner->spans(xml:$xml, tag: $package['tag']) as $span) {
@@ -218,7 +238,7 @@ class PackageCodec {
 		}
 
 		$package = $this->packageFor(extension: $extension);
-		$xml = $this->readPart(packageBytes: $packageBytes, part: $package['part']);
+		$xml = $this->io->readPart(packageBytes: $packageBytes, part: $package['part']);
 
 		$spans = $this->scanner->spans(xml:$xml, tag: $package['tag']);
 		$texts = [];
@@ -245,7 +265,7 @@ class PackageCodec {
 		}
 
 		return [
-			'bytes' => $this->writePart(
+			'bytes' => $this->io->writePart(
 				packageBytes: $packageBytes,
 				part: $package['part'],
 				xml: $xml
@@ -300,9 +320,24 @@ class PackageCodec {
 			}
 
 			$text = (string)($edit['text'] ?? '');
-			if ($action !== self::ACTION_DELETE && $text === '') {
+			$textless = [self::ACTION_DELETE, self::ACTION_STYLE];
+			if (in_array($action, $textless, true) === false && $text === '') {
 				throw new RuntimeException(
 					sprintf('Edit %d: action "%s" requires non-empty text.', ((int)$position + 1), $action)
+				);
+			}
+
+			// A style edit carries no text by design — see ACTION_STYLE. It must
+			// carry style properties instead, or it is a request to change nothing
+			// that would otherwise report success.
+			$style = ($edit['style'] ?? []);
+			if ($action === self::ACTION_STYLE && (is_array($style) === false || $style === [])) {
+				throw new RuntimeException(
+					sprintf(
+						'Edit %d: action "style" requires a non-empty "style" object. Supported properties: %s.',
+						((int)$position + 1),
+						implode(', ', BlockStyleCodec::STYLE_KEYS)
+					)
 				);
 			}
 
@@ -311,6 +346,7 @@ class PackageCodec {
 				'anchor' => $anchor,
 				'action' => $action,
 				'text' => $text,
+				'style' => (array)$style,
 			];
 		}//end foreach
 
@@ -336,6 +372,11 @@ class PackageCodec {
 			self::ACTION_INSERT_AFTER => $markup . $this->setText(
 				markup: $markup,
 				text: $edit['text'],
+				format: $format
+			),
+			self::ACTION_STYLE => $this->styles->applyStyle(
+				markup: $markup,
+				style: $edit['style'],
 				format: $format
 			),
 			default => $this->setText(markup: $markup, text: $edit['text'], format: $format),
@@ -371,103 +412,13 @@ class PackageCodec {
 	}//end packageFor()
 
 	/**
-	 * Read one entry out of a ZIP package held in memory.
+	 * Package part IO moved to {@see PackagePartIo}.
 	 *
-	 * @param string $packageBytes The raw package bytes.
-	 * @param string $part The entry name.
-	 *
-	 * @return string The entry contents.
-	 *
-	 * @throws RuntimeException When the package or the entry cannot be read.
+	 * Metadata lives in a different part from the body, so the choice was one
+	 * shared reader or two divergent copies of the same ZipArchive dance. The
+	 * property that untouched parts survive an edit byte-identical is a property
+	 * of exactly that code, and it should exist once.
 	 */
-	private function readPart(string $packageBytes, string $part): string {
-		$path = $this->spill(bytes: $packageBytes);
-
-		try {
-			$zip = new ZipArchive();
-			if ($zip->open($path) !== true) {
-				throw new RuntimeException('The file is not a readable document package.');
-			}
-
-			$xml = $zip->getFromName($part);
-			$zip->close();
-
-			if ($xml === false) {
-				throw new RuntimeException(
-					sprintf('The document package has no "%s" part; it may be corrupt.', $part)
-				);
-			}
-
-			return $xml;
-		} finally {
-			unlink($path);
-		}
-
-	}//end readPart()
-
-	/**
-	 * Write one entry back into a ZIP package, leaving every other entry as-is.
-	 *
-	 * `ZipArchive` copies untouched entries' raw compressed data rather than
-	 * recompressing them, which is what keeps the rest of the package -- and
-	 * ODF's uncompressed leading `mimetype` entry -- intact.
-	 *
-	 * @param string $packageBytes The raw package bytes.
-	 * @param string $part The entry name.
-	 * @param string $xml The new entry contents.
-	 *
-	 * @return string The rewritten package bytes.
-	 *
-	 * @throws RuntimeException When the package cannot be rewritten.
-	 */
-	private function writePart(string $packageBytes, string $part, string $xml): string {
-		$path = $this->spill(bytes: $packageBytes);
-
-		try {
-			$zip = new ZipArchive();
-			if ($zip->open($path) !== true) {
-				throw new RuntimeException('The file is not a writable document package.');
-			}
-
-			if ($zip->addFromString($part, $xml) === false) {
-				$zip->close();
-				throw new RuntimeException(sprintf('Could not rewrite the "%s" part.', $part));
-			}
-
-			$zip->close();
-
-			$bytes = file_get_contents($path);
-			if ($bytes === false) {
-				throw new RuntimeException('Could not read the rewritten document package.');
-			}
-
-			return $bytes;
-		} finally {
-			unlink($path);
-		}
-
-	}//end writePart()
-
-	/**
-	 * Spill bytes to a temporary file, because `ZipArchive` has no in-memory mode.
-	 *
-	 * @param string $bytes The bytes to spill.
-	 *
-	 * @return string The temporary file path.
-	 *
-	 * @throws RuntimeException When no temporary file can be created.
-	 */
-	private function spill(string $bytes): string {
-		$path = tempnam(sys_get_temp_dir(), 'docudesk-pkg-');
-		if ($path === false) {
-			throw new RuntimeException('Could not create a temporary file for the document package.');
-		}
-
-		file_put_contents($path, $bytes);
-
-		return $path;
-
-	}//end spill()
 
 	/**
 	 * Extract a block's visible text from its markup.

--- a/lib/Service/Editing/PackageCodec.php
+++ b/lib/Service/Editing/PackageCodec.php
@@ -290,7 +290,7 @@ class PackageCodec {
 	 * @param array<int, array<string, mixed>> $edits The requested edits.
 	 * @param array<int, string> $anchors The anchors of the current blocks, in document order.
 	 *
-	 * @return array<int, array{index: int, anchor: string, action: string, text: string}>
+	 * @return array<int, array{index: int, anchor: string, action: string, text: string, style: array<string, mixed>}>
 	 *
 	 * @throws RuntimeException When an anchor is unknown or an action is not supported.
 	 */
@@ -359,7 +359,7 @@ class PackageCodec {
 	 *
 	 * @param string $xml The part XML.
 	 * @param array{0: int, 1: int} $span The span offset and length.
-	 * @param array{action: string, text: string} $edit The edit to apply.
+	 * @param array{action: string, text: string, style: array<string, mixed>} $edit The edit to apply.
 	 * @param string $format The package family.
 	 *
 	 * @return string The rewritten part XML.

--- a/lib/Service/Editing/PackageMetadataCodec.php
+++ b/lib/Service/Editing/PackageMetadataCodec.php
@@ -1,0 +1,355 @@
+<?php
+
+/**
+ * DocuDesk PackageMetadataCodec
+ *
+ * Reads and writes document metadata — title, subject, creator, keywords,
+ * description — in ODF and OOXML packages.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service\Editing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service\Editing;
+
+use RuntimeException;
+
+/**
+ * Document metadata, addressed by a format-neutral field name.
+ *
+ * Both families store the same handful of Dublin Core fields, in different parts
+ * under different element names:
+ *
+ *   OOXML  docProps/core.xml   dc:title, dc:subject, dc:creator,
+ *                              cp:keywords, dc:description
+ *   ODF    meta.xml            dc:title, dc:subject, dc:creator,
+ *                              meta:keyword, dc:description
+ *
+ * Callers name a field once (`title`, `subject`, …) and the codec resolves the
+ * element. A caller that had to know `cp:keywords` for one format and
+ * `meta:keyword` for the other would be writing per-format code, which is the
+ * thing ADR-087 §2 exists to prevent — the formats differ, but the CAPABILITY does
+ * not.
+ *
+ * Only these five fields are writable. `dcterms:created` / `dcterms:modified` and
+ * ODF's `meta:editing-cycles` are deliberately excluded: they are a record of what
+ * happened to the document, and letting an agent set them would make that record
+ * a claim rather than a fact.
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service\Editing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ *
+ * @spec openspec/specs/document-rich-editing/spec.md
+ */
+class PackageMetadataCodec {
+
+	/**
+	 * Per-extension metadata part and element mapping.
+	 *
+	 * @var array<string, array{part: string, root: string, ns: string, fields: array<string, string>}>
+	 */
+	private const PACKAGES = [
+		'docx' => [
+			'part'   => 'docProps/core.xml',
+			'root'   => 'cp:coreProperties',
+			'ns'     => 'xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" '
+				. 'xmlns:dc="http://purl.org/dc/elements/1.1/" '
+				. 'xmlns:dcterms="http://purl.org/dc/terms/" '
+				. 'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
+			'fields' => [
+				'title'       => 'dc:title',
+				'subject'     => 'dc:subject',
+				'creator'     => 'dc:creator',
+				'keywords'    => 'cp:keywords',
+				'description' => 'dc:description',
+			],
+		],
+		'odt'  => [
+			'part'   => 'meta.xml',
+			'root'   => 'office:document-meta',
+			'ns'     => 'xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" '
+				. 'xmlns:dc="http://purl.org/dc/elements/1.1/" '
+				. 'xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0"',
+			'fields' => [
+				'title'       => 'dc:title',
+				'subject'     => 'dc:subject',
+				'creator'     => 'dc:creator',
+				'keywords'    => 'meta:keyword',
+				'description' => 'dc:description',
+			],
+		],
+	];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param PackagePartIo $io The package part reader/writer.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly PackagePartIo $io = new PackagePartIo(),
+	) {
+	}//end __construct()
+
+	/**
+	 * Whether metadata can be addressed for this extension.
+	 *
+	 * @param string $extension The file extension, without a leading dot.
+	 *
+	 * @return bool True when supported.
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function supports(string $extension): bool {
+		return isset(self::PACKAGES[strtolower($extension)]);
+	}//end supports()
+
+	/**
+	 * The field names this codec understands.
+	 *
+	 * @return array<int, string> The field names.
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function fields(): array {
+		return array_keys(self::PACKAGES['docx']['fields']);
+	}//end fields()
+
+	/**
+	 * Read a document's metadata.
+	 *
+	 * A field the document does not carry comes back as an empty string rather
+	 * than being omitted, so a caller can tell "this document has no subject" from
+	 * "I forgot to ask for the subject".
+	 *
+	 * @param string $packageBytes The raw package bytes.
+	 * @param string $extension    The file extension.
+	 *
+	 * @return array<string, string> Field name => value.
+	 *
+	 * @throws RuntimeException When the extension is unsupported.
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function readMetadata(string $packageBytes, string $extension): array {
+		$package = $this->packageFor(extension: $extension);
+
+		$xml = '';
+		if ($this->io->hasPart(packageBytes: $packageBytes, part: $package['part']) === true) {
+			$xml = $this->io->readPart(packageBytes: $packageBytes, part: $package['part']);
+		}
+
+		$values = [];
+		foreach ($package['fields'] as $field => $element) {
+			$values[$field] = $this->readElement(xml: $xml, element: $element);
+		}
+
+		return $values;
+	}//end readMetadata()
+
+	/**
+	 * Write metadata fields, leaving unnamed fields and every other part untouched.
+	 *
+	 * @param string                $packageBytes The raw package bytes.
+	 * @param string                $extension    The file extension.
+	 * @param array<string, string> $values       Field name => new value.
+	 *
+	 * @return array{bytes: string, written: array<int, string>}
+	 *
+	 * @throws RuntimeException When the extension or a field name is unsupported.
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function writeMetadata(string $packageBytes, string $extension, array $values): array {
+		$package = $this->packageFor(extension: $extension);
+
+		if ($values === []) {
+			throw new RuntimeException('At least one metadata field is required.');
+		}
+
+		foreach (array_keys($values) as $field) {
+			if (isset($package['fields'][$field]) === false) {
+				throw new RuntimeException(
+					sprintf(
+						'Unknown metadata field "%s". This document supports: %s.',
+						(string)$field,
+						implode(', ', array_keys($package['fields']))
+					)
+				);
+			}
+		}
+
+		$xml = $this->existingOrEmpty(packageBytes: $packageBytes, package: $package);
+
+		$written = [];
+		foreach ($values as $field => $value) {
+			$xml       = $this->writeElement(
+				xml: $xml,
+				element: $package['fields'][$field],
+				value: (string)$value
+			);
+			$written[] = (string)$field;
+		}
+
+		return [
+			'bytes'   => $this->io->writePart(
+				packageBytes: $packageBytes,
+				part: $package['part'],
+				xml: $xml
+			),
+			'written' => $written,
+		];
+	}//end writeMetadata()
+
+	/**
+	 * Return the existing metadata part, or a minimal well-formed one.
+	 *
+	 * A document with no metadata part is ordinary — PhpWord-generated ODF often
+	 * has none — so this creates one rather than refusing. The namespace
+	 * declarations must be present on the root or the written elements resolve to
+	 * nothing and the suite silently ignores them.
+	 *
+	 * @param string $packageBytes The raw package bytes.
+	 * @param array  $package      The package mapping.
+	 *
+	 * @return string The metadata XML.
+	 */
+	private function existingOrEmpty(string $packageBytes, array $package): string {
+		if ($this->io->hasPart(packageBytes: $packageBytes, part: $package['part']) === true) {
+			return $this->io->readPart(packageBytes: $packageBytes, part: $package['part']);
+		}
+
+		return sprintf(
+			'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' . "\n" . '<%s %s></%s>',
+			$package['root'],
+			$package['ns'],
+			$package['root']
+		);
+	}//end existingOrEmpty()
+
+	/**
+	 * Read one element's text.
+	 *
+	 * @param string $xml     The metadata XML.
+	 * @param string $element The element name.
+	 *
+	 * @return string The text, or an empty string.
+	 */
+	private function readElement(string $xml, string $element): string {
+		$pattern = sprintf('#<%s(?:\s[^>]*)?>(.*?)</%s>#s', preg_quote($element, '#'), preg_quote($element, '#'));
+		if (preg_match($pattern, $xml, $matches) !== 1) {
+			return '';
+		}
+
+		return html_entity_decode($matches[1], (ENT_QUOTES | ENT_XML1), 'UTF-8');
+	}//end readElement()
+
+	/**
+	 * Set one element's text, adding the element when it is absent.
+	 *
+	 * @param string $xml     The metadata XML.
+	 * @param string $element The element name.
+	 * @param string $value   The new text.
+	 *
+	 * @return string The rewritten XML.
+	 *
+	 * @throws RuntimeException When the root element cannot be found.
+	 */
+	private function writeElement(string $xml, string $element, string $value): string {
+		$escaped = htmlspecialchars($value, (ENT_QUOTES | ENT_XML1), 'UTF-8');
+		$quoted  = preg_quote($element, '#');
+
+		$existing = sprintf('#<%s(?:\s[^>]*)?>.*?</%s>#s', $quoted, $quoted);
+		if (preg_match($existing, $xml) === 1) {
+			return (string)preg_replace(
+				$existing,
+				sprintf('<%s>%s</%s>', $element, $escaped, $element),
+				$xml,
+				1
+			);
+		}
+
+		// Self-closing form, which is what an empty field is often serialised as.
+		$selfClosing = sprintf('#<%s(?:\s[^>]*)?/>#', $quoted);
+		if (preg_match($selfClosing, $xml) === 1) {
+			return (string)preg_replace(
+				$selfClosing,
+				sprintf('<%s>%s</%s>', $element, $escaped, $element),
+				$xml,
+				1
+			);
+		}
+
+		// A metadata part can carry a SELF-CLOSING root — `<cp:coreProperties/>` is
+		// what several writers emit for a document with no properties set. There is
+		// no closing tag to insert before, so expand it into an open/close pair
+		// first. Without this, the ordinary "document has an empty metadata part"
+		// case reports the part as corrupt.
+		$xml = (string)preg_replace(
+			'#<([A-Za-z0-9:_-]+)((?:\s[^>]*?)?)/>\s*$#',
+			'<$1$2></$1>',
+			$xml,
+			1
+		);
+
+		// Absent: insert before the root's closing tag.
+		if (preg_match('#</([A-Za-z0-9:_-]+)>\s*$#', $xml, $matches) !== 1) {
+			throw new RuntimeException('The metadata part has no closing root element; it may be corrupt.');
+		}
+
+		$closing = sprintf('</%s>', $matches[1]);
+
+		return (string)preg_replace(
+			'#' . preg_quote($closing, '#') . '\s*$#',
+			sprintf('<%s>%s</%s>%s', $element, $escaped, $element, $closing),
+			$xml,
+			1
+		);
+	}//end writeElement()
+
+	/**
+	 * Resolve the package mapping for an extension.
+	 *
+	 * @param string $extension The file extension.
+	 *
+	 * @return array{part: string, root: string, ns: string, fields: array<string, string>}
+	 *
+	 * @throws RuntimeException When the extension is unsupported.
+	 */
+	private function packageFor(string $extension): array {
+		$key = strtolower($extension);
+		if (isset(self::PACKAGES[$key]) === false) {
+			throw new RuntimeException(
+				sprintf(
+					'Metadata cannot be addressed in a "%s" file. Supported: %s.',
+					$extension,
+					implode(', ', array_keys(self::PACKAGES))
+				)
+			);
+		}
+
+		return self::PACKAGES[$key];
+	}//end packageFor()
+}//end class

--- a/lib/Service/Editing/PackagePartIo.php
+++ b/lib/Service/Editing/PackagePartIo.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * DocuDesk PackagePartIo
+ *
+ * Reads and writes a single entry of an ODF/OOXML ZIP package while leaving every
+ * other entry byte-identical.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service\Editing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service\Editing;
+
+use RuntimeException;
+use ZipArchive;
+
+/**
+ * Single-entry package IO, shared by every codec that edits a document in place.
+ *
+ * Extracted from {@see PackageCodec} when metadata editing arrived: metadata lives
+ * in a DIFFERENT part (`docProps/core.xml`, `meta.xml`) from the body, so the
+ * choice was one shared reader or two divergent copies of the same ZipArchive
+ * dance. Divergence here would be expensive — the reason untouched parts survive
+ * an edit is a property of exactly this code.
+ *
+ * `ZipArchive` copies untouched entries' raw compressed data rather than
+ * recompressing them, which is what keeps the rest of the package — and ODF's
+ * uncompressed leading `mimetype` entry — intact.
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service\Editing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ *
+ * @spec openspec/specs/document-editing/spec.md
+ */
+class PackagePartIo {
+
+	/**
+	 * Read one entry from a ZIP package.
+	 *
+	 * @param string $packageBytes The raw package bytes.
+	 * @param string $part         The entry name.
+	 *
+	 * @return string The entry contents.
+	 *
+	 * @throws RuntimeException When the package or the entry cannot be read.
+	 *
+	 * @spec openspec/specs/document-editing/spec.md
+	 */
+	public function readPart(string $packageBytes, string $part): string {
+		$path = $this->spill(bytes: $packageBytes);
+
+		try {
+			$zip = new ZipArchive();
+			if ($zip->open($path) !== true) {
+				throw new RuntimeException('The file is not a readable document package.');
+			}
+
+			$xml = $zip->getFromName($part);
+			$zip->close();
+
+			if ($xml === false) {
+				throw new RuntimeException(
+					sprintf('The document package has no "%s" part; it may be corrupt.', $part)
+				);
+			}
+
+			return $xml;
+		} finally {
+			unlink($path);
+		}
+	}//end readPart()
+
+	/**
+	 * Whether a package carries an entry.
+	 *
+	 * Distinct from catching {@see readPart()}'s exception, because "this document
+	 * has no metadata part yet" is an ordinary state that must be handled by
+	 * creating one — not an error to be reported to a user.
+	 *
+	 * @param string $packageBytes The raw package bytes.
+	 * @param string $part         The entry name.
+	 *
+	 * @return bool True when the entry exists.
+	 *
+	 * @spec openspec/specs/document-editing/spec.md
+	 */
+	public function hasPart(string $packageBytes, string $part): bool {
+		$path = $this->spill(bytes: $packageBytes);
+
+		try {
+			$zip = new ZipArchive();
+			if ($zip->open($path) !== true) {
+				return false;
+			}
+
+			$found = ($zip->locateName($part) !== false);
+			$zip->close();
+
+			return $found;
+		} finally {
+			unlink($path);
+		}
+	}//end hasPart()
+
+	/**
+	 * Write one entry back into a ZIP package, leaving every other entry as-is.
+	 *
+	 * @param string $packageBytes The raw package bytes.
+	 * @param string $part         The entry name.
+	 * @param string $xml          The new entry contents.
+	 *
+	 * @return string The rewritten package bytes.
+	 *
+	 * @throws RuntimeException When the package cannot be rewritten.
+	 *
+	 * @spec openspec/specs/document-editing/spec.md
+	 */
+	public function writePart(string $packageBytes, string $part, string $xml): string {
+		$path = $this->spill(bytes: $packageBytes);
+
+		try {
+			$zip = new ZipArchive();
+			if ($zip->open($path) !== true) {
+				throw new RuntimeException('The file is not a writable document package.');
+			}
+
+			if ($zip->addFromString($part, $xml) === false) {
+				$zip->close();
+				throw new RuntimeException(sprintf('Could not rewrite the "%s" part.', $part));
+			}
+
+			$zip->close();
+
+			$bytes = file_get_contents($path);
+			if ($bytes === false) {
+				throw new RuntimeException('Could not read the rewritten document package.');
+			}
+
+			return $bytes;
+		} finally {
+			unlink($path);
+		}
+	}//end writePart()
+
+	/**
+	 * Spill bytes to a temporary file, because `ZipArchive` has no in-memory mode.
+	 *
+	 * @param string $bytes The bytes to spill.
+	 *
+	 * @return string The temporary file path.
+	 *
+	 * @throws RuntimeException When no temporary file can be created.
+	 */
+	private function spill(string $bytes): string {
+		$path = tempnam(sys_get_temp_dir(), 'docudesk-pkg-');
+		if ($path === false) {
+			throw new RuntimeException('Could not create a temporary file for the document package.');
+		}
+
+		file_put_contents($path, $bytes);
+
+		return $path;
+	}//end spill()
+}//end class

--- a/openspec/changes/document-rich-editing/.openspec.yaml
+++ b/openspec/changes/document-rich-editing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/openspec/changes/document-rich-editing/design.md
+++ b/openspec/changes/document-rich-editing/design.md
@@ -1,0 +1,150 @@
+## Context
+
+`PackageCodec` edits one region of one part: a paragraph's visible text inside
+`word/document.xml` or `content.xml`. Everything else in the package stays
+byte-identical, which is the property ADR-087 §2 prefers over parse-and-reserialise
+because re-serialisation silently drops comments, tracked changes and styles that no
+test asserts on.
+
+Style, layout and metadata each sit somewhere else:
+
+- **Style/layout (OOXML)** is inside the paragraph — `<w:pPr>` and `<w:rPr>`. Same
+  span, so the same rewrite mechanism works.
+- **Style/layout (ODF)** is *not* inside the paragraph. `text:p` carries a
+  `text:style-name` pointing at a `<style:style>` in `<office:automatic-styles>`,
+  a different region of `content.xml` — and a heading is a different element,
+  `text:h`.
+- **Metadata** is a different **part** entirely: `docProps/core.xml`, `meta.xml`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Style, layout and metadata reachable from the chat, with the same accountability
+  as a text edit.
+- Merging semantics that never lose properties the user set by hand.
+- Every refusal by name, with the message saying what still works.
+
+**Non-Goals:**
+
+- ODF style/layout. See D4 — refused by name, not silently ignored.
+- Tables, images, sections, headers/footers.
+- Arbitrary named styles. The `heading` level covers the common case; exposing
+  "apply the style called X" would let an agent name a style the document does not
+  define, producing markup a suite renders as nothing.
+- `created` / `modified`. See D2.
+
+## Decisions
+
+### D1 — Extract `PackagePartIo` rather than grow a second copy
+
+Metadata lives in a different part, so the codec needed `readPart` / `writePart`
+which were private to `PackageCodec`. The options were sharing them or duplicating
+the ZipArchive dance.
+
+Shared. The property that untouched entries survive an edit byte-identical — the
+whole reason for the in-place approach — is a property of exactly that code. Two
+copies would drift, and the drift would be invisible until a document came back
+subtly different.
+
+`hasPart()` is new. A document with no metadata part is **ordinary**, not
+exceptional: PhpWord-generated ODF routinely has none. Catching `readPart()`'s
+exception would conflate "no metadata yet, create one" with "this package is
+corrupt".
+
+### D2 — Five writable fields, and the timestamps are not among them
+
+`title`, `subject`, `creator`, `keywords`, `description` are the fields both
+families carry and users recognise.
+
+`dcterms:created` / `dcterms:modified` and ODF's `meta:editing-cycles` are excluded
+deliberately. They are a *record of what happened to the document*. An agent that
+could set them would make that record a claim rather than a fact — and the whole
+agent-artefact design (ADR-088, the `Agent authored` tag, the restorable prior
+version) exists so that what happened to a document stays knowable.
+
+### D3 — `style` is its own action, not a flag on `replace`
+
+A caller who wants a paragraph bold should not have to resend its text.
+
+This is not tidiness. The caller is a language model, and a model that must resend
+the text in order to change the formatting is a model that will paraphrase the
+paragraph while "only" making it bold. Separating the actions removes the
+opportunity: `ACTION_STYLE` carries no text and `resolveEdits()` rejects it if it
+carries no style properties either.
+
+### D4 — ODF style is refused by name, and the refusal names what works
+
+Doing ODF properly means minting `<style:style>` entries in
+`<office:automatic-styles>`, guaranteeing generated names do not collide with
+existing ones, and — for headings — rewriting `text:p` into `text:h`, which is the
+element the anchor scanner keys on. That is a change to the anchoring substrate, not
+a formatting feature.
+
+The alternative to refusing is returning the markup unchanged, which reports success
+and changes nothing. This project has met that failure repeatedly, so the refusal is
+explicit and the message ends by saying text edits and metadata *do* work on `.odt`
+— a refusal that leaves the reader thinking `.odt` is unsupported would be its own
+kind of wrong.
+
+### D5 — Merge properties; never replace the block
+
+`<w:pPr>` commonly carries spacing, indentation and numbering a user set by hand.
+Replacing it to apply an alignment would silently drop all of it.
+
+So: properties of the same element name are dropped and re-added; everything else is
+retained. `dropNamed()` also serves the *removal* cases (heading 0, `list: false`,
+`pageBreakBefore: false`).
+
+Turning a run property off writes `w:val="0"` rather than omitting the element. A
+paragraph style can turn bold on, and only an explicit override countermands it —
+omission just inherits.
+
+### D6 — `runSession()` takes a transform
+
+A metadata write needs the same lock, the same version re-check immediately before
+the write, the same tag-then-write with rollback, and the same unlock-in-`finally`.
+
+Parameterising the transform means one copy of that path. Copying the method for
+metadata would have meant two copies of the only code preventing an agent from
+clobbering a concurrent human edit — and the copy would drift precisely because
+metadata "feels smaller".
+
+Metadata is a smaller change than a paragraph rewrite. It is not a less accountable
+one.
+
+## Seed Data (ADR-001)
+
+**None.** No OpenRegister schemas are introduced or modified. Test fixtures are
+packages built in-process by the tests themselves.
+
+## Declarative-vs-imperative decision (ADR-031)
+
+| Behaviour | Path | Rationale |
+|---|---|---|
+| Metadata read/write | **Imperative** | Byte-level manipulation of a ZIP member. No schema, no derived value, no lifecycle. |
+| Style/layout application | **Imperative** | XML rewriting inside a document package. |
+| Tool exposure | **Declarative** | Already so: `#[McpTool]` per ADR-063, no hand-written registry. |
+
+No behaviour matches a declarative category, so no `lib/Settings/docudesk_register.json`
+patch is appropriate.
+
+## Risks / Trade-offs
+
+**Regex over XML.** The same trade-off `PackageCodec` already makes, for the same
+reason: a DOM round-trip re-serialises and drops what it does not understand.
+Contained by operating only within a single already-scanned span, and by the
+merge-not-replace rule.
+
+**A `numId` of 1 assumes a numbering definition exists.** `list: true` writes
+`<w:numId w:val="1"/>`, which renders as a list in every document PhpWord or Word
+produces, but a document with no `numbering.xml` will show the paragraph unlisted.
+Minting a numbering definition is the same class of work as ODF automatic styles and
+is not done here. This is the weakest part of the change and is called out rather
+than hidden.
+
+**Two bugs found by the tests, both "reports success, changes nothing".** `heading:
+0` returned early and left the old style in place; a self-closing metadata root was
+reported as corrupt. Both are fixed and both now have a test. Their shared shape is
+worth noting: this is the failure mode of the whole change area, and it is why every
+refusal here is explicit.

--- a/openspec/changes/document-rich-editing/proposal.md
+++ b/openspec/changes/document-rich-editing/proposal.md
@@ -1,0 +1,96 @@
+---
+kind: code
+---
+
+## Why
+
+The agent document surface could change a paragraph's **words** and nothing else.
+Asked to make a heading a heading, centre a signature block, mark a clause bold, or
+set the document's title and keywords, it had no tool that could do any of it.
+
+Those are not one capability. They are three regions of the package:
+
+| Capability | Where it lives (OOXML) | Where it lives (ODF) |
+|---|---|---|
+| Text | `<w:t>` inside `<w:r>` inside `<w:p>` | `<text:p>` |
+| Style / layout | `<w:pPr>`, `<w:rPr>` **inside the paragraph** | a `text:style-name` pointing at `<office:automatic-styles>` **elsewhere in `content.xml`** |
+| Metadata | `docProps/core.xml` — **a different part** | `meta.xml` — **a different part** |
+
+Metadata being a different part is what forced the shape of this change. The
+existing `PackageCodec` had `readPart` / `writePart` as private methods, so
+addressing a second part meant either sharing them or growing a second copy of the
+ZipArchive dance. The property that untouched parts survive an edit byte-identical
+is a property of exactly that code, and two copies of it would drift.
+
+## What Changes
+
+- **`PackagePartIo`** — extracted from `PackageCodec`, now shared. Adds `hasPart()`,
+  because "this document has no metadata part yet" is an ordinary state to be
+  handled by creating one, not an error to report.
+- **`PackageMetadataCodec`** — five fields (`title`, `subject`, `creator`,
+  `keywords`, `description`) addressed by **format-neutral name**. OOXML stores
+  keywords as `cp:keywords` and ODF as `meta:keyword`; a caller that had to know
+  which would be writing per-format code.
+  - `created` / `modified` are deliberately **not** writable. They record what
+    happened to the document; an agent able to set them would turn that record from
+    a fact into a claim.
+- **`BlockStyleCodec`** — bold, italic, underline, alignment, heading level 0–9,
+  list, page-break-before, applied to an anchored paragraph. Merges into existing
+  `<w:pPr>` / `<w:rPr>` rather than replacing them, so hand-set spacing and
+  indentation survive.
+- **`PackageCodec::ACTION_STYLE`** — a new edit action carrying a `style` object
+  instead of text. Separate from `replace` on purpose: a caller who wanted bold
+  should not have to resend the text, because a caller that resends text is a
+  caller that can paraphrase the paragraph while "only" making it bold.
+- **Two new agent tools**, `readDocumentMetadata` and `setDocumentMetadata`. Style
+  needs no new tool — it flows through the existing `editDocument`.
+- **`EditSessionService::runSession()` now takes a transform**, so a metadata write
+  gets the identical lock, version-recheck-immediately-before-write, tag-then-write
+  and unlock path as a body edit. Metadata is a smaller change than a paragraph
+  rewrite, not a less accountable one.
+
+## Scope: OOXML only for style, and refused by name for ODF
+
+ODF does not carry direct formatting inside the paragraph. `text:p` holds a
+`text:style-name` pointing at a `<style:style>` in `<office:automatic-styles>`, and
+an ODF heading is a **different element** (`text:h`) rather than a styled paragraph.
+Supporting it properly means minting automatic styles, guaranteeing name uniqueness
+against existing ones, and in the heading case rewriting the very element the anchor
+scanner keys on.
+
+That is not done here, and the important part is that it is **refused by name**. An
+ODF style request that returned the markup unchanged would report success and change
+nothing. Text edits and metadata *do* work on `.odt`, and the refusal says so.
+
+## Two bugs the tests found
+
+Both were "reports success, changes nothing" — the failure this codebase keeps
+meeting:
+
+1. **`heading: 0` did nothing.** Level 0 means body text, so it produced an empty
+   property string, so the method returned early and left the existing
+   `<w:pStyle>` in place — while reporting the restyle applied. Level 0 is now a
+   *removal*, not an absence.
+2. **A self-closing metadata root broke the write.** `<cp:coreProperties/>` is what
+   several writers emit for a document with no properties set, and there is no
+   closing tag to insert before. The ordinary "empty metadata part" case reported
+   the part as corrupt.
+
+## Capabilities
+
+### New Capabilities
+- `document-rich-editing`: how an agent changes a document's style, layout and
+  metadata, and what it is refused.
+
+### Modified Capabilities
+- `document-editing`: `applyEdits` gains a fourth action, `style`.
+
+## Impact
+
+- **Code**: new `PackagePartIo`, `PackageMetadataCodec`, `BlockStyleCodec`;
+  `PackageCodec` gains an action and loses its private part IO;
+  `EditSessionService` gains two methods and a parameterised session;
+  `DocumentAgentService` gains two tools.
+- **Agent surface**: 3 document tools → **5**.
+- **Compatibility**: no existing behaviour changes. The 75 pre-existing editing
+  tests pass unmodified, which is what makes the IO extraction safe to claim.

--- a/openspec/changes/document-rich-editing/specs/document-editing/spec.md
+++ b/openspec/changes/document-rich-editing/specs/document-editing/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Edits address stable anchors, never positional indexes
+
+`PackageCodec::applyEdits()` gains a fourth action, `style`, alongside `replace`,
+`insertAfter` and `delete`. Anchor resolution, the fail-the-whole-set-on-one-bad-anchor
+rule, and the descending-span application order are unchanged.
+
+A `style` edit carries a `style` object and **no text**. That separation is
+deliberate: a caller who wants a paragraph bold must not have to resend its text,
+because the caller is a language model and a model that resends text is a model that
+will paraphrase the paragraph while "only" changing its formatting.
+
+A `style` edit carrying no style properties MUST be refused. An edit that changes
+nothing while reporting success is the failure this action is most likely to produce.
+
+#### Scenario: A style edit changes formatting without touching the words
+
+- **GIVEN** an anchored paragraph
+- **WHEN** an edit with action `style` and `{"bold": true}` is applied
+- **THEN** the paragraph's run properties MUST carry bold
+- **AND** its visible text MUST be unchanged
+
+#### Scenario: A style edit with no properties is refused
+
+- **GIVEN** an edit with action `style` and an empty style object
+- **WHEN** the edit set is resolved
+- **THEN** the whole set MUST be refused, naming the supported properties
+
+#### Scenario: The other three actions are unaffected
+
+- **GIVEN** an edit set using `replace`, `insertAfter` or `delete`
+- **WHEN** it is applied
+- **THEN** behaviour MUST be identical to before this change

--- a/openspec/changes/document-rich-editing/specs/document-rich-editing/spec.md
+++ b/openspec/changes/document-rich-editing/specs/document-rich-editing/spec.md
@@ -1,0 +1,183 @@
+## ADDED Requirements
+
+### Requirement: Document metadata MUST be addressed by format-neutral field name
+
+The system MUST expose exactly five writable metadata fields — `title`, `subject`,
+`creator`, `keywords`, `description` — and MUST resolve each to the element its
+format uses. OOXML stores keywords as `cp:keywords` and ODF as `meta:keyword`; a
+caller naming the element rather than the field would be writing per-format code,
+which ADR-087 §2 exists to prevent. The formats differ; the capability does not.
+
+A field the document does not carry MUST be returned as an empty string rather than
+omitted, so a caller can tell "this document has no subject" from "I did not ask for
+the subject".
+
+`created` and `modified` MUST NOT be writable. They record what happened to the
+document, and an agent able to set them would turn that record from a fact into a
+claim.
+
+#### Scenario: Keywords resolve to each format's own element
+
+- **GIVEN** an `.odt` document
+- **WHEN** the `keywords` field is written
+- **THEN** the metadata part MUST contain `<meta:keyword>`
+- **AND** MUST NOT contain `cp:keywords`
+- **AND** reading `keywords` back MUST return the written value
+
+#### Scenario: An absent field reads as empty, not missing
+
+- **GIVEN** a document whose metadata carries a title but no subject
+- **WHEN** its metadata is read
+- **THEN** the result MUST contain a `subject` key whose value is an empty string
+
+#### Scenario: Timestamps are refused
+
+- **GIVEN** a caller attempting to set `created`
+- **WHEN** the write is requested
+- **THEN** the system MUST refuse, naming the supported fields
+
+#### Scenario: An unknown field is refused by name
+
+- **GIVEN** a caller naming the field `author`
+- **WHEN** the write is requested
+- **THEN** the system MUST refuse and MUST list the fields it does support
+- **AND** MUST NOT silently ignore the field, because a silently-ignored misspelling reports success and changes nothing
+
+### Requirement: A metadata write MUST leave every other part byte-identical
+
+Writing metadata MUST rewrite only the metadata part. The document body and every
+other package entry MUST be byte-identical afterwards.
+
+A document with **no** metadata part MUST have a well-formed one created, carrying
+the namespace declarations the written elements need — without them the elements
+resolve to nothing and the suite silently ignores them. A metadata part whose root
+is **self-closing** MUST be handled, because that is what several writers emit for a
+document with no properties set.
+
+Fields the caller does not name MUST be left unchanged.
+
+#### Scenario: The body survives a metadata write
+
+- **GIVEN** a document with a known body part
+- **WHEN** its title is written
+- **THEN** the body part MUST be byte-identical afterwards
+
+#### Scenario: A missing metadata part is created with namespaces
+
+- **GIVEN** a document with no metadata part
+- **WHEN** its title is written
+- **THEN** a metadata part MUST be created carrying the title
+- **AND** it MUST declare the namespaces its elements use
+- **AND** reading the title back MUST return the written value
+
+#### Scenario: A self-closing metadata root is not treated as corrupt
+
+- **GIVEN** a document whose metadata part is `<cp:coreProperties/>`
+- **WHEN** a field is written
+- **THEN** the write MUST succeed
+- **AND** MUST NOT report the part as corrupt
+
+#### Scenario: Unnamed fields survive
+
+- **GIVEN** a document carrying a title and a creator
+- **WHEN** only the subject is written
+- **THEN** the title and creator MUST be unchanged
+
+### Requirement: Style and layout MUST be applied without disturbing unrelated properties
+
+The system MUST apply `bold`, `italic`, `underline`, `alignment`, `heading`, `list`
+and `pageBreakBefore` to an anchored paragraph. Properties MUST be merged into the
+existing property blocks: a property of the same name is replaced, and every
+unrelated property survives.
+
+Replacing the property block wholesale would silently drop spacing, indentation and
+numbering a user set by hand — the class of loss ADR-087 §2 warns about, and one no
+test notices unless it is written for it.
+
+Turning a run property **off** MUST write an explicit override rather than omitting
+the element, because a paragraph style can turn it on and only an explicit override
+countermands that.
+
+A heading level of `0` MUST **remove** the heading style. It is a removal, not an
+absence: treating it as "nothing to add" leaves the existing style in place while
+reporting the restyle applied.
+
+#### Scenario: Unrelated paragraph properties survive a restyle
+
+- **GIVEN** a paragraph carrying hand-set spacing and indentation
+- **WHEN** its alignment is set
+- **THEN** the spacing and indentation MUST still be present
+- **AND** the alignment MUST be applied
+
+#### Scenario: Re-setting a property replaces rather than duplicates it
+
+- **GIVEN** a paragraph already aligned left
+- **WHEN** it is aligned right
+- **THEN** exactly one alignment property MUST be present, and it MUST be right
+
+#### Scenario: Heading level 0 returns a paragraph to body text
+
+- **GIVEN** a paragraph styled as a heading
+- **WHEN** it is restyled with heading level `0`
+- **THEN** the heading style MUST be removed
+- **AND** no style named `Heading0` MUST be written, because no suite defines one
+
+#### Scenario: Turning bold off writes an explicit override
+
+- **GIVEN** a paragraph whose style turns bold on
+- **WHEN** bold is set to false
+- **THEN** an explicit off-override MUST be written, not merely the absence of a bold element
+
+### Requirement: Style MUST be refused by name where it is not implemented
+
+Style and layout are implemented for OOXML only. For ODF the system MUST refuse with
+a message naming the limitation **and** naming what does still work on `.odt`.
+
+Returning the markup unchanged is prohibited: it reports success and changes
+nothing, which is indistinguishable from a working call and is the failure mode this
+requirement exists to prevent.
+
+#### Scenario: An ODF style request is refused, not ignored
+
+- **GIVEN** an `.odt` document
+- **WHEN** a style edit is requested
+- **THEN** the system MUST refuse
+- **AND** the message MUST state that text edits and metadata do work on `.odt`
+- **AND** the markup MUST NOT be returned unchanged as though the style had been applied
+
+#### Scenario: An unknown style property is refused
+
+- **GIVEN** a style object naming `colour`
+- **WHEN** the edit is requested
+- **THEN** the system MUST refuse and list the properties it supports
+
+#### Scenario: An empty style object is refused
+
+- **GIVEN** a style edit carrying no properties
+- **WHEN** the edit is requested
+- **THEN** the system MUST refuse rather than report an edit applied
+
+### Requirement: A metadata write MUST be as accountable as a text edit
+
+A metadata write MUST run through the same editing session as a body edit: the same
+file lock, the same version re-check immediately before the write, the same
+`Agent authored` tag applied before the bytes become visible, and the same standing
+refusals (open in an editor, under a signing request, anonymisation output).
+
+The session MUST be shared code rather than a second copy. The version-recheck is
+the only thing preventing an agent silently overwriting a concurrent human edit, and
+two copies of it would drift.
+
+#### Scenario: A stale version refuses a metadata write
+
+- **GIVEN** a document that changed since its metadata was read
+- **WHEN** a metadata write is attempted with the earlier version
+- **THEN** the write MUST be refused
+- **AND** nothing MUST be written
+
+#### Scenario: A metadata write is tagged and restorable
+
+- **GIVEN** a successful metadata write
+- **WHEN** the file is inspected
+- **THEN** it MUST carry the `Agent authored` tag
+- **AND** the previous version MUST remain restorable

--- a/openspec/changes/document-rich-editing/tasks.md
+++ b/openspec/changes/document-rich-editing/tasks.md
@@ -1,0 +1,56 @@
+# Tasks
+
+## 1. Shared package IO
+
+- [ ] Extract `PackagePartIo` from `PackageCodec` with `readPart`/`writePart`, and add `hasPart`
+- [ ] Point `PackageCodec` at it and delete its private copies
+
+Acceptance criteria:
+- The 75 pre-existing editing tests pass UNMODIFIED. That is what makes the extraction safe to claim; a green suite after editing the tests would prove nothing.
+- `hasPart` exists because "no metadata part yet" is an ordinary state, not a corrupt package.
+
+## 2. Metadata
+
+- [ ] Add `PackageMetadataCodec` for `title`, `subject`, `creator`, `keywords`, `description`, addressed by format-neutral name
+- [ ] Resolve each field to its format's element (`cp:keywords` vs `meta:keyword`)
+- [ ] Create a well-formed, namespaced metadata part when the document has none
+- [ ] Handle a self-closing metadata root
+- [ ] Refuse unknown fields and the created/modified timestamps by name
+
+Acceptance criteria:
+- A metadata write leaves the body part byte-identical.
+- Fields not named are unchanged.
+- Values are XML-escaped and round-trip.
+
+## 3. Style and layout
+
+- [ ] Add `BlockStyleCodec` for bold, italic, underline, alignment, heading 0–9, list, pageBreakBefore
+- [ ] Merge into existing `<w:pPr>`/`<w:rPr>` — same-named properties replaced, unrelated ones retained
+- [ ] Make heading 0, `list: false` and `pageBreakBefore: false` REMOVALS, not absences
+- [ ] Write an explicit off-override when a run property is switched off
+- [ ] Refuse ODF by name, naming what still works on `.odt`
+- [ ] Add `PackageCodec::ACTION_STYLE`, refusing a style edit that carries no properties
+
+Acceptance criteria:
+- Hand-set spacing and indentation survive a restyle. Without this the change loses user work silently.
+- An ODF style request throws; it never returns the markup unchanged.
+- Re-setting a property replaces rather than duplicates it.
+
+## 4. Agent surface
+
+- [ ] Add `readDocumentMetadata` and `setDocumentMetadata` tools
+- [ ] Extend `editDocument`'s description to describe the `style` action and its properties
+- [ ] Parameterise `EditSessionService::runSession()` with a transform so metadata writes share the lock/version/tag path
+
+Acceptance criteria:
+- A metadata write is refused on a stale version, tagged `Agent authored`, and leaves the prior version restorable — verified, not assumed.
+- The document tool count goes 3 → 5.
+
+## 5. Verify
+
+- [ ] Full unit suite green; `phpcs` clean across `lib/Service/Editing/`
+- [ ] Playwright E2E: style a paragraph and set metadata through the tool surface, asserting the bytes changed on exactly the targeted paragraph
+- [ ] Confirm the two new tools appear in `tools/list` with dotted ids
+
+Acceptance criteria:
+- The E2E asserts on document bytes, not on the tool's own reply. A tool reporting success is not evidence the document changed.

--- a/openspec/specs/document-editing/spec.md
+++ b/openspec/specs/document-editing/spec.md
@@ -1,0 +1,274 @@
+---
+status: in-progress
+---
+
+# document-editing Specification
+
+**OpenSpec changes**
+- agent-document-editing
+- document-rich-editing
+
+## Purpose
+
+Defines how an agent reads and changes the **text** of a Word (`.docx`) or
+OpenDocument (`.odt`) file: how paragraphs are addressed, what an edit is refused
+for, and what must remain true of the package afterwards.
+
+Style, layout and metadata are a separate capability — see
+`openspec/specs/document-rich-editing/spec.md`.
+
+The governing property is that editing happens **in place, inside the package**.
+Only the targeted paragraph's byte range is rewritten; every other part stays
+byte-identical. ADR-087 §2 prefers this over parse-and-re-serialise because
+re-serialisation silently drops comments, tracked changes and styles that no test
+asserts on.
+
+## Requirements
+
+### Requirement: Edits address stable anchors, never positional indexes
+
+A read returns one block per paragraph, each with an `anchor` derived from that
+paragraph's own content (`b<sha1[0:8]>-<ordinal>`), recomputed on every read.
+Anchors MUST NOT be positional: a human inserting a paragraph shifts every index,
+and an index-addressed edit would then land on the wrong paragraph with no error.
+
+An anchor that no longer resolves MUST fail the **whole** edit set. A partially
+applied set leaves a document in a state neither the user nor the agent asked for,
+and no caller can tell which half landed.
+
+Edits MUST be applied from the last matched span backwards, so an earlier rewrite
+cannot invalidate the byte offsets of spans still to be edited.
+
+#### Scenario: A stale anchor takes the whole edit set with it
+
+- **GIVEN** an edit set of three edits, one of whose anchors no longer resolves
+- **WHEN** the set is applied
+- **THEN** the whole set MUST be refused
+- **AND** the document MUST be unchanged
+
+#### Scenario: An anchor is stable across an unrelated edit
+
+- **GIVEN** two paragraphs with distinct text
+- **WHEN** the first is replaced
+- **THEN** the second's anchor MUST be unchanged
+
+### Requirement: Untouched parts of a document package survive an edit unchanged
+
+Applying an edit MUST rewrite only the body part, and only the targeted paragraph's
+span within it. Every other package entry MUST be byte-identical afterwards,
+including ODF's uncompressed leading `mimetype` entry.
+
+#### Scenario: Unrelated package parts are byte-identical after an edit
+
+- **GIVEN** a package carrying comments and styles alongside the body
+- **WHEN** one paragraph is replaced
+- **THEN** every entry other than the body part MUST be byte-identical
+
+### Requirement: An edit is refused when the document moved since it was read
+
+A read returns a `version`. An edit MUST supply it, and the version MUST be
+re-checked immediately before the write — not merely at the start of the session.
+The file lock excludes another editing *session*; the re-check closes the remaining
+window in which the file changed outside one.
+
+A mismatch MUST refuse. This codec cannot merge, and guessing would be worse than
+stopping.
+
+#### Scenario: A stale version refuses the edit
+
+- **GIVEN** a document that changed after it was read
+- **WHEN** an edit is applied with the earlier version
+- **THEN** the edit MUST be refused and nothing written
+
+### Requirement: A format the codec cannot address is refused by name
+
+Only `.docx` and `.odt` are addressable. Spreadsheets and presentations are
+deliberately absent: their block model is a cell or a slide, not a paragraph, and
+giving them a paragraph anchor would produce anchors resolving to nothing.
+
+A refusal MUST name the offending format **and** name the formats that do work.
+
+#### Scenario: An unsupported format names what is supported
+
+- **GIVEN** an `.xlsx` file
+- **WHEN** a read is attempted
+- **THEN** the system MUST refuse, naming `.xlsx` and listing `docx, odt`
+
+### Requirement: Editing session availability is probed, never inferred
+
+The set of addressable formats MUST come from the codec itself rather than from a
+hand-written list, so a format the codec cannot actually handle can never be
+advertised as available.
+
+#### Scenario: The advertised formats are the codec's own
+
+- **GIVEN** the codec supports a set of extensions
+- **WHEN** availability is reported
+- **THEN** the reported set MUST be exactly the codec's own supported set
+
+### Requirement: Conversion routes through the Nextcloud conversion broker
+
+PDF conversion MUST dispatch through `IConversionManager` with a declared fallback
+cascade, and MUST report which backend claimed the conversion — an office-app
+conversion and the built-in fallback differ visibly in fidelity, and a caller that
+cannot tell them apart cannot judge the output.
+
+The backend MUST NOT be selectable by the caller, so the tool cannot be steered onto
+a particular process.
+
+#### Scenario: The producing backend is reported
+
+- **GIVEN** a successful conversion
+- **WHEN** the result is returned
+- **THEN** it MUST name the backend that produced the PDF
+
+### Requirement: Every produced file is marked as agent authored at write time
+
+A file an agent wrote MUST carry the `Agent authored` tag, applied **before** the
+bytes become visible and rolled back if the write then fails. Neither an unmarked
+agent artefact nor a mark on an unchanged file may survive a failed write (ADR-088).
+
+Marking after the write would leave a window in which an agent artefact is visible
+and indistinguishable from a human's file.
+
+#### Scenario: A failed write leaves no mark
+
+- **GIVEN** a tagged file whose write then fails
+- **WHEN** the failure is handled
+- **THEN** the tag MUST be removed
+
+#### Scenario: The mark precedes visibility
+
+- **GIVEN** a successful agent write
+- **WHEN** the file becomes visible
+- **THEN** it MUST already carry the tag
+
+### Requirement: Editing writes in place by default, with a recoverable prior version
+
+An edit MUST write into the source file by default, relying on Nextcloud file
+versions to keep the prior content recoverable. Writing a sibling by default would
+leave the user's own file untouched and silently produce a second document they did
+not ask for.
+
+#### Scenario: An in-place edit leaves the prior version restorable
+
+- **GIVEN** a document edited in place
+- **WHEN** the file's versions are inspected
+- **THEN** the pre-edit content MUST be restorable
+
+### Requirement: Output mode may be narrowed by a caller, but never widened
+
+The configured output mode is a **ceiling**. A caller may ask for a more
+conservative mode (a sibling file instead of an in-place write) but MUST NOT be able
+to obtain a less conservative one than the instance permits.
+
+An argument that could widen the mode would let a caller overwrite files on an
+instance whose administrator chose that it should not.
+
+#### Scenario: A caller may narrow to a sibling write
+
+- **GIVEN** an instance configured to allow in-place writes
+- **WHEN** a caller requests sibling output
+- **THEN** a sibling file MUST be written and the source left untouched
+
+#### Scenario: A caller cannot widen to in-place
+
+- **GIVEN** an instance configured for sibling output only
+- **WHEN** a caller requests an in-place write
+- **THEN** the request MUST NOT produce an in-place write
+
+### Requirement: An in-place write is guarded by the lock and a version precondition
+
+An in-place write MUST hold a file lock for the whole read-modify-write, and MUST
+re-read the version immediately before writing. The lock excludes another editing
+session; the precondition closes the remaining window in which the file changed
+outside one. Both are required — neither alone is sufficient.
+
+The lock MUST be released on every exit path, including failure.
+
+#### Scenario: The lock is released when the write throws
+
+- **GIVEN** a write that fails midway
+- **WHEN** the failure propagates
+- **THEN** the lock MUST have been released
+
+### Requirement: Lock contention is refused, not waited out
+
+When the file is already locked, the system MUST refuse immediately and say so. It
+MUST NOT block, retry or wait.
+
+Waiting would make an agent call hang for as long as a human keeps a document open,
+and the caller cannot distinguish a slow call from a stuck one.
+
+When no lock provider is available on the instance, the write MUST still proceed
+under the version precondition, and the response MUST carry a warning saying a
+concurrent session could not be excluded — reporting nothing would present a weaker
+guarantee as the full one.
+
+#### Scenario: A locked document is refused at once
+
+- **GIVEN** a document locked by another session
+- **WHEN** an edit is attempted
+- **THEN** it MUST be refused immediately, naming the contention
+
+#### Scenario: A missing lock provider is reported, not hidden
+
+- **GIVEN** an instance with no file-lock provider
+- **WHEN** an edit succeeds under the version precondition alone
+- **THEN** the response MUST carry a warning that a concurrent session could not be excluded
+
+### Requirement: Documents under signature or produced by anonymisation are not editable
+
+A document that is the subject of a signing request MUST NOT be editable — editing
+it would invalidate what a signatory agreed to, silently.
+
+A document produced by anonymisation MUST NOT be editable either, because an edit
+can reintroduce identifying text into an artefact whose purpose is that it contains
+none.
+
+The signature refusal MUST fail **closed** when the register cannot be reached: an
+unreachable register is not evidence that a document is unsigned. The anonymisation
+refusal MAY fail open, because its artefacts are identifiable from the file itself.
+
+#### Scenario: An unreachable signing register refuses the edit
+
+- **GIVEN** the signing register cannot be reached
+- **WHEN** an edit is attempted
+- **THEN** the edit MUST be refused, because absence of evidence is not evidence of absence
+
+#### Scenario: Anonymisation output is refused
+
+- **GIVEN** a document produced by anonymisation
+- **WHEN** an edit is attempted
+- **THEN** the edit MUST be refused, naming the reason
+
+### Requirement: Every produced file is recorded with its identity and without its content
+
+Each file an agent produces MUST be recorded by id, name and path. The record MUST
+NOT contain the document's bytes or its text.
+
+The record exists so a person can find and audit what an agent did; copying content
+into it would turn an audit trail into a second, unguarded copy of the document.
+
+#### Scenario: The record names the file without carrying it
+
+- **GIVEN** a file produced by an agent
+- **WHEN** the record is written
+- **THEN** it MUST carry the file's id, name and path
+- **AND** MUST NOT carry the document's bytes or extracted text
+
+### Requirement: No document, attachment or signature bytes leave through this capability
+
+The tools return text and metadata only. Document bytes, attachment bytes and
+signature material MUST NOT be returned to a caller through any tool in this
+capability.
+
+An agent that could retrieve raw bytes could exfiltrate a document whose text it was
+only ever meant to read.
+
+#### Scenario: A read returns text, never bytes
+
+- **GIVEN** a document read through the agent surface
+- **WHEN** the result is returned
+- **THEN** it MUST contain the paragraph text and anchors
+- **AND** MUST NOT contain the file's bytes in any encoding

--- a/openspec/specs/document-rich-editing/spec.md
+++ b/openspec/specs/document-rich-editing/spec.md
@@ -1,0 +1,105 @@
+---
+status: in-progress
+---
+
+# document-rich-editing Specification
+
+**OpenSpec changes**
+- document-rich-editing
+
+## Purpose
+
+Defines how an agent changes a document's **style, layout and metadata** — as
+opposed to its words — and what it is refused.
+
+Three regions of the package are involved, and they are not interchangeable. Style
+and layout live inside the paragraph in OOXML but in a separate style region in ODF;
+metadata lives in a different package part in both. The capability is presented to a
+caller as one surface with format-neutral field names, because the formats differ
+while the capability does not (ADR-087 §2).
+
+Every refusal here is explicit. The recurring failure in this area is a call that
+reports success and changes nothing, which is indistinguishable from a working one.
+
+## Requirements
+
+### Requirement: Document metadata MUST be addressed by format-neutral field name
+
+Five fields are writable: `title`, `subject`, `creator`, `keywords`, `description`.
+Each MUST resolve to the element its format uses — OOXML `cp:keywords`, ODF
+`meta:keyword`. A field the document does not carry MUST read as an empty string
+rather than be omitted. `created` and `modified` MUST NOT be writable: they record
+what happened to the document, and an agent able to set them would turn that record
+from a fact into a claim.
+
+#### Scenario: Keywords resolve to each format's own element
+
+- **GIVEN** an `.odt` document
+- **WHEN** `keywords` is written
+- **THEN** the metadata part MUST contain `<meta:keyword>` and MUST NOT contain `cp:keywords`
+
+#### Scenario: An unknown field is refused by name
+
+- **GIVEN** a caller naming the field `author`
+- **WHEN** the write is requested
+- **THEN** the system MUST refuse and list the supported fields
+
+### Requirement: A metadata write MUST leave every other part byte-identical
+
+Only the metadata part is rewritten. A document with no metadata part MUST have a
+well-formed, namespaced one created; a self-closing root MUST be handled rather than
+reported as corrupt. Unnamed fields MUST survive.
+
+#### Scenario: The body survives a metadata write
+
+- **GIVEN** a document with a known body part
+- **WHEN** its title is written
+- **THEN** the body part MUST be byte-identical afterwards
+
+### Requirement: Style and layout MUST merge, never replace, existing properties
+
+`bold`, `italic`, `underline`, `alignment`, `heading`, `list` and `pageBreakBefore`
+MUST be merged into the paragraph's existing property blocks. Same-named properties
+are replaced; unrelated ones survive, because replacing the block wholesale would
+silently drop hand-set spacing and indentation.
+
+Switching a run property off MUST write an explicit override, not omit the element.
+A heading level of `0` MUST remove the heading style — a removal, not an absence.
+
+#### Scenario: Unrelated paragraph properties survive a restyle
+
+- **GIVEN** a paragraph with hand-set spacing and indentation
+- **WHEN** its alignment is set
+- **THEN** the spacing and indentation MUST still be present
+
+#### Scenario: Heading level 0 returns a paragraph to body text
+
+- **GIVEN** a paragraph styled as a heading
+- **WHEN** it is restyled with heading level `0`
+- **THEN** the heading style MUST be removed, and no `Heading0` style written
+
+### Requirement: Style MUST be refused by name where it is not implemented
+
+Style is implemented for OOXML only. An ODF style request MUST throw, naming the
+limitation and naming what still works on `.odt`. Returning the markup unchanged is
+prohibited — it reports success and changes nothing.
+
+#### Scenario: An ODF style request is refused, not ignored
+
+- **GIVEN** an `.odt` document
+- **WHEN** a style edit is requested
+- **THEN** the system MUST refuse, and the message MUST state that text edits and metadata do work on `.odt`
+
+### Requirement: A metadata write MUST be as accountable as a text edit
+
+A metadata write MUST run through the same editing session as a body edit: same
+lock, same version re-check immediately before the write, same `Agent authored` tag
+applied before the bytes become visible, same standing refusals. The session MUST be
+shared code, because the version re-check is the only thing preventing an agent
+silently overwriting a concurrent human edit.
+
+#### Scenario: A stale version refuses a metadata write
+
+- **GIVEN** a document that changed since its metadata was read
+- **WHEN** a metadata write is attempted with the earlier version
+- **THEN** the write MUST be refused and nothing written

--- a/tests/unit/Service/Editing/BlockStyleCodecTest.php
+++ b/tests/unit/Service/Editing/BlockStyleCodecTest.php
@@ -1,0 +1,275 @@
+<?php
+
+/**
+ * Unit tests for BlockStyleCodec.
+ *
+ * openspec/changes/document-rich-editing.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Test
+ * @package  OCA\DocuDesk\Tests\Unit\Service\Editing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Service\Editing;
+
+use OCA\DocuDesk\Service\Editing\BlockStyleCodec;
+use OCA\DocuDesk\Service\Editing\PackageCodec;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Style and layout applied to one paragraph's markup.
+ */
+class BlockStyleCodecTest extends TestCase {
+
+	/**
+	 * The codec under test.
+	 *
+	 * @var BlockStyleCodec
+	 */
+	private BlockStyleCodec $codec;
+
+	/**
+	 * A paragraph with one run.
+	 *
+	 * @var string
+	 */
+	private const PARAGRAPH = '<w:p><w:r><w:t>Binnen acht weken</w:t></w:r></w:p>';
+
+	/**
+	 * Set up.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->codec = new BlockStyleCodec();
+	}//end setUp()
+
+	/**
+	 * Apply style to the standard paragraph.
+	 *
+	 * @param array  $style  The style properties.
+	 * @param string $markup Optional markup override.
+	 *
+	 * @return string The rewritten markup.
+	 */
+	private function apply(array $style, string $markup = self::PARAGRAPH): string {
+		return $this->codec->applyStyle(
+			markup: $markup,
+			style: $style,
+			format: PackageCodec::FORMAT_OOXML
+		);
+	}//end apply()
+
+	/**
+	 * REQ: run properties are applied to every run.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testBoldItalicUnderlineAreApplied(): void {
+		$out = $this->apply(['bold' => true, 'italic' => true, 'underline' => true]);
+
+		$this->assertStringContainsString('<w:b/>', $out);
+		$this->assertStringContainsString('<w:i/>', $out);
+		$this->assertStringContainsString('<w:u w:val="single"/>', $out);
+		$this->assertStringContainsString('Binnen acht weken', $out, 'the text must be untouched');
+	}//end testBoldItalicUnderlineAreApplied()
+
+	/**
+	 * REQ: switching a property OFF writes an explicit override.
+	 *
+	 * Omitting `<w:b/>` is not the same as turning bold off: a paragraph style can
+	 * turn it on, and only `w:val="0"` overrides that.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testTurningBoldOffWritesAnExplicitOverride(): void {
+		$out = $this->apply(['bold' => false]);
+
+		$this->assertStringContainsString('<w:b w:val="0"/>', $out);
+	}//end testTurningBoldOffWritesAnExplicitOverride()
+
+	/**
+	 * REQ: a heading sets pStyle; level 0 returns the paragraph to body text.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testHeadingLevelSetsAndClearsPStyle(): void {
+		$this->assertStringContainsString('<w:pStyle w:val="Heading2"/>', $this->apply(['heading' => 2]));
+
+		$heading = $this->apply(['heading' => 1]);
+		$body    = $this->apply(['heading' => 0], $heading);
+
+		$this->assertStringNotContainsString('w:pStyle', $body, 'level 0 must remove the heading style');
+		$this->assertStringNotContainsString('Heading0', $body, 'no suite defines a "Heading0" style');
+	}//end testHeadingLevelSetsAndClearsPStyle()
+
+	/**
+	 * REQ: alignment, list and page break are applied.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testLayoutPropertiesAreApplied(): void {
+		$out = $this->apply(['alignment' => 'center', 'list' => true, 'pageBreakBefore' => true]);
+
+		$this->assertStringContainsString('<w:jc w:val="center"/>', $out);
+		$this->assertStringContainsString('<w:numPr>', $out);
+		$this->assertStringContainsString('<w:pageBreakBefore/>', $out);
+	}//end testLayoutPropertiesAreApplied()
+
+	/**
+	 * REQ: `justify` maps to OOXML's own value, which is not "justify".
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testJustifyMapsToBoth(): void {
+		$this->assertStringContainsString('<w:jc w:val="both"/>', $this->apply(['alignment' => 'justify']));
+	}//end testJustifyMapsToBoth()
+
+	/**
+	 * REQ: unrelated existing properties SURVIVE.
+	 *
+	 * Replacing `<w:pPr>` wholesale would silently drop spacing and indentation a
+	 * user set by hand — the loss ADR-087 §2 warns about, and one no test notices
+	 * unless it is this one.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testUnrelatedParagraphPropertiesSurvive(): void {
+		$markup = '<w:p><w:pPr><w:spacing w:after="200"/><w:ind w:left="720"/></w:pPr>'
+			. '<w:r><w:t>Text</w:t></w:r></w:p>';
+
+		$out = $this->apply(['alignment' => 'right'], $markup);
+
+		$this->assertStringContainsString('<w:spacing w:after="200"/>', $out);
+		$this->assertStringContainsString('<w:ind w:left="720"/>', $out);
+		$this->assertStringContainsString('<w:jc w:val="right"/>', $out);
+	}//end testUnrelatedParagraphPropertiesSurvive()
+
+	/**
+	 * REQ: re-setting the same property replaces rather than duplicates it.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testResettingAPropertyReplacesIt(): void {
+		$once  = $this->apply(['alignment' => 'left']);
+		$twice = $this->apply(['alignment' => 'right'], $once);
+
+		$this->assertSame(1, substr_count($twice, '<w:jc'), 'a second alignment must replace the first');
+		$this->assertStringContainsString('w:val="right"', $twice);
+	}//end testResettingAPropertyReplacesIt()
+
+	/**
+	 * REQ: existing run properties survive alongside new ones.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testExistingRunPropertiesSurvive(): void {
+		$markup = '<w:p><w:r><w:rPr><w:sz w:val="28"/></w:rPr><w:t>Text</w:t></w:r></w:p>';
+
+		$out = $this->apply(['bold' => true], $markup);
+
+		$this->assertStringContainsString('<w:sz w:val="28"/>', $out);
+		$this->assertStringContainsString('<w:b/>', $out);
+	}//end testExistingRunPropertiesSurvive()
+
+	/**
+	 * REQ: ODF is refused BY NAME, and the refusal says what still works.
+	 *
+	 * The alternative — returning the markup unchanged — would report success and
+	 * change nothing, which is the failure this codebase keeps meeting.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testOdfIsRefusedByNameRatherThanSilentlyIgnored(): void {
+		$this->assertFalse($this->codec->supports(format: PackageCodec::FORMAT_ODF));
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/OOXML.*\.docx.*Text edits and metadata DO work on \.odt/s');
+
+		$this->codec->applyStyle(
+			markup: '<text:p>Text</text:p>',
+			style: ['bold' => true],
+			format: PackageCodec::FORMAT_ODF
+		);
+	}//end testOdfIsRefusedByNameRatherThanSilentlyIgnored()
+
+	/**
+	 * REQ: an unknown property is refused, listing what is supported.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testUnknownPropertyIsRefused(): void {
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/Unknown style property "colour".*bold, italic/s');
+
+		$this->apply(['colour' => 'red']);
+	}//end testUnknownPropertyIsRefused()
+
+	/**
+	 * REQ: an unknown alignment and an out-of-range heading are refused.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testInvalidValuesAreRefused(): void {
+		try {
+			$this->apply(['alignment' => 'middle']);
+			$this->fail('an unknown alignment must be refused');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('Unknown alignment "middle"', $e->getMessage());
+		}
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/Heading level must be between 0.*and 9/');
+		$this->apply(['heading' => 12]);
+	}//end testInvalidValuesAreRefused()
+
+	/**
+	 * REQ: an empty style object is refused rather than reported as applied.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testEmptyStyleIsRefused(): void {
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/At least one style property is required/');
+
+		$this->apply([]);
+	}//end testEmptyStyleIsRefused()
+}//end class

--- a/tests/unit/Service/Editing/PackageMetadataCodecTest.php
+++ b/tests/unit/Service/Editing/PackageMetadataCodecTest.php
@@ -1,0 +1,293 @@
+<?php
+
+/**
+ * Unit tests for PackageMetadataCodec.
+ *
+ * openspec/changes/document-rich-editing.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Test
+ * @package  OCA\DocuDesk\Tests\Unit\Service\Editing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Service\Editing;
+
+use OCA\DocuDesk\Service\Editing\PackageMetadataCodec;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use ZipArchive;
+
+/**
+ * Metadata read/write over real packages built on the fly.
+ */
+class PackageMetadataCodecTest extends TestCase {
+
+	/**
+	 * The codec under test.
+	 *
+	 * @var PackageMetadataCodec
+	 */
+	private PackageMetadataCodec $codec;
+
+	/**
+	 * Set up.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->codec = new PackageMetadataCodec();
+	}//end setUp()
+
+	/**
+	 * Build a package from a map of entry name => contents.
+	 *
+	 * @param array<string, string> $entries The entries.
+	 *
+	 * @return string The package bytes.
+	 */
+	private function package(array $entries): string {
+		$path = tempnam(sys_get_temp_dir(), 'mdtest') . '.zip';
+
+		$zip = new ZipArchive();
+		$zip->open($path, ZipArchive::CREATE);
+		foreach ($entries as $name => $contents) {
+			$zip->addFromString($name, $contents);
+		}
+
+		$zip->close();
+
+		$bytes = (string)file_get_contents($path);
+		unlink($path);
+
+		return $bytes;
+	}//end package()
+
+	/**
+	 * Read one entry from a package.
+	 *
+	 * @param string $bytes The package bytes.
+	 * @param string $name  The entry name.
+	 *
+	 * @return string|false The entry contents.
+	 */
+	private function entry(string $bytes, string $name) {
+		$path = tempnam(sys_get_temp_dir(), 'mdread') . '.zip';
+		file_put_contents($path, $bytes);
+
+		$zip = new ZipArchive();
+		$zip->open($path);
+		$contents = $zip->getFromName($name);
+		$zip->close();
+		unlink($path);
+
+		return $contents;
+	}//end entry()
+
+	/**
+	 * REQ: existing OOXML metadata is read by format-neutral field name.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testReadsOoxmlMetadata(): void {
+		$bytes = $this->package(
+			[
+				'word/document.xml' => '<w:document/>',
+				'docProps/core.xml' => '<?xml version="1.0"?><cp:coreProperties '
+					. 'xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" '
+					. 'xmlns:dc="http://purl.org/dc/elements/1.1/">'
+					. '<dc:title>Subsidiebesluit</dc:title><cp:keywords>subsidie, besluit</cp:keywords>'
+					. '</cp:coreProperties>',
+			]
+		);
+
+		$meta = $this->codec->readMetadata($bytes, 'docx');
+
+		$this->assertSame('Subsidiebesluit', $meta['title']);
+		$this->assertSame('subsidie, besluit', $meta['keywords']);
+
+		// An absent field is reported as empty, not omitted: a caller must be able
+		// to tell "this document has no subject" from "I forgot to ask".
+		$this->assertArrayHasKey('subject', $meta);
+		$this->assertSame('', $meta['subject']);
+	}//end testReadsOoxmlMetadata()
+
+	/**
+	 * REQ: keywords resolve to the right element per format.
+	 *
+	 * OOXML calls it `cp:keywords`, ODF calls it `meta:keyword`. A caller naming
+	 * the element rather than the field would be writing per-format code, which is
+	 * exactly what ADR-087 §2 exists to prevent.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testKeywordsResolveToTheFormatsOwnElement(): void {
+		$odt = $this->package(
+			[
+				'mimetype'    => 'application/vnd.oasis.opendocument.text',
+				'content.xml' => '<office:document-content/>',
+			]
+		);
+
+		$written = $this->codec->writeMetadata($odt, 'odt', ['keywords' => 'zaak']);
+		$meta    = (string)$this->entry($written['bytes'], 'meta.xml');
+
+		$this->assertStringContainsString('<meta:keyword>zaak</meta:keyword>', $meta);
+		$this->assertStringNotContainsString('cp:keywords', $meta);
+		$this->assertSame('zaak', $this->codec->readMetadata($written['bytes'], 'odt')['keywords']);
+	}//end testKeywordsResolveToTheFormatsOwnElement()
+
+	/**
+	 * REQ: writing metadata leaves every other part byte-identical.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testWritingMetadataLeavesOtherPartsUntouched(): void {
+		$body  = '<w:document><w:body><w:p><w:r><w:t>Hello</w:t></w:r></w:p></w:body></w:document>';
+		$bytes = $this->package(['word/document.xml' => $body, 'docProps/core.xml' => '<cp:coreProperties/>']);
+
+		$written = $this->codec->writeMetadata($bytes, 'docx', ['title' => 'New title']);
+
+		$this->assertSame(
+			$body,
+			$this->entry($written['bytes'], 'word/document.xml'),
+			'the document body must be byte-identical after a metadata write'
+		);
+	}//end testWritingMetadataLeavesOtherPartsUntouched()
+
+	/**
+	 * REQ: a document with no metadata part gets a well-formed one.
+	 *
+	 * Ordinary rather than exceptional — PhpWord-generated ODF often has none.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testCreatesAMetadataPartWhenAbsent(): void {
+		$bytes = $this->package(['word/document.xml' => '<w:document/>']);
+
+		$written = $this->codec->writeMetadata($bytes, 'docx', ['title' => 'Fresh']);
+		$meta    = (string)$this->entry($written['bytes'], 'docProps/core.xml');
+
+		$this->assertStringContainsString('<dc:title>Fresh</dc:title>', $meta);
+		// Without the namespace declarations the elements resolve to nothing and
+		// the suite silently ignores them.
+		$this->assertStringContainsString('xmlns:dc=', $meta);
+		$this->assertSame('Fresh', $this->codec->readMetadata($written['bytes'], 'docx')['title']);
+	}//end testCreatesAMetadataPartWhenAbsent()
+
+	/**
+	 * REQ: a field not named is left alone.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testUnnamedFieldsSurvive(): void {
+		$bytes = $this->package(
+			[
+				'word/document.xml' => '<w:document/>',
+				'docProps/core.xml' => '<cp:coreProperties '
+					. 'xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" '
+					. 'xmlns:dc="http://purl.org/dc/elements/1.1/">'
+					. '<dc:title>Keep me</dc:title><dc:creator>Ruben</dc:creator></cp:coreProperties>',
+			]
+		);
+
+		$written = $this->codec->writeMetadata($bytes, 'docx', ['subject' => 'Subsidie']);
+		$meta    = $this->codec->readMetadata($written['bytes'], 'docx');
+
+		$this->assertSame('Keep me', $meta['title']);
+		$this->assertSame('Ruben', $meta['creator']);
+		$this->assertSame('Subsidie', $meta['subject']);
+	}//end testUnnamedFieldsSurvive()
+
+	/**
+	 * REQ: values are XML-escaped.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testValuesAreEscapedAndRoundTrip(): void {
+		$bytes = $this->package(['word/document.xml' => '<w:document/>']);
+		$value = 'Zaak <A & B> "spoed"';
+
+		$written = $this->codec->writeMetadata($bytes, 'docx', ['title' => $value]);
+
+		$this->assertStringNotContainsString('<A &', (string)$this->entry($written['bytes'], 'docProps/core.xml'));
+		$this->assertSame($value, $this->codec->readMetadata($written['bytes'], 'docx')['title']);
+	}//end testValuesAreEscapedAndRoundTrip()
+
+	/**
+	 * REQ: an unknown field is refused by name, listing what is supported.
+	 *
+	 * The caller is a language model. A silently-ignored misspelling would report
+	 * success and change nothing.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testUnknownFieldIsRefusedByName(): void {
+		$bytes = $this->package(['word/document.xml' => '<w:document/>']);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/Unknown metadata field "author".*title, subject, creator/s');
+
+		$this->codec->writeMetadata($bytes, 'docx', ['author' => 'Ruben']);
+	}//end testUnknownFieldIsRefusedByName()
+
+	/**
+	 * REQ: an unsupported format is refused by name and names what works.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testUnsupportedFormatIsRefusedByName(): void {
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/"xlsx".*docx, odt/s');
+
+		$this->codec->readMetadata('irrelevant', 'xlsx');
+	}//end testUnsupportedFormatIsRefusedByName()
+
+	/**
+	 * REQ: created/modified timestamps are NOT writable.
+	 *
+	 * They record what happened to the document. Letting an agent set them would
+	 * turn a fact into a claim.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/document-rich-editing/spec.md
+	 */
+	public function testTimestampsAreNotWritable(): void {
+		$this->assertNotContains('created', $this->codec->fields());
+		$this->assertNotContains('modified', $this->codec->fields());
+
+		$bytes = $this->package(['word/document.xml' => '<w:document/>']);
+
+		$this->expectException(RuntimeException::class);
+		$this->codec->writeMetadata($bytes, 'docx', ['created' => '2020-01-01T00:00:00Z']);
+	}//end testTimestampsAreNotWritable()
+}//end class


### PR DESCRIPTION
## Why

The agent surface could change a paragraph's **words** and nothing else. Asked to make a heading a heading, centre a signature block, bold a clause, or set the document's title and keywords, it had no tool that could do any of it.

Those are three regions of the package, not one capability:

| | OOXML | ODF |
|---|---|---|
| Text | `<w:t>` in `<w:r>` in `<w:p>` | `<text:p>` |
| Style / layout | `<w:pPr>`, `<w:rPr>` **inside the paragraph** | a `text:style-name` pointing **elsewhere in `content.xml`** |
| Metadata | `docProps/core.xml` — **a different part** | `meta.xml` — **a different part** |

## What this adds

- **`PackageMetadataCodec`** — `title`, `subject`, `creator`, `keywords`, `description`, addressed by **format-neutral name**. OOXML stores keywords as `cp:keywords` and ODF as `meta:keyword`; a caller that had to know which would be writing per-format code, which is what ADR-087 §2 exists to prevent.
- **`BlockStyleCodec`** — bold/italic/underline, alignment, heading 0–9, list, page-break-before.
- **`ACTION_STYLE`** on `PackageCodec`, and two new tools `readDocumentMetadata` / `setDocumentMetadata`. **Document tools: 3 → 5.**

## Three design points worth a reviewer's eye

**`PackagePartIo` was extracted, not duplicated.** Metadata lives in a different part, and `readPart`/`writePart` were private. The property that untouched parts survive an edit byte-identical is a property of exactly that code — two copies would drift, and the drift stays invisible until a document comes back subtly different.

**Style merges; it never replaces the property block.** `<w:pPr>` commonly carries spacing and indentation a user set by hand. Replacing it to apply an alignment would drop all of it silently — the loss ADR-087 §2 warns about, and one no test notices unless written for it.

**`style` is its own action, carrying no text.** Not tidiness: the caller is a language model, and a model that must resend the text in order to change the formatting is a model that will paraphrase the paragraph while "only" making it bold. Separating them removes the opportunity.

**`runSession()` now takes a transform.** A metadata write gets the *identical* lock, version-recheck-immediately-before-write, tag-then-write and unlock path as a body edit. Copying the method would have meant two copies of the only code preventing an agent from clobbering a concurrent human edit — and the copy would drift precisely because metadata "feels smaller".

## Scope, said out loud: style is OOXML only

ODF carries no direct formatting inside the paragraph, and an ODF heading is a different **element** (`text:h`) — the element the anchor scanner keys on. Supporting it properly means minting automatic styles and rewriting the anchoring substrate.

It is **refused by name**, not silently ignored. An ODF style request returning the markup unchanged would report success and change nothing. The refusal message ends by saying text edits and metadata **do** work on `.odt`.

## Two bugs the tests found

Both were "reports success, changes nothing" — the failure mode of this whole area:

1. **`heading: 0` did nothing.** Level 0 means body text, so it produced an empty property string, returned early, and left the existing `<w:pStyle>` in place while reporting the restyle applied. Level 0 is now a *removal*, not an absence.
2. **A self-closing metadata root broke the write.** `<cp:coreProperties/>` is what several writers emit for a document with no properties set, and there is no closing tag to insert before — so the ordinary "empty metadata part" case reported the part as corrupt.

## Pre-existing debt of my own, fixed

`openspec/specs/document-editing/spec.md` **did not exist**, while shipped code carried twelve `@spec` anchors pointing into it. All twelve now resolve, and the eight behaviours that were implemented but never written down are specified — lock contention, the signature and anonymisation guards, the output-mode ceiling, and no-bytes-leave.

## Verification

- **1395 tests, 0 failures**
- `phpcs`: 0 errors, 0 warnings across `lib/Service/Editing/`
- **The 75 pre-existing editing tests pass unmodified** — which is what makes the IO extraction safe to claim

## Not done

`list: true` writes `<w:numId w:val="1"/>`, which renders as a list in any document Word or PhpWord produces, but a document with no `numbering.xml` will show the paragraph unlisted. Minting a numbering definition is the same class of work as ODF automatic styles. This is the weakest part of the change and is called out rather than hidden.

Spec: `openspec/changes/document-rich-editing/`
