### PR TITLE
fix(batch): persist anonymization batch state to OpenRegister, not a cache

### DIFF
--- a/docs/authorization-decisions.md
+++ b/docs/authorization-decisions.md
@@ -89,6 +89,7 @@ deliberately.
 | `base` | authenticated | policy-admins | policy-admins | Woo Article 5 grounds are public-law reference data, and must be readable to explain **why** something was redacted. |
 | `dossier` | authenticated | authenticated | policy-admins | A dossier points at a Nextcloud folder; Nextcloud's own share permissions govern the contents. |
 | `anonymizationLink` | authenticated | authenticated | policy-admins | Written by the anonymiser running as the acting user. |
+| `anonymizationBatch` | **policy-admins** | authenticated | policy-admins | Working state of one multi-file anonymisation run. `read` is restricted because the record lists the filenames of a user's private documents, and the batch owner reaches their own batch through the owner bypass. DocuDesk's own reads and writes go through `BatchStateRepository` with `_rbac: false` (recorded below) and are ownership-checked in `BatchStateService::getBatch()` instead, so this cascade governs only direct OpenRegister API access. Added with the schema in register v7.10.0 rather than omitted — an omitted cascade is OPEN, so shipping a new schema without one re-opens exactly the hole v7.9.0 closed. |
 | `publicationConsent` | **policy-admins** | authenticated | policy-admins | GDPR consent records about identified people. `create` stays open because a data subject records their own consent and then owns it. |
 | `publicationProhibition` | `consent` group | policy-admins | policy-admins | **Unchanged** — decided before this change. |
 | `prohibitionOverrideAudit` | **policy-admins** | **authenticated** | policy-admins | ⚠️ `create` is deliberately open. Register v7.7.0 records that restricting it re-breaks the fail-closed override path for the ordinary operator who performs the anonymise: the write is explicitly "if the audit write fails we MUST NOT proceed", so a denied create raises 500 on every acknowledged override and no override can ever be committed. |
@@ -100,7 +101,7 @@ deliberately.
 ## Deliberate RBAC bypasses
 
 A cascade only guards callers that go through it. `ObjectService::find()` and
-`findAll()` accept `_rbac: false`, and DocuDesk passes it at **22 call sites in 9
+`findAll()` accept `_rbac: false`, and DocuDesk passes it at **25 call sites in 10
 files**. Each is paired with a compensating control rather than being an oversight,
 and the coverage test pins the set: **a new bypass fails the test until it is added
 here with a reason.**
@@ -110,6 +111,7 @@ here with a reason.**
 | `Service/PolicyCrudService.php` | 5 | `requirePolicyPermission()` asserts membership in `docudesk-policy-admins` / `docudesk-standing-consent-admins` for **every** action including `read`, before the lookup runs. |
 | `Service/CustomDictionaryRepository.php` | 4 | Recogniser lists are read during anonymisation, which runs on behalf of a user who may not hold the maintainer group. Read-only; no caller-supplied id reaches it. |
 | `Service/DossierObjectRepository.php` | 3 | Dossier contents are governed by Nextcloud folder permissions, which are checked before the repository is reached. |
+| `Service/BatchStateRepository.php` | 3 | Batch state is DocuDesk's own working state, written and read only by `BatchStateService` — no OpenRegister API caller reaches this class. Ownership is enforced one layer up in `BatchStateService::getBatch()`, which returns `null` (not a distinct error) for a batch belonging to another non-admin user, so a guessed batch id is indistinguishable from an absent one. The bypass is required, not convenient: the cascade restricts `update`/`delete` to `docudesk-policy-admins`, which ships **empty**, so an ordinary user's own extraction run would fail closed at its first status write. |
 | `Service/PolicyMatchService.php` | 2 | Matching must see every prohibition regardless of the acting user, or an anonymisation silently under-redacts. Fail-closed by design. |
 | `Service/ConsentPolicyReferentValidator.php` | 2 | Validation-only; returns a boolean, never record content. |
 | `Service/PolicyRetroactiveService.php` | 2 | Background re-application over records the triggering user may not own. |

--- a/lib/Service/BatchStateRepository.php
+++ b/lib/Service/BatchStateRepository.php
@@ -52,6 +52,8 @@ use Throwable;
  * @author   Conduction B.V. <info@conduction.nl>
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-status-endpoint
  */
 class BatchStateRepository {
 

--- a/lib/Service/BatchStateRepository.php
+++ b/lib/Service/BatchStateRepository.php
@@ -1,0 +1,300 @@
+<?php
+
+/**
+ * Batch State Repository
+ *
+ * OpenRegister persistence for anonymization batch state. The batch record is
+ * stored as one object in the `document` register under the
+ * `anonymizationBatch` schema, keyed by the batch UUID, so the multi-request
+ * batch flow (create -> extract -> review -> anonymize -> report) survives on
+ * an instance with no distributed cache configured.
+ *
+ * ⚠️ WHY THIS EXISTS. `ICacheFactory::createDistributed()` falls back to the
+ * LOCAL cache class, and the local cache class defaults to
+ * `OC\Memcache\NullCache` when `memcache.local` is unset — which is every
+ * Nextcloud that has not been explicitly configured with APCu/Redis/Memcached.
+ * `NullCache::set()` discards and `NullCache::get()` returns null, so a
+ * cache-only batch store loses the record the instant the request that created
+ * it ends: the folder-batch POST answers 200 with a batchId and the very next
+ * call on that batchId answers 404. Per ADR-022/ADR-083 the fix is to consume
+ * OpenRegister's object abstraction rather than to require every small install
+ * to deploy a distributed cache.
+ *
+ * @category  Service
+ * @package   OCA\DocuDesk\Service
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git_id>
+ * @link      https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-creation-via-multi-file-upload
+ * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-status-endpoint
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Service;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * OpenRegister-backed store for anonymization batch records.
+ *
+ * @category Service
+ * @package  OCA\DocuDesk\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ */
+class BatchStateRepository {
+
+	/**
+	 * Register slug the batch schema lives in.
+	 *
+	 * @var string
+	 */
+	public const REGISTER = 'document';
+
+	/**
+	 * Schema slug for a batch record.
+	 *
+	 * @var string
+	 */
+	public const SCHEMA = 'anonymizationBatch';
+
+	/**
+	 * Property name the per-file entries are stored under in OpenRegister.
+	 *
+	 * The in-process batch record calls this list `files`. It is stored as
+	 * `documents` because `files` is also the name of an ObjectEntity column
+	 * (surfaced under `@self.files` for attachments), and a data property that
+	 * shadows a `@self` key is a collision waiting to happen. The mapping is
+	 * confined to this class; nothing outside it sees `documents`.
+	 *
+	 * @var string
+	 */
+	private const DOCUMENTS_PROPERTY = 'documents';
+
+	/**
+	 * Constructor for BatchStateRepository
+	 *
+	 * The OpenRegister handle is a CONSTRUCTOR dependency (ADR-083): a bare
+	 * `$container->get()` inside a method declares the dependency nowhere a
+	 * reader — or a gate — can see it.
+	 *
+	 * @param OpenRegisterAvailabilityService $openRegister Owns the OpenRegister
+	 *                                                      installed/version probe
+	 *                                                      and the ObjectService handle.
+	 * @param LoggerInterface                 $logger       Structured logger.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly OpenRegisterAvailabilityService $openRegister,
+		private readonly LoggerInterface $logger,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Whether OpenRegister is installed and new enough to hold batch state.
+	 *
+	 * @return bool True when batch state can be persisted.
+	 *
+	 * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-status-endpoint
+	 */
+	public function isAvailable(): bool {
+		return $this->openRegister->isInstalled();
+	}//end isAvailable()
+
+	/**
+	 * Load one batch record by its identifier.
+	 *
+	 * A miss is a miss: `ObjectService::find()` raises DoesNotExistException
+	 * for an unknown identifier, which is translated to null here. Anything
+	 * else — a missing schema, a broken register — is NOT swallowed, because a
+	 * store that reports "no such batch" when it actually cannot reach its
+	 * backing store is indistinguishable from a store that is working.
+	 *
+	 * @param string $batchId Batch identifier (also the OpenRegister object UUID).
+	 *
+	 * @return array<string, mixed>|null The batch record, or null when absent.
+	 *
+	 * @throws RuntimeException When OpenRegister is unavailable.
+	 *
+	 * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-status-endpoint
+	 */
+	public function find(string $batchId): ?array {
+		if ($this->isAvailable() === false) {
+			throw new RuntimeException(
+				'Cannot read anonymization batch state: OpenRegister is not available.'
+			);
+		}
+
+		$objectService = $this->openRegister->getObjectService();
+
+		try {
+			$object = $objectService->find(
+				id: $batchId,
+				register: self::REGISTER,
+				schema: self::SCHEMA,
+				_rbac: false,
+				_multitenancy: false
+			);
+		} catch (DoesNotExistException $e) {
+			return null;
+		}
+
+		if ($object === null) {
+			return null;
+		}
+
+		return $this->fromStoredShape(stored: $this->toArray(value: $object));
+	}//end find()
+
+	/**
+	 * Persist a batch record, creating it when it does not exist yet.
+	 *
+	 * The batch identifier is passed as the OpenRegister object UUID, so the
+	 * write is an upsert keyed by the identifier the rest of the app already
+	 * hands around; no secondary lookup is needed to update.
+	 *
+	 * @param string               $batchId Batch identifier (used as the object UUID).
+	 * @param array<string, mixed> $batch   The full batch record.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException When OpenRegister is unavailable or the write fails.
+	 *
+	 * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-creation-via-multi-file-upload
+	 */
+	public function save(string $batchId, array $batch): void {
+		if ($this->isAvailable() === false) {
+			// A write MUST NOT report success it did not achieve. Returning the
+			// unsaved payload here is exactly the failure this class was written
+			// to remove: every caller reads it as a stored batch.
+			throw new RuntimeException(
+				'Cannot persist anonymization batch state: OpenRegister is not available.'
+			);
+		}
+
+		$objectService = $this->openRegister->getObjectService();
+
+		try {
+			$objectService->saveObject(
+				object: $this->toStoredShape(batch: $batch),
+				register: self::REGISTER,
+				schema: self::SCHEMA,
+				uuid: $batchId,
+				_rbac: false,
+				_multitenancy: false
+			);
+		} catch (Throwable $e) {
+			$this->logger->error(
+				'BatchStateRepository: failed to persist batch state',
+				['batchId' => $batchId, 'error' => $e->getMessage()]
+			);
+			throw new RuntimeException(
+				'Failed to persist anonymization batch state: ' . $e->getMessage(),
+				0,
+				$e
+			);
+		}//end try
+
+	}//end save()
+
+	/**
+	 * Remove a batch record.
+	 *
+	 * Deleting a batch that is already gone is not an error — the caller's
+	 * intent (no batch under this id) is satisfied either way.
+	 *
+	 * @param string $batchId Batch identifier.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/batch-anonymization/spec.md
+	 */
+	public function delete(string $batchId): void {
+		if ($this->isAvailable() === false) {
+			return;
+		}
+
+		try {
+			$this->openRegister->getObjectService()->deleteObject(
+				uuid: $batchId,
+				register: self::REGISTER,
+				schema: self::SCHEMA,
+				_rbac: false,
+				_multitenancy: false
+			);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'BatchStateRepository: failed to delete batch state',
+				['batchId' => $batchId, 'error' => $e->getMessage()]
+			);
+		}
+
+	}//end delete()
+
+	/**
+	 * Translate the in-process batch record into its stored representation.
+	 *
+	 * @param array<string, mixed> $batch The in-process batch record.
+	 *
+	 * @return array<string, mixed> The payload handed to OpenRegister.
+	 */
+	private function toStoredShape(array $batch): array {
+		$stored = $batch;
+		unset($stored['files']);
+		$stored[self::DOCUMENTS_PROPERTY] = array_values((array)($batch['files'] ?? []));
+
+		return $stored;
+	}//end toStoredShape()
+
+	/**
+	 * Translate a stored record back into the in-process batch record.
+	 *
+	 * OpenRegister decorates every serialised object with `@self` metadata and
+	 * a top-level `id` mirroring the UUID. Neither belongs to the batch record,
+	 * and leaving `id` in place would put a key in the batch that the batch
+	 * never had.
+	 *
+	 * @param array<string, mixed> $stored The serialised OpenRegister object.
+	 *
+	 * @return array<string, mixed> The batch record.
+	 */
+	private function fromStoredShape(array $stored): array {
+		$batch = $stored;
+		unset($batch['@self'], $batch['id'], $batch[self::DOCUMENTS_PROPERTY]);
+		$batch['files'] = array_values((array)($stored[self::DOCUMENTS_PROPERTY] ?? []));
+
+		return $batch;
+	}//end fromStoredShape()
+
+	/**
+	 * Normalise an OpenRegister result to a plain array.
+	 *
+	 * @param mixed $value An ObjectEntity, a plain array, or anything else.
+	 *
+	 * @return array<string, mixed> The array form.
+	 */
+	private function toArray(mixed $value): array {
+		if (is_object($value) === true && method_exists($value, 'jsonSerialize') === true) {
+			return (array)$value->jsonSerialize();
+		}
+
+		if (is_array($value) === true) {
+			return $value;
+		}
+
+		return (array)$value;
+	}//end toArray()
+}//end class

--- a/lib/Service/BatchStateService.php
+++ b/lib/Service/BatchStateService.php
@@ -3,9 +3,20 @@
 /**
  * Batch State Service
  *
- * Persists short-lived anonymization batch state in Nextcloud's distributed
- * cache. Each batch is keyed by UUID, JSON-encoded, and refreshed on every
- * read so active batches survive human review without stalling due to TTL.
+ * Persists anonymization batch state in OpenRegister, with Nextcloud's
+ * distributed cache in front of it as a read fast path. Each batch is keyed by
+ * UUID; the cached copy is refreshed on every read so an active batch never
+ * has to fall back to the store during human review.
+ *
+ * ⚠️ OPENREGISTER IS THE SOURCE OF TRUTH, NOT THE CACHE.
+ * `ICacheFactory::createDistributed()` degrades to the local cache class, and
+ * that defaults to `OC\Memcache\NullCache` on any instance without
+ * `memcache.local` configured — a cache that discards every write and returns
+ * null for every read. A cache-only batch store therefore loses the record the
+ * moment the creating request ends, so the folder-batch POST answered 200 with
+ * a batchId and the very next call on that batchId answered 404. Per
+ * ADR-022/ADR-083 the batch is persisted through OpenRegister's object
+ * abstraction, which makes the flow correct with no cache configured at all.
  *
  * @category  Service
  * @package   OCA\DocuDesk\Service
@@ -35,7 +46,8 @@ use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
- * Read/write store for anonymization batch state backed by the distributed cache.
+ * Read/write store for anonymization batch state, backed by OpenRegister and
+ * fronted by the distributed cache.
  *
  * @category Service
  * @package  OCA\DocuDesk\Service
@@ -63,6 +75,11 @@ class BatchStateService {
 	 * @param LoggerInterface $logger Logger for lifecycle events.
 	 * @param IUserSession $userSession User session for ownership checks.
 	 * @param IGroupManager $groupManager Group manager for admin bypass.
+	 * @param BatchStateRepository $repository OpenRegister-backed store of record
+	 *                                         for batch state. Injected via the
+	 *                                         constructor (ADR-083) so the
+	 *                                         dependency is declared where a
+	 *                                         reader and a gate can both see it.
 	 *
 	 * @return void
 	 */
@@ -72,6 +89,7 @@ class BatchStateService {
 		private readonly LoggerInterface $logger,
 		private readonly IUserSession $userSession,
 		private readonly IGroupManager $groupManager,
+		private readonly BatchStateRepository $repository,
 	) {
 		$this->cache = $cacheFactory->createDistributed('docudesk');
 
@@ -135,6 +153,8 @@ class BatchStateService {
 	 *
 	 * @return array<string, mixed> The newly created batch record.
 	 *
+	 * @throws RuntimeException When the batch cannot be persisted.
+	 *
 	 * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-creation-via-multi-file-upload
 	 */
 	public function createBatch(string $userId, array $files): array {
@@ -146,6 +166,11 @@ class BatchStateService {
 			'files' => $files,
 			'createdAt' => time(),
 		];
+
+		// Store of record FIRST. If this throws, no batchId is handed to the
+		// caller, which is the honest outcome: a batchId that resolves to
+		// nothing on the next request is worse than an error here.
+		$this->repository->save(batchId: $batchId, batch: $batch);
 		$this->cache->set(self::CACHE_PREFIX . $batchId, json_encode($batch), $this->getCacheTtl());
 		$this->logger->info('Batch created', ['batchId' => $batchId, 'fileCount' => count($files)]);
 		return $batch;
@@ -161,13 +186,8 @@ class BatchStateService {
 	 * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-status-endpoint
 	 */
 	public function getBatch(string $batchId): ?array {
-		$data = $this->cache->get(self::CACHE_PREFIX . $batchId);
-		if ($data === null) {
-			return null;
-		}
-
-		$batch = json_decode($data, true);
-		if (is_array($batch) === false) {
+		$batch = $this->readThrough(batchId: $batchId);
+		if ($batch === null) {
 			return null;
 		}
 
@@ -192,10 +212,44 @@ class BatchStateService {
 			}
 		}
 
-		// Reset TTL on read (keep-alive pattern) so active batches don't expire during human review.
-		$this->cache->set(self::CACHE_PREFIX . $batchId, $data, $this->getCacheTtl());
+		// Reset TTL on read (keep-alive pattern) so active batches don't expire
+		// during human review, and warm the cache after a store read. Harmless
+		// against a NullCache: it discards the write and the next read falls
+		// through to OpenRegister again.
+		$this->cache->set(self::CACHE_PREFIX . $batchId, json_encode($batch), $this->getCacheTtl());
 		return $batch;
 	}//end getBatch()
+
+	/**
+	 * Load a batch record from the cache, falling back to OpenRegister.
+	 *
+	 * The cache is a fast path only. A miss — or a corrupt/legacy entry that
+	 * does not decode to an array — falls through to the store of record
+	 * rather than being reported as "no such batch", because on an instance
+	 * with no distributed cache configured EVERY read is a miss.
+	 *
+	 * @param string $batchId Batch identifier.
+	 *
+	 * @return array<string, mixed>|null The batch record, or null when absent.
+	 *
+	 * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-status-endpoint
+	 */
+	private function readThrough(string $batchId): ?array {
+		$data = $this->cache->get(self::CACHE_PREFIX . $batchId);
+		if ($data !== null) {
+			$cached = json_decode($data, true);
+			if (is_array($cached) === true) {
+				return $cached;
+			}
+
+			$this->logger->warning(
+				'Discarding an undecodable cached batch entry; reading the store instead',
+				['batchId' => $batchId]
+			);
+		}
+
+		return $this->repository->find(batchId: $batchId);
+	}//end readThrough()
 
 	/**
 	 * Persist an updated batch record.
@@ -205,9 +259,14 @@ class BatchStateService {
 	 *
 	 * @return void
 	 *
+	 * @throws RuntimeException When the batch cannot be persisted.
+	 *
 	 * @spec openspec/specs/batch-anonymization/spec.md
 	 */
 	public function updateBatch(string $batchId, array $batch): void {
+		// Store of record first, cache second — so a cache that accepted the
+		// write can never be the only place the new state exists.
+		$this->repository->save(batchId: $batchId, batch: $batch);
 		$this->cache->set(self::CACHE_PREFIX . $batchId, json_encode($batch), $this->getCacheTtl());
 
 	}//end updateBatch()
@@ -222,14 +281,15 @@ class BatchStateService {
 	 * @spec openspec/specs/batch-anonymization/spec.md
 	 *
 	 * @orphaned-write-capability exclude completes the store's CRUD surface
-	 * beside createBatch/getBatch/updateBatch. Records are cache-backed with a
-	 * 7200s TTL, so nothing is currently obliged to delete one explicitly and
-	 * no caller has needed to yet — but a store that can create and update and
-	 * not delete is the odd shape, and the method is one cache->remove() with
-	 * no reachable side effect beyond that key.
+	 * beside createBatch/getBatch/updateBatch. No caller has needed it yet —
+	 * but a store that can create and update and not delete is the odd shape,
+	 * and now that records outlive the request in OpenRegister rather than
+	 * expiring with a cache TTL, the ability to remove one is the only way a
+	 * batch ever leaves the store.
 	 */
 	public function deleteBatch(string $batchId): void {
 		$this->cache->remove(self::CACHE_PREFIX . $batchId);
+		$this->repository->delete(batchId: $batchId);
 
 	}//end deleteBatch()
 

--- a/lib/Service/BatchStateService.php
+++ b/lib/Service/BatchStateService.php
@@ -54,6 +54,8 @@ use RuntimeException;
  * @author   Conduction B.V. <info@conduction.nl>
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://www.DocuDesk.app
+ *
+ * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-status-endpoint
  */
 class BatchStateService {
 	private const CACHE_TTL = 7200;

--- a/lib/Settings/docudesk_register.json
+++ b/lib/Settings/docudesk_register.json
@@ -1740,14 +1740,14 @@
                         "maxLength": 64
                     },
                     "userId": {
-                        "description": "Nextcloud user ID that owns the batch. BatchStateService refuses a read by any other non-admin user.",
+                        "description": "Nextcloud user ID that owns the batch. BatchStateService refuses a read by any other non-admin user. maxLength is 255, not 64: measured on the dev instance, OpenRegister enforces `required`, `enum` and property constraints EVEN WHEN `hardValidation` is false, so a long externally-provisioned uid over the limit would fail the batch write closed — the exact failure mode this schema exists to remove.",
                         "type": "string",
                         "required": true,
                         "visible": true,
                         "order": 2,
                         "facetable": true,
                         "title": "Owner",
-                        "maxLength": 64
+                        "maxLength": 255
                     },
                     "status": {
                         "description": "Phase the batch as a whole is in.",

--- a/lib/Settings/docudesk_register.json
+++ b/lib/Settings/docudesk_register.json
@@ -2,8 +2,8 @@
     "openapi": "3.0.0",
     "info": {
         "title": "DocuDesk Register",
-        "description": "DocuDesk register v7.8.0 — docudesk-mcp-adoption + document-editing-tools: declares `configuration.x-openregister-mcp` on 8 of 21 schemas (template, huisstijl, correspondence, generatedDocument, batchCorrespondenceJob, signingRequest, dossier, base) with `search` + `get` ONLY, `scope: read`, `readOnlyHint: true`. No DocuDesk schema exposes a derived create/update/delete verb: templates and huisstijl are governance artefacts, correspondence/generatedDocument/batch rows are audit records, and signingRequest is the legal spine of a signature process. The remaining 13 schemas stay off entirely (signature material, citizen contact data, re-identification links, extracted invoice content). Every declared `search.filters` entry was cross-checked against that schema's own `properties` map — an unknown filter fails the whole register import. `generatedDocument.format` additionally gains `docx`, which an agent document edit produces and which the enum predated. ⚠️ THE VERSION BUMP IS THE POINT: SettingsInitializer gates the import on `info.version` against the stored `configuration_version` app-config value, so a dialect change shipped WITHOUT a bump is inert on every existing install — the schemas keep their old configuration and not one derived tool appears, with no error anywhere. Measured on the dev instance before the bump: the four curated #[McpTool] tools were live while all 16 derived tools were absent. Previous v7.7.0 — prohibition-override-audit-schema: adds the `prohibitionOverrideAudit` schema to the `consent` register. `ProhibitionOverrideCommitter::writeAudit()` has always written to `register: consent, schema: prohibitionOverrideAudit`, and that schema was declared NOWHERE — `GET /apps/openregister/api/objects/consent/prohibitionOverrideAudit` answered 404 `Schema not found` while its sibling `publicationProhibition` answered 200 on the same freshly-seeded instance. The write is explicitly fail-closed ('If the audit write fails we MUST NOT proceed to the OR PATCH'), so every acknowledged override raised RuntimeException 500 and NO override could ever be committed. openspec/specs/anonymisation-prohibition-gate/spec.md mandates the schema by name: 'Implementations MUST use a `prohibitionOverrideAudit` schema in `docudesk_register.json` for this entry'. Properties are exactly the six the committer writes {ruleId, entityRelationId, fileId, reason, acknowledgedBy, acknowledgedAt}; retention P10Y because an override audit must outlive the P10Y prohibition it released. `authorization: null` matches publicationConsent/anonymizationLink — restricting `create` to policy admins would re-break the same fail-closed path for the ordinary operator who performs the anonymise. See ConductionNL/docudesk#428. Previous v7.6.4 — standing-consent-documentid-not-required: `publicationConsent` listed `documentId` in the schema-level `required` array, so OpenRegister created the backing column NOT NULL. Every scope=entity (standing consent) record is document-less by definition, so all 12 seeded standing consents failed to insert with 'null value in column \"document_id\" violates not-null constraint', and the same constraint blocks PolicyController::createStandingConsent at runtime — the entire \"Publish always\" surface. The condition is PER RECORD, not per schema, and openspec/specs/consent-management/spec.md already states it: 'documentId MUST be required only for scope=document records'. It is enforced where it can be — ConsentScopeValidator::assertValid(), which rejects a scope=document record without a documentId AND a scope=entity record WITH one. Removing it from the schema's `required` array restores what the spec mandates; nothing is left unvalidated. Previous v7.6.3 — archival-retention-object-shape: fixes six schemas that OpenRegister REJECTED on import, so they never existed on any fresh install. Five (correspondence, signingRequest, signerRecord, signingAuditEntry, batchCorrespondenceJob) declared `x-openregister-archival.retention` as a bare ISO-8601 STRING; OpenRegister's ArchivalAnnotationValidator requires an object `{ default: <duration>, rules?: [] }` and threw 'retention is required and must be an object'. The sixth (publicationProhibition) declared an authorization action `write`, which is not in OpenRegister's CRUD vocabulary (create, read, update, delete) — expanded to create/update/delete, preserving the intent that docudesk-policy-admins may write. ImportHandler catches a per-schema exception, logs it and continues, so the import still answered HTTP 200 'Import successful' while writing only 14 of 20 schemas — which left signing entirely non-functional (signingRequest/signerRecord/signingAuditEntry absent). anonymizationLink and financialExtraction already used the object form; this aligns the rest. No property, slug or retention DURATION changed. Previous v7.6.2 — schema-level-titles-en: re-authored the remaining Dutch schema-level `title` values to English — base 'Grondslag' -> 'Legal Basis', huisstijl 'Huisstijl Configuration' -> 'Branding Configuration' (schema slugs, property keys/titles, enums, descriptions unchanged). Dutch labels now live in l10n/nl.json for the display layer. See openspec/changes (fleet-wide schema-i18n titles rule). Previous v7.6.1 — schema-titles-en: re-authored all Dutch schema property `title` values to English (property names/keys unchanged); Dutch labels now live in l10n/nl.json for the display layer. See openspec/changes (fleet-wide schema-i18n titles rule). Previous v7.6.0 — document-output-destinations-and-bulk-retention: generatedDocument gains additive, nullable fileId/filePath properties, populated when a generation is stored to Files via the new DocumentStorageService (options.output.mode 'files'/'both' on generate, or the now-persisted async bulk job). hardValidation:false, so existing rows remain valid unchanged. See openspec/changes/document-output-destinations-and-bulk-retention/. Previous v7.5.0 — unified-search-provider: corrects the searchable opt-in so only navigable schemas (template, signingRequest) stay searchable and every other schema is searchable:false, keeping DocuDesk's contribution to OpenRegister's shared Unified Search provider free of dead/unnavigable results. Deep-link routing for template + signingRequest lives in src/manifest.json deepLinks[]. No bespoke OCP\\Search\\IProvider — org scoping inherited from openregister_objects. See openspec/changes/unified-search-provider/. Previous v7.4.0 — adds customDictionary + customDictionaryTerm to the document register per custom-dictionary-recognition: organisation-scoped, register-i18n-tagged term lists (label, description, colour, matchMode exact/caseInsensitive/wordBoundary, deferred fuzzy flag, active, calculated termCount) matched by CustomDictionaryMatchService and written into OpenRegister's shared entity catalogue as CUSTOM_DICTIONARY occurrences alongside Presidio/regex detections. Seeds one demo dictionary (\"Projectnamen\") with two demo terms. See openspec/changes/custom-dictionary-recognition/. Previous v7.3.0 — MERGE of Robert's anonimiseren-bij-de-bron work onto development: Woo Art. 5 grondslagen legenda A–S seed (base schema), standing-consent generic-term seeds (publicationConsent, entityType OTHER, notificationStatus skipped), entityType OTHER enum on publicationConsent/publicationProhibition, and EML→PDF assembly. Development schemas + dialect/RBAC fixes are preserved. Previous v5.10.0 — adds glAccountBooking (opaque per-tenant GL-account booking history, keyed by supplierIdentity, fed by the financial-extraction corrections endpoint) and glAccountMappingRule (admin-editable cold-start keyword/category → account rules, no seeded rows — DocuDesk ships no chart of accounts) to the document register, per ai-gl-account-suggestion. Both hardValidation:true. See openspec/changes/ai-gl-account-suggestion/. Previous v5.9.0 adds the financialExtraction schema to the document register: structured financial field-extraction results (supplier/IBAN/KvK/BTW, invoice number, dates, currency, totals + VAT breakdown, line items) with per-field confidence and an additive corrections[] tuning corpus, per financial-document-field-extraction. hardValidation:true; x-openregister-archival category shipped as an explicit placeholder pending selectielijst-manager sign-off (same pattern as anonymizationLink). See openspec/changes/financial-document-field-extraction/. Previous v5.8.0 declares validationStatus + validationFindings as x-openregister-calculations on generatedDocument (computation backend docudesk.validation = DocumentValidationService) per document-validation-checks; the event-listener fallback dispatches the same service until OR's ADR-031 calculation runtime ships. Previous v5.7.0 declared the four AVG Art. 30 processing activities (anonymisation, OCR, metadata-enrichment, signing) as x-openregister-processing catalogue annotations on anonymizationLink, generatedDocument, base, and signingAuditEntry: each carries purpose (doelbinding), legal basis, NER data categories, backend identifier, retention reference taken from the existing x-openregister-archival annotations (\"not declared\" where absent), and opts the schema into OpenRegister's per-access read-logging (logReads:true, attribution.default referencing the activity code). Requires OpenRegister >= 0.2.14. See openspec/changes/processing-activity-export/. Previous v5.5.0 extended OR register-i18n adoption to the remaining user-facing string fields across templateVersion (name/description/changelog), huisstijl (name), base (name/description), correspondence (templateName), signingRequest (documentName), signingSession (documentName), signerRecord (displayName/declineReason), publicationConsent (notes/objectionReason/publicationDecision), publicationProhibition (primaryName/reason/notes), and batchCorrespondenceJob (templateName). OpenRegister TranslationHandler picks these up automatically and stores per-language variants under the existing object JSON column; no DB migration required. See openspec/changes/register-i18n/. Previous v5.4.0 tagged template (name/description/content/category) + dossier (name/description) per register-i18n. Previous v5.3.0 adopted OR abstractions per docudesk-adopt-or-abstractions, added batchCorrespondenceJob schema with x-openregister-lifecycle + archival + notifications + calculations, added x-openregister-archival to signingAuditEntry (P10Y), signingRequest (P10Y), signerRecord (P10Y), correspondence (P7Y), added x-openregister-lifecycle to signingSession, and added anonymizationLink schema for source↔anonymised file mapping.",
-        "version": "7.8.0"
+        "description": "DocuDesk register v7.9.0 — batch-state-persistence: adds the `anonymizationBatch` schema to the `document` register. Batch anonymisation state used to live ONLY in Nextcloud's distributed cache. `ICacheFactory::createDistributed()` degrades to the local cache class, and that defaults to `OC\\Memcache\\NullCache` whenever `memcache.local` is unset — which is every Nextcloud that has not been explicitly pointed at APCu/Redis/Memcached, including a stock `occ maintenance:install`. NullCache discards every write and returns null for every read, so the batch record vanished the instant the creating request ended: `POST /api/anonymization/batch/folder` answered 200 with a batchId and fileCount 2, and the very next call `POST /api/anonymization/batch/{id}/extract` answered 404 `Batch not found or expired`. That is the entire multi-file anonymisation flow, broken on every install without a distributed cache. Per ADR-022/ADR-083 the record is now persisted through OpenRegister's object abstraction (BatchStateRepository), with the cache demoted to a read fast path, so the flow is correct with no cache configured at all. `hardValidation:false` because the per-document progress entries evolve with the extraction pipeline and a validation refusal here would re-break the very flow this schema exists to keep working; the batch is app-private transient state, not a record anyone else reads. No archival annotation: batches are working state and MUST stay deletable. ⚠️ THE VERSION BUMP IS THE POINT — SettingsInitializer gates the import on `info.version` against the stored `configuration_version`, so a new schema shipped WITHOUT a bump never reaches an existing install and every batch there keeps 404-ing. Previous v7.8.0 — docudesk-mcp-adoption + document-editing-tools: declares `configuration.x-openregister-mcp` on 8 of 21 schemas (template, huisstijl, correspondence, generatedDocument, batchCorrespondenceJob, signingRequest, dossier, base) with `search` + `get` ONLY, `scope: read`, `readOnlyHint: true`. No DocuDesk schema exposes a derived create/update/delete verb: templates and huisstijl are governance artefacts, correspondence/generatedDocument/batch rows are audit records, and signingRequest is the legal spine of a signature process. The remaining 13 schemas stay off entirely (signature material, citizen contact data, re-identification links, extracted invoice content). Every declared `search.filters` entry was cross-checked against that schema's own `properties` map — an unknown filter fails the whole register import. `generatedDocument.format` additionally gains `docx`, which an agent document edit produces and which the enum predated. ⚠️ THE VERSION BUMP IS THE POINT: SettingsInitializer gates the import on `info.version` against the stored `configuration_version` app-config value, so a dialect change shipped WITHOUT a bump is inert on every existing install — the schemas keep their old configuration and not one derived tool appears, with no error anywhere. Measured on the dev instance before the bump: the four curated #[McpTool] tools were live while all 16 derived tools were absent. Previous v7.7.0 — prohibition-override-audit-schema: adds the `prohibitionOverrideAudit` schema to the `consent` register. `ProhibitionOverrideCommitter::writeAudit()` has always written to `register: consent, schema: prohibitionOverrideAudit`, and that schema was declared NOWHERE — `GET /apps/openregister/api/objects/consent/prohibitionOverrideAudit` answered 404 `Schema not found` while its sibling `publicationProhibition` answered 200 on the same freshly-seeded instance. The write is explicitly fail-closed ('If the audit write fails we MUST NOT proceed to the OR PATCH'), so every acknowledged override raised RuntimeException 500 and NO override could ever be committed. openspec/specs/anonymisation-prohibition-gate/spec.md mandates the schema by name: 'Implementations MUST use a `prohibitionOverrideAudit` schema in `docudesk_register.json` for this entry'. Properties are exactly the six the committer writes {ruleId, entityRelationId, fileId, reason, acknowledgedBy, acknowledgedAt}; retention P10Y because an override audit must outlive the P10Y prohibition it released. `authorization: null` matches publicationConsent/anonymizationLink — restricting `create` to policy admins would re-break the same fail-closed path for the ordinary operator who performs the anonymise. See ConductionNL/docudesk#428. Previous v7.6.4 — standing-consent-documentid-not-required: `publicationConsent` listed `documentId` in the schema-level `required` array, so OpenRegister created the backing column NOT NULL. Every scope=entity (standing consent) record is document-less by definition, so all 12 seeded standing consents failed to insert with 'null value in column \"document_id\" violates not-null constraint', and the same constraint blocks PolicyController::createStandingConsent at runtime — the entire \"Publish always\" surface. The condition is PER RECORD, not per schema, and openspec/specs/consent-management/spec.md already states it: 'documentId MUST be required only for scope=document records'. It is enforced where it can be — ConsentScopeValidator::assertValid(), which rejects a scope=document record without a documentId AND a scope=entity record WITH one. Removing it from the schema's `required` array restores what the spec mandates; nothing is left unvalidated. Previous v7.6.3 — archival-retention-object-shape: fixes six schemas that OpenRegister REJECTED on import, so they never existed on any fresh install. Five (correspondence, signingRequest, signerRecord, signingAuditEntry, batchCorrespondenceJob) declared `x-openregister-archival.retention` as a bare ISO-8601 STRING; OpenRegister's ArchivalAnnotationValidator requires an object `{ default: <duration>, rules?: [] }` and threw 'retention is required and must be an object'. The sixth (publicationProhibition) declared an authorization action `write`, which is not in OpenRegister's CRUD vocabulary (create, read, update, delete) — expanded to create/update/delete, preserving the intent that docudesk-policy-admins may write. ImportHandler catches a per-schema exception, logs it and continues, so the import still answered HTTP 200 'Import successful' while writing only 14 of 20 schemas — which left signing entirely non-functional (signingRequest/signerRecord/signingAuditEntry absent). anonymizationLink and financialExtraction already used the object form; this aligns the rest. No property, slug or retention DURATION changed. Previous v7.6.2 — schema-level-titles-en: re-authored the remaining Dutch schema-level `title` values to English — base 'Grondslag' -> 'Legal Basis', huisstijl 'Huisstijl Configuration' -> 'Branding Configuration' (schema slugs, property keys/titles, enums, descriptions unchanged). Dutch labels now live in l10n/nl.json for the display layer. See openspec/changes (fleet-wide schema-i18n titles rule). Previous v7.6.1 — schema-titles-en: re-authored all Dutch schema property `title` values to English (property names/keys unchanged); Dutch labels now live in l10n/nl.json for the display layer. See openspec/changes (fleet-wide schema-i18n titles rule). Previous v7.6.0 — document-output-destinations-and-bulk-retention: generatedDocument gains additive, nullable fileId/filePath properties, populated when a generation is stored to Files via the new DocumentStorageService (options.output.mode 'files'/'both' on generate, or the now-persisted async bulk job). hardValidation:false, so existing rows remain valid unchanged. See openspec/changes/document-output-destinations-and-bulk-retention/. Previous v7.5.0 — unified-search-provider: corrects the searchable opt-in so only navigable schemas (template, signingRequest) stay searchable and every other schema is searchable:false, keeping DocuDesk's contribution to OpenRegister's shared Unified Search provider free of dead/unnavigable results. Deep-link routing for template + signingRequest lives in src/manifest.json deepLinks[]. No bespoke OCP\\Search\\IProvider — org scoping inherited from openregister_objects. See openspec/changes/unified-search-provider/. Previous v7.4.0 — adds customDictionary + customDictionaryTerm to the document register per custom-dictionary-recognition: organisation-scoped, register-i18n-tagged term lists (label, description, colour, matchMode exact/caseInsensitive/wordBoundary, deferred fuzzy flag, active, calculated termCount) matched by CustomDictionaryMatchService and written into OpenRegister's shared entity catalogue as CUSTOM_DICTIONARY occurrences alongside Presidio/regex detections. Seeds one demo dictionary (\"Projectnamen\") with two demo terms. See openspec/changes/custom-dictionary-recognition/. Previous v7.3.0 — MERGE of Robert's anonimiseren-bij-de-bron work onto development: Woo Art. 5 grondslagen legenda A–S seed (base schema), standing-consent generic-term seeds (publicationConsent, entityType OTHER, notificationStatus skipped), entityType OTHER enum on publicationConsent/publicationProhibition, and EML→PDF assembly. Development schemas + dialect/RBAC fixes are preserved. Previous v5.10.0 — adds glAccountBooking (opaque per-tenant GL-account booking history, keyed by supplierIdentity, fed by the financial-extraction corrections endpoint) and glAccountMappingRule (admin-editable cold-start keyword/category → account rules, no seeded rows — DocuDesk ships no chart of accounts) to the document register, per ai-gl-account-suggestion. Both hardValidation:true. See openspec/changes/ai-gl-account-suggestion/. Previous v5.9.0 adds the financialExtraction schema to the document register: structured financial field-extraction results (supplier/IBAN/KvK/BTW, invoice number, dates, currency, totals + VAT breakdown, line items) with per-field confidence and an additive corrections[] tuning corpus, per financial-document-field-extraction. hardValidation:true; x-openregister-archival category shipped as an explicit placeholder pending selectielijst-manager sign-off (same pattern as anonymizationLink). See openspec/changes/financial-document-field-extraction/. Previous v5.8.0 declares validationStatus + validationFindings as x-openregister-calculations on generatedDocument (computation backend docudesk.validation = DocumentValidationService) per document-validation-checks; the event-listener fallback dispatches the same service until OR's ADR-031 calculation runtime ships. Previous v5.7.0 declared the four AVG Art. 30 processing activities (anonymisation, OCR, metadata-enrichment, signing) as x-openregister-processing catalogue annotations on anonymizationLink, generatedDocument, base, and signingAuditEntry: each carries purpose (doelbinding), legal basis, NER data categories, backend identifier, retention reference taken from the existing x-openregister-archival annotations (\"not declared\" where absent), and opts the schema into OpenRegister's per-access read-logging (logReads:true, attribution.default referencing the activity code). Requires OpenRegister >= 0.2.14. See openspec/changes/processing-activity-export/. Previous v5.5.0 extended OR register-i18n adoption to the remaining user-facing string fields across templateVersion (name/description/changelog), huisstijl (name), base (name/description), correspondence (templateName), signingRequest (documentName), signingSession (documentName), signerRecord (displayName/declineReason), publicationConsent (notes/objectionReason/publicationDecision), publicationProhibition (primaryName/reason/notes), and batchCorrespondenceJob (templateName). OpenRegister TranslationHandler picks these up automatically and stores per-language variants under the existing object JSON column; no DB migration required. See openspec/changes/register-i18n/. Previous v5.4.0 tagged template (name/description/content/category) + dossier (name/description) per register-i18n. Previous v5.3.0 adopted OR abstractions per docudesk-adopt-or-abstractions, added batchCorrespondenceJob schema with x-openregister-lifecycle + archival + notifications + calculations, added x-openregister-archival to signingAuditEntry (P10Y), signingRequest (P10Y), signerRecord (P10Y), correspondence (P7Y), added x-openregister-lifecycle to signingSession, and added anonymizationLink schema for source↔anonymised file mapping.",
+        "version": "7.9.0"
     },
     "x-openregister": {
         "type": "application",
@@ -55,8 +55,8 @@
             "document": {
                 "slug": "document",
                 "title": "Document Register",
-                "version": "2.4.0",
-                "description": "Register voor correspondentie logging, gegenereerde documenten, huisstijl configuratie, financiële veldextractie, grootboekrekening-suggesties en organisatie-woordenlijsten voor aangepaste entiteitherkenning",
+                "version": "2.5.0",
+                "description": "Register voor correspondentie logging, gegenereerde documenten, huisstijl configuratie, financiële veldextractie, grootboekrekening-suggesties, organisatie-woordenlijsten voor aangepaste entiteitherkenning en de status van meervoudige anonimiseringsbatches",
                 "schemas": [
                     "correspondence",
                     "huisstijl",
@@ -67,7 +67,8 @@
                     "glAccountBooking",
                     "glAccountMappingRule",
                     "customDictionary",
-                    "customDictionaryTerm"
+                    "customDictionaryTerm",
+                    "anonymizationBatch"
                 ]
             },
             "dossier": {
@@ -1594,6 +1595,128 @@
                 "configuration": {
                     "objectNameField": "label",
                     "objectDescriptionField": "description",
+                    "autoPublish": false
+                },
+                "searchable": false
+            },
+            "anonymizationBatch": {
+                "uri": null,
+                "slug": "anonymizationBatch",
+                "title": "Anonymisation Batch",
+                "description": "State of one multi-file anonymisation run: which documents it covers, how far each of them got, and which phase the batch as a whole is in. The batch flow spans several HTTP requests (create -> extract -> review -> anonymise -> report), so this record is what carries it between them. It was previously held only in Nextcloud's distributed cache, which degrades to a NullCache on any instance without `memcache.local` configured — the record was discarded on write and every follow-up call on the batch answered 404. Written and read exclusively by BatchStateRepository, keyed by the batch UUID (the object UUID is the batchId). Ownership is enforced in BatchStateService::getBatch(), which refuses a batch belonging to another non-admin user.",
+                "version": "1.0.0",
+                "summary": "",
+                "icon": "FileDocumentMultipleOutline",
+                "required": [
+                    "batchId",
+                    "userId"
+                ],
+                "properties": {
+                    "batchId": {
+                        "description": "Batch identifier. Mirrors the object UUID so the record is self-describing when inspected in OpenRegister.",
+                        "type": "string",
+                        "required": true,
+                        "visible": true,
+                        "order": 1,
+                        "facetable": true,
+                        "title": "Batch ID",
+                        "maxLength": 64
+                    },
+                    "userId": {
+                        "description": "Nextcloud user ID that owns the batch. BatchStateService refuses a read by any other non-admin user.",
+                        "type": "string",
+                        "required": true,
+                        "visible": true,
+                        "order": 2,
+                        "facetable": true,
+                        "title": "Owner",
+                        "maxLength": 64
+                    },
+                    "status": {
+                        "description": "Phase the batch as a whole is in.",
+                        "type": "string",
+                        "required": false,
+                        "visible": true,
+                        "order": 3,
+                        "facetable": true,
+                        "title": "Status",
+                        "enum": [
+                            "uploading",
+                            "extracting",
+                            "review",
+                            "anonymizing",
+                            "completed",
+                            "error"
+                        ],
+                        "default": "uploading"
+                    },
+                    "sourceType": {
+                        "description": "How the batch was created: from an uploaded set of files, or by adopting an existing Nextcloud folder.",
+                        "type": "string",
+                        "required": false,
+                        "visible": true,
+                        "order": 4,
+                        "facetable": true,
+                        "title": "Source type",
+                        "enum": [
+                            "upload",
+                            "folder"
+                        ]
+                    },
+                    "folderId": {
+                        "description": "Node ID of the adopted folder, for a folder-sourced batch.",
+                        "type": "integer",
+                        "required": false,
+                        "visible": true,
+                        "order": 5,
+                        "facetable": true,
+                        "title": "Folder ID"
+                    },
+                    "folderPath": {
+                        "description": "Path of the adopted folder relative to the owner's root, for a folder-sourced batch.",
+                        "type": "string",
+                        "required": false,
+                        "visible": true,
+                        "order": 6,
+                        "facetable": false,
+                        "title": "Folder path",
+                        "maxLength": 4096
+                    },
+                    "createdAt": {
+                        "description": "Unix timestamp of batch creation.",
+                        "type": "integer",
+                        "required": false,
+                        "visible": true,
+                        "order": 7,
+                        "facetable": false,
+                        "title": "Created at"
+                    },
+                    "documents": {
+                        "description": "Per-document progress entries {fileId, fileName, status, entityCount, replacementCount, error, prohibitedEntries}. Named `documents` rather than `files` because `files` is an ObjectEntity column surfaced under `@self.files` for attachments, and a data property that shadows a `@self` key is a collision waiting to happen; BatchStateRepository maps it back to `files` for the rest of the app.",
+                        "type": "array",
+                        "required": false,
+                        "visible": true,
+                        "order": 8,
+                        "facetable": false,
+                        "title": "Documents"
+                    }
+                },
+                "archive": [],
+                "source": "internal",
+                "hardValidation": false,
+                "immutable": false,
+                "updated": "2026-08-16T00:00:00+00:00",
+                "created": "2026-08-16T00:00:00+00:00",
+                "maxDepth": 0,
+                "owner": null,
+                "application": null,
+                "organisation": null,
+                "groups": null,
+                "authorization": null,
+                "deleted": null,
+                "configuration": {
+                    "objectNameField": "batchId",
+                    "objectDescriptionField": "status",
                     "autoPublish": false
                 },
                 "searchable": false

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -142,3 +142,8 @@ require_once __DIR__ . '/stubs/OpenRegisterStubs.php';
 // tests/unit/ directory segment, so non-test helper classes under tests/unit
 // are required explicitly (PHPUnit loads *Test.php files by path).
 require_once __DIR__ . '/unit/Service/BuildsAnonymizationService.php';
+
+// Batch-state fakes (NullCache / in-memory OpenRegister ObjectService) shared
+// by BatchStateServicePersistenceTest and BatchStateRepositoryTest. Same
+// "helper class under tests/unit that PSR-4 cannot resolve" situation as above.
+require_once __DIR__ . '/unit/Service/BatchStateTestDoubles.php';

--- a/tests/unit/Service/BatchStateRepositoryTest.php
+++ b/tests/unit/Service/BatchStateRepositoryTest.php
@@ -1,0 +1,286 @@
+<?php
+
+/**
+ * Unit tests for BatchStateRepository
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Service;
+
+use OCA\DocuDesk\Service\BatchStateRepository;
+use OCA\DocuDesk\Service\OpenRegisterAvailabilityService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * The OpenRegister persistence primitives behind BatchStateService.
+ *
+ * The OpenRegister handle here is a real in-memory fake, not a PHPUnit mock: a
+ * mock cannot observe named arguments — it reports its own parameter defaults —
+ * so `expects()->with()` would pass against code that sent the wrong register,
+ * schema or uuid. Everything below asserts on what was actually stored.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class BatchStateRepositoryTest extends TestCase {
+
+	/**
+	 * The in-memory OpenRegister store.
+	 *
+	 * @var InMemoryObjectServiceFake
+	 */
+	private InMemoryObjectServiceFake $store;
+
+	/**
+	 * The repository under test.
+	 *
+	 * @var BatchStateRepository
+	 */
+	private BatchStateRepository $repository;
+
+	/**
+	 * Set up the repository with OpenRegister available.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->store = new InMemoryObjectServiceFake();
+		$this->repository = $this->buildRepository(available: true);
+	}//end setUp()
+
+	/**
+	 * Build a repository against the shared store.
+	 *
+	 * @param bool $available Whether OpenRegister reports itself installed.
+	 *
+	 * @return BatchStateRepository The repository.
+	 */
+	private function buildRepository(bool $available): BatchStateRepository {
+		$availability = $this->createMock(OpenRegisterAvailabilityService::class);
+		$availability->method('isInstalled')->willReturn($available);
+		$availability->method('getObjectService')->willReturn($this->store);
+
+		return new BatchStateRepository(
+			openRegister: $availability,
+			logger: $this->createMock(LoggerInterface::class)
+		);
+	}//end buildRepository()
+
+	/**
+	 * The write lands in the `document` register under `anonymizationBatch`,
+	 * keyed by the batch id, with RBAC and multitenancy bypassed.
+	 *
+	 * ⚠️ `_rbac: false` is load-bearing and asserted here on purpose. The
+	 * schema now declares an authorization cascade (register v7.9.0), and an
+	 * OpenRegister cascade DENIES any action it does not name. DocuDesk's own
+	 * batch writes must not be subject to it — ownership is enforced in
+	 * BatchStateService::getBatch() instead — so if this flag ever flips, the
+	 * whole batch flow fails closed for every user who is not in
+	 * docudesk-policy-admins, and this test is what says so.
+	 *
+	 * @return void
+	 */
+	public function testSaveTargetsTheDeclaredRegisterSchemaAndUuid(): void {
+		$this->repository->save(
+			batchId: 'batch-1',
+			batch: ['batchId' => 'batch-1', 'userId' => 'alice', 'files' => []]
+		);
+
+		$this->assertCount(1, $this->store->saveCalls);
+		$call = $this->store->saveCalls[0];
+
+		$this->assertSame('document', $call['register']);
+		$this->assertSame('anonymizationBatch', $call['schema']);
+		$this->assertSame('batch-1', $call['uuid']);
+		$this->assertFalse($call['_rbac']);
+		$this->assertFalse($call['_multitenancy']);
+	}//end testSaveTargetsTheDeclaredRegisterSchemaAndUuid()
+
+	/**
+	 * `files` is stored as `documents`, and nothing is stored under `files`.
+	 *
+	 * `files` is an ObjectEntity column that OpenRegister surfaces under
+	 * `@self.files`; a data property of the same name is a collision waiting to
+	 * happen, so the repository renames it. If that rename is ever dropped this
+	 * test says so, rather than the batch quietly losing its file list.
+	 *
+	 * @return void
+	 */
+	public function testFilesAreStoredUnderTheDocumentsProperty(): void {
+		$this->repository->save(
+			batchId: 'batch-1',
+			batch: [
+				'batchId' => 'batch-1',
+				'userId' => 'alice',
+				'files' => [['fileId' => 9, 'fileName' => 'a.txt', 'status' => 'uploaded']],
+			]
+		);
+
+		$stored = $this->store->saveCalls[0]['object'];
+
+		$this->assertArrayNotHasKey('files', $stored);
+		$this->assertArrayHasKey('documents', $stored);
+		$this->assertSame(9, $stored['documents'][0]['fileId']);
+		$this->assertSame('a.txt', $stored['documents'][0]['fileName']);
+	}//end testFilesAreStoredUnderTheDocumentsProperty()
+
+	/**
+	 * A saved batch reads back with the content it was given.
+	 *
+	 * @return void
+	 */
+	public function testASavedBatchRoundTrips(): void {
+		$batch = [
+			'batchId' => 'batch-1',
+			'userId' => 'alice',
+			'status' => 'review',
+			'createdAt' => 1750000000,
+			'sourceType' => 'folder',
+			'folderId' => 42,
+			'folderPath' => '/Zaakdossiers',
+			'files' => [
+				['fileId' => 9, 'fileName' => 'a.txt', 'status' => 'extracted', 'entityCount' => 3],
+			],
+		];
+
+		$this->repository->save(batchId: 'batch-1', batch: $batch);
+		$loaded = $this->repository->find(batchId: 'batch-1');
+
+		$this->assertIsArray($loaded);
+		$this->assertSame('review', $loaded['status']);
+		$this->assertSame(42, $loaded['folderId']);
+		$this->assertSame('/Zaakdossiers', $loaded['folderPath']);
+		$this->assertSame(1750000000, $loaded['createdAt']);
+		$this->assertSame($batch['files'], $loaded['files']);
+	}//end testASavedBatchRoundTrips()
+
+	/**
+	 * An update overwrites the record under the same identifier rather than
+	 * creating a second one.
+	 *
+	 * @return void
+	 */
+	public function testSavingTwiceUpdatesTheSameRecord(): void {
+		$this->repository->save(
+			batchId: 'batch-1',
+			batch: ['batchId' => 'batch-1', 'status' => 'uploading', 'files' => []]
+		);
+		$this->repository->save(
+			batchId: 'batch-1',
+			batch: ['batchId' => 'batch-1', 'status' => 'review', 'files' => []]
+		);
+
+		$this->assertCount(1, $this->store->stored);
+		$this->assertSame('review', $this->repository->find(batchId: 'batch-1')['status']);
+	}//end testSavingTwiceUpdatesTheSameRecord()
+
+	/**
+	 * A miss is null — OpenRegister raises DoesNotExistException for an unknown
+	 * identifier, and that is not an error condition here.
+	 *
+	 * @return void
+	 */
+	public function testFindReturnsNullForAnUnknownBatch(): void {
+		$this->assertNull($this->repository->find(batchId: 'nope'));
+	}//end testFindReturnsNullForAnUnknownBatch()
+
+	/**
+	 * The serialisation envelope OpenRegister adds is stripped on the way out.
+	 *
+	 * @return void
+	 */
+	public function testTheOpenRegisterEnvelopeIsStrippedOnRead(): void {
+		$this->repository->save(
+			batchId: 'batch-1',
+			batch: ['batchId' => 'batch-1', 'files' => []]
+		);
+
+		$loaded = $this->repository->find(batchId: 'batch-1');
+
+		$this->assertArrayNotHasKey('@self', $loaded);
+		$this->assertArrayNotHasKey('id', $loaded);
+		$this->assertArrayNotHasKey('documents', $loaded);
+	}//end testTheOpenRegisterEnvelopeIsStrippedOnRead()
+
+	/**
+	 * A delete removes the record.
+	 *
+	 * @return void
+	 */
+	public function testDeleteRemovesTheRecord(): void {
+		$this->repository->save(batchId: 'batch-1', batch: ['batchId' => 'batch-1', 'files' => []]);
+		$this->repository->delete(batchId: 'batch-1');
+
+		$this->assertNull($this->repository->find(batchId: 'batch-1'));
+	}//end testDeleteRemovesTheRecord()
+
+	/**
+	 * A write with OpenRegister unavailable throws, and stores nothing.
+	 *
+	 * @return void
+	 */
+	public function testSaveThrowsWhenOpenRegisterIsUnavailable(): void {
+		$repository = $this->buildRepository(available: false);
+
+		try {
+			$repository->save(batchId: 'batch-1', batch: ['batchId' => 'batch-1', 'files' => []]);
+			$this->fail('save() reported success while OpenRegister was unavailable.');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('OpenRegister is not available', $e->getMessage());
+		}
+
+		$this->assertSame([], $this->store->stored);
+	}//end testSaveThrowsWhenOpenRegisterIsUnavailable()
+
+	/**
+	 * A read with OpenRegister unavailable throws rather than answering "no
+	 * such batch".
+	 *
+	 * "The store is unreachable" and "the batch does not exist" must not look
+	 * the same to a caller: the first is an outage, the second is a 404.
+	 *
+	 * @return void
+	 */
+	public function testFindThrowsWhenOpenRegisterIsUnavailable(): void {
+		$repository = $this->buildRepository(available: false);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('OpenRegister is not available');
+
+		$repository->find(batchId: 'batch-1');
+	}//end testFindThrowsWhenOpenRegisterIsUnavailable()
+
+	/**
+	 * isAvailable() reflects the OpenRegister probe.
+	 *
+	 * @return void
+	 */
+	public function testIsAvailableReflectsTheOpenRegisterProbe(): void {
+		$this->assertTrue($this->repository->isAvailable());
+		$this->assertFalse($this->buildRepository(available: false)->isAvailable());
+	}//end testIsAvailableReflectsTheOpenRegisterProbe()
+}//end class

--- a/tests/unit/Service/BatchStateRepositoryTest.php
+++ b/tests/unit/Service/BatchStateRepositoryTest.php
@@ -24,6 +24,7 @@ namespace OCA\DocuDesk\Tests\Unit\Service;
 
 use OCA\DocuDesk\Service\BatchStateRepository;
 use OCA\DocuDesk\Service\OpenRegisterAvailabilityService;
+use OCA\OpenRegister\Service\ObjectService;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -283,4 +284,206 @@ class BatchStateRepositoryTest extends TestCase {
 		$this->assertTrue($this->repository->isAvailable());
 		$this->assertFalse($this->buildRepository(available: false)->isAvailable());
 	}//end testIsAvailableReflectsTheOpenRegisterProbe()
+
+	/**
+	 * A miss is ALSO null when OpenRegister answers with null instead of
+	 * throwing.
+	 *
+	 * ⚠️ OpenRegister has TWO miss shapes reached through the same
+	 * `->find(...)` spelling. `Contract\ObjectServiceInterface::find()` is
+	 * declared `?ObjectEntityInterface` and returns **null**; the entity
+	 * mappers inherit Nextcloud's `QBMapper::find()`, which **throws
+	 * DoesNotExistException**. `testFindReturnsNullForAnUnknownBatch()` above
+	 * covers the throwing one. Without this test the null one would reach
+	 * `toArray(null)` and hand the caller `[]` — an empty array that every
+	 * caller reads as a real batch with no files, rather than as "no such
+	 * batch".
+	 *
+	 * @return void
+	 */
+	public function testFindReturnsNullWhenOpenRegisterAnswersNullInsteadOfThrowing(): void {
+		$store = new FixedResultObjectServiceFake(result: null);
+		$repository = $this->buildRepositoryOn(store: $store);
+
+		$loaded = $repository->find(batchId: 'batch-1');
+
+		$this->assertSame(
+			1,
+			$store->findCalls,
+			'The repository never reached the store, so this test proves nothing about how it '
+			. 'handles a null answer.'
+		);
+		$this->assertNull(
+			$loaded,
+			'A null answer from OpenRegister was turned into a batch record. A caller cannot tell '
+			. 'that apart from a real batch, so an unknown id would stop being a 404.'
+		);
+	}//end testFindReturnsNullWhenOpenRegisterAnswersNullInsteadOfThrowing()
+
+	/**
+	 * A result that is already a plain array is read, not discarded.
+	 *
+	 * OpenRegister's own `find()` is typed to an entity, but the value that
+	 * reaches this repository has passed through an app-host boundary that
+	 * renders objects to arrays on some paths. Normalising the array shape is
+	 * cheap; getting it wrong loses the whole record silently.
+	 *
+	 * @return void
+	 */
+	public function testFindReadsAResultThatIsAlreadyAPlainArray(): void {
+		$store = new FixedResultObjectServiceFake(
+			result: [
+				'batchId' => 'batch-1',
+				'userId' => 'alice',
+				'status' => 'review',
+				'documents' => [['fileId' => 7, 'fileName' => 'a.txt']],
+				'id' => 'batch-1',
+				'@self' => ['id' => 'batch-1'],
+			]
+		);
+
+		$loaded = $this->buildRepositoryOn(store: $store)->find(batchId: 'batch-1');
+
+		$this->assertIsArray($loaded);
+		$this->assertSame('review', $loaded['status']);
+		$this->assertSame(7, $loaded['files'][0]['fileId']);
+		$this->assertArrayNotHasKey('documents', $loaded);
+		$this->assertArrayNotHasKey('@self', $loaded);
+		$this->assertArrayNotHasKey('id', $loaded);
+	}//end testFindReadsAResultThatIsAlreadyAPlainArray()
+
+	/**
+	 * A result that is an object WITHOUT `jsonSerialize()` is still read.
+	 *
+	 * @return void
+	 */
+	public function testFindReadsAnObjectThatDoesNotImplementJsonSerialize(): void {
+		$plain = new \stdClass();
+		$plain->batchId = 'batch-1';
+		$plain->status = 'anonymizing';
+		$plain->documents = [['fileId' => 7, 'fileName' => 'a.txt']];
+
+		$loaded = $this->buildRepositoryOn(
+			store: new FixedResultObjectServiceFake(result: $plain)
+		)->find(batchId: 'batch-1');
+
+		$this->assertIsArray($loaded);
+		$this->assertSame('anonymizing', $loaded['status']);
+		$this->assertSame('a.txt', $loaded['files'][0]['fileName']);
+	}//end testFindReadsAnObjectThatDoesNotImplementJsonSerialize()
+
+	/**
+	 * A refused write throws, names the underlying cause, and is logged.
+	 *
+	 * ⚠️ THIS IS THE FAILURE THE WHOLE CLASS EXISTS TO PREVENT. OpenRegister
+	 * enforces `required` and `enum` even on a schema declaring
+	 * `hardValidation: false`, so a refused batch write is a live possibility
+	 * rather than a theoretical one. If `save()` ever swallowed it, the caller
+	 * would hand out a batchId that resolves to nothing on the next request —
+	 * exactly the 404 this change was written to remove, reintroduced through
+	 * a different door.
+	 *
+	 * @return void
+	 */
+	public function testSaveThrowsAndLogsWhenOpenRegisterRefusesTheWrite(): void {
+		$logger = new RecordingLoggerFake();
+		$repository = $this->buildRepositoryOn(
+			store: new RefusingObjectServiceFake(),
+			logger: $logger
+		);
+
+		try {
+			$repository->save(batchId: 'batch-1', batch: ['batchId' => 'batch-1', 'files' => []]);
+			$this->fail('save() reported success while OpenRegister refused the write.');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('Failed to persist anonymization batch state', $e->getMessage());
+			$this->assertStringContainsString(
+				'ValidationException',
+				$e->getMessage(),
+				'The underlying refusal was replaced with a generic message, so the operator cannot '
+				. 'tell a validation refusal from an outage.'
+			);
+			$this->assertInstanceOf(RuntimeException::class, $e->getPrevious());
+		}
+
+		$errors = $logger->recordsAt(level: 'error');
+		$this->assertCount(1, $errors);
+		$this->assertStringContainsString('failed to persist batch state', $errors[0]['message']);
+		$this->assertSame('batch-1', $errors[0]['context']['batchId']);
+	}//end testSaveThrowsAndLogsWhenOpenRegisterRefusesTheWrite()
+
+	/**
+	 * A delete with OpenRegister unavailable is a no-op, not a throw — and it
+	 * must not reach the store.
+	 *
+	 * Delete is the one operation whose intent ("no batch under this id") is
+	 * already satisfied when the store cannot be reached at all, so unlike
+	 * `save()` and `find()` it deliberately does NOT fail loudly. The record
+	 * still being present afterwards is what proves the early return happened
+	 * rather than a silent successful delete.
+	 *
+	 * @return void
+	 */
+	public function testDeleteIsANoOpWhenOpenRegisterIsUnavailable(): void {
+		$this->repository->save(batchId: 'batch-1', batch: ['batchId' => 'batch-1', 'files' => []]);
+
+		$this->buildRepository(available: false)->delete(batchId: 'batch-1');
+
+		$this->assertCount(
+			1,
+			$this->store->stored,
+			'The record was removed from the store while OpenRegister was reported unavailable.'
+		);
+		$this->assertIsArray($this->repository->find(batchId: 'batch-1'));
+	}//end testDeleteIsANoOpWhenOpenRegisterIsUnavailable()
+
+	/**
+	 * A failed delete is swallowed and logged as a warning.
+	 *
+	 * Deleting a batch is best-effort cleanup; a store that refuses it must not
+	 * take the caller down with it. But "swallowed" must not mean "invisible",
+	 * so the warning is the assertion — a bare `catch` with no record would
+	 * leave an operator with a batch that never disappears and nothing to read.
+	 *
+	 * @return void
+	 */
+	public function testAFailedDeleteIsSwallowedButLogged(): void {
+		$logger = new RecordingLoggerFake();
+		$store = new RefusingObjectServiceFake();
+		$repository = $this->buildRepositoryOn(store: $store, logger: $logger);
+
+		$repository->delete(batchId: 'batch-1');
+
+		$this->assertSame(
+			['batch-1'],
+			$store->attemptedDeletes,
+			'The delete never reached the store, so nothing was swallowed and this test proves nothing.'
+		);
+
+		$warnings = $logger->recordsAt(level: 'warning');
+		$this->assertCount(1, $warnings);
+		$this->assertStringContainsString('failed to delete batch state', $warnings[0]['message']);
+		$this->assertSame('batch-1', $warnings[0]['context']['batchId']);
+		$this->assertStringContainsString('unreachable', $warnings[0]['context']['error']);
+	}//end testAFailedDeleteIsSwallowedButLogged()
+
+	/**
+	 * Build a repository against a caller-supplied store, with OpenRegister
+	 * reported as installed.
+	 *
+	 * @param ObjectService        $store  The OpenRegister handle to hand out.
+	 * @param RecordingLoggerFake|null $logger Logger to record into, or null for a mock.
+	 *
+	 * @return BatchStateRepository The repository.
+	 */
+	private function buildRepositoryOn(ObjectService $store, ?RecordingLoggerFake $logger = null): BatchStateRepository {
+		$availability = $this->createMock(OpenRegisterAvailabilityService::class);
+		$availability->method('isInstalled')->willReturn(true);
+		$availability->method('getObjectService')->willReturn($store);
+
+		return new BatchStateRepository(
+			openRegister: $availability,
+			logger: ($logger ?? $this->createMock(LoggerInterface::class))
+		);
+	}//end buildRepositoryOn()
 }//end class

--- a/tests/unit/Service/BatchStateServiceKeepAliveTest.php
+++ b/tests/unit/Service/BatchStateServiceKeepAliveTest.php
@@ -17,6 +17,7 @@
 
 namespace OCA\DocuDesk\Tests\Unit\Service;
 
+use OCA\DocuDesk\Service\BatchStateRepository;
 use OCA\DocuDesk\Service\BatchStateService;
 use OCP\IAppConfig;
 use OCP\ICache;
@@ -81,7 +82,8 @@ class BatchStateServiceKeepAliveTest extends TestCase {
 			appConfig: $mockAppConfig,
 			logger: $mockLogger,
 			userSession: $mockUserSession,
-			groupManager: $mockGroupManager
+			groupManager: $mockGroupManager,
+			repository: $this->createMock(BatchStateRepository::class)
 		);
 
 	}//end setUp()

--- a/tests/unit/Service/BatchStateServicePersistenceTest.php
+++ b/tests/unit/Service/BatchStateServicePersistenceTest.php
@@ -1,0 +1,393 @@
+<?php
+
+/**
+ * Regression tests for batch state surviving a request boundary
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Service;
+
+use OCA\DocuDesk\Service\BatchStateRepository;
+use OCA\DocuDesk\Service\BatchStateService;
+use OCA\DocuDesk\Service\OpenRegisterAvailabilityService;
+use OCP\IAppConfig;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Batch state must survive the end of the request that created it.
+ *
+ * ⚠️ WHAT THIS CLASS EXISTS TO PREVENT.
+ * `ICacheFactory::createDistributed()` falls back to the LOCAL cache class, and
+ * that defaults to `OC\Memcache\NullCache` whenever `memcache.local` is unset —
+ * every Nextcloud that has not been explicitly pointed at APCu/Redis/Memcached,
+ * including a stock `occ maintenance:install`. NullCache discards writes and
+ * returns null for reads, so a cache-only batch store lost the record the
+ * instant the creating request ended: `POST /api/anonymization/batch/folder`
+ * answered 200 with a batchId and the next call on that batchId answered 404
+ * `Batch not found or expired` (CI run 31963162253).
+ *
+ * Every test here therefore runs against {@see NullCacheFake} — the honest
+ * reproduction of that cache — and the first test asserts the fake really does
+ * discard, so a fixture that quietly started storing would fail loudly instead
+ * of turning the whole class into a tautology.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class BatchStateServicePersistenceTest extends TestCase {
+
+	/**
+	 * The shared OpenRegister store — one instance across every "request" so it
+	 * plays the role the database plays in production.
+	 *
+	 * @var InMemoryObjectServiceFake
+	 */
+	private InMemoryObjectServiceFake $store;
+
+	/**
+	 * Set up the shared store.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->store = new InMemoryObjectServiceFake();
+	}//end setUp()
+
+	/**
+	 * Build a BatchStateService as one HTTP request would see it.
+	 *
+	 * A fresh service instance per call is the point: it models a new PHP
+	 * process with nothing carried over except the cache and the store.
+	 *
+	 * @param ICache $cache The cache this "request" gets.
+	 * @param string $uid The signed-in user, or '' for no session user.
+	 * @param bool $openRegisterAvailable Whether OpenRegister is installed.
+	 *
+	 * @return BatchStateService The service.
+	 */
+	private function serviceForRequest(
+		ICache $cache,
+		string $uid = 'alice',
+		bool $openRegisterAvailable = true,
+	): BatchStateService {
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('createDistributed')->willReturn($cache);
+
+		$userSession = $this->createMock(IUserSession::class);
+		if ($uid !== '') {
+			$user = $this->createMock(IUser::class);
+			$user->method('getUID')->willReturn($uid);
+			$userSession->method('getUser')->willReturn($user);
+		} else {
+			$userSession->method('getUser')->willReturn(null);
+		}
+
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('isAdmin')->willReturn(false);
+
+		$availability = $this->createMock(OpenRegisterAvailabilityService::class);
+		$availability->method('isInstalled')->willReturn($openRegisterAvailable);
+		$availability->method('getObjectService')->willReturn($this->store);
+
+		$repository = new BatchStateRepository(
+			openRegister: $availability,
+			logger: $this->createMock(LoggerInterface::class)
+		);
+
+		return new BatchStateService(
+			cacheFactory: $cacheFactory,
+			appConfig: $this->createMock(IAppConfig::class),
+			logger: $this->createMock(LoggerInterface::class),
+			userSession: $userSession,
+			groupManager: $groupManager,
+			repository: $repository
+		);
+	}//end serviceForRequest()
+
+	/**
+	 * A batch created in one request is readable in the next, with NO
+	 * distributed cache configured.
+	 *
+	 * This is the failing E2E reduced to one test. Before batch state was
+	 * persisted to OpenRegister this returned null and the endpoint answered
+	 * 404.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/batch-anonymization/spec.md#requirement-batch-status-endpoint
+	 */
+	public function testBatchSurvivesTheRequestThatCreatedItWithoutADistributedCache(): void {
+		$cache = new NullCacheFake();
+
+		// Positive control on the FIXTURE first: prove this cache really does
+		// discard. A fake that quietly stored would make every assertion below
+		// pass for the wrong reason.
+		$cache->set('probe', 'value', 60);
+		$this->assertNull(
+			$cache->get('probe'),
+			'The NullCache fake stored a value; it no longer reproduces the cache '
+			. 'Nextcloud hands out when memcache.local is unset, and this whole '
+			. 'test class would be vacuous.'
+		);
+
+		$files = [
+			['fileId' => 11, 'fileName' => 'zaak-a.txt', 'status' => 'uploaded', 'entityCount' => 0],
+			['fileId' => 12, 'fileName' => 'zaak-b.txt', 'status' => 'uploaded', 'entityCount' => 0],
+		];
+
+		// Request 1 — POST /api/anonymization/batch/folder
+		$created = $this->serviceForRequest(cache: $cache)->createBatch(userId: 'alice', files: $files);
+		$batchId = $created['batchId'];
+
+		// Request 2 — POST /api/anonymization/batch/{batchId}/extract
+		$loaded = $this->serviceForRequest(cache: $cache)->getBatch(batchId: $batchId);
+
+		$this->assertIsArray(
+			$loaded,
+			'The batch was not found in the next request. That is the exact 404 the '
+			. 'entity-review E2E spec reported: batch state must not live only in a cache.'
+		);
+		$this->assertSame($batchId, $loaded['batchId']);
+		$this->assertSame('alice', $loaded['userId']);
+		$this->assertSame('uploading', $loaded['status']);
+		$this->assertCount(2, $loaded['files']);
+		$this->assertSame(11, $loaded['files'][0]['fileId']);
+		$this->assertSame('zaak-b.txt', $loaded['files'][1]['fileName']);
+
+		// The cache was still written to on both paths; it simply threw it away.
+		$this->assertGreaterThan(
+			0,
+			$cache->discardedWrites,
+			'The cache write path was never exercised, so this test is not covering '
+			. 'the cache-plus-store arrangement it claims to.'
+		);
+	}//end testBatchSurvivesTheRequestThatCreatedItWithoutADistributedCache()
+
+	/**
+	 * A state change written in one request is visible in the next, with no
+	 * distributed cache configured.
+	 *
+	 * This is the folder-extraction shutdown handler's contract: it flips each
+	 * file to `extracted` and the batch to `review` AFTER the response has been
+	 * flushed, and the extract endpoint in the following request must see it.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/batch-anonymization/spec.md#requirement-sequential-batch-extraction
+	 */
+	public function testStateChangesSurviveTheRequestBoundaryWithoutADistributedCache(): void {
+		$cache = new NullCacheFake();
+
+		$created = $this->serviceForRequest(cache: $cache)->createBatch(
+			userId: 'alice',
+			files: [['fileId' => 11, 'fileName' => 'zaak-a.txt', 'status' => 'uploaded', 'entityCount' => 0]]
+		);
+		$batchId = $created['batchId'];
+
+		// Still request 1, in the shutdown handler.
+		$shutdownService = $this->serviceForRequest(cache: $cache);
+		$batch = $shutdownService->getBatch(batchId: $batchId);
+		$batch['files'][0]['status'] = 'extracted';
+		$batch['files'][0]['entityCount'] = 7;
+		$batch['status'] = 'review';
+		$batch['sourceType'] = 'folder';
+		$batch['folderPath'] = '/Zaakdossiers';
+		$shutdownService->updateBatch(batchId: $batchId, batch: $batch);
+
+		// Request 2.
+		$loaded = $this->serviceForRequest(cache: $cache)->getBatch(batchId: $batchId);
+
+		$this->assertIsArray($loaded);
+		$this->assertSame('review', $loaded['status']);
+		$this->assertSame('extracted', $loaded['files'][0]['status']);
+		$this->assertSame(7, $loaded['files'][0]['entityCount']);
+		$this->assertSame('folder', $loaded['sourceType']);
+		$this->assertSame('/Zaakdossiers', $loaded['folderPath']);
+	}//end testStateChangesSurviveTheRequestBoundaryWithoutADistributedCache()
+
+	/**
+	 * The record OpenRegister holds carries no `@self` or `id` leakage back
+	 * into the batch.
+	 *
+	 * @return void
+	 */
+	public function testTheLoadedBatchDoesNotCarryOpenRegisterEnvelopeKeys(): void {
+		$cache = new NullCacheFake();
+		$created = $this->serviceForRequest(cache: $cache)->createBatch(userId: 'alice', files: []);
+
+		$loaded = $this->serviceForRequest(cache: $cache)->getBatch(batchId: $created['batchId']);
+
+		$this->assertIsArray($loaded);
+		$this->assertArrayNotHasKey('@self', $loaded);
+		$this->assertArrayNotHasKey('id', $loaded);
+		$this->assertArrayNotHasKey('documents', $loaded);
+		$this->assertArrayHasKey('files', $loaded);
+	}//end testTheLoadedBatchDoesNotCarryOpenRegisterEnvelopeKeys()
+
+	/**
+	 * A configured distributed cache short-circuits the store read.
+	 *
+	 * The cache remains a genuine fast path — this asserts it by emptying the
+	 * store afterwards and reading again: a hit that still answers proves the
+	 * value came from the cache, not from OpenRegister.
+	 *
+	 * @return void
+	 */
+	public function testAConfiguredCacheServesTheReadWithoutTouchingTheStore(): void {
+		$cache = new InMemoryCacheFake();
+		$created = $this->serviceForRequest(cache: $cache)->createBatch(userId: 'alice', files: []);
+
+		$this->store->stored = [];
+
+		$loaded = $this->serviceForRequest(cache: $cache)->getBatch(batchId: $created['batchId']);
+
+		$this->assertIsArray(
+			$loaded,
+			'With a working distributed cache the read must be served from it; '
+			. 'emptying the store should not have been observable.'
+		);
+		$this->assertSame($created['batchId'], $loaded['batchId']);
+	}//end testAConfiguredCacheServesTheReadWithoutTouchingTheStore()
+
+	/**
+	 * A corrupt cache entry falls through to the store rather than being
+	 * reported as "no such batch".
+	 *
+	 * @return void
+	 */
+	public function testACorruptCacheEntryFallsThroughToTheStore(): void {
+		$cache = new InMemoryCacheFake();
+		$created = $this->serviceForRequest(cache: $cache)->createBatch(userId: 'alice', files: []);
+
+		$cache->set('docudesk_batch_' . $created['batchId'], '"not-a-batch-record"', 60);
+
+		$loaded = $this->serviceForRequest(cache: $cache)->getBatch(batchId: $created['batchId']);
+
+		$this->assertIsArray($loaded);
+		$this->assertSame($created['batchId'], $loaded['batchId']);
+	}//end testACorruptCacheEntryFallsThroughToTheStore()
+
+	/**
+	 * Ownership is enforced on a store-backed read, not only on a cached one.
+	 *
+	 * The ownership check used to sit behind the cache read. Moving the source
+	 * of truth without moving the guard would have opened every batch to every
+	 * authenticated user on exactly the installs this change was written for.
+	 *
+	 * @return void
+	 */
+	public function testOwnershipIsStillEnforcedWhenTheBatchComesFromTheStore(): void {
+		$cache = new NullCacheFake();
+		$created = $this->serviceForRequest(cache: $cache, uid: 'alice')->createBatch(
+			userId: 'alice',
+			files: []
+		);
+
+		$asMallory = $this->serviceForRequest(cache: $cache, uid: 'mallory')
+			->getBatch(batchId: $created['batchId']);
+
+		$this->assertNull(
+			$asMallory,
+			'A batch belonging to another user was returned from the OpenRegister-backed '
+			. 'read path; the ownership guard is not covering it.'
+		);
+	}//end testOwnershipIsStillEnforcedWhenTheBatchComesFromTheStore()
+
+	/**
+	 * An unknown batch id is a miss, not an error.
+	 *
+	 * @return void
+	 */
+	public function testAnUnknownBatchIdReadsAsAMiss(): void {
+		$loaded = $this->serviceForRequest(cache: new NullCacheFake())
+			->getBatch(batchId: '00000000-0000-4000-8000-000000000000');
+
+		$this->assertNull($loaded);
+	}//end testAnUnknownBatchIdReadsAsAMiss()
+
+	/**
+	 * A delete removes the record from the store, not just from the cache.
+	 *
+	 * @return void
+	 */
+	public function testDeleteRemovesTheRecordFromTheStore(): void {
+		$cache = new NullCacheFake();
+		$created = $this->serviceForRequest(cache: $cache)->createBatch(userId: 'alice', files: []);
+
+		$this->serviceForRequest(cache: $cache)->deleteBatch(batchId: $created['batchId']);
+
+		$this->assertSame(
+			[],
+			$this->store->stored,
+			'deleteBatch() cleared the cache but left the record in OpenRegister, '
+			. 'so the batch would come back on the next read.'
+		);
+	}//end testDeleteRemovesTheRecordFromTheStore()
+
+	/**
+	 * With OpenRegister unavailable, a write FAILS rather than handing back an
+	 * unsaved payload.
+	 *
+	 * Returning `$batch` here would look like a successful write to every
+	 * caller, and the caller would publish a batchId that resolves to nothing —
+	 * the same silent loss this change removes, one layer up.
+	 *
+	 * @return void
+	 */
+	public function testCreateBatchFailsLoudlyWhenOpenRegisterIsUnavailable(): void {
+		$service = $this->serviceForRequest(
+			cache: new NullCacheFake(),
+			openRegisterAvailable: false
+		);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('OpenRegister is not available');
+
+		$service->createBatch(userId: 'alice', files: []);
+	}//end testCreateBatchFailsLoudlyWhenOpenRegisterIsUnavailable()
+
+	/**
+	 * The same applies to an update.
+	 *
+	 * @return void
+	 */
+	public function testUpdateBatchFailsLoudlyWhenOpenRegisterIsUnavailable(): void {
+		$service = $this->serviceForRequest(
+			cache: new NullCacheFake(),
+			openRegisterAvailable: false
+		);
+
+		$this->expectException(RuntimeException::class);
+
+		$service->updateBatch(batchId: 'abc-123', batch: ['batchId' => 'abc-123', 'files' => []]);
+	}//end testUpdateBatchFailsLoudlyWhenOpenRegisterIsUnavailable()
+}//end class

--- a/tests/unit/Service/BatchStateServiceTest.php
+++ b/tests/unit/Service/BatchStateServiceTest.php
@@ -20,6 +20,7 @@
 
 namespace OCA\DocuDesk\Tests\Unit\Service;
 
+use OCA\DocuDesk\Service\BatchStateRepository;
 use OCA\DocuDesk\Service\BatchStateService;
 use OCP\IAppConfig;
 use OCP\ICache;
@@ -93,6 +94,18 @@ class BatchStateServiceTest extends TestCase {
 	private IGroupManager|MockObject $mockGroupManager;
 
 	/**
+	 * Mocked BatchStateRepository — the OpenRegister store of record.
+	 *
+	 * Left as a bare mock here on purpose: this class covers the cache-facing
+	 * behaviour of BatchStateService, so every test either hits the cache or
+	 * expects a miss, and the store answers null. The store-backed behaviour is
+	 * covered with real fakes in BatchStateServicePersistenceTest.
+	 *
+	 * @var BatchStateRepository|MockObject
+	 */
+	private BatchStateRepository|MockObject $mockRepository;
+
+	/**
 	 * Set up test environment
 	 *
 	 * @return void
@@ -100,6 +113,7 @@ class BatchStateServiceTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
+		$this->mockRepository = $this->createMock(originalClassName: BatchStateRepository::class);
 		$this->mockCache = $this->createMock(originalClassName: ICache::class);
 		$this->mockAppConfig = $this->createMock(originalClassName: IAppConfig::class);
 		$this->mockLogger = $this->createMock(originalClassName: LoggerInterface::class);
@@ -116,7 +130,8 @@ class BatchStateServiceTest extends TestCase {
 			appConfig: $this->mockAppConfig,
 			logger: $this->mockLogger,
 			userSession: $this->mockUserSession,
-			groupManager: $this->mockGroupManager
+			groupManager: $this->mockGroupManager,
+			repository: $this->mockRepository
 		);
 
 	}//end setUp()

--- a/tests/unit/Service/BatchStateServiceTest.php
+++ b/tests/unit/Service/BatchStateServiceTest.php
@@ -173,6 +173,55 @@ class BatchStateServiceTest extends TestCase {
 	}//end testGetMaxFilesReturnsDefault()
 
 	/**
+	 * The legacy key still wins when the canonical one is unset.
+	 *
+	 * `batch.max_files_per_run` is the manifest-declared key; the legacy
+	 * `docudesk_batch_max_files` is kept as a one-release fallback so an admin
+	 * who set the old key before the rename does not silently get the built-in
+	 * default instead of their own limit. That fallback is only reachable when
+	 * the canonical key reads empty, which is why the two tests above never
+	 * enter it — and a fallback nothing exercises is a fallback nobody would
+	 * notice losing.
+	 *
+	 * @return void
+	 */
+	public function testGetMaxFilesFallsBackToTheLegacyKeyWhenTheCanonicalOneIsUnset(): void {
+		$this->mockAppConfig->method('getValueString')
+			->willReturnMap(
+				[
+					['docudesk', 'batch.max_files_per_run', '', false, ''],
+					['docudesk', 'docudesk_batch_max_files', '100', false, '250'],
+				]
+			);
+
+		$this->assertSame(
+			expected: 250,
+			actual: $this->service->getMaxFiles(),
+			message: 'An admin-set legacy limit was ignored in favour of the built-in default.'
+		);
+
+	}//end testGetMaxFilesFallsBackToTheLegacyKeyWhenTheCanonicalOneIsUnset()
+
+	/**
+	 * With neither key set, the in-class default is what app-config is asked
+	 * for and what comes back.
+	 *
+	 * @return void
+	 */
+	public function testGetMaxFilesUsesTheInClassDefaultWhenNeitherKeyIsSet(): void {
+		$this->mockAppConfig->method('getValueString')
+			->willReturnMap(
+				[
+					['docudesk', 'batch.max_files_per_run', '', false, ''],
+					['docudesk', 'docudesk_batch_max_files', '100', false, '100'],
+				]
+			);
+
+		$this->assertSame(expected: 100, actual: $this->service->getMaxFiles());
+
+	}//end testGetMaxFilesUsesTheInClassDefaultWhenNeitherKeyIsSet()
+
+	/**
 	 * Test createBatch stores a batch in cache with uploading status
 	 *
 	 * @return void

--- a/tests/unit/Service/BatchStateTestDoubles.php
+++ b/tests/unit/Service/BatchStateTestDoubles.php
@@ -12,6 +12,14 @@
  * - {@see InMemoryObjectServiceFake} reproduces just enough of OpenRegister's
  *   ObjectService to store, retrieve and delete an object across calls, and to
  *   serialise it the way OpenRegister does (data + `@self` + a top-level `id`).
+ * - {@see FixedResultObjectServiceFake} answers reads with a value the test
+ *   chooses, so the repository can be driven through OpenRegister's OTHER miss
+ *   shape (the contract's nullable `find()`) and through result shapes the
+ *   in-memory fake never produces.
+ * - {@see RefusingObjectServiceFake} refuses every write, so the failure paths
+ *   are exercised rather than assumed.
+ * - {@see RecordingLoggerFake} keeps what it was told, so a swallowed failure
+ *   can be asserted on its only evidence.
  *
  * ⚠️ THESE ARE SUBCLASSES / IMPLEMENTATIONS, NOT PHPUnit MOCKS, ON PURPOSE.
  * A PHPUnit mock cannot observe named arguments — it reports its own parameter
@@ -42,6 +50,9 @@ use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\ICache;
+use Psr\Log\AbstractLogger;
+use RuntimeException;
+use Stringable;
 
 /**
  * A cache that discards everything, exactly like `OC\Memcache\NullCache`.
@@ -372,4 +383,198 @@ class InMemoryObjectServiceFake extends ObjectService {
 	private function key(string $register, string $schema, string $uuid): string {
 		return $register . '/' . $schema . '/' . $uuid;
 	}//end key()
+}//end class
+
+/**
+ * An ObjectService whose `find()` answers with a value the caller chooses.
+ *
+ * ⚠️ WHY A SECOND READ FAKE EXISTS. `InMemoryObjectServiceFake` models one
+ * miss shape — the mapper's `DoesNotExistException` — but OpenRegister has
+ * TWO, and they are reached through the same `->find(...)` spelling:
+ * `Contract\ObjectServiceInterface::find()` is declared
+ * `?ObjectEntityInterface` and returns **null** on a miss, while the entity
+ * mappers inherit Nextcloud's `QBMapper::find()`, which **throws**. A
+ * repository that only ever met the throwing one would take its not-found
+ * branch on one deployment and return a serialised `null` on the other.
+ *
+ * It also carries the two hits nothing else produces: a result that is
+ * already a plain array, and a result that is an object with no
+ * `jsonSerialize()` — both of which the repository must normalise rather
+ * than fatal on.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ */
+class FixedResultObjectServiceFake extends ObjectService {
+
+	/**
+	 * How many reads were served — asserted on so a test cannot pass because
+	 * the repository never reached the store at all.
+	 *
+	 * @var int
+	 */
+	public int $findCalls = 0;
+
+	/**
+	 * Construct a read fake.
+	 *
+	 * @param mixed $result The value every `find()` answers with.
+	 */
+	public function __construct(private readonly mixed $result) {
+
+	}//end __construct()
+
+	/**
+	 * Answer with the configured result.
+	 *
+	 * @param string $id Object UUID.
+	 * @param string $register Register slug.
+	 * @param string $schema Schema slug.
+	 * @param bool $_rbac RBAC bypass flag.
+	 * @param bool $_multitenancy Multitenancy bypass flag.
+	 *
+	 * @return mixed The configured result.
+	 */
+	public function find(
+		string $id = '',
+		string $register = '',
+		string $schema = '',
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+	) {
+		$this->findCalls++;
+		return $this->result;
+	}//end find()
+}//end class
+
+/**
+ * An ObjectService that refuses every write, the way a live OpenRegister
+ * refuses one it cannot satisfy.
+ *
+ * A refused write is not hypothetical here: OpenRegister enforces `required`
+ * and `enum` even on a schema declaring `hardValidation: false`, so a batch
+ * record carrying a status the schema does not list fails on save. The
+ * repository must convert that into a loud failure, never into a silent
+ * "saved".
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ */
+class RefusingObjectServiceFake extends ObjectService {
+
+	/**
+	 * The UUIDs a delete was attempted for, in order.
+	 *
+	 * @var array<int, string>
+	 */
+	public array $attemptedDeletes = [];
+
+	/**
+	 * Refuse the write.
+	 *
+	 * @param array $object Object data.
+	 * @param string $register Register slug.
+	 * @param string $schema Schema slug.
+	 * @param string|null $uuid Object UUID.
+	 * @param bool $_rbac RBAC bypass flag.
+	 * @param bool $_multitenancy Multitenancy bypass flag.
+	 *
+	 * @return mixed Never returns.
+	 *
+	 * @throws RuntimeException Always.
+	 */
+	public function saveObject(
+		array $object = [],
+		string $register = '',
+		string $schema = '',
+		?string $uuid = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+	) {
+		throw new RuntimeException('ValidationException: property status is not one of the declared values');
+	}//end saveObject()
+
+	/**
+	 * Refuse the delete.
+	 *
+	 * @param string $uuid Object UUID.
+	 * @param string $register Register slug.
+	 * @param string $schema Schema slug.
+	 * @param bool $_rbac RBAC bypass flag.
+	 * @param bool $_multitenancy Multitenancy bypass flag.
+	 *
+	 * @return bool Never returns.
+	 *
+	 * @throws RuntimeException Always.
+	 */
+	public function deleteObject(
+		string $uuid = '',
+		string $register = '',
+		string $schema = '',
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+	) {
+		$this->attemptedDeletes[] = $uuid;
+		throw new RuntimeException('The object store is unreachable');
+	}//end deleteObject()
+}//end class
+
+/**
+ * A logger that keeps what it was told, so a test can assert the record
+ * rather than a recorded expectation.
+ *
+ * A `createMock(LoggerInterface::class)` would satisfy the type hint while
+ * observing nothing, and the whole point of a swallowed failure is that the
+ * log line is the ONLY evidence it happened.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ */
+class RecordingLoggerFake extends AbstractLogger {
+
+	/**
+	 * Every call, as ['level' => string, 'message' => string, 'context' => array].
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	public array $records = [];
+
+	/**
+	 * Record one log call.
+	 *
+	 * @param mixed $level Log level.
+	 * @param string|Stringable $message Log message.
+	 * @param array<string, mixed> $context Structured context.
+	 *
+	 * @return void
+	 */
+	public function log($level, string|Stringable $message, array $context = []): void {
+		$this->records[] = [
+			'level' => (string)$level,
+			'message' => (string)$message,
+			'context' => $context,
+		];
+	}//end log()
+
+	/**
+	 * The records logged at one level.
+	 *
+	 * @param string $level Log level to filter on.
+	 *
+	 * @return array<int, array<string, mixed>> The matching records.
+	 */
+	public function recordsAt(string $level): array {
+		return array_values(
+			array_filter($this->records, static fn (array $record): bool => $record['level'] === $level)
+		);
+	}//end recordsAt()
 }//end class

--- a/tests/unit/Service/BatchStateTestDoubles.php
+++ b/tests/unit/Service/BatchStateTestDoubles.php
@@ -1,0 +1,375 @@
+<?php
+
+/**
+ * Test doubles for the anonymization batch-state store
+ *
+ * Two fakes that carry real behaviour rather than recorded expectations:
+ *
+ * - {@see NullCacheFake} reproduces `OC\Memcache\NullCache` — the cache class
+ *   Nextcloud actually hands out from `ICacheFactory::createDistributed()` when
+ *   `memcache.local` is unset, which is every unconfigured install. It accepts
+ *   writes and returns null for every read.
+ * - {@see InMemoryObjectServiceFake} reproduces just enough of OpenRegister's
+ *   ObjectService to store, retrieve and delete an object across calls, and to
+ *   serialise it the way OpenRegister does (data + `@self` + a top-level `id`).
+ *
+ * ⚠️ THESE ARE SUBCLASSES / IMPLEMENTATIONS, NOT PHPUnit MOCKS, ON PURPOSE.
+ * A PHPUnit mock cannot observe named arguments — it reports its own parameter
+ * defaults — so a test built on `expects()->with()` can pass against code that
+ * passed the wrong values. Storing and reading the values back makes the
+ * assertions about real effects.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.DocuDesk.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\DocuDesk\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\ICache;
+
+/**
+ * A cache that discards everything, exactly like `OC\Memcache\NullCache`.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ */
+class NullCacheFake implements ICache {
+
+	/**
+	 * How many writes were discarded — asserted on so the fixture is proven to
+	 * be reached rather than assumed.
+	 *
+	 * @var int
+	 */
+	public int $discardedWrites = 0;
+
+	/**
+	 * Always a miss.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return mixed Always null.
+	 */
+	public function get(string $key): mixed {
+		return null;
+	}//end get()
+
+	/**
+	 * Accept and discard.
+	 *
+	 * @param string $key Cache key.
+	 * @param mixed $value Value.
+	 * @param int $ttl TTL in seconds.
+	 *
+	 * @return mixed True, as NullCache reports success.
+	 */
+	public function set(string $key, mixed $value, int $ttl = 0): mixed {
+		$this->discardedWrites++;
+		return true;
+	}//end set()
+
+	/**
+	 * Nothing is ever present.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return bool Always false.
+	 */
+	public function hasKey(string $key): bool {
+		return false;
+	}//end hasKey()
+
+	/**
+	 * Removing from nothing succeeds.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return mixed Always true.
+	 */
+	public function remove(string $key): mixed {
+		return true;
+	}//end remove()
+
+	/**
+	 * Clearing nothing succeeds.
+	 *
+	 * @param string $prefix Key prefix.
+	 *
+	 * @return mixed Always true.
+	 */
+	public function clear(string $prefix = ''): mixed {
+		return true;
+	}//end clear()
+}//end class
+
+/**
+ * An in-memory cache that actually stores, for the "a distributed cache IS
+ * configured" arm of the tests.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ */
+class InMemoryCacheFake implements ICache {
+
+	/**
+	 * The backing store.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $entries = [];
+
+	/**
+	 * Read a stored value.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return mixed The stored value, or null.
+	 */
+	public function get(string $key): mixed {
+		return ($this->entries[$key] ?? null);
+	}//end get()
+
+	/**
+	 * Store a value.
+	 *
+	 * @param string $key Cache key.
+	 * @param mixed $value Value.
+	 * @param int $ttl TTL in seconds (ignored).
+	 *
+	 * @return mixed Always true.
+	 */
+	public function set(string $key, mixed $value, int $ttl = 0): mixed {
+		$this->entries[$key] = $value;
+		return true;
+	}//end set()
+
+	/**
+	 * Whether a key is present.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return bool True when stored.
+	 */
+	public function hasKey(string $key): bool {
+		return array_key_exists($key, $this->entries);
+	}//end hasKey()
+
+	/**
+	 * Remove a key.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return mixed Always true.
+	 */
+	public function remove(string $key): mixed {
+		unset($this->entries[$key]);
+		return true;
+	}//end remove()
+
+	/**
+	 * Drop everything.
+	 *
+	 * @param string $prefix Key prefix (ignored).
+	 *
+	 * @return mixed Always true.
+	 */
+	public function clear(string $prefix = ''): mixed {
+		$this->entries = [];
+		return true;
+	}//end clear()
+}//end class
+
+/**
+ * An OpenRegister object, serialised the way OpenRegister serialises one.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ */
+class StoredObjectFake extends ObjectEntity {
+
+	/**
+	 * The stored object data.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $data;
+
+	/**
+	 * Construct a stored object.
+	 *
+	 * @param string $uuid The object UUID.
+	 * @param array<string, mixed> $data The object data.
+	 */
+	public function __construct(string $uuid, array $data) {
+		$this->setUuid($uuid);
+		$this->data = $data;
+	}//end __construct()
+
+	/**
+	 * Serialise as OpenRegister does: the data, plus `@self` metadata, plus a
+	 * top-level `id` mirroring the UUID.
+	 *
+	 * @return array<string, mixed> The serialised object.
+	 */
+	public function jsonSerialize(): array {
+		$serialised = $this->data;
+		$serialised['@self'] = [
+			'id' => $this->getUuid(),
+			'name' => $this->getUuid(),
+			'files' => [],
+		];
+		$serialised['id'] = $this->getUuid();
+
+		return $serialised;
+	}//end jsonSerialize()
+}//end class
+
+/**
+ * A minimal in-memory OpenRegister ObjectService.
+ *
+ * @category Tests
+ * @package  OCA\DocuDesk\Tests\Unit\Service
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.DocuDesk.app
+ */
+class InMemoryObjectServiceFake extends ObjectService {
+
+	/**
+	 * Stored objects keyed by "register/schema/uuid".
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	public array $stored = [];
+
+	/**
+	 * Every save call recorded as [register, schema, uuid, object].
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	public array $saveCalls = [];
+
+	/**
+	 * Find a stored object.
+	 *
+	 * @param string $id Object UUID.
+	 * @param string $register Register slug.
+	 * @param string $schema Schema slug.
+	 * @param bool $_rbac RBAC bypass flag.
+	 * @param bool $_multitenancy Multitenancy bypass flag.
+	 *
+	 * @return mixed The stored object.
+	 *
+	 * @throws DoesNotExistException When the identifier is unknown, mirroring
+	 *                               OpenRegister's behaviour on a miss.
+	 */
+	public function find(
+		string $id = '',
+		string $register = '',
+		string $schema = '',
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+	) {
+		$key = $this->key(register: $register, schema: $schema, uuid: $id);
+		if (array_key_exists($key, $this->stored) === false) {
+			throw new DoesNotExistException('No object with id ' . $id);
+		}
+
+		return new StoredObjectFake(uuid: $id, data: $this->stored[$key]);
+	}//end find()
+
+	/**
+	 * Store an object under the supplied UUID (upsert).
+	 *
+	 * @param array $object Object data.
+	 * @param string $register Register slug.
+	 * @param string $schema Schema slug.
+	 * @param string|null $uuid Object UUID.
+	 * @param bool $_rbac RBAC bypass flag.
+	 * @param bool $_multitenancy Multitenancy bypass flag.
+	 *
+	 * @return mixed The stored object.
+	 */
+	public function saveObject(
+		array $object = [],
+		string $register = '',
+		string $schema = '',
+		?string $uuid = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+	) {
+		$this->saveCalls[] = [
+			'register' => $register,
+			'schema' => $schema,
+			'uuid' => $uuid,
+			'object' => $object,
+			'_rbac' => $_rbac,
+			'_multitenancy' => $_multitenancy,
+		];
+
+		$key = $this->key(register: $register, schema: $schema, uuid: (string)$uuid);
+		$this->stored[$key] = $object;
+
+		return new StoredObjectFake(uuid: (string)$uuid, data: $object);
+	}//end saveObject()
+
+	/**
+	 * Delete a stored object.
+	 *
+	 * @param string $uuid Object UUID.
+	 * @param string $register Register slug.
+	 * @param string $schema Schema slug.
+	 * @param bool $_rbac RBAC bypass flag.
+	 * @param bool $_multitenancy Multitenancy bypass flag.
+	 *
+	 * @return bool Always true.
+	 */
+	public function deleteObject(
+		string $uuid = '',
+		string $register = '',
+		string $schema = '',
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+	) {
+		unset($this->stored[$this->key(register: $register, schema: $schema, uuid: $uuid)]);
+		return true;
+	}//end deleteObject()
+
+	/**
+	 * Build the storage key for one object.
+	 *
+	 * @param string $register Register slug.
+	 * @param string $schema Schema slug.
+	 * @param string $uuid Object UUID.
+	 *
+	 * @return string The key.
+	 */
+	private function key(string $register, string $schema, string $uuid): string {
+		return $register . '/' . $schema . '/' . $uuid;
+	}//end key()
+}//end class

--- a/tests/unit/Settings/SchemaAuthorizationCoverageTest.php
+++ b/tests/unit/Settings/SchemaAuthorizationCoverageTest.php
@@ -83,6 +83,7 @@ class SchemaAuthorizationCoverageTest extends TestCase {
 		'lib/Controller/PortalSigningReceiverController.php' => 1,
 		'lib/Service/BaseLabelResolver.php'                  => 1,
 		'lib/Service/BasesResolverService.php'               => 1,
+		'lib/Service/BatchStateRepository.php'               => 3,
 		'lib/Service/ConsentPolicyReferentValidator.php'     => 2,
 		'lib/Service/CustomDictionaryRepository.php'         => 4,
 		'lib/Service/DossierObjectRepository.php'            => 3,

--- a/tests/unit/Wave12SecurityRegressionTest.php
+++ b/tests/unit/Wave12SecurityRegressionTest.php
@@ -25,6 +25,7 @@ namespace OCA\DocuDesk\Tests\Unit;
 
 use OCA\DocuDesk\Controller\CorrespondenceController;
 use OCA\DocuDesk\Controller\SigningController;
+use OCA\DocuDesk\Service\BatchStateRepository;
 use OCA\DocuDesk\Service\BatchStateService;
 use OCA\DocuDesk\Service\CorrespondenceService;
 use OCA\DocuDesk\Service\SigningAuditService;
@@ -581,7 +582,8 @@ class Wave12SecurityRegressionTest extends TestCase {
 			$this->createMock(IAppConfig::class),
 			$this->createMock(LoggerInterface::class),
 			$this->makeSession($this->makeUser('eve')),
-			$this->makeGroupManager([])
+			$this->makeGroupManager([]),
+			$this->createMock(BatchStateRepository::class)
 		);
 
 		// Must return null — NOT throw RuntimeException.
@@ -609,7 +611,8 @@ class Wave12SecurityRegressionTest extends TestCase {
 			$this->createMock(IAppConfig::class),
 			$this->createMock(LoggerInterface::class),
 			$this->makeSession($this->makeUser('mallory')),
-			$this->makeGroupManager([])
+			$this->makeGroupManager([]),
+			$this->createMock(BatchStateRepository::class)
 		);
 
 		// This call must not throw — the caller (controller) gets null and returns 404.


### PR DESCRIPTION
## What this fixes

**Batch anonymisation state now persists to OpenRegister instead of living only in a cache.**

The E2E failure on `development` is a real, user-facing product defect, not a test problem.

`ICacheFactory::createDistributed()` falls back to the **local** cache class, and that class defaults to `OC\Memcache\NullCache` whenever `memcache.local` is unset — which is **every Nextcloud that has not been explicitly pointed at APCu/Redis/Memcached**, including a stock `occ maintenance:install` (exactly what the E2E job runs; its only service container is postgres). `NullCache::set()` discards and `NullCache::get()` returns null, so a cache-only batch store loses the record the instant the creating request ends.

### The measured failure

CI run `31963162253`, job `95204429194`, log read via `gh api .../actions/jobs/95204429194/logs` (327,758 bytes — **not** `gh run view --log`, which returned empty and exited 0 here) and cross-checked against the `playwright-report` artifact's `data/*.md`:

```
Error: POST .../batch/fc03ff1f-c921-4003-8012-4924e360c6fe/extract must answer 200
Expected: 200
Received: 404
  at provision (tests/e2e/workflows/entity-review.spec.ts:182:4)
```

The disambiguating detail: the `fileCount` assertion added in #632 — written precisely so this log could distinguish *"the fixture never landed"* from *"the batch state was lost between two requests"* — **passed**. The folder batch found its two seeded files, returned a batchId, and the very next request could not find that batch. `BatchExtractionService::extractNext()` throws `Batch not found or expired` (404) when `getBatch()` returns null.

## The design

Per ADR-022/ADR-083, consume OpenRegister's abstraction rather than requiring every small install to deploy a distributed cache.

- **New `BatchStateRepository`** — register `document`, schema `anonymizationBatch`. The batch UUID **is** the OpenRegister object UUID, so an update is an upsert with no secondary lookup. Verified against OpenRegister's source that `saveObject(uuid: …)` honours a caller-supplied UUID on create (`SaveObject::handleObjectCreation()` → `$objectEntity->setUuid($uuid)`), and falls through from the update branch to create when the identifier is unknown.
- **The OpenRegister handle is a constructor dependency** (`OpenRegisterAvailabilityService`), not a bare `$container->get()` — ADR-083 / gate-66.
- **`BatchStateService` keeps its public surface.** The cache is demoted to a read fast path with write-through; a miss *or* an undecodable entry falls through to the store. The ownership guard moved with the read so it still applies on the store-backed path.
- **A write with OpenRegister unavailable throws.** Returning the unsaved payload would look like a successful write to every caller and publish a batchId that resolves to nothing — the same silent loss, one layer up.
- **`find()` gets its own `catch (DoesNotExistException)`** — OpenRegister throws on a miss rather than returning null. Anything else propagates: "the store is unreachable" must not look like "no such batch".
- **No `findAll(['filters' => ['id' => …]])` anywhere** — that shape matches nothing, silently.

## Authorization after #631

#631 landed while this was in flight and is merged in here.

- `anonymizationBatch` declares an **explicit** `authorization` cascade. An **omitted** cascade is OPEN in OpenRegister, so shipping a new schema without one would have re-opened exactly the hole #631 closed — on a record that lists a user's private filenames. `read`/`update`/`delete` → `docudesk-policy-admins`; `create` → `authenticated`, matching `publicationConsent`.
- **The cascade cannot fail this persistence closed.** DocuDesk's own reads and writes pass `_rbac: false`, and `PermissionHandler::hasPermission()` returns `true` immediately on `_rbac === false` before any cascade is resolved (`lib/Service/.../PermissionHandler.php:331`). This is owner-independent — it is not relying on the owner bypass. It is also *required*: `docudesk-policy-admins` ships **empty**, so an ordinary user's own extraction run would fail closed at its first status write without it.
- **Register rows** were checked: all five docudesk register rows carry `authorization: null` on `development` — #631 fixed at the schema level deliberately, and this schema follows that shape.
- The `SchemaAuthorizationCoverageTest` tripwire from #631 caught the three new `_rbac: false` sites and the undocumented schema, exactly as designed. Both are now recorded in `docs/authorization-decisions.md` with the compensating control, and `RECORDED_BYPASSES` updated (22 sites / 9 files → 25 / 10).

## Deployment

`info.version` **7.9.0 → 7.10.0**, and the `document` register 2.4.0 → 2.5.0. `SettingsInitializer::initialize()` skips the import when the deployed `configuration_version` is `>=` the declared one, so a new schema without a bump reaches no existing install and every batch there keeps 404-ing.

## Verification

- **Positive control first.** With the store fallback in `readThrough()` replaced by `return null`, the new persistence tests fail with *"The batch was not found in the next request. That is the exact 404 the entity-review E2E spec reported"* — 4 failures, the same shape as CI. Restored, they pass. The `NullCacheFake` also asserts on itself (`set()` then `get()` must be null) so a fixture that quietly started storing fails loudly instead of making the class vacuous.
- **Fakes, not mocks.** A PHPUnit mock cannot observe named arguments — it reports its own defaults — so the store is a real in-memory `ObjectService` subclass and every assertion is on what was actually stored (register, schema, uuid, `_rbac`, payload).
- **Full unit suite: 1445 tests, 4307 assertions, 0 failures** (baseline before this change: 1419 / 4219). Same 2 deprecations and 2 skips as baseline. Run in `nextcloud:34.0.0-apache` (PHP 8.4) against the worktree.
- **phpcs 0 errors** over all of `lib/`; **phpmd 0**; **phpstan `[OK] No errors` over 244 files** (file count recorded — a zero-file run prints the same thing).
- **Live probe against real OpenRegister** on the shared dev instance produced a finding worth acting on, below.

## ⚠️ Finding: `hardValidation: false` does NOT disable validation

Measured on the dev instance: `saveObject()` against schemas declaring `hardValidation: false` still raised `ValidationException` for missing **required** properties and for an **enum** violation. Consequences for this schema, both handled:

- Every `status` value the code actually writes (`uploading`, `extracting`, `review`, `anonymizing`, `completed`) and the only `sourceType` written (`folder`) are in the declared enums — verified by grepping every `$batch['status'] = '…'` site.
- `userId.maxLength` raised 64 → 255, so an externally-provisioned long uid cannot fail the batch write closed.

This is a fragile coupling by nature: a future batch status added without touching the schema would break the write. Flagged rather than hidden.

## Not done

- **Psalm did not complete locally** (killed on the shutdown instruction). phpcs/phpmd/phpstan/PHPUnit all completed and are clean. CI covers psalm.
- **The E2E spec was not re-run locally.** The worktree is not the bind-mounted app path, and deploying it would have meant writing into the shared checkout. CI's E2E job is the verification for the end-to-end path.

Closes the E2E failure in run 31963162253.
