### PR TITLE
docs(spec): signing requests cannot be cancelled, and one provider lies about it

### DIFF
--- a/openspec/changes/signing-cancellation/.openspec.yaml
+++ b/openspec/changes/signing-cancellation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/openspec/changes/signing-cancellation/design.md
+++ b/openspec/changes/signing-cancellation/design.md
@@ -1,0 +1,104 @@
+## Context
+
+`SigningProviderInterface::cancelSigning(string $externalId): bool` is declared,
+implemented twice, and called nowhere. Gate-57 found it on 2026-08-16 as one of
+three genuine orphaned write capabilities in docudesk (the gate's other twelve
+findings were routed controllers it could not see callers for — fixed separately in
+`.github#475`).
+
+The two implementations are not equivalent, and that asymmetry is the whole reason
+this needs a spec rather than a wiring commit:
+
+- `NativeSigningProvider` loads the session, sets `status = 'cancelled'`, persists.
+- `ValidSignProvider` is `return true;`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A cancellation that is either real or loudly absent.
+- An authorisation rule stated once, decided by a human.
+- An audit record of who withdrew what, including failed attempts.
+
+**Non-Goals:**
+- `BatchStateService::deleteBatch`, the third orphan. Unrelated, and it needs its own
+  decision about what deleting a batch does to the documents in it.
+- Partial cancellation (withdrawing one signatory from a multi-party request). A
+  different feature with a different legal shape.
+- Reinstating a cancelled request.
+
+## Decisions
+
+### D1 — void-or-throw, not `bool`
+
+The current `: bool` contract is what let `return true;` pass for an implementation.
+A boolean encourages one caller to write `if ($ok)` and the next to ignore it, and
+neither is wrong under the type.
+
+Void-or-throw removes the option: a provider either completes or raises something a
+caller must handle. A provider that genuinely cannot cancel throws a named
+"unsupported" error, which is information the user can act on — unlike `false`,
+which is indistinguishable from a transient failure.
+
+### D2 — Refuse rather than default the authorisation rule
+
+The rule is unsettled (see the proposal's table). The implementation must refuse
+until it is settled rather than pick a permissive default.
+
+The asymmetry is the reason: a default that lets too many people cancel is an
+authorisation hole discovered after someone withdraws a colleague's legal process. A
+refusal is an inconvenience discovered immediately, by the person who needed the
+feature, who will then ask for the decision.
+
+### D3 — Authorise before contacting the provider
+
+Two reasons, and the second is the less obvious one:
+
+1. An unauthorised call must not produce a partial cancellation.
+2. If the request-lookup ran first, an unauthorised caller could distinguish "no such
+   request" from "not allowed" and enumerate valid request ids from the error
+   messages.
+
+### D4 — Idempotent on an already-cancelled request, refused on a completed one
+
+Cancelling twice is a double-click, not an error, and must not call the provider a
+second time.
+
+Cancelling a *completed* request is different: the signatures exist and the process
+is over. Accepting it would let the UI display "cancelled" over a document that is,
+in fact, signed — a claim the system cannot make good on.
+
+### D5 — Record failures, not just successes
+
+The interesting audit case is the cancellation that did **not** work. "Cancelled at
+14:02 by Ruben" is easy; "attempted at 14:02 by Ruben, provider refused, request
+still live" is the record that prevents someone concluding a document was withdrawn
+when it was not.
+
+## Seed Data (ADR-001)
+
+**None.** No new OpenRegister schemas. The signing request schema already carries a
+status; `cancelled` is an existing value in the native provider's own usage.
+
+## Declarative-vs-imperative decision (ADR-031)
+
+| Behaviour | Path | Rationale |
+|---|---|---|
+| Provider cancellation call | **Imperative** | A side-effecting call across an instance boundary — the ADR-031 external-integration exception. |
+| Request state transition | **Declarative candidate** | If the signing request schema carries `x-openregister-lifecycle`, `cancelled` belongs there as a transition with a guard rather than as a service-set field. **Check the schema register before implementing**; ADR-031's default path is declarative and a hand-set status would be the wrong one. |
+| Audit record | **Imperative** | An explicit record of an attempt and its outcome. |
+
+## Risks / Trade-offs
+
+**The ValidSign implementation is unknown work.** Its cancellation API has not been
+read. It may require the original submission token, may not support cancellation
+after the first signature, or may not support it at all — in which case D1's
+"unsupported" throw is the honest answer and the UI must say so per provider.
+
+**A cancelled-but-still-live request is the failure to design against.** Every
+requirement here points at it: fail loudly, record failures, refuse when
+unauthorised, and never claim a state the provider has not confirmed.
+
+**Blocking on a human decision has a cost.** The capability stays unavailable until
+the authorisation rule is settled. That is the right trade: it has been unavailable
+since it was written, and shipping it with a guessed rule is how it becomes
+unavailable *and* wrong.

--- a/openspec/changes/signing-cancellation/proposal.md
+++ b/openspec/changes/signing-cancellation/proposal.md
@@ -63,20 +63,33 @@ attached.
   invites `if ($ok)` at one call site and a bare call at another, and the stub above
   is what a `bool` contract encourages.
 
-## The decision this change needs from a human
+## The authorisation rule — DECIDED 2026-08-16
 
-**Who may cancel a signing request?** The candidates are not equivalent:
+**Only the request's creator may cancel it. Not an app admin. Not a user with write
+access to the document.**
 
-| Candidate | Argument for | Argument against |
-|---|---|---|
-| The request's creator only | Simplest, clearly authorised | A creator on leave blocks everyone |
-| Creator + anyone with write on the document | Matches Nextcloud's sharing model | Write access to a file is not obviously authority to withdraw a legal process |
-| Creator + app admin | Gives an escape hatch | Admin is not a role in the signing domain |
+The alternatives were considered and rejected:
 
-This is not a detail to be picked by whoever implements it. Cancelling a signing
-request is a legally meaningful act, and the wrong answer is either an
-authorisation hole or an operational dead end. **The proposal deliberately does not
-choose.**
+| Candidate | Why not |
+|---|---|
+| Creator + write access on the document | Write permission on a file is not authority to withdraw a legal process from every signatory. The two happen to coincide often, which is what makes the conflation easy and wrong. |
+| Creator + app admin | Admin is not a role in the signing domain. A DocuDesk administrator administers an application; they are not a party to an agreement between a requester and its signatories. |
+
+### The consequence, stated rather than discovered
+
+**A creator who has left the organisation, or is on long leave, blocks cancellation
+of their requests permanently.** There is no in-app escape hatch by design.
+
+That is accepted, and it is the honest reading of the rule rather than an oversight
+to be quietly patched later. Two things follow, and the implementation MUST NOT
+paper over either:
+
+1. The refusal message MUST name the creator, so a blocked user knows who to ask
+   rather than concluding the feature is broken.
+2. A future "the creator has left" escape hatch is a **separate change with its own
+   authorisation argument** — not a quiet widening of this rule. Widening an
+   authorisation rule in a follow-up commit, on operational grounds, is how the
+   admin path gets in through the back door.
 
 ## Capabilities
 

--- a/openspec/changes/signing-cancellation/proposal.md
+++ b/openspec/changes/signing-cancellation/proposal.md
@@ -1,0 +1,104 @@
+---
+kind: code
+---
+
+## Why
+
+`SigningProviderInterface` declares `cancelSigning(string $externalId): bool`. Both
+providers implement it. **Nothing calls it.**
+
+```
+$ grep -rn '\->cancelSigning(' lib/ src/
+(no output)
+```
+
+So a signing request, once sent, cannot be withdrawn through DocuDesk. The capability
+was built and never connected — gate-57 surfaced it on 2026-08-16 as one of exactly
+three genuine orphaned write capabilities in the app.
+
+That alone would be an ordinary gap. What makes it urgent is the state the two
+implementations are in.
+
+### The two providers do not do the same thing
+
+`NativeSigningProvider::cancelSigning()` genuinely cancels:
+
+```php
+$session = $this->loadSessionByExternalId(externalId: $externalId);
+$session['status'] = 'cancelled';
+$this->persistSession(session: $session);
+return true;
+```
+
+`ValidSignProvider::cancelSigning()` is **a stub**:
+
+```php
+public function cancelSigning(string $externalId): bool {
+    return true;
+}
+```
+
+It makes no call to ValidSign. It returns `true` unconditionally.
+
+**Wiring a cancel button to the interface as it stands would be worse than leaving
+the capability disconnected.** A user cancels a ValidSign request, is told it
+succeeded, and the request stays live at the provider — signatories can still open
+and sign a document the user believes withdrawn, and the resulting signature is
+legally valid. The user has no way to discover this from DocuDesk.
+
+That is the "reports success, changes nothing" failure with a legal consequence
+attached.
+
+## What Changes
+
+- **`ValidSignProvider::cancelSigning()` actually calls ValidSign**, or throws. The
+  one thing it must never do again is return `true` without contacting the provider.
+- **`SigningCancellationService`** owning the cancellation: resolve the request,
+  authorise the actor, call the provider, record the outcome, update the request's
+  state.
+- **A controller route and a UI action**, so the capability is reachable.
+- **An authorisation rule** — the open question this change exists to settle. See
+  below.
+- **`cancelSigning()` returns void or throws**, rather than `bool`. A boolean return
+  invites `if ($ok)` at one call site and a bare call at another, and the stub above
+  is what a `bool` contract encourages.
+
+## The decision this change needs from a human
+
+**Who may cancel a signing request?** The candidates are not equivalent:
+
+| Candidate | Argument for | Argument against |
+|---|---|---|
+| The request's creator only | Simplest, clearly authorised | A creator on leave blocks everyone |
+| Creator + anyone with write on the document | Matches Nextcloud's sharing model | Write access to a file is not obviously authority to withdraw a legal process |
+| Creator + app admin | Gives an escape hatch | Admin is not a role in the signing domain |
+
+This is not a detail to be picked by whoever implements it. Cancelling a signing
+request is a legally meaningful act, and the wrong answer is either an
+authorisation hole or an operational dead end. **The proposal deliberately does not
+choose.**
+
+## Capabilities
+
+### New Capabilities
+- `signing-cancellation`: how a signing request is withdrawn, who may do it, and what
+  the system must never claim.
+
+## Impact
+
+- **Code**: `lib/Service/Signing/ValidSignProvider.php` (real implementation),
+  `lib/Service/Signing/NativeSigningProvider.php` (return shape),
+  `lib/Service/Signing/SigningProviderInterface.php` (return shape), new
+  `SigningCancellationService`, a controller method, a route, a UI action.
+- **Behaviour**: a capability that currently does not exist for users becomes
+  available. Nothing that works today changes.
+- **Not in scope**: `BatchStateService::deleteBatch`, the third orphan gate-57 found.
+  It is unrelated to signing and needs its own decision about what deleting a batch
+  should do to the documents in it.
+
+## Related
+
+- Found by hydra gate-57. Twelve of that gate's fifteen docudesk findings were false
+  positives — routed controller methods it could not see a caller for — fixed in
+  [ConductionNL/.github#475](https://github.com/ConductionNL/.github/pull/475). These
+  three are the real remainder.

--- a/openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+++ b/openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
@@ -40,32 +40,80 @@ provider" error, so the caller can tell the user the truth.
 - **THEN** it MUST throw an error naming the provider and the unsupported operation
 - **AND** MUST NOT silently succeed
 
-### Requirement: Cancellation MUST be authorised, and the rule MUST be explicit
+### Requirement: Only the creator of a signing request may cancel it
 
-Every cancellation MUST pass an authorisation check before the provider is called.
-The rule MUST be stated in one place and MUST NOT be inferred from file permissions
-by accident.
+The system MUST permit cancellation **only** by the user who created the signing
+request. An app administrator MUST NOT be able to cancel. A user holding write
+access to the underlying document MUST NOT be able to cancel on that basis.
 
-Cancelling a signing request withdraws a legal process from every signatory. The
-authority to do that is a domain decision, not a consequence of holding write
-permission on a file.
+Cancelling withdraws a legal process from every signatory. Write permission on a
+file is not authority to do that — the two coincide often, which is precisely what
+makes the conflation easy and wrong. An administrator administers an application;
+they are not a party to an agreement between a requester and its signatories.
 
-Until the rule is settled by a human (see the proposal), the implementation MUST
-refuse rather than default to a permissive answer. A default that lets too many
-people cancel is an authorisation hole; refusing is merely an inconvenience.
+The rule MUST live in one place and MUST NOT be reachable by any other path, so
+adding a second caller cannot accidentally introduce a second, laxer rule.
+
+#### Scenario: An app administrator is refused
+
+- **GIVEN** a signing request created by user `alice`
+- **AND** an app administrator `root` who did not create it
+- **WHEN** `root` attempts to cancel it
+- **THEN** the attempt MUST be refused
+- **AND** the provider MUST NOT be contacted
+
+#### Scenario: Write access to the document does not confer cancellation
+
+- **GIVEN** a signing request created by `alice` over a document shared with `bob` with write permission
+- **WHEN** `bob` attempts to cancel it
+- **THEN** the attempt MUST be refused
+
+#### Scenario: The creator may cancel
+
+- **GIVEN** a signing request created by `alice`
+- **WHEN** `alice` cancels it
+- **THEN** the cancellation MUST proceed
 
 #### Scenario: An unauthorised actor is refused before the provider is contacted
 
-- **GIVEN** an actor who does not satisfy the authorisation rule
-- **WHEN** they attempt to cancel a signing request
-- **THEN** the attempt MUST be refused
-- **AND** the provider MUST NOT be contacted, so no partial cancellation can occur
+- **GIVEN** an actor who is not the creator
+- **WHEN** they attempt to cancel
+- **THEN** the provider MUST NOT be contacted, so no partial cancellation can occur
 
-#### Scenario: The authorisation check runs first
+#### Scenario: The authorisation check runs before the request is resolved
 
-- **GIVEN** a cancellation request that is both unauthorised and names an unknown request id
+- **GIVEN** a cancellation that is both unauthorised and names an unknown request id
 - **WHEN** it is processed
 - **THEN** the authorisation refusal MUST take precedence, so an unauthorised caller cannot use error messages to learn which request ids exist
+
+### Requirement: A blocked cancellation MUST name the creator
+
+When cancellation is refused because the actor is not the creator, the refusal MUST
+name the creator.
+
+An absent creator — someone who has left the organisation or is on long leave —
+permanently blocks cancellation of their requests. That is the accepted consequence
+of the creator-only rule, not a defect. But a bare "not permitted" leaves the user
+concluding the feature is broken, when what they actually need is to know who to
+ask.
+
+The system MUST NOT provide an administrative override for this case. An escape
+hatch for an absent creator is a separate change with its own authorisation
+argument; adding one here on operational grounds is how the administrator path
+returns through the back door.
+
+#### Scenario: The refusal says who can do it
+
+- **GIVEN** a signing request created by `alice`
+- **WHEN** `bob` attempts to cancel it
+- **THEN** the refusal MUST name `alice` as the only user who can cancel it
+
+#### Scenario: No administrative override exists
+
+- **GIVEN** a signing request whose creator's account is disabled
+- **WHEN** an administrator attempts to cancel it
+- **THEN** the attempt MUST be refused
+- **AND** no configuration option MUST exist that would permit it
 
 ### Requirement: A cancelled request MUST be visibly cancelled and MUST NOT be re-signable
 

--- a/openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+++ b/openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: A provider MUST NOT report a cancellation it did not perform
+
+A signing provider's cancellation MUST either complete against the provider or fail
+loudly. It MUST NOT return success without having contacted the provider.
+
+`ValidSignProvider::cancelSigning()` currently consists of `return true;`. Connected
+to a UI as it stands, a user would cancel a request, be told it succeeded, and the
+request would remain live at ValidSign — signatories could still open and sign a
+document the user believes withdrawn, producing a legally valid signature the user
+never expected. DocuDesk would show no trace of the discrepancy.
+
+Cancellation MUST therefore be typed as void-or-throw rather than returning a
+boolean. A boolean return invites one call site to write `if ($ok)` and another to
+ignore it, and is what made an unconditional `return true` look like an
+implementation.
+
+A provider that genuinely cannot cancel MUST throw a named "not supported by this
+provider" error, so the caller can tell the user the truth.
+
+#### Scenario: A provider that cannot reach its backend fails loudly
+
+- **GIVEN** a provider whose backend is unreachable
+- **WHEN** a cancellation is attempted
+- **THEN** the operation MUST throw
+- **AND** MUST NOT report the request as cancelled
+- **AND** the request's state MUST remain whatever it was before the attempt
+
+#### Scenario: A stub implementation cannot satisfy the contract
+
+- **GIVEN** a provider implementation that performs no call to its backend
+- **WHEN** the contract test for that provider runs
+- **THEN** it MUST fail, because a provider that always succeeds is indistinguishable from one that never does anything
+
+#### Scenario: A provider that does not support cancellation says so
+
+- **GIVEN** a provider with no cancellation capability
+- **WHEN** a cancellation is attempted
+- **THEN** it MUST throw an error naming the provider and the unsupported operation
+- **AND** MUST NOT silently succeed
+
+### Requirement: Cancellation MUST be authorised, and the rule MUST be explicit
+
+Every cancellation MUST pass an authorisation check before the provider is called.
+The rule MUST be stated in one place and MUST NOT be inferred from file permissions
+by accident.
+
+Cancelling a signing request withdraws a legal process from every signatory. The
+authority to do that is a domain decision, not a consequence of holding write
+permission on a file.
+
+Until the rule is settled by a human (see the proposal), the implementation MUST
+refuse rather than default to a permissive answer. A default that lets too many
+people cancel is an authorisation hole; refusing is merely an inconvenience.
+
+#### Scenario: An unauthorised actor is refused before the provider is contacted
+
+- **GIVEN** an actor who does not satisfy the authorisation rule
+- **WHEN** they attempt to cancel a signing request
+- **THEN** the attempt MUST be refused
+- **AND** the provider MUST NOT be contacted, so no partial cancellation can occur
+
+#### Scenario: The authorisation check runs first
+
+- **GIVEN** a cancellation request that is both unauthorised and names an unknown request id
+- **WHEN** it is processed
+- **THEN** the authorisation refusal MUST take precedence, so an unauthorised caller cannot use error messages to learn which request ids exist
+
+### Requirement: A cancelled request MUST be visibly cancelled and MUST NOT be re-signable
+
+After a successful cancellation the request's state MUST be `cancelled`, and any
+signing surface derived from it MUST stop accepting signatures.
+
+A state change that leaves the signing link working is not a cancellation.
+
+#### Scenario: A cancelled request refuses a subsequent signature
+
+- **GIVEN** a signing request that has been cancelled
+- **WHEN** a signatory opens their signing link and submits a signature
+- **THEN** the submission MUST be refused
+- **AND** the refusal MUST say the request was withdrawn
+
+#### Scenario: Cancelling an already-cancelled request is not an error
+
+- **GIVEN** a request already in `cancelled`
+- **WHEN** cancellation is attempted again
+- **THEN** the operation MUST succeed without contacting the provider a second time
+
+#### Scenario: A completed request cannot be cancelled
+
+- **GIVEN** a signing request every signatory has already signed
+- **WHEN** cancellation is attempted
+- **THEN** it MUST be refused, naming the completed state
+- **AND** the existing signatures MUST be untouched
+
+### Requirement: Every cancellation MUST be recorded with its actor and outcome
+
+A cancellation MUST be recorded with who performed it, when, which request, and
+whether the provider confirmed it. A failed attempt MUST be recorded too.
+
+A withdrawn signing process is exactly the event someone will later need to
+reconstruct, and "the request is cancelled but nobody knows who did it" is not an
+acceptable end state for a legal artefact.
+
+#### Scenario: A failed cancellation is recorded as failed
+
+- **GIVEN** a cancellation whose provider call fails
+- **WHEN** the failure is handled
+- **THEN** the attempt MUST be recorded with its actor, the request, and the failure
+- **AND** the record MUST NOT show the request as cancelled

--- a/openspec/changes/signing-cancellation/tasks.md
+++ b/openspec/changes/signing-cancellation/tasks.md
@@ -1,11 +1,12 @@
 # Tasks
 
-## 0. Settle the authorisation rule — BLOCKING
+## 0. Authorisation rule — DECIDED 2026-08-16
 
-- [ ] Get a human decision on who may cancel a signing request (see the proposal's table) and record it in the spec
+**Only the request's creator may cancel. Not an admin. Not a holder of write access.**
 
-Acceptance criteria:
-- Nothing below ships until this is answered. A guessed rule is an authorisation hole in a legal process, and the refusal in task 2 is the deliberate placeholder until then.
+No longer blocking. The accepted consequence: an absent creator permanently blocks
+cancellation of their requests, with no in-app override. The refusal names the
+creator so a blocked user knows who to ask.
 
 ## 1. Make the contract honest
 
@@ -22,7 +23,8 @@ Acceptance criteria:
 
 - [ ] Add `SigningCancellationService` — authorise, resolve, call provider, record, transition
 - [ ] Authorise BEFORE contacting the provider and before resolving the request id
-- [ ] Refuse when the authorisation rule is unsettled, rather than defaulting permissive
+- [ ] Enforce creator-only: refuse admins and refuse write-access holders, with the refusal naming the creator
+- [ ] Add a test asserting NO configuration option can permit an administrative override
 - [ ] Make an already-cancelled request idempotent, and a completed request a refusal
 - [ ] Check whether the signing request schema carries `x-openregister-lifecycle`; if it does, the transition belongs there (ADR-031), not in a hand-set status field
 

--- a/openspec/changes/signing-cancellation/tasks.md
+++ b/openspec/changes/signing-cancellation/tasks.md
@@ -1,0 +1,49 @@
+# Tasks
+
+## 0. Settle the authorisation rule — BLOCKING
+
+- [ ] Get a human decision on who may cancel a signing request (see the proposal's table) and record it in the spec
+
+Acceptance criteria:
+- Nothing below ships until this is answered. A guessed rule is an authorisation hole in a legal process, and the refusal in task 2 is the deliberate placeholder until then.
+
+## 1. Make the contract honest
+
+- [ ] Change `SigningProviderInterface::cancelSigning()` to void-or-throw
+- [ ] Add a named "cancellation not supported by this provider" exception
+- [ ] Implement `ValidSignProvider::cancelSigning()` against ValidSign's real API, or throw unsupported if it has none
+- [ ] Update `NativeSigningProvider::cancelSigning()` to the new return shape
+
+Acceptance criteria:
+- `ValidSignProvider::cancelSigning()` no longer returns success without contacting ValidSign. This is the defect: as written it tells a user their request is withdrawn while signatories can still sign.
+- A provider contract test fails against an implementation that always succeeds without a backend call.
+
+## 2. The cancellation service
+
+- [ ] Add `SigningCancellationService` — authorise, resolve, call provider, record, transition
+- [ ] Authorise BEFORE contacting the provider and before resolving the request id
+- [ ] Refuse when the authorisation rule is unsettled, rather than defaulting permissive
+- [ ] Make an already-cancelled request idempotent, and a completed request a refusal
+- [ ] Check whether the signing request schema carries `x-openregister-lifecycle`; if it does, the transition belongs there (ADR-031), not in a hand-set status field
+
+Acceptance criteria:
+- An unauthorised caller cannot distinguish "no such request" from "not allowed", so request ids cannot be enumerated from error text.
+- A cancelled request's signing link refuses a subsequent signature. A state change that leaves the link working is not a cancellation.
+
+## 3. Reachability and audit
+
+- [ ] Add the controller method, the route, and the UI action
+- [ ] Record every attempt with actor, request, timestamp and outcome — including failures
+
+Acceptance criteria:
+- A failed cancellation is recorded as failed and the request is NOT shown as cancelled. That record is what stops someone concluding a document was withdrawn when it was not.
+- Verify the route is registered; an unrouted controller method is exactly the orphan class that produced this change.
+
+## 4. Verify
+
+- [ ] Unit tests for each requirement, including the provider contract test and the enumeration guard
+- [ ] Playwright E2E: cancel a native signing request, then confirm the signing link refuses a signature
+- [ ] Re-run gate-57 and confirm `cancelSigning` is no longer orphaned on either provider
+
+Acceptance criteria:
+- The E2E asserts the signing surface REFUSES afterwards, not merely that the status field changed. The status is what the app believes; the refusal is what the signatory experiences.


### PR DESCRIPTION
> **Spec only — no implementation.** Task 0 is blocking and needs a decision from you.

## The gap

`SigningProviderInterface` declares `cancelSigning()`. Both providers implement it. **Nothing calls it.**

```
$ grep -rn '\->cancelSigning(' lib/ src/
(no output)
```

A signing request, once sent, cannot be withdrawn through DocuDesk. Gate-57 surfaced this as one of exactly **three genuine** orphaned write capabilities in the app.

## Why this is urgent rather than ordinary

The two implementations are **not equivalent**.

`NativeSigningProvider::cancelSigning()` genuinely cancels — loads the session, sets `status = 'cancelled'`, persists.

`ValidSignProvider::cancelSigning()` is:

```php
public function cancelSigning(string $externalId): bool {
    return true;
}
```

No call to ValidSign. Returns `true` unconditionally.

**Wiring a cancel button to the interface as it stands would be worse than leaving the capability disconnected.** A user cancels a ValidSign request, is told it succeeded, and the request stays live at the provider — signatories can still open and sign a document the user believes withdrawn, and that signature is legally valid. DocuDesk would show no trace of the discrepancy.

That is "reports success, changes nothing" with a legal consequence attached, which is why this ships as a spec and not as a wiring commit.

## What the spec settles

- **`cancelSigning()` becomes void-or-throw.** The `: bool` contract is what let `return true;` pass for an implementation — a boolean invites one caller to write `if ($ok)` and the next to ignore it, and neither is wrong under the type.
- **Authorise before contacting the provider *and* before resolving the request id.** Otherwise an unauthorised caller can distinguish "no such request" from "not allowed" and enumerate valid ids from the error text.
- **Already-cancelled is idempotent; already-completed is refused.** Accepting the latter would let the UI show "cancelled" over a document that is in fact signed.
- **Failed attempts are recorded as failed.** *"Attempted 14:02, provider refused, request still live"* is the record that stops someone concluding a document was withdrawn when it was not.

## The decision I need from you

**Who may cancel a signing request?** These are not equivalent, and I deliberately did not choose:

| Candidate | For | Against |
|---|---|---|
| Creator only | Simplest, clearly authorised | A creator on leave blocks everyone |
| Creator + write access on the document | Matches Nextcloud's sharing model | Write access to a file is not obviously authority to withdraw a legal process |
| Creator + app admin | Gives an escape hatch | Admin is not a role in the signing domain |

Until it's answered, the spec requires the implementation to **refuse** rather than default permissive. A too-broad default is an authorisation hole discovered after someone withdraws a colleague's legal process; a refusal is discovered immediately by the person who needed the feature.

## Flagged for whoever implements it

Check whether the signing request schema carries `x-openregister-lifecycle`. If it does, `cancelled` belongs there as a guarded transition per ADR-031 — **not** as a hand-set status field.

## Not in scope

`BatchStateService::deleteBatch`, the third gate-57 orphan. Unrelated to signing, and it needs its own decision about what deleting a batch does to the documents in it.

## Context

Twelve of gate-57's fifteen docudesk findings were **false positives** — routed controller methods the gate could not see callers for — fixed in [ConductionNL/.github#475](https://github.com/ConductionNL/.github/pull/475). These three are the real remainder.

Spec: `openspec/changes/signing-cancellation/`
