### PR TITLE
docs(openspec): change proposals for the AI-tooling and leaf-integration sweep

### DIFF
--- a/openspec/changes/hermiq-ai-tooling/.openspec.yaml
+++ b/openspec/changes/hermiq-ai-tooling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/hermiq-ai-tooling/design.md
+++ b/openspec/changes/hermiq-ai-tooling/design.md
@@ -1,0 +1,64 @@
+# Design — hermiq-ai-tooling
+
+Context: the fleet PO direction that every app action is in principle AI-automatable
+under per-agent, per-tool governance. Hermiq supplies the governance substrate — scope
+(`read/create/update/delete`) × reach (`self/user/instance/external`) grants
+(`agent-tool-governance`, `agent-capability-reach`), default-deny writes, the
+human-approval gate (`human-approval-gate`), audit — and the app supplies honest tools.
+DocuDesk at HEAD already has the plumbing: 16 derived read tools, four curated tools
+(`generateCorrespondence`, `readDocument`, `editDocument`, `convertDocumentToPdf`), the
+`mcp-generation-tools` change adding `getDocumentStatus` + `anonymizeDocument`, and the
+`DocudeskScannableServices` extension point built for exactly this kind of sibling
+change. decidesk's `lib/Mcp/` (gated meeting/action-item write tools behind
+`McpMeetingGate`) is the fleet reference for writes that only make sense gated.
+
+## Why these two writes, and no others
+
+The action inventory (from the controllers/services at HEAD) sorts into four buckets:
+
+| Bucket | Actions | Verdict |
+|--------|---------|---------|
+| Already covered | template/status/dossier/signing-status reads; generation; read/edit/convert; anonymisation intake | No change (ADR-063: never duplicate) |
+| **This change** | `SigningService::createRequest()`; `ConsentUpdateHandler::updateConsentStatus()` | The two human-initiated workflow writes with a governance story: additive or transition-validated, gate-presentable, audit-attributable |
+| Permanently refused | `sign()`, `decline()`, `bulkSign()`, `cancelRequest()`, verification, `generateBatch()` | Legal act / bulk personal-data primitive — no gate makes these safe to hand an agent |
+| Not worth a tool | dictionary CRUD, huisstijl/template authoring, GL bookkeeping | Governance artefacts or side-domain; derived write verbs stay off (bias to fewer) |
+
+`startSigningRequest` is the workflow spine: without it, "generate and send for signing"
+dead-ends after generation. It is safe *only* because the gate shows a human the resolved
+request before dispatch — the human approves the same facts the UI form would show
+(document, signers, level, deadline, provider). `cancelRequest()` stays refused even
+though it looks symmetric: cancelling a running signature process has legal-notice
+implications for signers already notified, and no chat workflow needs it.
+
+`recordConsentDecision` is deliberately shaped as a **keyhole**: write-only-by-id, no
+enumeration, result stripped to status fields. The `publicationConsent` schema stays OFF
+the derived surface (its exclusion in the adoption change is the hardest one in the app);
+the tool only lets an agent complete a transition a human names and approves. Transition
+validity is enforced by the same consent-flow rules as the UI, so the gate cannot be
+talked into an illegal state.
+
+## Narrowing a standing refusal honestly
+
+The adoption spec's "Signing is never agent-writable" said *no tool initiates, advances,
+cancels, or verifies*. This change MODIFIES that requirement rather than quietly adding
+an exception elsewhere — the delta rewrites the requirement so the spec stays the single
+place the boundary is defined. The narrowed line is: **initiation gated, the act never**.
+The reachability test (`testNoSigningServiceIsReachableByAnAgent`) is extended, not
+deleted: it now asserts that exactly one signing-domain method carries the attribute and
+that it is `createRequest()`.
+
+## Approval-gate mechanics
+
+DocuDesk does not build a gate. The tools declare honest write hints
+(`scope: create`/`update`, `readOnlyHint: false`); Hermiq's classifier routes them
+through the human-approval gate (hint-driven classification is load-bearing — hermiq #57
+fail-open lesson), and OR's tool-grant whitelist keeps them invisible until an admin
+grants them per agent. What DocuDesk *does* own: transition/validation parity with the
+UI paths, `mcp` attribution on the persisted records, and result-shape guarantees (no
+citizen data, no signature material). Reach for both tools is `user` — they act on
+records the invoking principal can already reach through the app, never cross-tenant.
+
+## Rollback
+
+Remove the two attributes and the two scannable-services entries; the tools disappear
+from the registry on the next scan. No config, schema, or route is touched.

--- a/openspec/changes/hermiq-ai-tooling/proposal.md
+++ b/openspec/changes/hermiq-ai-tooling/proposal.md
@@ -1,0 +1,100 @@
+---
+kind: code
+depends_on:
+  - docudesk-mcp-adoption
+  - mcp-generation-tools
+---
+
+# Proposal: hermiq-ai-tooling
+
+## Why
+
+The product line's direction is that **every app action is in principle
+AI-automatable**: an app exposes its actions as governed MCP tools, and Hermiq decides —
+per agent, per tool — what an agent may actually do, via its scope
+(`read/create/update/delete`) × reach (`self/user/instance/external`) grant model
+(hermiq `agent-tool-governance`, `agent-capability-reach`), default-deny for writes,
+human approval gates on consequential writes (hermiq `human-approval-gate`), and an
+audit trail on every invocation. Even before anyone automates anything, chat becomes a
+command surface for the app: "generate the contract from the template and send it for
+signing" should be one governed conversation, not five UI screens.
+
+DocuDesk's current surface stops half-way through that sentence. The adoption baseline
+(`docudesk-mcp-adoption`, complete) ships 16 derived read tools plus curated
+`generateCorrespondence`, and `mcp-generation-tools` (in flight) adds `getDocumentStatus`
+and `anonymizeDocument`. An agent can therefore *generate* the contract and *ask* whether
+it was signed — but the workflow's spine, actually starting the signing request, and its
+tail, recording the outcome of a consent conversation, have no tool at all. Both are real
+service actions today (`SigningService::createRequest()`,
+`ConsentUpdateHandler::updateConsentStatus()`), reachable only by hand in the UI.
+
+The adoption change refused signing wholesale, and for the right reason at the time: an
+*ungoverned* agent that could initiate signatures could bind the organisation. What has
+changed is the governance substrate — Hermiq's human-approval gate is now the fleet
+mechanism for exactly this class of write (decidesk's `lib/Mcp/` gated meeting/action
+tools are the working reference). This change therefore **narrows, not abandons** the
+refusal: the signing *act* (apply/advance/cancel/verify a signature) remains permanently
+agent-unreachable, while *initiating a request* becomes a curated, approval-gated write —
+a human still confirms the concrete document, signers, and signature level before
+anything is dispatched.
+
+## What Changes
+
+- **Add curated write tool `docudesk.startSigningRequest`**: `#[McpTool]` on
+  `SigningService::createRequest()` (`scope: 'create'`, `readOnlyHint: false`,
+  `destructiveHint: false`, `idempotentHint: false`). Declared **approval-required**: the
+  tool MUST only execute after Hermiq's human-approval gate has shown the resolved
+  request (document name, signers, signature level, deadline, provider) to a human and
+  received an explicit approval. No signer notification leaves the building on an
+  agent's own authority.
+- **Add curated write tool `docudesk.recordConsentDecision`**: `#[McpTool]` on the
+  consent status-update path (`ConsentUpdateHandler::updateConsentStatus()`), taking a
+  consent-record id the *user* supplies plus the new `consentStatus`. Approval-gated the
+  same way. The tool returns status fields only; it MUST NOT return `contactEmail`,
+  `contactAddress`, `entityText`, or `objectionReason`, and the `publicationConsent`
+  schema itself stays OFF the derived surface — this tool is a keyhole, not a window.
+- **Extend `lib/Mcp/DocudeskScannableServices.php`** with `SigningService::class` and the
+  consent service class (the existing extension point; no new provider mechanism).
+- **Modify the standing refusal** in the `docudesk-mcp-surface` spec: "Signing is never
+  agent-writable" is narrowed to "the signing act is never agent-performable" —
+  `sign()`, `decline()`, `bulkSign()`, `cancelRequest()`, verification, and the
+  signature-material schemas remain permanently refused; `createRequest()` alone is
+  exposed, approval-gated.
+- **Chat workflows this enables** (2 writes + existing reads):
+  1. "Generate the contract from the template and send it for signing" —
+     `generateCorrespondence` → `startSigningRequest` (one human approval on the resolved
+     request).
+  2. "The objector withdrew — record consent on that record" —
+     `recordConsentDecision` (human approves the concrete status transition).
+  3. "Has it been signed yet?" — `signingRequest.search` (already shipped, no gate).
+- CHANGELOG entry.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `docudesk-mcp-surface` — two approval-gated curated write tools are added through the
+  scannable-services extension path; the signing refusal is narrowed to the signing act;
+  all other standing refusals (no batch, no signature material, no consent/prohibition
+  enumeration, no derived write verbs) are restated and remain binding.
+
+### New Capabilities
+
+_None — this extends the surface the adoption change created, under its rules._
+
+## Impact
+
+- **Code:** `lib/Service/SigningService.php` (one attribute + import on
+  `createRequest()`; `sign`/`decline`/`bulkSign`/`cancelRequest` untouched and asserted
+  attribute-free), the consent status-update service (one attribute),
+  `lib/Mcp/DocudeskScannableServices.php` (two entries appended).
+- **Config:** none — no `x-openregister-mcp` block changes; no derived verb is enabled.
+- **Governance dependency:** the approval gate is enforced in Hermiq
+  (`human-approval-gate` spec) keyed on the tools' declared write scope; OR's tool-grant
+  whitelist stays default-deny. DocuDesk declares honest hints and refuses to implement
+  a parallel grant system (same posture as `mcp-generation-tools` REQ-DDMGT-005).
+- **Audit:** signing requests already persist initiator and audit entries via the signing
+  flow; agent-initiated ones MUST be attributable as `mcp` with the invoking principal,
+  mirroring the anonymisation-intake attribution contract.
+- **Data protection:** the consent tool is deliberately asymmetric — write-only-by-id,
+  no read — so the citizen-data exclusions of the adoption change are not weakened.

--- a/openspec/changes/hermiq-ai-tooling/specs/docudesk-mcp-surface/spec.md
+++ b/openspec/changes/hermiq-ai-tooling/specs/docudesk-mcp-surface/spec.md
@@ -1,0 +1,153 @@
+# docudesk-mcp-surface Specification (delta)
+
+Extends DocuDesk's agent-facing surface with two approval-gated curated write tools
+(`startSigningRequest`, `recordConsentDecision`) through the scannable-services extension
+path the adoption change declared, and narrows the signing refusal from "no signing tool
+of any kind" to "the signing act is never agent-performable". Every other standing
+refusal is restated and remains binding.
+
+## ADDED Requirements
+
+### Requirement: An approval-gated signing-request initiation tool exists (REQ-DDHAT-001)
+
+`SigningService::createRequest()` MUST carry `#[McpTool(name: 'startSigningRequest',
+scope: 'create', readOnlyHint: false, destructiveHint: false, idempotentHint: false)]`,
+and `DocudeskScannableServices` MUST include `SigningService::class`. The tool MUST be
+approval-required: Hermiq's human-approval gate MUST present the resolved request —
+document name, signer list, `signatureLevel`, `deadline`, `provider`, `signingMode` — to
+a human and receive explicit approval before the request is created or any signer is
+notified. Grants remain default-deny per agent in OpenRegister's tool-grant whitelist;
+DocuDesk MUST NOT implement a parallel grant or approval mechanism of its own.
+
+#### Scenario: Generate-and-send-for-signing is one governed conversation
+
+- GIVEN an agent asked to "generate the contract from the template and send it for signing"
+- WHEN it chains `docudesk.generateCorrespondence` and `docudesk.startSigningRequest`
+- THEN the signing request is created only after a human approves the resolved request in the gate
+- AND the created request carries the approved document, signers, and signature level unchanged
+- @e2e exclude agent-runtime tool invocation (approval gate lives in hermiq); covered by PHPUnit (tests/unit/Service/SigningServiceTest.php) + the MCP surface probe (tests/integration/Mcp/McpSurfaceTest.php)
+
+#### Scenario: No approval, no request
+
+- GIVEN an agent granted `startSigningRequest` whose approval is rejected or times out
+- WHEN the gate resolves without an approval
+- THEN no `signingRequest` object exists and no signer has been notified
+- @e2e exclude gate-refusal contract enforced in hermiq; covered by the hermiq human-approval-gate suite + the MCP surface probe
+
+#### Scenario: The tool's hints are complete and honest
+
+- GIVEN the registered tool `docudesk.startSigningRequest`
+- WHEN its annotation is inspected
+- THEN it reports `scope: create`, `readOnlyHint: false`, `destructiveHint: false`, `idempotentHint: false`
+- AND Hermiq classifies it as a write requiring approval
+- @e2e exclude registry-shape contract; covered by the MCP surface probe (tests/integration/Mcp/McpSurfaceTest.php)
+
+### Requirement: An approval-gated consent-decision tool exists (REQ-DDHAT-002)
+
+The consent status-update path (`ConsentUpdateHandler::updateConsentStatus()`) MUST carry
+`#[McpTool(name: 'recordConsentDecision', scope: 'update', readOnlyHint: false,
+destructiveHint: false, idempotentHint: true)]`, taking a caller-supplied consent-record
+id and a target `consentStatus`, and MUST be approval-required in the same way as
+REQ-DDHAT-001. The tool MUST enforce the same status-transition validity rules as the
+in-app consent flow. Its result MUST carry status fields only — it MUST NOT return
+`contactEmail`, `contactAddress`, `entityText`, `objectionReason`, or any other
+citizen-data property, and no search, list, or get over `publicationConsent` is added:
+the schema remains OFF the derived surface.
+
+#### Scenario: A withdrawal is recorded with human approval
+
+- GIVEN a caseworker telling the agent an objector withdrew, naming the consent record
+- WHEN `docudesk.recordConsentDecision` runs after gate approval
+- THEN the record's `consentStatus` reflects the approved transition
+- AND the tool result contains no contact details, entity text, or objection reason
+- @e2e exclude agent-runtime invocation; covered by PHPUnit (tests/unit/Service/ConsentUpdateHandlerTest.php) + the MCP surface probe
+
+#### Scenario: The keyhole is not a window
+
+- GIVEN an agent granted `recordConsentDecision`
+- WHEN it enumerates the DocuDesk tool surface
+- THEN no tool searches, lists, or gets `publicationConsent` objects
+- AND an invalid or inaccessible consent id yields a not-found result identical in shape to a nonexistent id
+- @e2e exclude access-contract; covered by PHPUnit mirroring the ConsentCrudService IDOR pattern
+
+#### Scenario: Invalid transitions are refused
+
+- GIVEN a consent record in a state from which the requested transition is invalid
+- WHEN the tool is invoked with that transition
+- THEN the invocation fails with the same validation error as the in-app flow
+- AND the record is unchanged
+- @e2e exclude validation contract; covered by PHPUnit (consent transition tests)
+
+### Requirement: Agent-initiated writes are attributable (REQ-DDHAT-003)
+
+Every invocation of `startSigningRequest` and `recordConsentDecision` MUST leave an
+attributable record distinguishing agent initiation from manual action: the persisted
+signing request and the consent update MUST carry an `mcp` attribution with the invoking
+principal, alongside the human approver recorded by the gate. Reads stay ungated and
+unchanged.
+
+#### Scenario: An agent-started signing request is attributable
+
+- GIVEN a signing request created through the tool
+- WHEN its audit records are inspected
+- THEN the initiation is attributed `mcp` with the invoking principal
+- AND the approving human is identifiable through the gate's record
+- @e2e exclude audit-attribution contract; covered by PHPUnit (signing audit tests)
+
+### Requirement: All other standing refusals remain binding (REQ-DDHAT-004)
+
+Beyond the narrowed signing refusal (see MODIFIED below), every refusal declared by
+`docudesk-mcp-adoption` and restated by `mcp-generation-tools` MUST hold across this
+extended surface: no batch or multi-recipient tool, no derived
+`create`/`update`/`delete` verb on any schema, no exposure of `signerRecord`,
+`signingSession`, `signingAuditEntry`, `publicationProhibition`, `anonymizationLink`,
+`financialExtraction`, `templateVersion`, or the GL schemas through any new tool's
+parameters or results, and no entity values or citizen contact data in any tool result.
+
+#### Scenario: The extended surface stays within the refusal lines
+
+- GIVEN the full DocuDesk tool surface after this change
+- WHEN it is enumerated
+- THEN it is exactly the derived read tools plus the curated tools (`generateCorrespondence`, `readDocument`, `editDocument`, `convertDocumentToPdf`, `getDocumentStatus`, `anonymizeDocument`, `startSigningRequest`, `recordConsentDecision`)
+- AND no tool name ends in `.create`, `.update` or `.delete`
+- AND no tool result carries citizen contact data, entity values, or signature material
+- @e2e exclude registry-shape contract; covered by the MCP surface probe (tests/integration/Mcp/McpSurfaceTest.php)
+
+## MODIFIED Requirements
+
+### Requirement: Signing is never agent-writable
+
+The signing **act** is never agent-performable. DocuDesk MUST NOT add `#[McpTool]` to
+`SigningService::sign()`, `SigningService::decline()`, `SigningService::bulkSign()`,
+`SigningService::cancelRequest()`, `SigningVerificationService`, `SigningAuditService`,
+`Service/Signing/SigningProviderInterface` or any of its implementations
+(`NativeSigningProvider`, `ValidSignProvider`), and the `signingRequest` schema MUST NOT
+enable a derived write verb. Applying, advancing, declining, cancelling, or verifying an
+electronic signature is an act with legal effect under eIDAS and MUST remain a deliberate
+human action. The signature-bearing schemas `signerRecord` (holds `signatureData` and the
+signer's `ipAddress`), `signingSession` (holds `signatures` and the signed-document path)
+and `signingAuditEntry` (holds the tamper-evident trail and actor IPs) MUST NOT be
+exposed at all — not even for reading.
+
+The sole permitted agent entry into the signing domain is
+`docudesk.startSigningRequest` (REQ-DDHAT-001): *initiating* a request, through the
+curated scannable-services path, gated on explicit human approval of the resolved
+request. No other signing method may ever be exposed, gated or not.
+
+#### Scenario: Only initiation exists, and only gated
+
+- **WHEN** an agent enumerates DocuDesk's tool surface
+- **THEN** `startSigningRequest` is the only signing-domain tool
+- **AND** no tool applies, advances, declines, cancels, or verifies a signature
+- @e2e exclude registry-shape contract; covered by the MCP surface probe (tests/integration/Mcp/McpSurfaceTest.php) and the no-signing-service reachability test (DocumentAgentServiceTest::testNoSigningServiceIsReachableByAnAgent, extended)
+
+#### Scenario: Signature material is unreadable
+
+- **WHEN** an agent tries to read a signer's `signatureData` or `ipAddress`
+- **THEN** no MCP tool exposes `signerRecord`, `signingSession` or `signingAuditEntry`
+
+#### Scenario: Signing status is still answerable
+
+- **WHEN** a user asks an agent whether a document has been signed yet
+- **THEN** `docudesk.signingRequest.search` answers from `status`, `signatureLevel`,
+  `provider` and `deadline` — the process metadata — without any signature material

--- a/openspec/changes/hermiq-ai-tooling/tasks.md
+++ b/openspec/changes/hermiq-ai-tooling/tasks.md
@@ -1,0 +1,56 @@
+# Tasks — hermiq-ai-tooling
+
+## 1. The signing-request initiation tool (code)
+
+- [ ] 1.1 Add `#[McpTool(name: 'startSigningRequest', scope: 'create', readOnlyHint:
+  false, destructiveHint: false, idempotentHint: false)]` to
+  `SigningService::createRequest()`; logic and signature unchanged.
+- [ ] 1.2 Append `SigningService::class` to
+  `DocudeskScannableServices::getScannableServiceClasses()`, updating the class docblock
+  that currently documents "nothing under `Service/Signing/`, no `SigningService`" to
+  state the narrowed boundary (initiation gated, the act never).
+- [ ] 1.3 Extend `DocumentAgentServiceTest::testNoSigningServiceIsReachableByAnAgent` to
+  assert exactly one signing-domain method carries `#[McpTool]` and that it is
+  `createRequest()` — `sign()`, `decline()`, `bulkSign()`, `cancelRequest()`,
+  `SigningVerificationService`, `SigningAuditService`, and everything under
+  `Service/Signing/` stay attribute-free.
+
+## 2. The consent-decision tool (code)
+
+- [ ] 2.1 Add `#[McpTool(name: 'recordConsentDecision', scope: 'update', readOnlyHint:
+  false, destructiveHint: false, idempotentHint: true)]` to the consent status-update
+  path (`ConsentUpdateHandler::updateConsentStatus()`), reusing the in-app transition
+  validation unchanged.
+- [ ] 2.2 Strip the tool's result to status fields — assert by unit test that
+  `contactEmail`, `contactAddress`, `entityText`, and `objectionReason` never appear in
+  a tool result, and that an inaccessible id yields a not-found identical in shape to a
+  nonexistent id.
+- [ ] 2.3 Append the consent service class to `DocudeskScannableServices`.
+
+## 3. Attribution and governance wiring
+
+- [ ] 3.1 Record `mcp` attribution with the invoking principal on agent-initiated signing
+  requests and consent updates (mirror the anonymisation-intake attribution contract).
+- [ ] 3.2 Verify in Hermiq's tool-governance grant editor that both tools classify as
+  approval-required writes (hint-driven; no DocuDesk-side gate code), and that an
+  ungranted agent does not see them.
+
+## 4. Verify
+
+- [ ] 4.1 MCP surface probe: the surface is exactly the derived read tools plus the eight
+  curated tools; no tool name ends in `.create`/`.update`/`.delete`; no tool exposes
+  `publicationConsent`, `signerRecord`, `signingSession`, or `signingAuditEntry`.
+- [ ] 4.2 Live chat walkthrough on the dev instance: "generate the contract from the
+  template and send it for signing" completes with exactly one human approval; rejecting
+  the approval leaves no `signingRequest` object and no notification.
+- [ ] 4.3 Scoped `composer check:strict` clean on touched files; zero new PHPUnit
+  failures vs a self-measured baseline.
+- [ ] 4.4 CHANGELOG entry.
+
+## Acceptance criteria
+
+- `startSigningRequest` and `recordConsentDecision` are discoverable, approval-gated,
+  attributable writes; the signing act and every other standing refusal remain
+  agent-unreachable.
+- The modified "Signing is never agent-writable" requirement matches the shipped code and
+  is asserted by the extended reachability test, not by a one-off grep.

--- a/openspec/changes/leaf-integrations/.openspec.yaml
+++ b/openspec/changes/leaf-integrations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/leaf-integrations/design.md
+++ b/openspec/changes/leaf-integrations/design.md
@@ -1,0 +1,65 @@
+# Design — leaf-integrations
+
+Context: the fleet leaf wave (ADR-019 registry, ADR-022 consume-don't-build). DocuDesk at
+HEAD declares no `linkedTypes` and no `mailObjectTemplate` on any of its 23 schemas
+(verified by grep over `lib/Settings/docudesk_register.json`) — this change is the app's
+first leaf adoption. Sibling changes already cover adjacent ground:
+`document-detail-leaf-widgets` (contacts/activity/shares on the generic document detail
+page) and `signer-consent-notifications-to-email-leaf` (outbound comms through the email
+leaf). This change is the remaining declarative surface: Mail linkage/intake, deadlines,
+signer contacts, pipeline files, and follow-up cards.
+
+## Mechanics
+
+- `configuration.linkedTypes` is validated by OR's `Schema::validateLinkedTypes()` and
+  read per leaf: `EmailService` selects "schemas that opt into mail linkage via
+  `linkedTypes: ["mail"]`" as Mail-sidebar link targets; the registry
+  (`IntegrationRegistry::getEnabled()`) drives the tab/widget render for the other leaf
+  ids. Provider ids verified in OR at HEAD: `email` (`EmailProvider`, requiredApp
+  `mail`), `calendar` (`CalendarProvider`), `contacts` (`ContactsProvider`), `files`
+  (builtin `FilesProvider`), `deck` (`DeckProvider`).
+- `configuration.mailObjectTemplate` is the Mail-sidebar create-object-from-email field
+  map (`Schema.php` §configuration docs); every key must be a real property name and
+  every value scalar, or the register import fails — the same fail-the-import discipline
+  as the MCP dialect's `search.filters`.
+- All declarations land directly in `docudesk_register.json` (this repo keeps a single
+  monolith register; there is no `register.d/` fragment mechanism here), with an
+  `info.version` bump so `SettingsInitializer` re-imports on existing installs — the
+  lesson recorded in `docudesk-mcp-adoption` task 1.5: without the bump the change is
+  inert on every installed instance.
+
+## Adoption table
+
+| Schema | Leaf(s) | Anchor / mapping | Why |
+|--------|---------|------------------|-----|
+| `signingRequest` | mail, calendar | `deadline` | "Has that contract been signed / when does it expire?" — expiry becomes visible where deadlines live; provider mail links to the request. |
+| `signerRecord` | contacts | `displayName`, `email` | A signer is a person; the contacts leaf is the standard person bridge (mirrors the archived consent-recipients contacts migration). |
+| `publicationConsent` | mail (+`mailObjectTemplate`), calendar, deck | `objectionDeadline`; sender→`contactEmail`, subject→`notes` | The Woo objection window is the app's most consequential deadline; objection traffic is email-borne; publication follow-ups need a task surface. |
+| `correspondence` | mail (+`mailObjectTemplate`) | subject→`caseReference` context | Letters relate to mail threads; inbound case mail can seed the register record. |
+| `generatedDocument` | files | `fileId` / `filePath` | The pipeline's output is an NC file; the files leaf is the standard surface for it. |
+| `dossier` | files, deck | linked source/produced files | Dossier review (`checkedOn`) and publication follow-up need files visibility and a card surface. |
+
+Deliberately not adopted here: `template` / `huisstijl` (governance artefacts, no leaf
+need), `batchCorrespondenceJob` (progress record, no per-object leaf value),
+`publicationProhibition` / `anonymizationLink` / signing-material schemas (their detail
+exposure is intentionally minimal; adding leaves would invite exactly the linkage those
+records exist to prevent), the GL side-domain, and Talk/Polls/Forms/Maps leaves (no
+DocuDesk workflow maps onto them — bias to fewer, ADR-063's rule 3 applied to leaves).
+
+## Privacy boundary
+
+The leaves are authenticated UI surfaces under DocuDesk's normal access control. They do
+not move any schema across the agent boundary: `signerRecord` and `publicationConsent`
+remain excluded from the MCP surface exactly as `docudesk-mcp-adoption` declares (both
+delta specs restate this as a requirement so the two surfaces cannot drift apart
+silently). The contacts leaf on `signerRecord` shows identity fields a caseworker already
+sees on the signer surface; it must never render `signatureData` or `ipAddress`.
+Create-from-email produces records in their initial state only — no decision, no status
+advance, no send — so Mail intake cannot short-circuit a consent or generation flow.
+
+## Degradation
+
+Every leaf hides when its NC app is absent (`requiredApp` per provider) and the record
+surface renders without error — the same graceful-degradation contract as
+`document-detail-leaf-widgets`. No leaf introduces a second write path for the fields it
+visualises; the register object stays canonical throughout.

--- a/openspec/changes/leaf-integrations/proposal.md
+++ b/openspec/changes/leaf-integrations/proposal.md
@@ -1,0 +1,101 @@
+# Proposal: leaf-integrations
+
+## Why
+
+OpenRegister ships app-agnostic integration leaves (mail, calendar, contacts, files, deck,
+and others) that any consuming app surfaces declaratively: `configuration.linkedTypes` on a
+schema makes its objects a leaf target (and, for `"mail"`, an NC Mail sidebar link target
+via `EmailService`), and `configuration.mailObjectTemplate` adds a create-object-from-email
+field map to the Mail sidebar. DocuDesk today declares **zero** `linkedTypes` and no
+`mailObjectTemplate` anywhere in `lib/Settings/docudesk_register.json` (verified at HEAD:
+no schema carries either key) — it operates on files through its own
+generation/anonymisation/signing pipeline, and its records are invisible to every standard
+leaf surface.
+
+That leaves real workflow gaps that per **ADR-022** (Apps Consume OpenRegister
+Abstractions) must be closed by *consuming* the leaves, not by app-local widgets:
+
+- A signing request has a `deadline` and a consent record has an `objectionDeadline` (the
+  Woo four-week objection window), but neither surfaces as a calendar item anywhere.
+- Signing-request and consent traffic arrives and leaves by email, but an NC Mail message
+  cannot be linked to the DocuDesk record it concerns, and a caseworker reading an
+  objection email cannot create the consent/correspondence record from it.
+- A signer (`signerRecord`) is a person, but has no bridge to NC Contacts.
+- The pipeline's outputs (`generatedDocument.fileId`, dossier source files) are NC files,
+  yet the dossier and generated-document detail pages have no standard files leaf.
+- Publication decisions produce follow-up work (notify, wait out the objection window,
+  publish/withhold) with no task surface; the deck leaf is the standard answer.
+
+## What
+
+Declare five leaf adoptions on existing schemas in `lib/Settings/docudesk_register.json` —
+configuration-only, no property or `required` change:
+
+1. **mail linkage** — `configuration.linkedTypes: ["mail"]` on `signingRequest`,
+   `correspondence`, and `publicationConsent`, so NC Mail's sidebar can link a message to
+   the signing request, the produced letter, or the consent record it concerns.
+2. **create-from-email** — `configuration.mailObjectTemplate` on `publicationConsent`
+   (objection email → consent record: subject/sender mapped to `notes`/`contactEmail`)
+   and on `correspondence` (inbound case mail → correspondence record: subject →
+   `caseReference` context, sender → `recipientId` context).
+3. **calendar leaf** — `linkedTypes: ["calendar"]` on `publicationConsent`
+   (`objectionDeadline`, the Woo objection window) and `signingRequest` (`deadline`,
+   signing-request expiry), so deadlines surface as leaf calendar items on the record.
+4. **contacts leaf** — `linkedTypes: ["contacts"]` on `signerRecord`, bridging signers to
+   NC Contacts on the signer surface (mirrors the consent-recipients contacts-leaf
+   migration already archived).
+5. **files + deck leaves** — `linkedTypes: ["files"]` on `dossier` and
+   `generatedDocument` (linking the pipeline's file outputs into the standard leaf
+   surface on their detail pages), and `linkedTypes: ["deck"]` on `dossier` and
+   `publicationConsent` (publication follow-up cards).
+
+All leaves render through the integration registry tab/widget mechanism (ADR-019) on the
+existing detail surfaces; no bespoke sidebar-tab or widget system is introduced.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `document-signing`: `signingRequest` becomes a mail link target and a calendar leaf
+  host (deadline); `signerRecord` hosts the contacts leaf.
+- `publication-consent`: `publicationConsent` becomes a mail link target with a
+  create-from-email template, a calendar leaf host (`objectionDeadline`), and a deck leaf
+  host for publication follow-ups.
+- `document-register`: `correspondence` becomes a mail link target with a
+  create-from-email template; `generatedDocument` and `dossier` host the files leaf;
+  `dossier` hosts the deck leaf.
+
+## Affected Projects
+
+- [x] Project: `docudesk` — all implementation work is in this repo (register JSON +
+  detail-surface leaf hosting)
+- Reference: `openregister/openspec/specs/integration-email/`,
+  `integration-calendar/`, `integration-contacts/`, `integration-deck/`,
+  `integration-leaf-foundation/` (the leaves consumed)
+- Reference: `hydra/openspec/architecture/adr-022-apps-consume-or-abstractions.md`,
+  `adr-019-*` (registry mechanism)
+
+## Out of Scope
+
+- The contacts / activity / shares leaves on the generic document detail page — covered by
+  `document-detail-leaf-widgets`.
+- Routing outbound signer/consent notifications through the email-leaf comms surface —
+  covered by `signer-consent-notifications-to-email-leaf` (that change is the *outbound*
+  comms path; this change is the Mail-sidebar *linkage and intake* direction).
+- Any MCP exposure. The leaves are authenticated UI surfaces under DocuDesk's normal RBAC;
+  they do not alter the `docudesk-mcp-adoption` exclusions (`signerRecord` and
+  `publicationConsent` remain OFF for agents — see design.md §Privacy boundary).
+- Modifying any OR leaf or the integration registry (consumed, not changed).
+
+## Success Criteria
+
+- `openspec validate --strict leaf-integrations` exits 0.
+- `docudesk_register.json` imports cleanly (linkedTypes/mailObjectTemplate validation in
+  OR's `Schema` passes) with all declared blocks present and no other schema touched.
+- NC Mail's sidebar offers signingRequest / correspondence / publicationConsent as link
+  targets and offers create-from-email for consent and correspondence records.
+- Deadline calendar items, signer contacts, files, and deck leaves render on their record
+  detail surfaces via the registry when the corresponding NC apps are installed, and each
+  leaf is hidden without error when its app is absent.
+- DocuDesk's in-app pipeline surfaces (generation, anonymisation, eIDAS signing) are
+  untouched.

--- a/openspec/changes/leaf-integrations/specs/document-register/spec.md
+++ b/openspec/changes/leaf-integrations/specs/document-register/spec.md
@@ -1,0 +1,91 @@
+# document-register Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Surface the standard OR leaves on the register's production records: NC Mail linkage plus
+a create-from-email template on `correspondence`, the files leaf on `generatedDocument`
+and `dossier` (linking the pipeline's file outputs into the standard leaf surface), and
+the deck leaf on `dossier`. Consumes `integration-email`, the OR files leaf, and
+`integration-deck` via the registry (ADR-019, ADR-022).
+
+## ADDED Requirements
+
+### Requirement: Correspondence Is A Mail Link Target With Create-From-Email
+
+The `correspondence` schema SHALL declare `configuration.linkedTypes` containing `"mail"`
+and a `configuration.mailObjectTemplate` field map, so that a produced letter's related
+NC Mail traffic can be linked to the correspondence record, and an inbound case email can
+create a correspondence record with the subject pre-filling `caseReference` context.
+Every key in the `mailObjectTemplate` map SHALL name a real `correspondence` property.
+Creation from email SHALL create the register record only — it SHALL NOT trigger
+generation, rendering, or any send.
+
+#### Scenario: Inbound case mail becomes a correspondence record
+
+- GIVEN an inbound email about case "Z-2026-114" in NC Mail
+- WHEN the caseworker uses the create-from-email action targeting `correspondence`
+- THEN a correspondence record SHALL be created with the mapped fields pre-filled
+- AND no document SHALL be generated and no message SHALL be sent by the action
+
+#### Scenario: Linking mail leaves the audit record intact
+
+- GIVEN an existing correspondence record with `status` "generated"
+- WHEN a related NC Mail message is linked to it from the Mail sidebar
+- THEN the message SHALL appear on the record's leaf surface
+- AND `status`, `templateId`, `generatedAt`, and `generatedBy` SHALL be unchanged
+
+### Requirement: Pipeline File Outputs Surface Through The Files Leaf
+
+The `generatedDocument` and `dossier` schemas SHALL declare
+`configuration.linkedTypes` containing `"files"`, so the standard files leaf renders on
+their detail surfaces and the pipeline's outputs (the `fileId`/`filePath` a generation
+produced; a dossier's source and produced files) are reachable through the leaf rather
+than through bespoke file widgets. The leaf SHALL be a linking/visibility surface: it
+SHALL NOT become a second write path for `fileId`/`filePath`, and DocuDesk's in-app
+generation, anonymisation, and signing pipeline surfaces SHALL remain untouched.
+
+#### Scenario: A generated document's file is reachable from its record
+
+- GIVEN a `generatedDocument` with `status` "completed" and a `fileId`
+- WHEN the caseworker opens the record's detail surface
+- THEN the files leaf SHALL be rendered with the produced file linked
+- AND opening the file SHALL go through NC Files under normal file ACLs
+
+#### Scenario: Dossier files are linked on the dossier record
+
+- GIVEN a dossier with linked source documents
+- WHEN the dossier detail surface renders
+- THEN the files leaf SHALL be present and list the linked files
+- AND the app-owned dossier surfaces SHALL remain present and unchanged
+
+### Requirement: Dossier Follow-Ups Use The Deck Leaf
+
+The `dossier` schema SHALL declare `configuration.linkedTypes` containing `"deck"`, so
+dossier-level publication follow-up work is tracked as linked Deck cards through the leaf
+instead of an app-local task system. Card state SHALL NOT drive any dossier field.
+
+#### Scenario: Follow-up card on a dossier
+
+- GIVEN a dossier awaiting its periodic `checkedOn` review
+- WHEN a review card is created via the deck leaf
+- THEN the card SHALL be linked to the dossier and visible on its leaf surface
+- AND `bases` and `checkedOn` SHALL be unchanged until a human edits them in-app
+
+### Requirement: Leaf Declarations Are Configuration-Only And Import Cleanly
+
+This delta SHALL change only `configuration` blocks (`linkedTypes`,
+`mailObjectTemplate`) on the named schemas in `lib/Settings/docudesk_register.json`
+(with an `info.version` bump so existing installs re-import). No schema property, no
+`required` list, and no other schema SHALL be touched, and the register SHALL import
+into OpenRegister with zero configuration-validation errors.
+
+#### Scenario: Register imports cleanly with the leaf declarations
+
+- GIVEN the updated `docudesk_register.json`
+- WHEN it is imported into OpenRegister
+- THEN `linkedTypes` and `mailObjectTemplate` validation SHALL pass with zero errors
+- AND every schema not named by this delta SHALL be byte-identical to before

--- a/openspec/changes/leaf-integrations/specs/document-signing/spec.md
+++ b/openspec/changes/leaf-integrations/specs/document-signing/spec.md
@@ -1,0 +1,76 @@
+# document-signing Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Surface the standard OR leaves on the signing records: NC Mail linkage and the calendar
+deadline leaf on `signingRequest`, and the contacts leaf on `signerRecord`. Consumes the
+`integration-email`, `integration-calendar`, and `integration-contacts` leaves via the
+registry (ADR-019, ADR-022); changes no signing behaviour.
+
+## ADDED Requirements
+
+### Requirement: Signing Request Is A Mail Link Target
+
+The `signingRequest` schema SHALL declare `configuration.linkedTypes` containing `"mail"`,
+so that OR's `EmailService` offers signing requests as link targets in the NC Mail sidebar
+and linked messages surface on the signing-request record. The linkage SHALL be link-only:
+NC Mail owns compose/send, and linking a message SHALL NOT create, advance, or cancel any
+signing state.
+
+#### Scenario: A provider email is linked to its signing request
+
+- GIVEN a signing request for "contract-2026-114.pdf" and a related message in NC Mail
+- WHEN the user links the message to the signing request from the Mail sidebar
+- THEN the message SHALL appear on the signing request's comms/leaf surface
+- AND the signing request's `status`, `signerIds`, and `deadline` SHALL be unchanged
+
+#### Scenario: Mail app absent
+
+- GIVEN a host instance without NC Mail
+- WHEN the signing-request detail surface renders
+- THEN the mail leaf SHALL NOT be present and the page SHALL render without error
+
+### Requirement: Signing Deadline Surfaces On The Calendar Leaf
+
+The `signingRequest` schema SHALL declare `configuration.linkedTypes` containing
+`"calendar"`, so the calendar leaf renders on the signing-request record and the request's
+`deadline` is visible as its temporal anchor. The `signingRequest` object SHALL remain the
+canonical store of the deadline; the leaf SHALL NOT introduce a second write path for it.
+
+#### Scenario: An expiring request is visible as a deadline
+
+- GIVEN a signing request with `deadline` 2026-09-01 and `status` "pending"
+- WHEN the initiator opens the signing-request record
+- THEN the calendar leaf SHALL be rendered with the request's deadline visible
+
+#### Scenario: A request without a deadline renders no calendar entry
+
+- GIVEN a signing request with no `deadline` set
+- WHEN its record surface renders
+- THEN the calendar leaf SHALL render without an entry for that object and SHALL NOT error
+
+### Requirement: Signers Bridge To NC Contacts Via The Contacts Leaf
+
+The `signerRecord` schema SHALL declare `configuration.linkedTypes` containing
+`"contacts"`, so the contacts leaf renders on the signer surface and a signer can be
+linked to (or looked up as) an NC Contacts entry. This is an authenticated UI surface
+under DocuDesk's normal access control; it SHALL NOT expose `signatureData` or
+`ipAddress` through the leaf, and it SHALL NOT alter the MCP exclusion of `signerRecord`
+declared by `docudesk-mcp-adoption`.
+
+#### Scenario: A signer is linked to a contact
+
+- GIVEN a signer record with `displayName` "J. de Vries" and `email` set
+- WHEN the caseworker uses the contacts leaf on the signer surface
+- THEN the signer SHALL be linkable to the matching NC Contacts entry
+- AND the leaf SHALL show contact identity fields only — never `signatureData` or `ipAddress`
+
+#### Scenario: Contacts leaf does not widen the agent surface
+
+- GIVEN the contacts leaf enabled on `signerRecord`
+- WHEN an agent enumerates DocuDesk's MCP tool surface
+- THEN no tool exposes `signerRecord` (the `docudesk-mcp-adoption` exclusion still holds)

--- a/openspec/changes/leaf-integrations/specs/publication-consent/spec.md
+++ b/openspec/changes/leaf-integrations/specs/publication-consent/spec.md
@@ -1,0 +1,97 @@
+# publication-consent Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Surface the standard OR leaves on the consent record: NC Mail linkage plus a
+create-from-email template, the calendar leaf for the Woo objection window
+(`objectionDeadline`), and the deck leaf for publication follow-ups. Consumes
+`integration-email`, `integration-calendar`, and `integration-deck` via the registry
+(ADR-019, ADR-022); consent semantics and statuses are unchanged.
+
+## ADDED Requirements
+
+### Requirement: Consent Records Are A Mail Link Target With Create-From-Email
+
+The `publicationConsent` schema SHALL declare `configuration.linkedTypes` containing
+`"mail"` and a `configuration.mailObjectTemplate` field map, so that from the NC Mail
+sidebar a caseworker can (a) link an objection or consent email to the existing consent
+record it concerns, and (b) create a new consent record from an email, with the message's
+sender address pre-filling `contactEmail` and the subject pre-filling `notes`. Every key
+in the `mailObjectTemplate` map SHALL name a real `publicationConsent` property (OR's
+`Schema` configuration validation rejects the import otherwise). Creation from email
+SHALL produce a record in the normal initial consent state; it SHALL NOT set a
+`publicationDecision` or advance `consentStatus` by itself.
+
+#### Scenario: Objection email becomes a consent record
+
+- GIVEN an inbound objection email in NC Mail from "burger@example.org"
+- WHEN the caseworker uses the create-from-email action targeting `publicationConsent`
+- THEN a new consent record SHALL be created with `contactEmail` pre-filled from the sender
+- AND the record SHALL carry the normal initial status, with no publication decision taken
+
+#### Scenario: Objection email linked to an existing record
+
+- GIVEN an existing consent record and a follow-up email about the same entity
+- WHEN the caseworker links the message from the Mail sidebar
+- THEN the message SHALL appear on the consent record's leaf surface
+- AND `consentStatus`, `objectionDeadline`, and `publicationDecision` SHALL be unchanged
+
+### Requirement: The Objection Window Surfaces On The Calendar Leaf
+
+The `publicationConsent` schema SHALL declare `configuration.linkedTypes` containing
+`"calendar"`, so the calendar leaf renders on the consent record and the record's
+`objectionDeadline` — the Woo four-week objection window — is visible as its temporal
+anchor. The consent object SHALL remain the canonical store of the deadline; the leaf
+SHALL NOT introduce a second write path for it, and passing the deadline SHALL NOT be
+acted on by the leaf (decision flows stay in-app).
+
+#### Scenario: The objection deadline is visible on the record
+
+- GIVEN a consent record with `objectionDeadline` four weeks after notification
+- WHEN the caseworker opens the consent record
+- THEN the calendar leaf SHALL be rendered with the objection deadline visible
+
+#### Scenario: No deadline, no entry
+
+- GIVEN a consent record without an `objectionDeadline`
+- WHEN its record surface renders
+- THEN the calendar leaf SHALL render without an entry and SHALL NOT error
+
+### Requirement: Publication Follow-Ups Use The Deck Leaf
+
+The `publicationConsent` schema SHALL declare `configuration.linkedTypes` containing
+`"deck"`, so publication follow-up work (send notification, await objection window,
+publish or withhold) can be tracked as Deck cards linked to the consent record through
+the leaf, instead of an app-local task widget. Deck cards SHALL be follow-up tracking
+only: completing or moving a card SHALL NOT change `consentStatus` or
+`publicationDecision`.
+
+#### Scenario: A follow-up card is created from the consent record
+
+- GIVEN a consent record whose objection window is running
+- WHEN the caseworker creates a "publish after 2026-09-12" card via the deck leaf
+- THEN the card SHALL be linked to the consent record and visible on its leaf surface
+- AND the consent record's own status fields SHALL be unchanged
+
+#### Scenario: Deck absent
+
+- GIVEN a host instance without the Deck app
+- WHEN the consent record surface renders
+- THEN the deck leaf SHALL NOT be present and the page SHALL render without error
+
+### Requirement: Consent Leaves Do Not Widen The Agent Surface
+
+Enabling mail, calendar, and deck leaves on `publicationConsent` SHALL NOT expose the
+schema through MCP: the `docudesk-mcp-adoption` exclusion of `publicationConsent`
+(citizen contact details and objection reasons) SHALL continue to hold, and no leaf
+SHALL be reachable through an agent tool.
+
+#### Scenario: Agent still cannot enumerate consent records
+
+- GIVEN the leaves of this delta enabled on `publicationConsent`
+- WHEN an agent enumerates DocuDesk's MCP tool surface
+- THEN no tool exposes `publicationConsent`

--- a/openspec/changes/leaf-integrations/tasks.md
+++ b/openspec/changes/leaf-integrations/tasks.md
@@ -1,0 +1,50 @@
+# Tasks — leaf-integrations
+
+## 1. Declare the leaves (config)
+
+- [ ] 1.1 Add `configuration.linkedTypes` to `signingRequest` (`["mail","calendar"]`),
+  `signerRecord` (`["contacts"]`), `publicationConsent` (`["mail","calendar","deck"]`),
+  `correspondence` (`["mail"]`), `generatedDocument` (`["files"]`), and `dossier`
+  (`["files","deck"]`) in `lib/Settings/docudesk_register.json`. No other schema gets a
+  block; no property or `required` list changes.
+- [ ] 1.2 Add `configuration.mailObjectTemplate` to `publicationConsent` (sender →
+  `contactEmail`, subject → `notes`) and `correspondence` (subject-derived
+  `caseReference` context), cross-checking every template key against that schema's
+  `properties` map (an unknown key fails the whole register import).
+- [ ] 1.3 Bump `info.version` so `SettingsInitializer` re-imports on existing installs
+  (the dialect-without-bump trap recorded in `docudesk-mcp-adoption` task 1.5).
+- [ ] 1.4 Validate: JSON parses with a duplicate-key-rejecting loader; schema count
+  unchanged; every schema not named in 1.1/1.2 byte-identical.
+
+## 2. Host the leaves on the record surfaces (frontend)
+
+- [ ] 2.1 Ensure the signing-request, consent, correspondence, generated-document, and
+  dossier detail surfaces mount the registry's enabled leaf tabs/widgets for their object
+  (shared registry tab host per ADR-019) — reusing the host wiring from
+  `document-detail-leaf-widgets`, not a parallel tab system.
+- [ ] 2.2 Graceful degradation: with Mail / Calendar / Contacts / Deck absent, the
+  corresponding leaf is hidden and each surface renders without error.
+- [ ] 2.3 nl + en translations for any new tab labels (ADR-007 / ADR-025).
+
+## 3. Verify
+
+- [ ] 3.1 Import the register into OpenRegister on the dev instance: zero
+  configuration-validation errors; NC Mail's sidebar lists the three link-target schemas
+  and offers create-from-email for consent and correspondence.
+- [ ] 3.2 Create-from-email produces records in their initial state only — assert no
+  `publicationDecision`, no `consentStatus` advance, no generation, no send.
+- [ ] 3.3 Assert the MCP surface is unchanged by this change: no tool exposes
+  `signerRecord` or `publicationConsent` after the leaves are enabled (extend the MCP
+  surface probe assertion rather than a one-off grep).
+- [ ] 3.4 Component/integration tests: leaves render when their apps are enabled, hidden
+  when absent; no second write path for `deadline` / `objectionDeadline` / `fileId`.
+- [ ] 3.5 CHANGELOG entry.
+
+## Acceptance criteria
+
+- Six schemas carry the declared `linkedTypes` (two also `mailObjectTemplate`); no other
+  schema is touched; the register imports cleanly on an existing install.
+- Mail linkage, calendar deadlines, signer contacts, pipeline files, and follow-up deck
+  cards all render through the registry on their record surfaces, and every leaf degrades
+  gracefully.
+- The agent-facing MCP surface is byte-for-byte unchanged.


### PR DESCRIPTION
OpenSpec change proposals — **artifacts only**. Every task box is unticked; nothing is wired to anything yet, and each change gets picked up by `/opsx-apply` when it is scheduled.

Opened because these were sitting **untracked in the shared dev checkout across the fleet**. An untracked directory is one file-sweep away from being swept into an unrelated commit, and one branch switch away from being gone. These carry the design reasoning, not just a title.
