### PR TITLE
fix(security): declare an authorization cascade on all 21 schemas

### DIFF
--- a/docs/authorization-decisions.md
+++ b/docs/authorization-decisions.md
@@ -1,0 +1,139 @@
+# Authorisation decisions
+
+Every schema DocuDesk declares in `lib/Settings/docudesk_register.json` carries an
+explicit authorisation decision. This file is the record of *why*, and
+`tests/unit/Settings/SchemaAuthorizationCoverageTest.php` fails if a schema exists
+without an entry here.
+
+> **The rule this file exists to prevent breaking again:** OpenRegister treats an
+> **unconfigured** cascade as OPEN. `_rbac: true` means "apply the cascade"; it does
+> not mean "a cascade exists". With `authorization: null`, applying the cascade
+> permits everything. Absence of an opt-out is not the presence of a guard.
+
+## What was measured
+
+Development instance, 2026-08-16, before the change:
+
+- **20 of 21** schemas declared no `authorization` cascade.
+- All three `docudesk` register rows carried `authorization = NULL`, so the
+  register-level cascade did not fill the gap either.
+- Two ordinary users in **no groups** and the **same organisation**:
+  `ddauth-bob` read `ddauth-alice`'s private template (HTTP 200, full `content`),
+  **overwrote its content** via `PUT` (HTTP 200), and duplicated it.
+
+That last point matters: this was a **write** exposure, not only disclosure.
+
+### The bound
+
+`ddauth-carol`, authenticated and in a different organisation (Gemeente Utrecht),
+requested the same template and received **404**, while `ddauth-bob` in the same
+organisation received **200** for the identical request.
+
+**Multitenancy is a separate axis and remains enforced.** The exposure was to
+authenticated users **within one organisation** — not anonymous, not cross-tenant.
+Both available one-line summaries are wrong in the same way: "it's an IDOR" reads as
+anonymous and drives panic-shaped work, and "RBAC covers it" is the belief that
+produced the gap.
+
+## The shape of the fix
+
+**`update` and `delete` are restricted on every schema.** That is where the proven
+harm was. OpenRegister's owner bypass is unconditional, so a creator keeps full
+control of their own objects — this closes cross-user writes with no read-path
+outage. Verified after deploy: `ddauth-bob` → **403** on `PUT`, `ddauth-alice` →
+**200** on the same object.
+
+**`read` is restricted only where the data justifies it**, because an over-tight read
+cascade is a visible outage, and a read restriction I cannot verify is a guess. Where
+`read` stays `authenticated`, that is a recorded decision below, not an omission.
+
+## Reserved principals
+
+`admin` and the object owner bypass every rule — they are not listed anywhere.
+`authenticated` is any logged-in user; combined with multitenancy that means
+"anyone in this organisation". `public` is anonymous and **is used by no DocuDesk
+schema**.
+
+## Groups
+
+Four groups are named. OpenRegister provisions declared groups create-only on import,
+ahead of the content-hash skip, so they exist on every instance.
+
+| Group | Owns |
+|---|---|
+| `docudesk-template-editors` | templates, versions, house style, and the correspondence/document audit rows they produce |
+| `docudesk-policy-admins` | Woo Art. 5 grounds, anonymisation recognisers, consent, prohibition overrides, dossiers |
+| `docudesk-financial-admins` | invoice/receipt extraction and GL-account mapping |
+| `docudesk-signing-admins` | signing requests, signers, sessions, signing audit |
+
+**They ship empty on purpose.** An empty group denies everyone except admins and
+object owners. That is the correct default and it is immediately visible, which is
+better than back-filling 21 schemas' worth of grants nobody chose. Populate them
+deliberately.
+
+## Per-schema decisions
+
+| Schema | read | create | update / delete | Why |
+|---|---|---|---|---|
+| `template` | authenticated | authenticated | template-editors | Templates exist to be **used** across the organisation, so read stays open; the measured defect was a foreign user rewriting one. |
+| `templateVersion` | authenticated | authenticated | template-editors | Snapshots follow their template. `create` must be as open as template create, because a version row is written as a side effect of editing. |
+| `huisstijl` | authenticated | template-editors | template-editors | Branding must be readable or nothing renders; changing the organisation's house style is a managed act. |
+| `correspondence` | authenticated | authenticated | template-editors | Audit row written as a side effect of generating, so `create` follows the generator. |
+| `generatedDocument` | authenticated | authenticated | template-editors | Same. |
+| `batchCorrespondenceJob` | authenticated | authenticated | authenticated / template-editors | Job state is advanced by the worker running **as the submitting user**, so `update` must stay open; deletion is not part of running a job. |
+| `financialExtraction` | **financial-admins** | authenticated | financial-admins | Carries supplier IBAN, KvK and BTW numbers. Not organisation-wide readable. `create` stays open so an ordinary user can scan a receipt — they then own the row and can read it back. |
+| `glAccountBooking` | **financial-admins** | authenticated | financial-admins | Ledger-mapping feedback derived from the above. |
+| `glAccountMappingRule` | authenticated | financial-admins | financial-admins | Must be readable at extraction time to be applied at all; maintained by finance. |
+| `customDictionary` | authenticated | policy-admins | policy-admins | A recogniser list must be readable when matching runs. |
+| `customDictionaryTerm` | authenticated | policy-admins | policy-admins | Same. |
+| `base` | authenticated | policy-admins | policy-admins | Woo Article 5 grounds are public-law reference data, and must be readable to explain **why** something was redacted. |
+| `dossier` | authenticated | authenticated | policy-admins | A dossier points at a Nextcloud folder; Nextcloud's own share permissions govern the contents. |
+| `anonymizationLink` | authenticated | authenticated | policy-admins | Written by the anonymiser running as the acting user. |
+| `publicationConsent` | **policy-admins** | authenticated | policy-admins | GDPR consent records about identified people. `create` stays open because a data subject records their own consent and then owns it. |
+| `publicationProhibition` | `consent` group | policy-admins | policy-admins | **Unchanged** — decided before this change. |
+| `prohibitionOverrideAudit` | **policy-admins** | **authenticated** | policy-admins | ⚠️ `create` is deliberately open. Register v7.7.0 records that restricting it re-breaks the fail-closed override path for the ordinary operator who performs the anonymise: the write is explicitly "if the audit write fails we MUST NOT proceed", so a denied create raises 500 on every acknowledged override and no override can ever be committed. |
+| `signingRequest` | **signing-admins** | authenticated | signing-admins | A signing request names its signers. Safe to restrict: the signer portal resolves records with `_rbac: false` behind its own token binding (see below), so the signer flow does not depend on this cascade. |
+| `signerRecord` | **signing-admins** | authenticated | signing-admins | Identifies an individual signer. Same portal reasoning. |
+| `signingAuditEntry` | **signing-admins** | authenticated | signing-admins | Deprecated, retained read-only history. |
+| `signingSession` | **signing-admins** | authenticated | authenticated / signing-admins | `update` stays open because the session is advanced by the signer themselves as they progress. |
+
+## Deliberate RBAC bypasses
+
+A cascade only guards callers that go through it. `ObjectService::find()` and
+`findAll()` accept `_rbac: false`, and DocuDesk passes it at **22 call sites in 9
+files**. Each is paired with a compensating control rather than being an oversight,
+and the coverage test pins the set: **a new bypass fails the test until it is added
+here with a reason.**
+
+| File | Sites | Compensating control |
+|---|---|---|
+| `Service/PolicyCrudService.php` | 5 | `requirePolicyPermission()` asserts membership in `docudesk-policy-admins` / `docudesk-standing-consent-admins` for **every** action including `read`, before the lookup runs. |
+| `Service/CustomDictionaryRepository.php` | 4 | Recogniser lists are read during anonymisation, which runs on behalf of a user who may not hold the maintainer group. Read-only; no caller-supplied id reaches it. |
+| `Service/DossierObjectRepository.php` | 3 | Dossier contents are governed by Nextcloud folder permissions, which are checked before the repository is reached. |
+| `Service/PolicyMatchService.php` | 2 | Matching must see every prohibition regardless of the acting user, or an anonymisation silently under-redacts. Fail-closed by design. |
+| `Service/ConsentPolicyReferentValidator.php` | 2 | Validation-only; returns a boolean, never record content. |
+| `Service/PolicyRetroactiveService.php` | 2 | Background re-application over records the triggering user may not own. |
+| `Service/BaseLabelResolver.php` | 1 | Resolves a legal-basis label for display; `base` is organisation-readable anyway. |
+| `Service/BasesResolverService.php` | 1 | Same. |
+| `Service/LegalBasisCatalog.php` | 1 | Static Woo Art. 5 catalogue. |
+| `Controller/PortalSigningReceiverController.php` | 1 | The signer portal is anonymous by design and binds a `signerRecord` to a token **and** an email **and** a signing-request id, refusing with the same `null` for a wrong email, a wrong request, and an unresolvable register — so no new signal is exposed. |
+
+`Service/ConsentCrudService.php` contains the string `_rbac: false` in a comment that
+**forbids** the bypass, and is not a bypass. It ends:
+
+> *"Do not delete either as 'redundant with OpenRegister RBAC' — measured, it is not
+> redundant."*
+
+That comment exists because someone had already reasoned their way to deleting a real
+control. It is why no guard in this change was added merely to make a gate green: an
+unjustified guard is that control with the reasoning stripped out, and it gets deleted
+the same way.
+
+## Deploying a change to this file
+
+A cascade edit reaches a running instance only if it is imported. `info.version` in
+the register **must** be bumped; the importer additionally compares schema content
+(`properties`, `required`, `authorization`) so an authorisation-only edit is not
+silently skipped, but the version bump is what moves the app-level configuration
+gate. Verify against the live instance — a cascade present in the file and absent
+from `oc_openregister_schemas` is a fix-shaped commit, not a fix.

--- a/lib/Settings/docudesk_register.json
+++ b/lib/Settings/docudesk_register.json
@@ -2,8 +2,8 @@
     "openapi": "3.0.0",
     "info": {
         "title": "DocuDesk Register",
-        "description": "DocuDesk register v7.8.0 — docudesk-mcp-adoption + document-editing-tools: declares `configuration.x-openregister-mcp` on 8 of 21 schemas (template, huisstijl, correspondence, generatedDocument, batchCorrespondenceJob, signingRequest, dossier, base) with `search` + `get` ONLY, `scope: read`, `readOnlyHint: true`. No DocuDesk schema exposes a derived create/update/delete verb: templates and huisstijl are governance artefacts, correspondence/generatedDocument/batch rows are audit records, and signingRequest is the legal spine of a signature process. The remaining 13 schemas stay off entirely (signature material, citizen contact data, re-identification links, extracted invoice content). Every declared `search.filters` entry was cross-checked against that schema's own `properties` map — an unknown filter fails the whole register import. `generatedDocument.format` additionally gains `docx`, which an agent document edit produces and which the enum predated. ⚠️ THE VERSION BUMP IS THE POINT: SettingsInitializer gates the import on `info.version` against the stored `configuration_version` app-config value, so a dialect change shipped WITHOUT a bump is inert on every existing install — the schemas keep their old configuration and not one derived tool appears, with no error anywhere. Measured on the dev instance before the bump: the four curated #[McpTool] tools were live while all 16 derived tools were absent. Previous v7.7.0 — prohibition-override-audit-schema: adds the `prohibitionOverrideAudit` schema to the `consent` register. `ProhibitionOverrideCommitter::writeAudit()` has always written to `register: consent, schema: prohibitionOverrideAudit`, and that schema was declared NOWHERE — `GET /apps/openregister/api/objects/consent/prohibitionOverrideAudit` answered 404 `Schema not found` while its sibling `publicationProhibition` answered 200 on the same freshly-seeded instance. The write is explicitly fail-closed ('If the audit write fails we MUST NOT proceed to the OR PATCH'), so every acknowledged override raised RuntimeException 500 and NO override could ever be committed. openspec/specs/anonymisation-prohibition-gate/spec.md mandates the schema by name: 'Implementations MUST use a `prohibitionOverrideAudit` schema in `docudesk_register.json` for this entry'. Properties are exactly the six the committer writes {ruleId, entityRelationId, fileId, reason, acknowledgedBy, acknowledgedAt}; retention P10Y because an override audit must outlive the P10Y prohibition it released. `authorization: null` matches publicationConsent/anonymizationLink — restricting `create` to policy admins would re-break the same fail-closed path for the ordinary operator who performs the anonymise. See ConductionNL/docudesk#428. Previous v7.6.4 — standing-consent-documentid-not-required: `publicationConsent` listed `documentId` in the schema-level `required` array, so OpenRegister created the backing column NOT NULL. Every scope=entity (standing consent) record is document-less by definition, so all 12 seeded standing consents failed to insert with 'null value in column \"document_id\" violates not-null constraint', and the same constraint blocks PolicyController::createStandingConsent at runtime — the entire \"Publish always\" surface. The condition is PER RECORD, not per schema, and openspec/specs/consent-management/spec.md already states it: 'documentId MUST be required only for scope=document records'. It is enforced where it can be — ConsentScopeValidator::assertValid(), which rejects a scope=document record without a documentId AND a scope=entity record WITH one. Removing it from the schema's `required` array restores what the spec mandates; nothing is left unvalidated. Previous v7.6.3 — archival-retention-object-shape: fixes six schemas that OpenRegister REJECTED on import, so they never existed on any fresh install. Five (correspondence, signingRequest, signerRecord, signingAuditEntry, batchCorrespondenceJob) declared `x-openregister-archival.retention` as a bare ISO-8601 STRING; OpenRegister's ArchivalAnnotationValidator requires an object `{ default: <duration>, rules?: [] }` and threw 'retention is required and must be an object'. The sixth (publicationProhibition) declared an authorization action `write`, which is not in OpenRegister's CRUD vocabulary (create, read, update, delete) — expanded to create/update/delete, preserving the intent that docudesk-policy-admins may write. ImportHandler catches a per-schema exception, logs it and continues, so the import still answered HTTP 200 'Import successful' while writing only 14 of 20 schemas — which left signing entirely non-functional (signingRequest/signerRecord/signingAuditEntry absent). anonymizationLink and financialExtraction already used the object form; this aligns the rest. No property, slug or retention DURATION changed. Previous v7.6.2 — schema-level-titles-en: re-authored the remaining Dutch schema-level `title` values to English — base 'Grondslag' -> 'Legal Basis', huisstijl 'Huisstijl Configuration' -> 'Branding Configuration' (schema slugs, property keys/titles, enums, descriptions unchanged). Dutch labels now live in l10n/nl.json for the display layer. See openspec/changes (fleet-wide schema-i18n titles rule). Previous v7.6.1 — schema-titles-en: re-authored all Dutch schema property `title` values to English (property names/keys unchanged); Dutch labels now live in l10n/nl.json for the display layer. See openspec/changes (fleet-wide schema-i18n titles rule). Previous v7.6.0 — document-output-destinations-and-bulk-retention: generatedDocument gains additive, nullable fileId/filePath properties, populated when a generation is stored to Files via the new DocumentStorageService (options.output.mode 'files'/'both' on generate, or the now-persisted async bulk job). hardValidation:false, so existing rows remain valid unchanged. See openspec/changes/document-output-destinations-and-bulk-retention/. Previous v7.5.0 — unified-search-provider: corrects the searchable opt-in so only navigable schemas (template, signingRequest) stay searchable and every other schema is searchable:false, keeping DocuDesk's contribution to OpenRegister's shared Unified Search provider free of dead/unnavigable results. Deep-link routing for template + signingRequest lives in src/manifest.json deepLinks[]. No bespoke OCP\\Search\\IProvider — org scoping inherited from openregister_objects. See openspec/changes/unified-search-provider/. Previous v7.4.0 — adds customDictionary + customDictionaryTerm to the document register per custom-dictionary-recognition: organisation-scoped, register-i18n-tagged term lists (label, description, colour, matchMode exact/caseInsensitive/wordBoundary, deferred fuzzy flag, active, calculated termCount) matched by CustomDictionaryMatchService and written into OpenRegister's shared entity catalogue as CUSTOM_DICTIONARY occurrences alongside Presidio/regex detections. Seeds one demo dictionary (\"Projectnamen\") with two demo terms. See openspec/changes/custom-dictionary-recognition/. Previous v7.3.0 — MERGE of Robert's anonimiseren-bij-de-bron work onto development: Woo Art. 5 grondslagen legenda A–S seed (base schema), standing-consent generic-term seeds (publicationConsent, entityType OTHER, notificationStatus skipped), entityType OTHER enum on publicationConsent/publicationProhibition, and EML→PDF assembly. Development schemas + dialect/RBAC fixes are preserved. Previous v5.10.0 — adds glAccountBooking (opaque per-tenant GL-account booking history, keyed by supplierIdentity, fed by the financial-extraction corrections endpoint) and glAccountMappingRule (admin-editable cold-start keyword/category → account rules, no seeded rows — DocuDesk ships no chart of accounts) to the document register, per ai-gl-account-suggestion. Both hardValidation:true. See openspec/changes/ai-gl-account-suggestion/. Previous v5.9.0 adds the financialExtraction schema to the document register: structured financial field-extraction results (supplier/IBAN/KvK/BTW, invoice number, dates, currency, totals + VAT breakdown, line items) with per-field confidence and an additive corrections[] tuning corpus, per financial-document-field-extraction. hardValidation:true; x-openregister-archival category shipped as an explicit placeholder pending selectielijst-manager sign-off (same pattern as anonymizationLink). See openspec/changes/financial-document-field-extraction/. Previous v5.8.0 declares validationStatus + validationFindings as x-openregister-calculations on generatedDocument (computation backend docudesk.validation = DocumentValidationService) per document-validation-checks; the event-listener fallback dispatches the same service until OR's ADR-031 calculation runtime ships. Previous v5.7.0 declared the four AVG Art. 30 processing activities (anonymisation, OCR, metadata-enrichment, signing) as x-openregister-processing catalogue annotations on anonymizationLink, generatedDocument, base, and signingAuditEntry: each carries purpose (doelbinding), legal basis, NER data categories, backend identifier, retention reference taken from the existing x-openregister-archival annotations (\"not declared\" where absent), and opts the schema into OpenRegister's per-access read-logging (logReads:true, attribution.default referencing the activity code). Requires OpenRegister >= 0.2.14. See openspec/changes/processing-activity-export/. Previous v5.5.0 extended OR register-i18n adoption to the remaining user-facing string fields across templateVersion (name/description/changelog), huisstijl (name), base (name/description), correspondence (templateName), signingRequest (documentName), signingSession (documentName), signerRecord (displayName/declineReason), publicationConsent (notes/objectionReason/publicationDecision), publicationProhibition (primaryName/reason/notes), and batchCorrespondenceJob (templateName). OpenRegister TranslationHandler picks these up automatically and stores per-language variants under the existing object JSON column; no DB migration required. See openspec/changes/register-i18n/. Previous v5.4.0 tagged template (name/description/content/category) + dossier (name/description) per register-i18n. Previous v5.3.0 adopted OR abstractions per docudesk-adopt-or-abstractions, added batchCorrespondenceJob schema with x-openregister-lifecycle + archival + notifications + calculations, added x-openregister-archival to signingAuditEntry (P10Y), signingRequest (P10Y), signerRecord (P10Y), correspondence (P7Y), added x-openregister-lifecycle to signingSession, and added anonymizationLink schema for source↔anonymised file mapping.",
-        "version": "7.8.0"
+        "description": "DocuDesk register v7.9.0 — consumer-schema-authorization-audit: declares an `authorization` cascade on ALL 21 schemas. Before this, 20 of 21 declared none, and OpenRegister treats an unconfigured cascade as OPEN — `PermissionHandler::resolveAuthorization()` returns null and every caller is admitted. The DocuDesk registers carry no register-level cascade either (measured live: all three rows NULL), so nothing filled the gap. MEASURED ON THE DEV INSTANCE BEFORE THE CHANGE, with two ordinary users in no groups and the same organisation: ddauth-bob read ddauth-alice's private template (HTTP 200, full `content`), OVERWROTE its content via PUT (HTTP 200), and duplicated it. This is a WRITE exposure, not only disclosure. The bound is authenticated users within one organisation — multitenancy is a separate axis and stays enforced; it is not anonymous and not cross-tenant. Shape of the fix: `update`/`delete` are restricted on EVERY schema, because that is where the proven harm was; OpenRegister's unconditional owner bypass means a creator keeps full control of their own objects, so this closes cross-user writes without an outage. `read` is additionally restricted only where the data justifies it — financialExtraction + glAccountBooking (supplier IBAN/KvK/BTW), publicationConsent + prohibitionOverrideAudit (GDPR records about identified people), and the four signing schemas (the signer portal resolves signerRecord with `_rbac: false` behind its own token binding in PortalSigningReceiverController, so restricting the cascade does NOT break the signer flow). Everything else keeps `read: authenticated` as a recorded decision, not an omission — reference data (base, customDictionary, glAccountMappingRule) and shared assets (template, huisstijl) must be readable to be applied. ⚠️ `prohibitionOverrideAudit.create` is deliberately `authenticated`, NOT policy-admins: v7.7.0 below records that restricting it re-breaks the fail-closed override path for the ordinary operator who performs the anonymise, raising 500 on every acknowledged override. Four groups are named — docudesk-template-editors, docudesk-policy-admins (already existed), docudesk-financial-admins, docudesk-signing-admins — and OpenRegister provisions declared groups create-only on import, ahead of the content-hash skip. They ship EMPTY on purpose: an empty group denies everyone except admins and object owners, which is the correct default and is immediately visible, rather than back-filling grants nobody chose. Previous v7.8.0 — docudesk-mcp-adoption + document-editing-tools: declares `configuration.x-openregister-mcp` on 8 of 21 schemas (template, huisstijl, correspondence, generatedDocument, batchCorrespondenceJob, signingRequest, dossier, base) with `search` + `get` ONLY, `scope: read`, `readOnlyHint: true`. No DocuDesk schema exposes a derived create/update/delete verb: templates and huisstijl are governance artefacts, correspondence/generatedDocument/batch rows are audit records, and signingRequest is the legal spine of a signature process. The remaining 13 schemas stay off entirely (signature material, citizen contact data, re-identification links, extracted invoice content). Every declared `search.filters` entry was cross-checked against that schema's own `properties` map — an unknown filter fails the whole register import. `generatedDocument.format` additionally gains `docx`, which an agent document edit produces and which the enum predated. ⚠️ THE VERSION BUMP IS THE POINT: SettingsInitializer gates the import on `info.version` against the stored `configuration_version` app-config value, so a dialect change shipped WITHOUT a bump is inert on every existing install — the schemas keep their old configuration and not one derived tool appears, with no error anywhere. Measured on the dev instance before the bump: the four curated #[McpTool] tools were live while all 16 derived tools were absent. Previous v7.7.0 — prohibition-override-audit-schema: adds the `prohibitionOverrideAudit` schema to the `consent` register. `ProhibitionOverrideCommitter::writeAudit()` has always written to `register: consent, schema: prohibitionOverrideAudit`, and that schema was declared NOWHERE — `GET /apps/openregister/api/objects/consent/prohibitionOverrideAudit` answered 404 `Schema not found` while its sibling `publicationProhibition` answered 200 on the same freshly-seeded instance. The write is explicitly fail-closed ('If the audit write fails we MUST NOT proceed to the OR PATCH'), so every acknowledged override raised RuntimeException 500 and NO override could ever be committed. openspec/specs/anonymisation-prohibition-gate/spec.md mandates the schema by name: 'Implementations MUST use a `prohibitionOverrideAudit` schema in `docudesk_register.json` for this entry'. Properties are exactly the six the committer writes {ruleId, entityRelationId, fileId, reason, acknowledgedBy, acknowledgedAt}; retention P10Y because an override audit must outlive the P10Y prohibition it released. `authorization: null` matches publicationConsent/anonymizationLink — restricting `create` to policy admins would re-break the same fail-closed path for the ordinary operator who performs the anonymise. See ConductionNL/docudesk#428. Previous v7.6.4 — standing-consent-documentid-not-required: `publicationConsent` listed `documentId` in the schema-level `required` array, so OpenRegister created the backing column NOT NULL. Every scope=entity (standing consent) record is document-less by definition, so all 12 seeded standing consents failed to insert with 'null value in column \"document_id\" violates not-null constraint', and the same constraint blocks PolicyController::createStandingConsent at runtime — the entire \"Publish always\" surface. The condition is PER RECORD, not per schema, and openspec/specs/consent-management/spec.md already states it: 'documentId MUST be required only for scope=document records'. It is enforced where it can be — ConsentScopeValidator::assertValid(), which rejects a scope=document record without a documentId AND a scope=entity record WITH one. Removing it from the schema's `required` array restores what the spec mandates; nothing is left unvalidated. Previous v7.6.3 — archival-retention-object-shape: fixes six schemas that OpenRegister REJECTED on import, so they never existed on any fresh install. Five (correspondence, signingRequest, signerRecord, signingAuditEntry, batchCorrespondenceJob) declared `x-openregister-archival.retention` as a bare ISO-8601 STRING; OpenRegister's ArchivalAnnotationValidator requires an object `{ default: <duration>, rules?: [] }` and threw 'retention is required and must be an object'. The sixth (publicationProhibition) declared an authorization action `write`, which is not in OpenRegister's CRUD vocabulary (create, read, update, delete) — expanded to create/update/delete, preserving the intent that docudesk-policy-admins may write. ImportHandler catches a per-schema exception, logs it and continues, so the import still answered HTTP 200 'Import successful' while writing only 14 of 20 schemas — which left signing entirely non-functional (signingRequest/signerRecord/signingAuditEntry absent). anonymizationLink and financialExtraction already used the object form; this aligns the rest. No property, slug or retention DURATION changed. Previous v7.6.2 — schema-level-titles-en: re-authored the remaining Dutch schema-level `title` values to English — base 'Grondslag' -> 'Legal Basis', huisstijl 'Huisstijl Configuration' -> 'Branding Configuration' (schema slugs, property keys/titles, enums, descriptions unchanged). Dutch labels now live in l10n/nl.json for the display layer. See openspec/changes (fleet-wide schema-i18n titles rule). Previous v7.6.1 — schema-titles-en: re-authored all Dutch schema property `title` values to English (property names/keys unchanged); Dutch labels now live in l10n/nl.json for the display layer. See openspec/changes (fleet-wide schema-i18n titles rule). Previous v7.6.0 — document-output-destinations-and-bulk-retention: generatedDocument gains additive, nullable fileId/filePath properties, populated when a generation is stored to Files via the new DocumentStorageService (options.output.mode 'files'/'both' on generate, or the now-persisted async bulk job). hardValidation:false, so existing rows remain valid unchanged. See openspec/changes/document-output-destinations-and-bulk-retention/. Previous v7.5.0 — unified-search-provider: corrects the searchable opt-in so only navigable schemas (template, signingRequest) stay searchable and every other schema is searchable:false, keeping DocuDesk's contribution to OpenRegister's shared Unified Search provider free of dead/unnavigable results. Deep-link routing for template + signingRequest lives in src/manifest.json deepLinks[]. No bespoke OCP\\Search\\IProvider — org scoping inherited from openregister_objects. See openspec/changes/unified-search-provider/. Previous v7.4.0 — adds customDictionary + customDictionaryTerm to the document register per custom-dictionary-recognition: organisation-scoped, register-i18n-tagged term lists (label, description, colour, matchMode exact/caseInsensitive/wordBoundary, deferred fuzzy flag, active, calculated termCount) matched by CustomDictionaryMatchService and written into OpenRegister's shared entity catalogue as CUSTOM_DICTIONARY occurrences alongside Presidio/regex detections. Seeds one demo dictionary (\"Projectnamen\") with two demo terms. See openspec/changes/custom-dictionary-recognition/. Previous v7.3.0 — MERGE of Robert's anonimiseren-bij-de-bron work onto development: Woo Art. 5 grondslagen legenda A–S seed (base schema), standing-consent generic-term seeds (publicationConsent, entityType OTHER, notificationStatus skipped), entityType OTHER enum on publicationConsent/publicationProhibition, and EML→PDF assembly. Development schemas + dialect/RBAC fixes are preserved. Previous v5.10.0 — adds glAccountBooking (opaque per-tenant GL-account booking history, keyed by supplierIdentity, fed by the financial-extraction corrections endpoint) and glAccountMappingRule (admin-editable cold-start keyword/category → account rules, no seeded rows — DocuDesk ships no chart of accounts) to the document register, per ai-gl-account-suggestion. Both hardValidation:true. See openspec/changes/ai-gl-account-suggestion/. Previous v5.9.0 adds the financialExtraction schema to the document register: structured financial field-extraction results (supplier/IBAN/KvK/BTW, invoice number, dates, currency, totals + VAT breakdown, line items) with per-field confidence and an additive corrections[] tuning corpus, per financial-document-field-extraction. hardValidation:true; x-openregister-archival category shipped as an explicit placeholder pending selectielijst-manager sign-off (same pattern as anonymizationLink). See openspec/changes/financial-document-field-extraction/. Previous v5.8.0 declares validationStatus + validationFindings as x-openregister-calculations on generatedDocument (computation backend docudesk.validation = DocumentValidationService) per document-validation-checks; the event-listener fallback dispatches the same service until OR's ADR-031 calculation runtime ships. Previous v5.7.0 declared the four AVG Art. 30 processing activities (anonymisation, OCR, metadata-enrichment, signing) as x-openregister-processing catalogue annotations on anonymizationLink, generatedDocument, base, and signingAuditEntry: each carries purpose (doelbinding), legal basis, NER data categories, backend identifier, retention reference taken from the existing x-openregister-archival annotations (\"not declared\" where absent), and opts the schema into OpenRegister's per-access read-logging (logReads:true, attribution.default referencing the activity code). Requires OpenRegister >= 0.2.14. See openspec/changes/processing-activity-export/. Previous v5.5.0 extended OR register-i18n adoption to the remaining user-facing string fields across templateVersion (name/description/changelog), huisstijl (name), base (name/description), correspondence (templateName), signingRequest (documentName), signingSession (documentName), signerRecord (displayName/declineReason), publicationConsent (notes/objectionReason/publicationDecision), publicationProhibition (primaryName/reason/notes), and batchCorrespondenceJob (templateName). OpenRegister TranslationHandler picks these up automatically and stores per-language variants under the existing object JSON column; no DB migration required. See openspec/changes/register-i18n/. Previous v5.4.0 tagged template (name/description/content/category) + dossier (name/description) per register-i18n. Previous v5.3.0 adopted OR abstractions per docudesk-adopt-or-abstractions, added batchCorrespondenceJob schema with x-openregister-lifecycle + archival + notifications + calculations, added x-openregister-archival to signingAuditEntry (P10Y), signingRequest (P10Y), signerRecord (P10Y), correspondence (P7Y), added x-openregister-lifecycle to signingSession, and added anonymizationLink schema for source↔anonymised file mapping.",
+        "version": "7.9.0"
     },
     "x-openregister": {
         "type": "application",
@@ -443,7 +443,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "docudesk-policy-admins"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "docudesk-policy-admins"
+                    ],
+                    "delete": [
+                        "docudesk-policy-admins"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "entityText",
@@ -588,7 +601,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "authenticated"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "docudesk-template-editors"
+                    ],
+                    "delete": [
+                        "docudesk-template-editors"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "name",
@@ -732,7 +758,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "authenticated"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "docudesk-template-editors"
+                    ],
+                    "delete": [
+                        "docudesk-template-editors"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "name",
@@ -905,7 +944,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "authenticated"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "docudesk-template-editors"
+                    ],
+                    "delete": [
+                        "docudesk-template-editors"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "templateName",
@@ -1128,7 +1180,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "authenticated"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "docudesk-template-editors"
+                    ],
+                    "delete": [
+                        "docudesk-template-editors"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "templateName",
@@ -1271,7 +1336,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "docudesk-financial-admins"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "docudesk-financial-admins"
+                    ],
+                    "delete": [
+                        "docudesk-financial-admins"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "documentUri",
@@ -1400,7 +1478,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "docudesk-financial-admins"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "docudesk-financial-admins"
+                    ],
+                    "delete": [
+                        "docudesk-financial-admins"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "supplierIdentity",
@@ -1483,7 +1574,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "authenticated"
+                    ],
+                    "create": [
+                        "docudesk-financial-admins"
+                    ],
+                    "update": [
+                        "docudesk-financial-admins"
+                    ],
+                    "delete": [
+                        "docudesk-financial-admins"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "accountCode",
@@ -1589,7 +1693,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "authenticated"
+                    ],
+                    "create": [
+                        "docudesk-policy-admins"
+                    ],
+                    "update": [
+                        "docudesk-policy-admins"
+                    ],
+                    "delete": [
+                        "docudesk-policy-admins"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "label",
@@ -1652,7 +1769,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "authenticated"
+                    ],
+                    "create": [
+                        "docudesk-policy-admins"
+                    ],
+                    "update": [
+                        "docudesk-policy-admins"
+                    ],
+                    "delete": [
+                        "docudesk-policy-admins"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "value",
@@ -1736,7 +1866,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "authenticated"
+                    ],
+                    "create": [
+                        "docudesk-template-editors"
+                    ],
+                    "update": [
+                        "docudesk-template-editors"
+                    ],
+                    "delete": [
+                        "docudesk-template-editors"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "name",
@@ -1932,7 +2075,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "docudesk-signing-admins"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "docudesk-signing-admins"
+                    ],
+                    "delete": [
+                        "docudesk-signing-admins"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "documentName",
@@ -2216,7 +2372,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "docudesk-signing-admins"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "docudesk-signing-admins"
+                    ],
+                    "delete": [
+                        "docudesk-signing-admins"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "displayName",
@@ -2377,7 +2546,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "docudesk-signing-admins"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "docudesk-signing-admins"
+                    ],
+                    "delete": [
+                        "docudesk-signing-admins"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "action",
@@ -2533,7 +2715,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "docudesk-signing-admins"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "authenticated"
+                    ],
+                    "delete": [
+                        "docudesk-signing-admins"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "documentName",
@@ -2664,7 +2859,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "authenticated"
+                    ],
+                    "create": [
+                        "docudesk-policy-admins"
+                    ],
+                    "update": [
+                        "docudesk-policy-admins"
+                    ],
+                    "delete": [
+                        "docudesk-policy-admins"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "name",
@@ -2760,7 +2968,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "authenticated"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "docudesk-policy-admins"
+                    ],
+                    "delete": [
+                        "docudesk-policy-admins"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "name",
@@ -2919,7 +3140,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "authenticated"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "authenticated"
+                    ],
+                    "delete": [
+                        "docudesk-template-editors"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "templateName",
@@ -3244,7 +3478,20 @@
                 "application": null,
                 "organisation": null,
                 "groups": null,
-                "authorization": null,
+                "authorization": {
+                    "read": [
+                        "authenticated"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "docudesk-policy-admins"
+                    ],
+                    "delete": [
+                        "docudesk-policy-admins"
+                    ]
+                },
                 "deleted": null,
                 "configuration": {
                     "objectNameField": "sourceFileName",
@@ -3564,7 +3811,20 @@
                     "action": "destroy",
                     "responsibleParty": "docudesk-privacy-officer"
                 },
-                "authorization": null
+                "authorization": {
+                    "read": [
+                        "docudesk-policy-admins"
+                    ],
+                    "create": [
+                        "authenticated"
+                    ],
+                    "update": [
+                        "docudesk-policy-admins"
+                    ],
+                    "delete": [
+                        "docudesk-policy-admins"
+                    ]
+                }
             }
         },
         "objects": [

--- a/openspec/changes/consumer-schema-authorization-audit/tasks.md
+++ b/openspec/changes/consumer-schema-authorization-audit/tasks.md
@@ -2,39 +2,62 @@
 
 ## 1. Establish the ground truth
 
-- [ ] Record, per schema, whether it has an `authorization` cascade (measured: 1 of 21 does)
-- [ ] For each of the 9 gate-7 endpoints, record which schema it touches and whether that schema is open
+- [x] Record, per schema, whether it has an `authorization` cascade (measured: 1 of 21 does)
+- [x] For each of the 9 gate-7 endpoints, record which schema it touches and whether that schema is open
 
 Acceptance criteria:
 - The record distinguishes "open by decision" from "open by omission". Only the second is a defect.
 - Confirm multitenancy is still enforced, so the exposure bound in the proposal is measured rather than assumed.
 
+Measured 2026-08-16 on the development instance:
+- 20 of 21 schemas had no cascade; all three `docudesk` **register** rows also had `authorization = NULL`, so the register-level cascade did not fill the gap either.
+- The gate-7 count is **17 across the whole app**, not 9 — the 9 was a diff-scoped run (ADR-020). All 17 route through `ObjectService::find()` / `findAll()` with `_rbac: true`.
+- Bound verified: `ddauth-carol` (different organisation) received **404** on the object `ddauth-bob` (same organisation) read with **200**. Multitenancy is enforced.
+- The defect is worse than disclosure: `ddauth-bob`, in no groups, **overwrote** `ddauth-alice`'s template content via `PUT` (HTTP 200) and duplicated it.
+
 ## 2. Decide authorisation per schema
 
-- [ ] For each of the 20 open schemas, declare an `authorization` cascade or record why org-wide readability is correct
-- [ ] Bump `info.version` in `lib/Settings/docudesk_register.json`
+- [x] For each of the 20 open schemas, declare an `authorization` cascade or record why org-wide readability is correct
+- [x] Bump `info.version` in `lib/Settings/docudesk_register.json`
 
 Acceptance criteria:
 - Without the version bump the import is SKIPPED and the change never deploys to any existing install. Verify the cascade is live on a running instance, not just present in the file.
 - Verify a locked-down schema still lets its legitimate owner read their own objects. An over-tight cascade is a visible outage; that is the safer failure, but it is still a failure.
 
+Decisions recorded in `docs/authorization-decisions.md`. `info.version` 7.8.0 → 7.9.0.
+Verified live after import: all 21 cascades present in `oc_openregister_schemas`, and the four declared groups auto-provisioned (empty, deliberately).
+Owner path intact: `ddauth-alice` still reads **and updates** her own template (200); `ddauth-bob` is refused on update (**403**).
+Read restriction bites: `ddauth-bob` gets **404** on another user's `prohibitionOverrideAudit` while its owner gets **200** — and 404, not 403, so the refusal is not an existence oracle.
+
+⚠️ `prohibitionOverrideAudit.create` is deliberately left `authenticated`. Register v7.7.0 records that restricting it re-breaks the fail-closed override path for the ordinary operator, raising 500 on every acknowledged override.
+
 ## 3. Guard what the cascade cannot cover
 
-- [ ] For each of the 9 endpoints, add a per-object guard OR record that its data is legitimately org-wide
-- [ ] Make each guard state which actor it excludes and why the data layer does not already exclude them
+- [x] For each of the 9 endpoints, add a per-object guard OR record that its data is legitimately org-wide
+- [x] Make each guard state which actor it excludes and why the data layer does not already exclude them
 
 Acceptance criteria:
 - No guard is added solely to clear the gate. `ConsentCrudService` documents someone already reasoning their way to deleting a real control as "redundant with OpenRegister RBAC" — an unjustified guard is that control with the reasoning removed.
 - A refusal must not reveal whether the requested id exists.
 
+**No controller guard was justified, and none was added.** Every flagged endpoint reaches its data through `ObjectService` with RBAC on, so the cascade guards them. Verified on the exemplar the spec names, `DocumentController::preview`: carol (other org) → **404**, bob (same org) → **200** with rendered content, which is the recorded decision that templates are organisation-shared assets.
+
+What the cascade genuinely cannot cover is the **22 deliberate `_rbac: false` call sites in 9 files**. Each was audited and each already carries a compensating control — `PolicyCrudService` asserts group membership for every action including `read` before its lookup; the signer portal binds a token *and* an email *and* a request id. They are recorded in `docs/authorization-decisions.md` and pinned by the ratchet rather than "fixed".
+
 ## 4. Ratchet
 
-- [ ] Add a test asserting every schema in the register has an authorisation decision
-- [ ] Add a test asserting no flagged endpoint relies on a 401 alone
+- [x] Add a test asserting every schema in the register has an authorisation decision
+- [x] Add a test asserting no flagged endpoint relies on a 401 alone
 
 Acceptance criteria:
 - The ratchet asserts COVERAGE per schema, not a findings count. A count passes the moment someone adds an exclude; coverage requires a decision.
 - Adding a schema with no decision fails on the day it is added.
+
+`tests/unit/Settings/SchemaAuthorizationCoverageTest.php`, 6 tests. The second bullet is implemented as the invariant that actually holds: a 401 is not the guard, the cascade is — so the test pins the set of `_rbac: false` bypasses that step around it. A new bypass fails until it is recorded with its compensating control; a removed one fails too, so a justification cannot outlive its call site.
+
+**Each assertion was shown to fail before it was trusted.** Six plants, all caught: a stripped cascade, a missing action, an anonymous read grant, a typo'd group, a new bypass, a rolled-back version.
+
+⚠️ The typo plant initially **passed**: `docudesk-template-editor` is a prefix of `docudesk-template-editors`, and the check used `str_contains`. That is the exact failure mode the assertion exists for, so the check was rewritten with explicit identifier-boundary lookarounds (`\b` is unusable — `_` is a word character and `-` is not). Full suite green afterwards: 1415 tests.
 
 ## 5. Raise it beyond this app
 

--- a/tests/unit/Settings/SchemaAuthorizationCoverageTest.php
+++ b/tests/unit/Settings/SchemaAuthorizationCoverageTest.php
@@ -1,0 +1,422 @@
+<?php
+
+/**
+ * Coverage ratchet for the `consumer-schema-authorization-audit` change.
+ *
+ * OpenRegister treats an UNCONFIGURED authorization cascade as OPEN:
+ * `PermissionHandler::resolveAuthorization()` returns null and every caller is
+ * admitted. `_rbac: true` means "apply the cascade"; it does not mean "a cascade
+ * exists". Measured on the development instance 2026-08-16, 20 of DocuDesk's 21
+ * schemas declared none, and the register rows carried none either — so an
+ * ordinary authenticated user in no groups could read AND overwrite another
+ * user's template.
+ *
+ * This test asserts COVERAGE, not a findings count. A count passes the moment
+ * someone adds an exclusion; coverage requires an actual decision per schema, and
+ * a schema added without one fails on the day it is added rather than at the next
+ * audit. The count returning to 20 by accretion is the failure mode this exists to
+ * prevent, and that happens one un-thought-about schema at a time.
+ *
+ * It also pins the set of deliberate `_rbac: false` bypasses. A cascade only
+ * guards callers that go through it, so a new bypass is a new hole in the control
+ * this change installed — it fails here until it is recorded in
+ * docs/authorization-decisions.md with a compensating control.
+ *
+ * Runs fully offline: it only reads files on disk.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Settings
+ *
+ * @author  Conduction Development Team <info@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.DocuDesk.app
+ *
+ * @spec openspec/changes/consumer-schema-authorization-audit/specs/consumer-schema-authorization-audit/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Settings;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies every owned schema carries an explicit authorisation decision.
+ */
+class SchemaAuthorizationCoverageTest extends TestCase {
+
+	/**
+	 * The four CRUD actions a cascade must decide.
+	 *
+	 * OpenRegister fails closed per action once a block is non-empty: an action
+	 * that is not listed is denied. Omitting one is therefore a silent deny
+	 * rather than a syntax error, which is exactly the kind of decision that
+	 * should be written down rather than inferred from an absence.
+	 *
+	 * @var array<int, string>
+	 */
+	private const ACTIONS = ['read', 'create', 'update', 'delete'];
+
+	/**
+	 * Principals that are not Nextcloud groups.
+	 *
+	 * `admin` and the object owner short-circuit before any group test and are
+	 * never listed in a block. `public` is anonymous; no DocuDesk schema grants
+	 * it, and testAnonymousReadIsNeverGranted() keeps it that way.
+	 *
+	 * @var array<int, string>
+	 */
+	private const PSEUDO_PRINCIPALS = ['public', 'authenticated'];
+
+	/**
+	 * Deliberate `_rbac: false` call sites, keyed by file with their count.
+	 *
+	 * Each is justified in docs/authorization-decisions.md. Adding one without
+	 * recording it fails testRbacBypassesAreRecorded(); removing one fails too,
+	 * so a bypass cannot be deleted while its justification stays behind
+	 * pretending a control exists.
+	 *
+	 * @var array<string, int>
+	 */
+	private const RECORDED_BYPASSES = [
+		'lib/Controller/PortalSigningReceiverController.php' => 1,
+		'lib/Service/BaseLabelResolver.php'                  => 1,
+		'lib/Service/BasesResolverService.php'               => 1,
+		'lib/Service/ConsentPolicyReferentValidator.php'     => 2,
+		'lib/Service/CustomDictionaryRepository.php'         => 4,
+		'lib/Service/DossierObjectRepository.php'            => 3,
+		'lib/Service/LegalBasisCatalog.php'                  => 1,
+		'lib/Service/PolicyCrudService.php'                  => 5,
+		'lib/Service/PolicyMatchService.php'                 => 2,
+		'lib/Service/PolicyRetroactiveService.php'           => 2,
+	];
+
+	/**
+	 * Repository root.
+	 *
+	 * @var string
+	 */
+	private string $root;
+
+	/**
+	 * Decoded register configuration.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $register;
+
+	/**
+	 * The authorisation-decisions record, as raw markdown.
+	 *
+	 * @var string
+	 */
+	private string $decisions;
+
+	/**
+	 * Load the register and the decisions record once per test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->root = realpath(__DIR__ . '/../../..');
+
+		$registerRaw = file_get_contents($this->root . '/lib/Settings/docudesk_register.json');
+		$this->assertNotFalse($registerRaw, 'docudesk_register.json must be readable');
+
+		$register = json_decode($registerRaw, true);
+		$this->assertIsArray($register, 'docudesk_register.json must be valid JSON');
+		$this->register = $register;
+
+		$decisionsRaw = file_get_contents($this->root . '/docs/authorization-decisions.md');
+		$this->assertNotFalse(
+			$decisionsRaw,
+			'docs/authorization-decisions.md must exist — it is where a schema\'s authorisation decision is justified'
+		);
+		$this->decisions = $decisionsRaw;
+
+	}//end setUp()
+
+	/**
+	 * The schemas DocuDesk owns, keyed by slug.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	private function schemas(): array {
+		$schemas = ($this->register['components']['schemas'] ?? []);
+		$this->assertNotEmpty($schemas, 'the register must declare schemas');
+
+		return $schemas;
+	}//end schemas()
+
+	/**
+	 * Every schema declares a cascade covering all four CRUD actions.
+	 *
+	 * @return void
+	 */
+	public function testEverySchemaDeclaresACascade(): void {
+		$undecided = [];
+		$incomplete = [];
+
+		foreach ($this->schemas() as $slug => $schema) {
+			$auth = ($schema['authorization'] ?? null);
+			if (is_array($auth) === false || $auth === []) {
+				$undecided[] = $slug;
+				continue;
+			}
+
+			foreach (self::ACTIONS as $action) {
+				if (isset($auth[$action]) === false || $auth[$action] === []) {
+					$incomplete[] = $slug . '.' . $action;
+				}
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$undecided,
+			"Schema(s) with no authorization cascade: " . implode(', ', $undecided)
+			. "\nOpenRegister treats an unconfigured cascade as OPEN — every authenticated user in the"
+			. " organisation may read, update and delete every object of that schema. Declare a cascade"
+			. " in lib/Settings/docudesk_register.json and record why in docs/authorization-decisions.md."
+		);
+
+		$this->assertSame(
+			[],
+			$incomplete,
+			"Cascade(s) missing an action: " . implode(', ', $incomplete)
+			. "\nOnce a block is non-empty OpenRegister fails closed per action, so an omitted action"
+			. " denies everyone except admins and object owners. That may well be what you want — but"
+			. " state it explicitly rather than leaving it to be read out of an absence."
+		);
+
+	}//end testEverySchemaDeclaresACascade()
+
+	/**
+	 * Every schema is named in the decisions record.
+	 *
+	 * This is the half that makes it a coverage assertion rather than a syntax
+	 * check: a cascade can be present and thoughtless. A new schema fails here
+	 * until someone writes down what its data is and who should reach it.
+	 *
+	 * @return void
+	 */
+	public function testEverySchemaHasARecordedJustification(): void {
+		$unrecorded = [];
+
+		foreach (array_keys($this->schemas()) as $slug) {
+			if (str_contains($this->decisions, '`' . $slug . '`') === false) {
+				$unrecorded[] = $slug;
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$unrecorded,
+			"Schema(s) absent from docs/authorization-decisions.md: " . implode(', ', $unrecorded)
+			. "\nA cascade without a recorded reason is deleted by the next person who reasons that the"
+			. " data layer covers it. ConsentCrudService carries a comment written by someone defending a"
+			. " real control from exactly that fate."
+		);
+
+	}//end testEverySchemaHasARecordedJustification()
+
+	/**
+	 * No schema grants anonymous read.
+	 *
+	 * DocuDesk holds consent records, signer identities and extracted invoice
+	 * content. `public` also disables multi-tenancy filtering in
+	 * ObjectService::searchObjectsPaginated(), so granting it widens two axes at
+	 * once — which is not obvious from reading the block.
+	 *
+	 * @return void
+	 */
+	public function testAnonymousReadIsNeverGranted(): void {
+		$anonymous = [];
+
+		foreach ($this->schemas() as $slug => $schema) {
+			$read = ($schema['authorization']['read'] ?? []);
+			if (in_array('public', $read, true) === true) {
+				$anonymous[] = $slug;
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$anonymous,
+			"Schema(s) granting anonymous read: " . implode(', ', $anonymous)
+			. "\n`public` in a read rule also bypasses multi-tenancy filtering, so it widens both the"
+			. " authentication and the organisation axis in one word."
+		);
+
+	}//end testAnonymousReadIsNeverGranted()
+
+	/**
+	 * Every named principal is a group, not a stray value.
+	 *
+	 * A typo in a group name is invisible at runtime: a group that was never
+	 * created and a group nobody belongs to both deny every caller, with nothing
+	 * logged. Pinning the vocabulary is the only place that mistake surfaces.
+	 *
+	 * @return void
+	 */
+	public function testEveryNamedGroupIsRecorded(): void {
+		$unknown = [];
+
+		foreach ($this->schemas() as $slug => $schema) {
+			foreach (self::ACTIONS as $action) {
+				foreach (($schema['authorization'][$action] ?? []) as $entry) {
+					// Conditional rules carry the principal under `group`.
+					$principal = $entry;
+					if (is_array($entry) === true) {
+						$principal = ($entry['group'] ?? null);
+					}
+
+					if (is_string($principal) === false) {
+						$unknown[] = $slug . '.' . $action . ' (not a string)';
+						continue;
+					}
+
+					if (in_array($principal, self::PSEUDO_PRINCIPALS, true) === true) {
+						continue;
+					}
+
+					if ($this->decisionsNameToken(token: $principal) === false) {
+						$unknown[] = $slug . '.' . $action . ' => ' . $principal;
+					}
+				}
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$unknown,
+			"Principal(s) not named in docs/authorization-decisions.md: " . implode(', ', $unknown)
+			. "\nA misspelt group denies everyone and logs nothing, so it is indistinguishable from a"
+			. " working access control. Every group must be listed in the decisions record."
+		);
+
+	}//end testEveryNamedGroupIsRecorded()
+
+	/**
+	 * Is this exact token named in the decisions record?
+	 *
+	 * A substring test is not good enough, and this was measured: planting the
+	 * typo `docudesk-template-editor` (singular) PASSED a `str_contains()` check,
+	 * because it is a prefix of the real `docudesk-template-editors`. A near-miss
+	 * group name is the single failure mode this assertion exists for, so a check
+	 * that cannot see it is worse than no check — it reports a control that is not
+	 * there.
+	 *
+	 * `\b` is not usable here: group ids contain `-` and `_`, which `\b` treats
+	 * inconsistently (`_` is a word character, `-` is not), so `\bfoo_bar\b`
+	 * behaves differently from `\bfoo-bar\b`. The lookarounds spell out the
+	 * identifier alphabet instead.
+	 *
+	 * @param string $token The principal to look for.
+	 *
+	 * @return bool True when the record names exactly this token.
+	 */
+	private function decisionsNameToken(string $token): bool {
+		$pattern = '/(?<![A-Za-z0-9_-])' . preg_quote($token, '/') . '(?![A-Za-z0-9_-])/';
+
+		return preg_match($pattern, $this->decisions) === 1;
+	}//end decisionsNameToken()
+
+	/**
+	 * The set of deliberate RBAC bypasses has not grown.
+	 *
+	 * @return void
+	 */
+	public function testRbacBypassesAreRecorded(): void {
+		$found = $this->countRbacBypasses();
+
+		$expected = self::RECORDED_BYPASSES;
+		ksort($expected);
+		ksort($found);
+
+		$this->assertSame(
+			$expected,
+			$found,
+			"The set of `_rbac: false` call sites has changed.\n"
+			. "A cascade only guards callers that go through it, so each bypass is a hole in the control"
+			. " installed by consumer-schema-authorization-audit. Add the new site to"
+			. " docs/authorization-decisions.md with the compensating control that makes it safe, then"
+			. " update RECORDED_BYPASSES. If a bypass was REMOVED, delete its row from the doc too —"
+			. " a justification outliving its call site describes a control that no longer exists."
+		);
+
+	}//end testRbacBypassesAreRecorded()
+
+	/**
+	 * Count real `_rbac: false` call sites per file, ignoring comments.
+	 *
+	 * ConsentCrudService contains the exact string inside a comment that FORBIDS
+	 * the bypass. Counting it would record a control as a hole — the same class
+	 * of error this whole change is about.
+	 *
+	 * @return array<string, int> Repository-relative path => call-site count.
+	 */
+	private function countRbacBypasses(): array {
+		$counts = [];
+
+		foreach (['lib/Controller', 'lib/Service'] as $dir) {
+			$iterator = new \RecursiveIteratorIterator(
+				new \RecursiveDirectoryIterator($this->root . '/' . $dir)
+			);
+
+			foreach ($iterator as $file) {
+				if ($file->isFile() === false || $file->getExtension() !== 'php') {
+					continue;
+				}
+
+				$relative = substr($file->getPathname(), (strlen($this->root) + 1));
+				$hits = 0;
+
+				foreach (file($file->getPathname()) as $line) {
+					$trimmed = ltrim($line);
+					// Skip docblock continuations and line comments — a mention
+					// is not a call.
+					if (str_starts_with($trimmed, '*') === true
+						|| str_starts_with($trimmed, '//') === true
+						|| str_starts_with($trimmed, '/*') === true
+					) {
+						continue;
+					}
+
+					if (preg_match('/_rbac:\s*false/', $trimmed) === 1) {
+						$hits++;
+					}
+				}
+
+				if ($hits > 0) {
+					$counts[$relative] = $hits;
+				}
+			}
+		}
+
+		return $counts;
+	}//end countRbacBypasses()
+
+	/**
+	 * The register version advanced, or the cascade never deploys.
+	 *
+	 * An authorisation change that is not imported is a fix-shaped commit. The
+	 * importer does compare schema content, but the app-level configuration gate
+	 * is keyed on info.version, and every previous DocuDesk register change that
+	 * forgot this was inert on every existing install with no error anywhere.
+	 *
+	 * @return void
+	 */
+	public function testRegisterVersionCoversTheCascade(): void {
+		$version = ($this->register['info']['version'] ?? '0.0.0');
+
+		$this->assertTrue(
+			version_compare($version, '7.9.0', '>='),
+			"Register info.version is {$version}; the authorisation cascade landed in 7.9.0."
+			. " A lower version means an existing install keeps its old, open schemas."
+		);
+
+	}//end testRegisterVersionCoversTheCascade()
+
+}//end class


### PR DESCRIPTION
Closes #618.

## The defect, measured

OpenRegister treats an **unconfigured** `authorization` cascade as OPEN — `PermissionHandler::resolveAuthorization()` returns `null` and every caller is admitted. `_rbac: true` means "apply the cascade"; it does not mean "a cascade exists".

**20 of 21** DocuDesk schemas declared none. All three `docudesk` **register** rows were `NULL` too, so the register-level cascade did not fill the gap either.

Development instance, two ordinary users in **no groups**, **same organisation**:

| Action | Before |
|---|---|
| `ddauth-bob` GET `ddauth-alice`'s private template | **200**, full `content` |
| `ddauth-bob` PUT, overwriting the content | **200** |
| `ddauth-bob` POST duplicate | **200** |

This was a **write** exposure, not only disclosure.

## The bound

`ddauth-carol`, authenticated in a different organisation, received **404** on the object `ddauth-bob` read with **200**.

**Multitenancy is a separate axis and remains enforced.** Not anonymous, not cross-tenant. Both available one-line summaries are wrong in the same way — "it's an IDOR" reads as anonymous and drives panic-shaped work, and "RBAC covers it" is the belief that produced the gap.

## The fix

`update`/`delete` restricted on **every** schema — that is where the proven harm was. OpenRegister's owner bypass is unconditional, so a creator keeps full control of their own objects; this closes cross-user writes with **no read-path outage**.

`read` restricted only where the data justifies it: `financialExtraction` + `glAccountBooking` (supplier IBAN/KvK/BTW), `publicationConsent` + `prohibitionOverrideAudit`, and the four signing schemas — safe because the signer portal resolves records with `_rbac: false` behind its own token binding. Elsewhere `read: authenticated` is a **recorded decision** in `docs/authorization-decisions.md`, not an omission.

⚠️ `prohibitionOverrideAudit.create` is deliberately left open. Register v7.7.0 records that restricting it re-breaks the fail-closed override path for the ordinary operator, raising 500 on every acknowledged override.

## Verified live after import

- `ddauth-bob` PUT → **403**; `ddauth-alice` PUT on her own → **200**
- `ddauth-bob` GET another user's override-audit → **404**, not 403, so the refusal is not an existence oracle; its owner → **200**
- `DocumentController::preview` (the endpoint the spec names): carol → **404**, bob → **200** with rendered content, which is the recorded decision that templates are organisation-shared
- All 21 cascades present in `oc_openregister_schemas`; four declared groups auto-provisioned, **empty on purpose**

## No controller guard was added

Every flagged endpoint reaches its data through `ObjectService` with RBAC on. `ConsentCrudService` already carries a comment written by someone defending a real control from deletion as "redundant with OpenRegister RBAC" — an unjustified guard is that control with the reasoning stripped out.

The 22 deliberate `_rbac: false` bypasses were audited; each already carries a compensating control, so they are **recorded and pinned**, not "fixed".

## The ratchet asserts coverage, not a count

A count passes the moment someone adds an exclusion. `SchemaAuthorizationCoverageTest` (6 tests) requires a decision per schema, and pins the bypass set — a new bypass fails until recorded, a removed one fails too, so a justification cannot outlive its call site.

**Every assertion was shown to FAIL before it was trusted.** Six plants, all caught: stripped cascade, missing action, anonymous read, typo'd group, new bypass, rolled-back version.

⚠️ The typo plant initially **passed** — `docudesk-template-editor` is a prefix of `docudesk-template-editors` and the check used `str_contains`, which is the exact failure mode the assertion exists for. Rewritten with explicit identifier-boundary lookarounds (`\b` is unusable: `_` is a word character, `-` is not).

Full unit suite green: **1415 tests**.

## Note for reviewers

The four groups ship **empty**. Until someone is added, only admins and object owners can update templates, house style, dictionaries, policy and signing records. That is the intended default and it is immediately visible — the alternative was back-filling 21 schemas' worth of grants nobody chose.