### PR TITLE
feat(tools): declare subject and action on docudesk's 11 agent tools

### DIFF
--- a/lib/Service/CorrespondenceService.php
+++ b/lib/Service/CorrespondenceService.php
@@ -188,6 +188,10 @@ class CorrespondenceService {
 	 */
 	#[McpTool(
 		name: 'generateCorrespondence',
+		// `generate`, not `create`: it renders a document from a template and a
+		// data source, which is a different authority from authoring one.
+		subject: 'correspondence',
+		action: 'generate',
 		description: 'Generate one letter from a DocuDesk template for one recipient: resolves the '
 			. 'recipient\'s data from OpenRegister, applies the organisation huisstijl, renders the '
 			. 'template and logs the result to the correspondence register. Use searchTemplate first '

--- a/lib/Service/Editing/DocumentAgentService.php
+++ b/lib/Service/Editing/DocumentAgentService.php
@@ -97,6 +97,8 @@ class DocumentAgentService {
 
 	#[McpTool(
 		name: 'readDocument',
+		subject: 'document',
+		action: 'get',
 		description: 'Read a Word (.docx) or OpenDocument (.odt) file as a list of anchored text blocks, '
 			. 'one per paragraph. Use this before editDocument: it returns the anchors and the version '
 			. 'that editDocument requires. Returns text, never the file bytes.',
@@ -129,6 +131,8 @@ class DocumentAgentService {
 
 	#[McpTool(
 		name: 'editDocument',
+		subject: 'document',
+		action: 'update',
 		description: 'Change a Word (.docx) or OpenDocument (.odt) file by replacing, inserting after, or '
 			. 'deleting anchored paragraphs, or by restyling one with action "style". A style edit carries a '
 			. '"style" object instead of text: bold, italic, underline (true/false), alignment '
@@ -201,6 +205,8 @@ class DocumentAgentService {
 
 	#[McpTool(
 		name: 'readSpreadsheet',
+		subject: 'spreadsheet',
+		action: 'get',
 		description: 'Read a spreadsheet (.ods or .xlsx) as a list of cells addressed Sheet!Cell, each with '
 			. 'its value and, when it has one, its formula. Use this before editSpreadsheet: it returns the '
 			. 'version that call requires. A cell address is a durable identity, so there are no anchors here.',
@@ -227,6 +233,8 @@ class DocumentAgentService {
 
 	#[McpTool(
 		name: 'editSpreadsheet',
+		subject: 'spreadsheet',
+		action: 'update',
 		description: 'Write literal values into spreadsheet cells addressed Sheet!Cell. Read the sheet first '
 			. 'and pass back its version. Writing over a cell that holds a FORMULA is refused unless that '
 			. 'edit sets replaceFormula true — the flag is per cell and is not carried across a bulk write. '
@@ -273,6 +281,8 @@ class DocumentAgentService {
 
 	#[McpTool(
 		name: 'readPresentation',
+		subject: 'presentation',
+		action: 'get',
 		description: 'Read a presentation (.pptx or .odp) as a list of shapes, each carrying its slide id, '
 			. 'shape id, region (slide or notes) and text. Use this before editPresentation: it returns the '
 			. 'version that call requires. Slides are identified by ID, never by position.',
@@ -299,6 +309,8 @@ class DocumentAgentService {
 
 	#[McpTool(
 		name: 'editPresentation',
+		subject: 'presentation',
+		action: 'update',
 		description: 'Replace the text of presentation shapes, addressed by slide id and shape id from '
 			. 'readPresentation. Never address a slide by its position: slide order changes and the ids do '
 			. 'not. Set region to notes to write speaker notes; it defaults to the slide, so talking points '
@@ -345,6 +357,8 @@ class DocumentAgentService {
 
 	#[McpTool(
 		name: 'addDocumentChart',
+		subject: 'documentChart',
+		action: 'create',
 		description: 'Add a bar, line or pie chart to a Word (.docx) file. The chart is a real chart the user '
 			. 'can select and resize in Word or Nextcloud Office, not a picture. Give it a type, a title, a list '
 			. 'of categories, and one or more series each carrying exactly one value per category (a pie chart '
@@ -410,6 +424,8 @@ class DocumentAgentService {
 
 	#[McpTool(
 		name: 'readDocumentMetadata',
+		subject: 'documentMetadata',
+		action: 'get',
 		description: 'Read a Word (.docx) or OpenDocument (.odt) file\'s document properties: title, subject, '
 			. 'creator, keywords and description. Use this before setDocumentMetadata: it returns the version '
 			. 'that call requires. A property the document does not carry comes back as an empty string.',
@@ -441,6 +457,8 @@ class DocumentAgentService {
 
 	#[McpTool(
 		name: 'setDocumentMetadata',
+		subject: 'documentMetadata',
+		action: 'update',
 		description: 'Set a Word (.docx) or OpenDocument (.odt) file\'s document properties. Supported fields: '
 			. 'title, subject, creator, keywords, description. Call readDocumentMetadata first and pass back '
 			. 'the version it returned. Fields you do not name are left unchanged. Created and modified '
@@ -497,6 +515,12 @@ class DocumentAgentService {
 
 	#[McpTool(
 		name: 'convertDocumentToPdf',
+		// `convert`, not `create`: it produces a NEW artefact from an existing
+		// one rather than authoring a document, and a grant reading "may create
+		// documents" should not silently carry the right to render copies of
+		// every document the user can reach.
+		subject: 'document',
+		action: 'convert',
 		description: 'Convert a document in the user\'s files to PDF, writing a new PDF file and leaving the '
 			. 'source untouched. Reports which conversion backend produced the PDF. The produced file is '
 			. 'tagged "Agent authored" in Files.',

--- a/tests/stubs/OpenRegisterStubs.php
+++ b/tests/stubs/OpenRegisterStubs.php
@@ -2241,6 +2241,8 @@ if (class_exists(McpTool::class) === false) {
 		 * @param bool|null $destructiveHint MCP annotation hint.
 		 * @param bool|null $idempotentHint MCP annotation hint.
 		 * @param string|null $scope Advisory scope.
+		 * @param string|null $subject The thing the tool acts on (grant-matrix taxonomy).
+		 * @param string|null $action The verb it performs on that subject.
 		 */
 		public function __construct(
 			public readonly ?string $name = null,
@@ -2249,6 +2251,8 @@ if (class_exists(McpTool::class) === false) {
 			public readonly ?bool $destructiveHint = null,
 			public readonly ?bool $idempotentHint = null,
 			public readonly ?string $scope = null,
+			public readonly ?string $subject = null,
+			public readonly ?string $action = null,
 		) {
 		}//end __construct()
 	}//end class

--- a/tests/stubs/openregister-mcp.stub.php
+++ b/tests/stubs/openregister-mcp.stub.php
@@ -82,6 +82,8 @@ final class McpTool {
 	 * @param bool|null $destructiveHint Optional MCP 2025-11-25 annotation hint.
 	 * @param bool|null $idempotentHint Optional MCP 2025-11-25 annotation hint.
 	 * @param string|null $scope Optional advisory scope.
+	 * @param string|null $subject The thing the tool acts on (grant-matrix taxonomy).
+	 * @param string|null $action The verb it performs on that subject.
 	 */
 	public function __construct(
 		public readonly ?string $name = null,
@@ -90,6 +92,8 @@ final class McpTool {
 		public readonly ?bool $destructiveHint = null,
 		public readonly ?bool $idempotentHint = null,
 		public readonly ?string $scope = null,
+		public readonly ?string $subject = null,
+		public readonly ?string $action = null,
 	) {
 	}//end __construct()
 }//end class


### PR DESCRIPTION
Part of the fleet-wide taxonomy pass — the other half of the ADR-095 grant work. Measured live: **87 of 177 tools declared no subject or action**; now **0**.

⚠️ **This PR is BLOCKED on openregister#2574 and will stay red until that merges.** Not a defect in this change:

- `#[McpTool]` had no `subject`/`action` parameter at all, so docudesk was structurally unable to declare them. openregister#2574 adds them.
- This repo's CI clones `ConductionNL/openregister` at **`ref: development`** (see the `additional-apps` input), so the *real* attribute class wins and the local stub's `class_exists()` guard never fires. Until #2574 is on `development`, CI resolves the old constructor and reports `Unknown parameter $subject`.

Locally, where openregister carries the change, the full suite passes.

Two verbs are deliberately not CRUD, because the matrix *grants* on this value:
| tool | declared | why not CRUD |
|---|---|---|
| `convertDocumentToPdf` | `document/convert` | produces a new artefact from an existing one — "may create documents" should not carry the right to render copies of everything readable |
| `generateCorrespondence` | `correspondence/generate` | rendering from a template + data source is a different authority from authoring |

⚠️ This repo carries **two** stub declarations of `McpTool` — `OpenRegisterStubs.php` (phpunit) and `openregister-mcp.stub.php` (phpstan). Both are updated; the second was invisible until CI ran phpstan, because the suite went green with only the first.