### PR TITLE
security(spec): OpenRegister is not guarding 20 of our 21 schemas

### DIFF
--- a/openspec/changes/consumer-schema-authorization-audit/.openspec.yaml
+++ b/openspec/changes/consumer-schema-authorization-audit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/openspec/changes/consumer-schema-authorization-audit/design.md
+++ b/openspec/changes/consumer-schema-authorization-audit/design.md
@@ -1,0 +1,98 @@
+## Context
+
+Two facts, both measured on 2026-08-16, and neither obvious from reading a
+controller:
+
+1. **20 of 21 DocuDesk schemas declare no `authorization` cascade**, and
+   OpenRegister treats an unconfigured cascade as OPEN.
+2. **9 controller methods have no authorisation guard in their body**, and at least
+   one of them (`DocumentController::preview`) acts on a request-supplied id behind
+   nothing but a `401`.
+
+Either alone is arguable. Together they mean the app is relying on a guard that is
+not there.
+
+## Goals / Non-Goals
+
+**Goals:**
+- An explicit authorisation decision for every schema DocuDesk owns.
+- A guard on every endpoint the schema decision cannot cover.
+- A ratchet so the schema count cannot drift back.
+
+**Non-Goals:**
+- Nine guards in one commit. See D2.
+- Changing OpenRegister's open-by-default behaviour. That is OR's decision to make
+  and would be a fleet-wide breaking change; this app's job is to stop assuming
+  otherwise.
+- Auditing other apps. The finding is fleet-shaped and should be raised, but each
+  app owns its own schemas.
+
+## Decisions
+
+### D1 — Fix at the schema layer first, the controller layer second
+
+A declared cascade fixes a whole class of access at the data layer, for every caller
+including ones that do not exist yet. A controller guard fixes one endpoint and must
+be repeated, correctly, at every future call site.
+
+So the schema decision comes first, and only what it cannot express becomes a
+controller guard.
+
+⚠️ A schema change needs an `info.version` bump or the import is skipped and the
+change never deploys — silently, on every existing install. That has bitten this
+codebase before.
+
+### D2 — Do not write nine guards to clear a gate
+
+Each of the nine needs its own answer to "who may do this, to this object". A guard
+written to satisfy a checker rather than a threat model looks identical to a real
+one in a diff, and is deleted the moment someone reasons that the data layer covers
+it.
+
+That is not hypothetical here. `ConsentCrudService` carries the comment *"Do not
+delete either as 'redundant with OpenRegister RBAC' — measured, it is not
+redundant"*, which exists because someone had already reasoned their way there. An
+unjustified guard is that control with the reasoning stripped out.
+
+### D3 — State the bound
+
+Multitenancy is a separate axis from RBAC and remains enforced, so the exposure is to
+authenticated users **within one organisation** — not anonymous, not cross-tenant.
+
+Both available summaries are wrong: "it's an IDOR" reads as anonymous and drives
+panic-shaped work; "RBAC covers it" is the belief that produced the gap. The bound
+has to be carried with the finding.
+
+### D4 — Ratchet on schema count, not on findings
+
+The test asserts that every schema has a decision, not that some number of findings
+is zero. A findings-count ratchet passes as soon as someone adds an `@exclude`; a
+coverage assertion requires an actual decision per schema, and a new schema without
+one fails on the day it is added rather than at the next audit.
+
+## Seed Data (ADR-001)
+
+**None** in the sense of new objects. The change edits authorisation blocks on
+existing schemas in `lib/Settings/docudesk_register.json`; no schema is introduced.
+
+## Declarative-vs-imperative decision (ADR-031)
+
+| Behaviour | Path | Rationale |
+|---|---|---|
+| Per-schema authorisation | **Declarative** | `authorization` in the schema register is exactly the declarative surface ADR-031 prefers, and it applies to every caller rather than every call site. |
+| Per-endpoint guard | **Imperative** | Only where the cascade cannot express the rule — e.g. an ownership comparison the cascade has no vocabulary for. |
+| Coverage ratchet | **Imperative** | A test over the register file. |
+
+## Risks / Trade-offs
+
+**An over-tight cascade locks users out of their own data**, and the failure is
+immediate and visible — which is the safer direction than the current one, where the
+failure is invisible and someone else reads your document.
+
+**A cascade is only as good as its deployment.** The `info.version` bump is the whole
+difference between a fix and a fix-shaped commit.
+
+**Nine endpoints is a lot of threat-modelling.** Accepted. The alternative — nine
+guards written quickly — produces controls nobody can justify later, and the codebase
+already contains a comment written by someone defending a real control from exactly
+that fate.

--- a/openspec/changes/consumer-schema-authorization-audit/proposal.md
+++ b/openspec/changes/consumer-schema-authorization-audit/proposal.md
@@ -1,0 +1,111 @@
+---
+kind: code
+---
+
+## Why
+
+**20 of DocuDesk's 21 schemas declare no `authorization` cascade, and OpenRegister
+treats an unconfigured cascade as OPEN.**
+
+This is not inferred. `ConsentCrudService::getConsent()` documents it in the code,
+from a measured security finding (#283):
+
+> ⚠️ But this is NOT what stops one user reading another's consent record… The
+> `publicationConsent` schema declares `"authorization": null` in
+> `lib/Settings/docudesk_register.json`, and OpenRegister treats an unconfigured
+> authorization cascade as **OPEN** — so the per-object RBAC half permits the read
+> for any authenticated caller in the org.
+>
+> The control that actually closes #283 is `ConsentController::canAccessConsent()`…
+> Do not delete either as "redundant with OpenRegister RBAC" — measured, it is not
+> redundant.
+
+So for 20 of 21 schemas, **OpenRegister's RBAC is not the guard.** Anything that
+protects those objects has to be an explicit check in DocuDesk's own code.
+
+Gate-7 reports **9 controller methods with no authorisation guard in the body**:
+
+```
+TemplatePreviewController::previewTemplate     ConsentController::create
+DocumentController::preview                    DocumentController::generateBulk
+ComparisonController::compare                  BatchAnonymizationController::folderBatch
+BatchAnonymizationController::batchExtract     BatchAnonymizationController::batchAnonymize
+BatchAnonymizationController::batchReport
+```
+
+`DocumentController::preview()` is representative. It reads `templateId` from the
+request, checks only that a user is **authenticated** — returning 401 when not — and
+proceeds. There is no check that the caller may see *that* template, and `template`
+is one of the 20 schemas with no cascade.
+
+An authentication check is not an authorisation check. This is the precise defect
+class that, once gate-7 stopped accepting a `401` as a guard, turned **0 findings
+across 18 apps into 167 real IDORs** fleet-wide.
+
+### A correction to the record
+
+An earlier reading of this concluded the opposite — that OpenRegister's default-on
+data layer already guarded these nine, because none of them passes `_rbac: false`.
+That reasoning was wrong, and the way it was wrong is worth keeping:
+
+`_rbac: true` means *"apply the cascade"*. It does not mean *"a cascade exists."*
+With `authorization: null`, applying the cascade permits everything. Absence of an
+opt-out is not presence of a guard.
+
+## Scope of exposure
+
+Bounded, and the bound matters for prioritisation:
+
+- **Multitenancy is separate from RBAC and remains enforced.** The
+  `ConsentCrudService` comment calls the multitenancy half "genuinely load-bearing",
+  so cross-organisation reads are still blocked.
+- The exposure is therefore **any authenticated user within the same organisation**
+  reading or acting on another user's object by id.
+
+That is a real IDOR, not a theoretical one, but it is not anonymous and not
+cross-tenant.
+
+## What Changes
+
+- **An authorisation decision per schema.** For each of the 20, either declare an
+  `authorization` cascade in `lib/Settings/docudesk_register.json`, or record why the
+  data is legitimately org-readable (reference data, catalogues, shared templates).
+- **An explicit guard on each of the 9 endpoints**, or a recorded finding that the
+  endpoint's data is legitimately org-wide.
+- **A test that fails when a schema is added without an authorisation decision**, so
+  the count cannot silently return to 20.
+
+## What this change deliberately does NOT do
+
+It does not add nine guards in one commit. Each of the nine needs its own answer to
+"who may do this to this object", and a guard written to satisfy a gate rather than a
+threat model is how `canAccessConsent()`-shaped controls get deleted later as
+"redundant with OpenRegister RBAC" — which the code comment above explicitly warns
+against, because someone already tried.
+
+The schema-level decision comes first: a declared cascade fixes a whole class at the
+data layer, and only the endpoints it cannot cover need a controller guard.
+
+## Capabilities
+
+### New Capabilities
+- `consumer-schema-authorization-audit`: what a consumer app must decide about
+  authorisation for every schema it owns, and what it may not assume OpenRegister is
+  doing for it.
+
+## Impact
+
+- **Data**: `lib/Settings/docudesk_register.json` — an `authorization` block per
+  schema is a schema change and therefore needs an `info.version` bump, or the import
+  is skipped and the change never deploys.
+- **Code**: guards on up to 9 controller methods.
+- **Risk of the fix**: an over-tight cascade locks users out of their own data. Each
+  schema needs the decision made deliberately, which is why this is a change with a
+  spec rather than a sweep.
+
+## Related
+
+- Found while triaging gate-7 for [ConductionNL/.github#475](https://github.com/ConductionNL/.github/pull/475).
+- ⚠️ **This finding is fleet-shaped.** Every consumer app that assumed OR's RBAC was
+  guarding it has the same question to answer. DocuDesk is where it was measured, not
+  necessarily where it is worst.

--- a/openspec/changes/consumer-schema-authorization-audit/specs/consumer-schema-authorization-audit/spec.md
+++ b/openspec/changes/consumer-schema-authorization-audit/specs/consumer-schema-authorization-audit/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Every owned schema MUST carry an explicit authorisation decision
+
+Every schema DocuDesk declares in `lib/Settings/docudesk_register.json` MUST either
+declare an `authorization` cascade, or carry a recorded justification for being
+readable by any authenticated user in the organisation.
+
+OpenRegister treats an **unconfigured** cascade as OPEN. `_rbac: true` means "apply
+the cascade"; it does not mean "a cascade exists". With `authorization: null`,
+applying the cascade permits everything — so absence of an opt-out is not presence of
+a guard.
+
+Measured 2026-08-16: **20 of 21** schemas had no cascade.
+
+A schema added without a decision MUST fail a test. The count returning to 20 by
+accretion is the failure mode this requirement exists to prevent, and it happens one
+un-thought-about schema at a time.
+
+#### Scenario: A new schema without an authorisation decision fails
+
+- **GIVEN** a schema added to the register with neither an `authorization` cascade nor a recorded justification
+- **WHEN** the authorisation-coverage test runs
+- **THEN** it MUST fail, naming the schema
+
+#### Scenario: A justified open schema passes
+
+- **GIVEN** a schema holding reference data legitimately readable across the organisation
+- **AND** a recorded justification saying so
+- **WHEN** the test runs
+- **THEN** it MUST pass, because "open" is a decision the app is allowed to make deliberately
+
+#### Scenario: The cascade change is deployable
+
+- **GIVEN** an `authorization` block added to a schema
+- **WHEN** the register is imported
+- **THEN** the register's `info.version` MUST have been bumped, or the import is skipped and the change never reaches a running instance
+
+### Requirement: Authentication MUST NOT be presented as authorisation
+
+A controller method reachable by any authenticated user, which acts on an object
+identified by a request parameter, MUST verify that the caller may act on **that
+object**. Returning `401` when no user is present is an authentication check and
+satisfies nothing here.
+
+`DocumentController::preview()` reads `templateId` from the request, returns `401`
+when unauthenticated, and proceeds with no per-object check, against a schema with no
+cascade.
+
+This is the defect class that turned **0 gate-7 findings across 18 apps into 167 real
+IDORs** once the gate stopped accepting a `401` as a guard.
+
+#### Scenario: Another user's object is refused
+
+- **GIVEN** an object belonging to user `alice`, under a schema with no authorisation cascade
+- **AND** an authenticated user `bob` in the same organisation
+- **WHEN** `bob` requests the endpoint with `alice`'s object id
+- **THEN** the request MUST be refused
+- **AND** the refusal MUST NOT reveal whether the id exists
+
+#### Scenario: A 401 does not satisfy the requirement
+
+- **GIVEN** an endpoint whose only check is that a session user exists
+- **WHEN** the authorisation test for that endpoint runs
+- **THEN** it MUST fail, because every authenticated user in the organisation passes that check
+
+### Requirement: A guard MUST be justified by a threat model, not by a gate
+
+Each guard added under this change MUST record which actor it excludes and from
+what. A guard written only to make a gate green MUST NOT be added.
+
+`ConsentCrudService` already carries the evidence for why this matters: its comment
+ends *"Do not delete either as 'redundant with OpenRegister RBAC' — measured, it is
+not redundant."* Someone had already reasoned their way to deleting a real control
+because they believed the data layer covered it. An unjustified guard is the same
+control with the reasoning missing, and it will be deleted the same way.
+
+#### Scenario: A guard records what it excludes
+
+- **GIVEN** a controller guard added under this change
+- **WHEN** the code is reviewed
+- **THEN** it MUST state which actor it refuses and why the data layer does not already refuse them
+
+### Requirement: The exposure bound MUST be stated, not implied
+
+Documentation of this finding MUST state that multitenancy remains enforced and that
+the exposure is to authenticated users **within the same organisation**.
+
+An unqualified "IDOR" reads as anonymous or cross-tenant and drives the wrong
+priority; an unqualified "it's fine, RBAC covers it" is what produced this finding in
+the first place. Both are wrong in the same way — they replace a measurement with a
+summary.
+
+#### Scenario: Cross-organisation access is still refused
+
+- **GIVEN** an object in organisation A
+- **AND** an authenticated user in organisation B
+- **WHEN** the object is requested by id
+- **THEN** the request MUST be refused by the multitenancy layer

--- a/openspec/changes/consumer-schema-authorization-audit/tasks.md
+++ b/openspec/changes/consumer-schema-authorization-audit/tasks.md
@@ -1,0 +1,44 @@
+# Tasks
+
+## 1. Establish the ground truth
+
+- [ ] Record, per schema, whether it has an `authorization` cascade (measured: 1 of 21 does)
+- [ ] For each of the 9 gate-7 endpoints, record which schema it touches and whether that schema is open
+
+Acceptance criteria:
+- The record distinguishes "open by decision" from "open by omission". Only the second is a defect.
+- Confirm multitenancy is still enforced, so the exposure bound in the proposal is measured rather than assumed.
+
+## 2. Decide authorisation per schema
+
+- [ ] For each of the 20 open schemas, declare an `authorization` cascade or record why org-wide readability is correct
+- [ ] Bump `info.version` in `lib/Settings/docudesk_register.json`
+
+Acceptance criteria:
+- Without the version bump the import is SKIPPED and the change never deploys to any existing install. Verify the cascade is live on a running instance, not just present in the file.
+- Verify a locked-down schema still lets its legitimate owner read their own objects. An over-tight cascade is a visible outage; that is the safer failure, but it is still a failure.
+
+## 3. Guard what the cascade cannot cover
+
+- [ ] For each of the 9 endpoints, add a per-object guard OR record that its data is legitimately org-wide
+- [ ] Make each guard state which actor it excludes and why the data layer does not already exclude them
+
+Acceptance criteria:
+- No guard is added solely to clear the gate. `ConsentCrudService` documents someone already reasoning their way to deleting a real control as "redundant with OpenRegister RBAC" — an unjustified guard is that control with the reasoning removed.
+- A refusal must not reveal whether the requested id exists.
+
+## 4. Ratchet
+
+- [ ] Add a test asserting every schema in the register has an authorisation decision
+- [ ] Add a test asserting no flagged endpoint relies on a 401 alone
+
+Acceptance criteria:
+- The ratchet asserts COVERAGE per schema, not a findings count. A count passes the moment someone adds an exclude; coverage requires a decision.
+- Adding a schema with no decision fails on the day it is added.
+
+## 5. Raise it beyond this app
+
+- [ ] Report the finding to the fleet: any consumer app assuming OR's RBAC guards it has the same question
+
+Acceptance criteria:
+- DocuDesk is where this was measured, not necessarily where it is worst.


### PR DESCRIPTION
> ⚠️ **This corrects a conclusion I reached earlier in the same investigation.** The way it was wrong is the useful part.

## The correction

Triaging gate-7's 9 findings, I checked whether any flagged controller passes `_rbac: false`. None does — so I concluded OpenRegister's default-on data layer was already guarding them, and reported "no IDOR".

That reasoning is invalid.

**`_rbac: true` means "apply the cascade". It does not mean "a cascade exists."** With `authorization: null`, applying the cascade permits everything. **Absence of an opt-out is not presence of a guard.**

## Measured

`lib/Settings/docudesk_register.json`:

| | |
|---|---|
| Schemas total | 21 |
| **With** an `authorization` cascade | **1** |
| **Without** — OR treats as OPEN | **20** |

This is documented in our own code. `ConsentCrudService::getConsent()`, from security finding #283:

> *"the `publicationConsent` schema declares `"authorization": null` … and OpenRegister treats an unconfigured authorization cascade as **OPEN** — so the per-object RBAC half permits the read for any authenticated caller in the org. The control that actually closes #283 is `ConsentController::canAccessConsent()` … **Do not delete either as 'redundant with OpenRegister RBAC' — measured, it is not redundant.**"*

## So gate-7's findings are not noise

`DocumentController::preview()` reads `templateId` from the request, returns `401` when there's no session user, and proceeds — **no per-object check**, against `template`, one of the 20 open schemas.

An authentication check is not an authorisation check. This is the exact class that turned **0 gate-7 findings across 18 apps into 167 real IDORs** once the gate stopped accepting a `401` as a guard.

## The bound, because both easy summaries are wrong

Multitenancy is a separate axis and **remains enforced**. The exposure is authenticated users **within one organisation** reading each other's objects by id. Not anonymous, not cross-tenant.

*"It's an IDOR"* drives panic-shaped work. *"RBAC covers it"* is the belief that produced the gap. Neither is the measurement.

## Why this is a spec and not nine guards

Each of the nine endpoints needs its own answer to *"who may do this, to this object"*. A guard written to satisfy a checker looks identical to a real one in a diff — and gets deleted the moment someone reasons the data layer covers it.

That is not hypothetical. The `ConsentCrudService` comment above exists **because someone already reasoned their way there.**

**Order matters:** the schema cascade comes first — it applies to every caller including ones that don't exist yet — and only what it cannot express becomes a controller guard. ⚠️ A cascade change needs an `info.version` bump or the import is silently skipped and nothing deploys.

## Fleet-shaped

Every consumer app that assumed OR's RBAC was guarding it has the same question to answer. **DocuDesk is where this was measured, not necessarily where it is worst.**

Spec: `openspec/changes/consumer-schema-authorization-audit/`
