### PR TITLE
fix(e2e): de-race docudesk's one isVisible() skip gate — a landmine, not a live bug

### DIFF
--- a/tests/e2e/spec-coverage/orphaned-surface-restoration.spec.ts
+++ b/tests/e2e/spec-coverage/orphaned-surface-restoration.spec.ts
@@ -169,7 +169,23 @@ test.describe('orphaned-surface-restoration — signing authoring + verify', () 
 		const firstRow = page
 			.locator('#content table tbody tr, .app-content table tbody tr')
 			.first()
-		if (!(await firstRow.isVisible().catch(() => false))) {
+		// ⚠️ POLL — do not put `isVisible()` back here. It is an IMMEDIATE
+		// predicate whose `timeout` option is ignored, so on the tick after
+		// `go()` it answers "no" before the SPA has fetched anything, and this
+		// guard then skips with the reason "no signing requests seeded" when the
+		// truth is "I looked too early". A skip whose stated reason is untrue is
+		// an invisible pass — worse than a failure, because the count looks
+		// deliberate and the reason looks investigated.
+		//
+		// This block is unreachable TODAY (the `test.fixme` above short-circuits
+		// the test), which is exactly why it is worth fixing now: whoever deletes
+		// that fixme when #339 lands would otherwise inherit a silent skip one
+		// line below a comment reading "do NOT weaken the assertion".
+		const hasRow = await firstRow
+			.waitFor({ state: 'visible', timeout: 10_000 })
+			.then(() => true)
+			.catch(() => false)
+		if (!hasRow) {
 			test.skip(
 				true,
 				'no signing requests seeded on this environment — nothing to open a detail for',
@@ -191,12 +207,15 @@ test.describe('orphaned-surface-restoration — signing authoring + verify', () 
 		// surface renders without erroring.
 		await expect(page).toHaveURL(/\/apps\/docudesk\/signing\/.+/)
 		await expect(page.locator('#content, .app-content').first()).toBeVisible()
-		if (
-			await verifyButton
-				.first()
-				.isVisible()
-				.catch(() => false)
-		) {
+		// Same reasoning as above: poll, so "absent" means absent rather than
+		// "not painted yet". A short budget — absence here is legitimate and is
+		// the expected branch whenever the request carries no documentFileId.
+		const hasVerify = await verifyButton
+			.first()
+			.waitFor({ state: 'visible', timeout: 5_000 })
+			.then(() => true)
+			.catch(() => false)
+		if (hasVerify) {
 			await expect(verifyButton.first()).toBeEnabled()
 		}
 	})


### PR DESCRIPTION
Reported as one of the fleet's 24 `test.skip()` gates built on the non-waiting
`locator.isVisible()`. Measured honestly, docudesk's single occurrence is
UNREACHABLE TODAY: it sits below `test.fixme(true, 'blocked by #339 …')`, which
short-circuits the test, so the guard never executes and no CI tally can move.

It is still worth fixing, and this is the interesting part. `isVisible()` is an
IMMEDIATE predicate — its `timeout` option is ignored — so on the tick after the
navigation it answers "no" before the SPA has fetched anything, and the guard
skips with the reason "no signing requests seeded on this environment" when the
truth is "I looked too early". A skip whose stated reason is untrue is an
invisible pass: worse than a failure, because the count looks deliberate and the
reason looks investigated.

🔑 Whoever deletes that `test.fixme` when #339 lands would otherwise inherit a
silent skip ONE LINE BELOW a comment reading "do NOT weaken the assertion" — the
assertion would be intact and the test would never reach it. Both probes in the
test now poll via `waitFor`, and a comment says why, so the trap is disarmed
before it is armed.

The `test.skip()` is KEPT: the fix is not to unskip, it is to make the gate tell
the truth.

Before/after: eslint on the changed file 4 problems → 4 problems, zero
introduced. `--list` collects 136 tests in 29 files on both sides. E2E tally
CANNOT change — the test is fixme'd — and this PR does not claim it will.

⚠️ S37's original sweep reported docudesk at SIXTEEN of these. That figure came
from a grep that walked `tests/e2e/test-results/`, whose `error-context.md`
artefacts quote the failing test's own source, so the same lines were counted
once per artefact directory. Re-measured from tracked source only, docudesk has
ONE. Reproduced both numbers as a control before trusting either: naive
working-tree grep 16, `git grep` on `origin/development` 1.

---

## Measurement

**Baseline** — `Code Quality` run `31952211396` on `development@d8d1adf6`, 38 jobs, **zero cancelled**, `enable-playwright: true`.

| | collected | passed | failed | **skipped** | other |
|---|---|---|---|---|---|
| base | 124 | 104 | 1 | **9** | **10 did not run** |

The target test appears in that run as `- 58 … a signing request detail with a document file id shows a Verify action` — **skipped by its `test.fixme`**, which is the proof that the guard below it never executes.

**This PR therefore cannot move the tally, and does not claim to.** Reporting a change it cannot produce would be the same class of error it fixes.

Local, both sides: `--list` collects **136 tests in 29 files**; `eslint` on the changed file **4 → 4 problems, zero introduced**.

## ⚠️ Correction to the dispatched figure
S37's fleet sweep first reported **docudesk 16** and corrected itself to **1**. The 16 came from a grep that walked `tests/e2e/test-results/`, whose `error-context.md` artefacts **quote the failing test's own source** — so the same three lines were counted once per artefact directory.

I reproduced **both** numbers as a control before trusting either:

```
naive working-tree grep (walks untracked test-results/): 16
git grep on origin/development (tracked source only):     1
```

**Directories excluded from my enumeration**: `test-results/`, `playwright-report/`, and — by reading from `git grep <ref>` rather than the working tree — every untracked path, which is where all the artefact debris lives. Verified no artefacts are *committed* in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)