### PR TITLE
feat(signing): make cancellation real, and make ValidSign stop lying

### DIFF
--- a/lib/Exception/SigningCancellationNotSupportedException.php
+++ b/lib/Exception/SigningCancellationNotSupportedException.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * DocuDesk SigningCancellationNotSupportedException
+ *
+ * Raised when a signing provider cannot withdraw a request it issued.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Exception
+ * @package  OCA\DocuDesk\Exception
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Exception;
+
+use RuntimeException;
+
+/**
+ * A provider that cannot cancel says so, rather than returning success.
+ *
+ * This exception exists because of a measured defect. `ValidSignProvider::
+ * cancelSigning()` was, in full:
+ *
+ *     public function cancelSigning(string $externalId): bool {
+ *         return true;
+ *     }
+ *
+ * No call to ValidSign. Connected to a UI, a user would cancel a request, be told
+ * it succeeded, and the request would stay live at the provider — signatories could
+ * still open and sign a document the user believed withdrawn, producing a legally
+ * valid signature nobody expected.
+ *
+ * A `bool` return is what made that look like an implementation. Void-or-throw
+ * removes the option: a provider either completes, or raises something the caller
+ * must handle. "I cannot do this" is information a user can act on; `false` is
+ * indistinguishable from a transient failure.
+ *
+ * @category Exception
+ * @package  OCA\DocuDesk\Exception
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ *
+ * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+ */
+class SigningCancellationNotSupportedException extends RuntimeException {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $provider The provider that cannot cancel.
+	 * @param string $reason   Why, in terms a user can act on.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+	 */
+	public function __construct(string $provider, string $reason = '') {
+		$message = sprintf(
+			'The "%s" signing provider cannot withdraw a signing request. '
+			. 'The request is still live and its signatories can still sign. '
+			. 'Withdraw it directly with the provider.',
+			$provider
+		);
+
+		if ($reason !== '') {
+			$message .= ' ' . $reason;
+		}
+
+		parent::__construct(message: $message);
+	}//end __construct()
+}//end class

--- a/lib/Service/Signing/NativeSigningProvider.php
+++ b/lib/Service/Signing/NativeSigningProvider.php
@@ -48,6 +48,21 @@ use Throwable;
  * @spec openspec/changes/digital-signing-integration/tasks.md#2-2
  */
 class NativeSigningProvider implements SigningProviderInterface {
+
+	/**
+	 * A withdrawn signing session.
+	 *
+	 * @var string
+	 */
+	public const STATUS_CANCELLED = 'cancelled';
+
+	/**
+	 * A signing session every signatory has signed.
+	 *
+	 * @var string
+	 */
+	public const STATUS_COMPLETED = 'completed';
+
 	/**
 	 * Constructor
 	 *
@@ -211,23 +226,41 @@ class NativeSigningProvider implements SigningProviderInterface {
 	}//end downloadSignedDocument()
 
 	/**
-	 * Cancel a native signing session
+	 * Withdraw a native signing session.
 	 *
-	 * @param string $externalId The signing session identifier
+	 * Idempotent on an already-cancelled session — a double-click, not an error.
+	 * Refuses a COMPLETED one: the signatures exist and the process is over, so
+	 * accepting it would let the UI show "cancelled" over a document that is in fact
+	 * signed, which is a claim the system cannot make good on.
 	 *
-	 * @return bool True if cancelled
+	 * @param string $externalId The signing session identifier.
 	 *
-	 * @throws RuntimeException If session not found
+	 * @return void
 	 *
-	 * @spec openspec/changes/digital-signing-integration/tasks.md#2-2
+	 * @throws RuntimeException If the session is not found, or is already completed.
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
 	 */
-	public function cancelSigning(string $externalId): bool {
+	public function cancelSigning(string $externalId): void {
 		$session = $this->loadSessionByExternalId(externalId: $externalId);
 
-		$session['status'] = 'cancelled';
-		$this->persistSession(session: $session);
+		// Already withdrawn: a double-click, not an error, and nothing to re-do.
+		if (($session['status'] ?? '') === self::STATUS_CANCELLED) {
+			return;
+		}
 
-		return true;
+		// A completed request cannot be withdrawn. The signatures exist and the
+		// process is over; accepting this would let the UI show "cancelled" over a
+		// document that is in fact signed — a claim the system cannot make good on.
+		if (($session['status'] ?? '') === self::STATUS_COMPLETED) {
+			throw new RuntimeException(
+				'This signing request is already completed and cannot be withdrawn. '
+				. 'Its existing signatures are unaffected.'
+			);
+		}
+
+		$session['status'] = self::STATUS_CANCELLED;
+		$this->persistSession(session: $session);
 	}//end cancelSigning()
 
 	/**

--- a/lib/Service/Signing/SigningCancellationService.php
+++ b/lib/Service/Signing/SigningCancellationService.php
@@ -1,0 +1,249 @@
+<?php
+
+/**
+ * DocuDesk SigningCancellationService
+ *
+ * Withdraws a signing request: authorise, call the provider, record the outcome.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service\Signing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service\Signing;
+
+use OCA\DocuDesk\Exception\SigningCancellationNotSupportedException;
+use OCA\DocuDesk\Service\SigningService;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * The one place a signing request is withdrawn.
+ *
+ * ## Only the creator, decided 2026-08-16
+ *
+ * Not an app administrator. Not a holder of write access to the document.
+ *
+ * Write permission on a file is not authority to withdraw a legal process from
+ * every signatory. The two coincide often, which is exactly what makes the
+ * conflation easy and wrong. An administrator administers an application; they are
+ * not a party to an agreement between a requester and its signatories.
+ *
+ * **The accepted consequence:** a creator who has left the organisation
+ * permanently blocks cancellation of their requests. There is no in-app override,
+ * deliberately. The refusal names the creator so a blocked user knows who to ask
+ * rather than concluding the feature is broken. An "absent creator" escape hatch is
+ * a separate change with its own authorisation argument — adding one here on
+ * operational grounds is how the administrator path returns through the back door.
+ *
+ * ## Order of checks is load-bearing
+ *
+ * Authorisation runs before the provider is contacted (so no partial cancellation)
+ * AND before the request id is resolved — otherwise an unauthorised caller could
+ * distinguish "no such request" from "not allowed" and enumerate valid ids from the
+ * error text.
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service\Signing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ *
+ * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+ */
+class SigningCancellationService {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param SigningProviderFactory $providers Resolves the configured provider.
+	 * @param SigningService         $requests  Signing request lookup.
+	 * @param LoggerInterface        $logger    The logger.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly SigningProviderFactory $providers,
+		private readonly SigningService $requests,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Withdraw a signing request.
+	 *
+	 * @param string $uid       The acting user id.
+	 * @param string $requestId The signing request id.
+	 *
+	 * @return array{requestId: string, status: string, alreadyCancelled: bool}
+	 *
+	 * @throws RuntimeException When the actor is not the creator, or the withdrawal fails.
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+	 */
+	public function cancel(string $uid, string $requestId): array {
+		// Scoped lookup: getRequest() already collapses access-denied to null and
+		// throws an id-free message for a genuine miss, so neither shape leaks
+		// which request ids exist.
+		$request = null;
+		try {
+			$request = $this->requests->getRequest(requestId: $requestId, callerUserId: $uid);
+		} catch (Throwable $e) {
+			$request = null;
+		}
+
+		// ONE refusal for "not yours" and "does not exist". Distinguishing them
+		// would let an unauthorised caller enumerate valid request ids from the
+		// error text, so the two cases must be indistinguishable from outside.
+		// A SIGNER reaches this point too — getRequest() admits signers — and is
+		// refused here, because signing a document is not authority to withdraw it.
+		if ($request === null || $this->isCreator(uid: $uid, request: $request) === false) {
+			$this->recordAttempt(
+				uid: $uid,
+				requestId: $requestId,
+				outcome: 'refused-not-creator',
+				detail: 'actor is not the creator, or the request does not exist'
+			);
+
+			throw new RuntimeException($this->refusalMessage(request: $request));
+		}
+
+		$externalId = (string)($request['externalId'] ?? '');
+		if ($externalId === '') {
+			throw new RuntimeException(
+				'This signing request has no provider reference, so it cannot be withdrawn at the provider.'
+			);
+		}
+
+		try {
+			$this->providers->getActiveProvider()->cancelSigning($externalId);
+		} catch (SigningCancellationNotSupportedException $e) {
+			// The provider CANNOT cancel. The request is still live, and the caller
+			// is told so rather than being shown a success they cannot rely on.
+			$this->recordAttempt(
+				uid: $uid,
+				requestId: $requestId,
+				outcome: 'failed-unsupported',
+				detail: $e->getMessage()
+			);
+			throw $e;
+		} catch (Throwable $e) {
+			// A failed cancellation is recorded AS FAILED. "Attempted, provider
+			// refused, request still live" is the record that stops someone later
+			// concluding the document was withdrawn when it was not.
+			$this->recordAttempt(
+				uid: $uid,
+				requestId: $requestId,
+				outcome: 'failed',
+				detail: $e->getMessage()
+			);
+			throw new RuntimeException(
+				'The signing request could not be withdrawn: ' . $e->getMessage()
+				. ' It is still live and its signatories can still sign.',
+				0,
+				$e
+			);
+		}//end try
+
+		$already = (($request['status'] ?? '') === NativeSigningProvider::STATUS_CANCELLED);
+
+		$this->recordAttempt(uid: $uid, requestId: $requestId, outcome: 'cancelled', detail: '');
+
+		return [
+			'requestId'        => $requestId,
+			'status'           => NativeSigningProvider::STATUS_CANCELLED,
+			'alreadyCancelled' => $already,
+		];
+	}//end cancel()
+
+	/**
+	 * Whether the actor created this request.
+	 *
+	 * The ONLY authorisation predicate. Kept as one method so a second caller
+	 * cannot introduce a second, laxer rule — and so that widening it is a visible
+	 * edit to a named thing rather than a condition drifting at a call site.
+	 *
+	 * @param string $uid     The acting user id.
+	 * @param array  $request The signing request.
+	 *
+	 * @return bool True when the actor is the creator.
+	 */
+	private function isCreator(string $uid, array $request): bool {
+		$creator = (string)($request['initiatorUserId'] ?? '');
+
+		return ($creator !== '' && $creator === $uid);
+	}//end isCreator()
+
+	/**
+	 * Build the refusal.
+	 *
+	 * Names the creator when there is one. A bare "not permitted" leaves the user
+	 * concluding the feature is broken, when what they need is to know who to ask —
+	 * which matters more here than usual, because an absent creator blocks
+	 * cancellation permanently and by design.
+	 *
+	 * @param array|null $request The request, or null when it does not exist.
+	 *
+	 * @return string The refusal message.
+	 */
+	private function refusalMessage(?array $request): string {
+		$creator = '';
+		if ($request !== null) {
+			$creator = (string)($request['initiatorUserId'] ?? '');
+		}
+
+		if ($creator !== '') {
+			return sprintf(
+				'Only the person who created this signing request can withdraw it: %s. '
+				. 'Administrators cannot withdraw it on their behalf.',
+				$creator
+			);
+		}
+
+		return 'Only the person who created this signing request can withdraw it.';
+	}//end refusalMessage()
+
+	/**
+	 * Record an attempt and its outcome.
+	 *
+	 * Every attempt, not only the successes. A withdrawn signing process is exactly
+	 * the event someone will later need to reconstruct.
+	 *
+	 * @param string $uid       The acting user id.
+	 * @param string $requestId The signing request id.
+	 * @param string $outcome   What happened.
+	 * @param string $detail    Why, when it failed.
+	 *
+	 * @return void
+	 */
+	private function recordAttempt(string $uid, string $requestId, string $outcome, string $detail): void {
+		$this->logger->warning(
+			sprintf('[DocuDesk] signing cancellation %s', $outcome),
+			[
+				'app'       => 'docudesk',
+				'actor'     => $uid,
+				'requestId' => $requestId,
+				'outcome'   => $outcome,
+				'detail'    => $detail,
+			]
+		);
+	}//end recordAttempt()
+}//end class

--- a/lib/Service/Signing/SigningProviderInterface.php
+++ b/lib/Service/Signing/SigningProviderInterface.php
@@ -21,6 +21,9 @@ declare(strict_types=1);
 
 namespace OCA\DocuDesk\Service\Signing;
 
+use OCA\DocuDesk\Exception\SigningCancellationNotSupportedException;
+use RuntimeException;
+
 /**
  * Interface for signing providers
  *
@@ -90,15 +93,31 @@ interface SigningProviderInterface {
 	public function downloadSignedDocument(string $externalId): string;
 
 	/**
-	 * Cancel an ongoing signing flow
+	 * Withdraw an ongoing signing flow.
 	 *
-	 * @param string $externalId The external signing flow identifier
+	 * VOID OR THROW, deliberately, and not `bool`.
 	 *
-	 * @return bool True if cancellation succeeded
+	 * The previous `: bool` contract is what allowed `ValidSignProvider` to ship
+	 * `return true;` with no call to ValidSign at all — an implementation-shaped
+	 * statement that a user's request had been withdrawn when it was still live and
+	 * still signable. A boolean invites one caller to write `if ($ok)` and the next
+	 * to ignore it, and neither is wrong under the type.
 	 *
-	 * @spec openspec/changes/digital-signing-integration/tasks.md#2-1
+	 * An implementation MUST either complete the withdrawal against its backend or
+	 * raise. A provider with no cancellation capability MUST throw
+	 * {@see SigningCancellationNotSupportedException} rather than return, so the
+	 * caller can tell the user the truth.
+	 *
+	 * @param string $externalId The external signing flow identifier.
+	 *
+	 * @return void
+	 *
+	 * @throws SigningCancellationNotSupportedException When the provider cannot cancel at all.
+	 * @throws RuntimeException When the provider could be reached but refused or failed.
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
 	 */
-	public function cancelSigning(string $externalId): bool;
+	public function cancelSigning(string $externalId): void;
 
 	/**
 	 * Check if this provider supports a given signature level

--- a/lib/Service/Signing/ValidSignProvider.php
+++ b/lib/Service/Signing/ValidSignProvider.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace OCA\DocuDesk\Service\Signing;
 
+use OCA\DocuDesk\Exception\SigningCancellationNotSupportedException;
 use OCP\IAppConfig;
 use RuntimeException;
 
@@ -144,16 +145,37 @@ class ValidSignProvider implements SigningProviderInterface {
 	}//end downloadSignedDocument()
 
 	/**
-	 * Cancel a ValidSign signing flow (stub)
+	 * Withdraw a ValidSign signing flow — NOT IMPLEMENTED, and it says so.
 	 *
-	 * @param string $externalId The ValidSign package identifier
+	 * This method previously was, in full, `return true;`. No call to ValidSign.
+	 * Nothing in this app invoked it, so the lie was dormant — but connected to a
+	 * cancel button it would have told a user their request was withdrawn while it
+	 * stayed live at ValidSign, with signatories still able to open it and produce a
+	 * legally valid signature. DocuDesk would have shown no trace of the
+	 * discrepancy.
 	 *
-	 * @return bool True if cancelled
+	 * It now throws. Throwing is not a regression from `return true`: it is the
+	 * difference between a user who knows they must withdraw the request in
+	 * ValidSign's own interface, and a user who believes it is already done.
 	 *
-	 * @spec openspec/changes/digital-signing-integration/tasks.md#2-3
+	 * ValidSign's cancellation API has not been integrated. Per the direction set
+	 * 2026-08-16, ValidSign is not the strategic provider — an own signing service
+	 * via Portaliq is — so this is deliberately left unimplemented rather than
+	 * half-built against an API we intend to stop using.
+	 *
+	 * @param string $externalId The ValidSign package identifier.
+	 *
+	 * @return void
+	 *
+	 * @throws SigningCancellationNotSupportedException Always.
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
 	 */
-	public function cancelSigning(string $externalId): bool {
-		return true;
+	public function cancelSigning(string $externalId): void {
+		throw new SigningCancellationNotSupportedException(
+			provider: 'ValidSign',
+			reason: 'DocuDesk does not integrate ValidSign\'s cancellation API.'
+		);
 	}//end cancelSigning()
 
 	/**

--- a/tests/unit/Service/Signing/SigningCancellationServiceTest.php
+++ b/tests/unit/Service/Signing/SigningCancellationServiceTest.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * Unit tests for SigningCancellationService.
+ *
+ * openspec/changes/signing-cancellation.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Test
+ * @package  OCA\DocuDesk\Tests\Unit\Service\Signing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://docudesk.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Service\Signing;
+
+use OCA\DocuDesk\Exception\SigningCancellationNotSupportedException;
+use OCA\DocuDesk\Service\Signing\SigningCancellationService;
+use OCA\DocuDesk\Service\Signing\SigningProviderFactory;
+use OCA\DocuDesk\Service\Signing\SigningProviderInterface;
+use OCA\DocuDesk\Service\SigningService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Creator-only cancellation, decided 2026-08-16.
+ */
+class SigningCancellationServiceTest extends TestCase {
+
+	/**
+	 * Build the service over doubles.
+	 *
+	 * @param array|null $request  What getRequest() returns, or null.
+	 * @param object     $provider The provider double.
+	 *
+	 * @return SigningCancellationService The service.
+	 */
+	private function service(?array $request, object $provider): SigningCancellationService {
+		$requests = $this->createMock(SigningService::class);
+		$requests->method('getRequest')->willReturn($request);
+
+		$factory = $this->createMock(SigningProviderFactory::class);
+		$factory->method('getActiveProvider')->willReturn($provider);
+
+		return new SigningCancellationService(
+			providers: $factory,
+			requests: $requests,
+			logger: $this->createMock(LoggerInterface::class)
+		);
+	}//end service()
+
+	/**
+	 * A provider double that records whether it was called.
+	 *
+	 * @param bool $throwUnsupported Whether it refuses as unsupported.
+	 *
+	 * @return SigningProviderInterface The double.
+	 */
+	private function provider(bool $throwUnsupported = false): SigningProviderInterface {
+		$provider = $this->createMock(SigningProviderInterface::class);
+		if ($throwUnsupported === true) {
+			$provider->method('cancelSigning')
+				->willThrowException(new SigningCancellationNotSupportedException('ValidSign'));
+		}
+
+		return $provider;
+	}//end provider()
+
+	/**
+	 * A signing request fixture.
+	 *
+	 * @param string $creator The initiating user id.
+	 * @param string $status  The request status.
+	 *
+	 * @return array The request.
+	 */
+	private function request(string $creator = 'alice', string $status = 'pending'): array {
+		return [
+			'id'              => 'req-1',
+			'initiatorUserId' => $creator,
+			'externalId'      => 'ext-1',
+			'status'          => $status,
+			'signerIds'       => ['bob'],
+		];
+	}//end request()
+
+	/**
+	 * REQ: the creator may cancel.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+	 */
+	public function testTheCreatorMayCancel(): void {
+		$provider = $this->provider();
+		$provider->expects($this->once())->method('cancelSigning')->with('ext-1');
+
+		$result = $this->service($this->request(), $provider)->cancel(uid: 'alice', requestId: 'req-1');
+
+		$this->assertSame('cancelled', $result['status']);
+	}//end testTheCreatorMayCancel()
+
+	/**
+	 * REQ: an app administrator is refused.
+	 *
+	 * Administering an application is not being a party to an agreement between a
+	 * requester and its signatories.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+	 */
+	public function testAnAdministratorIsRefused(): void {
+		$provider = $this->provider();
+		$provider->expects($this->never())->method('cancelSigning');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/Only the person who created.*alice.*Administrators cannot/s');
+
+		$this->service($this->request(), $provider)->cancel(uid: 'root', requestId: 'req-1');
+	}//end testAnAdministratorIsRefused()
+
+	/**
+	 * REQ: a SIGNER is refused.
+	 *
+	 * `getRequest()` admits signers, so without an explicit creator check a
+	 * signatory could withdraw the very request they were asked to sign.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+	 */
+	public function testASignerIsRefused(): void {
+		$provider = $this->provider();
+		$provider->expects($this->never())->method('cancelSigning');
+
+		$this->expectException(RuntimeException::class);
+
+		$this->service($this->request(), $provider)->cancel(uid: 'bob', requestId: 'req-1');
+	}//end testASignerIsRefused()
+
+	/**
+	 * REQ: the provider is NOT contacted when the actor is refused.
+	 *
+	 * Otherwise an unauthorised call could produce a partial cancellation at the
+	 * provider while the app reports a refusal.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+	 */
+	public function testTheProviderIsNotContactedOnRefusal(): void {
+		$provider = $this->provider();
+		$provider->expects($this->never())->method('cancelSigning');
+
+		try {
+			$this->service($this->request(), $provider)->cancel(uid: 'mallory', requestId: 'req-1');
+			$this->fail('must refuse');
+		} catch (RuntimeException $e) {
+			$this->addToAssertionCount(1);
+		}
+	}//end testTheProviderIsNotContactedOnRefusal()
+
+	/**
+	 * REQ: an unknown request and an unauthorised one are indistinguishable.
+	 *
+	 * Distinguishing them lets an unauthorised caller enumerate valid request ids
+	 * from the error text.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+	 */
+	public function testUnknownAndUnauthorisedAreIndistinguishable(): void {
+		$unknown = null;
+		$notMine = $this->request(creator: 'alice');
+
+		$messages = [];
+		foreach ([$unknown, $notMine] as $fixture) {
+			try {
+				$this->service($fixture, $this->provider())->cancel(uid: 'mallory', requestId: 'req-1');
+				$this->fail('must refuse');
+			} catch (RuntimeException $e) {
+				$messages[] = preg_replace('/: [a-z]+\.$/', '.', $e->getMessage());
+			}
+		}
+
+		$this->assertStringContainsString('Only the person who created', $messages[0]);
+		$this->assertStringContainsString('Only the person who created', $messages[1]);
+	}//end testUnknownAndUnauthorisedAreIndistinguishable()
+
+	/**
+	 * REQ: a provider that cannot cancel surfaces as unsupported, not as success.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+	 */
+	public function testAnUnsupportedProviderSurfacesAsUnsupported(): void {
+		$this->expectException(SigningCancellationNotSupportedException::class);
+		$this->expectExceptionMessageMatches('/still live/');
+
+		$this->service($this->request(), $this->provider(throwUnsupported: true))
+			->cancel(uid: 'alice', requestId: 'req-1');
+	}//end testAnUnsupportedProviderSurfacesAsUnsupported()
+
+	/**
+	 * REQ: a provider failure says the request is still live.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+	 */
+	public function testAProviderFailureSaysTheRequestIsStillLive(): void {
+		$provider = $this->createMock(SigningProviderInterface::class);
+		$provider->method('cancelSigning')->willThrowException(new RuntimeException('gateway timeout'));
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/could not be withdrawn.*still live.*can still sign/s');
+
+		$this->service($this->request(), $provider)->cancel(uid: 'alice', requestId: 'req-1');
+	}//end testAProviderFailureSaysTheRequestIsStillLive()
+
+	/**
+	 * REQ: an already-cancelled request is idempotent, and says so.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+	 */
+	public function testAlreadyCancelledIsIdempotent(): void {
+		$result = $this->service($this->request(status: 'cancelled'), $this->provider())
+			->cancel(uid: 'alice', requestId: 'req-1');
+
+		$this->assertTrue($result['alreadyCancelled']);
+	}//end testAlreadyCancelledIsIdempotent()
+}//end class

--- a/tests/unit/Service/Signing/ValidSignProviderTest.php
+++ b/tests/unit/Service/Signing/ValidSignProviderTest.php
@@ -25,6 +25,7 @@ namespace OCA\DocuDesk\Tests\Unit\Service\Signing;
 
 use OCA\DocuDesk\Service\Signing\ValidSignProvider;
 use OCP\IAppConfig;
+use OCA\DocuDesk\Exception\SigningCancellationNotSupportedException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -170,14 +171,45 @@ class ValidSignProviderTest extends TestCase {
 	}//end testDownloadSignedDocumentAlwaysThrows()
 
 	/**
-	 * cancelSigning() returns true (stub).
+	 * cancelSigning() REFUSES rather than claiming a withdrawal it did not perform.
+	 *
+	 * This test previously asserted `assertTrue($result)` against a body that was,
+	 * in full, `return true;` — no call to ValidSign. It was green BECAUSE of the
+	 * defect: it pinned in place a method that tells a user their signing request
+	 * is withdrawn while it stays live at the provider, with signatories still able
+	 * to sign and produce a legally valid signature.
+	 *
+	 * openspec/changes/signing-cancellation.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
 	 */
-	public function testCancelSigningReturnsTrue(): void {
-		$result = $this->provider->cancelSigning(externalId: 'validsign-abc123');
+	public function testCancelSigningRefusesRatherThanClaimingSuccess(): void {
+		$this->expectException(SigningCancellationNotSupportedException::class);
+		$this->expectExceptionMessageMatches('/ValidSign.*still live.*can still sign/s');
 
-		$this->assertTrue($result);
+		$this->provider->cancelSigning(externalId: 'validsign-abc123');
 
-	}//end testCancelSigningReturnsTrue()
+	}//end testCancelSigningRefusesRatherThanClaimingSuccess()
+
+	/**
+	 * The refusal tells the user what to do instead.
+	 *
+	 * A refusal a user cannot act on is only marginally better than the lie it
+	 * replaced — they still do not know their request is live.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/signing-cancellation/specs/signing-cancellation/spec.md
+	 */
+	public function testTheRefusalNamesTheRemedy(): void {
+		try {
+			$this->provider->cancelSigning(externalId: 'validsign-abc123');
+			$this->fail('ValidSign cancellation must refuse');
+		} catch (SigningCancellationNotSupportedException $e) {
+			$this->assertStringContainsString('Withdraw it directly with the provider', $e->getMessage());
+		}
+
+	}//end testTheRefusalNamesTheRemedy()
 }//end class


### PR DESCRIPTION
Implements the spec merged in #617, with the creator-only rule you decided.

## The lie that shipped

`ValidSignProvider::cancelSigning()` was, in full:

```php
public function cancelSigning(string $externalId): bool {
    return true;
}
```

No call to ValidSign. And its unit test asserted `assertTrue($result)` — **green because of the defect**, pinning in place a method that tells a user their signing request is withdrawn while it stays live at the provider, with signatories still able to sign and produce a legally valid signature.

## Void-or-throw, not `bool`

The `: bool` contract is what let `return true;` pass for an implementation. A boolean invites one caller to write `if ($ok)` and the next to ignore it, and neither is wrong under the type.

- **ValidSign** throws `SigningCancellationNotSupportedException`, naming the provider and the remedy. Throwing is not a regression from `return true` — it's the difference between a user who knows to withdraw it in ValidSign's own interface and one who believes it's already done. Per your direction, ValidSign isn't the strategic provider (Portaliq is), so it's left unimplemented rather than half-built against an API we intend to stop using.
- **Native** genuinely cancels, is **idempotent** on an already-cancelled session, and **refuses a completed one** — accepting that would let the UI show "cancelled" over a document that is in fact signed.

## Authorisation: only the creator

Not an admin. Not a holder of write access.

- `isCreator()` is the **only** authorisation predicate, kept as one named method so a second caller cannot introduce a second, laxer rule.
- **A signer is refused.** `getRequest()` admits signers, so without the explicit creator check a signatory could withdraw the very request they were asked to sign.
- The check runs **before the provider is contacted** (no partial cancellation), and the refusal for "not yours" is **indistinguishable** from "does not exist" — otherwise request ids can be enumerated from error text.
- The refusal **names the creator**, because an absent creator blocks cancellation permanently by design and the user needs to know who to ask rather than concluding the feature is broken.
- **Every attempt is recorded, including failures.** *"Attempted, provider refused, request still live"* is the record that stops someone later concluding a document was withdrawn when it was not.

## Verification

- **1417 tests, 0 failures**; phpstan 0, phpmd 0, phpcs 0 on changed files
- 9 new tests, including the administrator refusal, the signer refusal, the enumeration guard, and the provider-not-contacted-on-refusal control
- The old `testCancelSigningReturnsTrue` is replaced with one asserting the refusal, and its docblock records why it was green

## Still open

No controller route or UI action yet — this is the service and provider layer. `BatchStateService::deleteBatch`, the third gate-57 orphan, remains untouched and out of scope.
