### PR TITLE
chore(deps): take @conduction/nextcloud-vue 2.8.2 (was 2.3.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2137,9 +2137,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.3.0.tgz",
-      "integrity": "sha512-jwQJ5gqcUfWbKMCXUNO8BteRD4yakLVEAIx6Qd+2+BLZaiENLUFDYVnHxARef9AyZmvBAOxQCVHC3Fk8jgDBOA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.8.2.tgz",
+      "integrity": "sha512-kqzqQ2uFyzpHUL6VxzNsfJ5iDOsy/S1iQ9UVn7W0w3CdlVb4RxWz5AFym/onB1eKewF2WtF+9vzBM5CHWsaHTQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",


### PR DESCRIPTION
Lockfile-only bump of `@conduction/nextcloud-vue` to **2.8.2**. The existing caret already allowed it — as with hydra-gates, it was the *lockfile* doing the pinning, not the constraint. Three-line diff: version, resolved, integrity.

Two user-visible defects are fixed by it.

## 1. Two AI-companion hexes on every page

The companion singleton landed in **2.7.0**. Below that, the host app's own companion never stands down, so hermiq's page-wide companion renders alongside it. Measured on a running instance this morning:

| page | nc-vue | `.cn-ai-floating-button` |
|---|---|---|
| `/apps/openconnector/` | 2.7.1 | **1** |
| `/apps/openbuild/` | 2.6.3 | **2**, both visible at 52×60, 8 px apart |

They are two *separate mounts*, not one duplicated:

```
button → div.cn-ai-companion → div#content-vue.app-openbuild   ← host app's bundle
button → div.cn-ai-companion → div#hermiq-companion-root       ← hermiq's init script
```

`window.__cnAiCompanionPrimary` was claimed and both still rendered `display:flex / visible / opacity:1`, well past the 1200 ms `LEGACY_SIBLING_DELAY` — the negotiation works between two 2.7.x instances and fails when the host copy predates it.

## 2. The detail page reclosed its own sidebar while hydrating

`CnDetailPage.syncSidebarState()` documented the rule — *"Seed `open` only on the inactive→active edge … Subsequent syncs must NOT clobber it"* — but set `sidebarSeeded` and **never read it**, so `open` was re-applied on every sync. A detail page emits several while it hydrates, and each reset `open` to the prop default of `false`.

Fixed in ConductionNL/nextcloud-vue#711, with three regression tests written against the unfixed component first (the key one failed: expected `true`, received `false`). Full library suite after the fix: **535 suites, 6408 tests, all passing**.

That is the cause behind ConductionNL/openbuild#268 (`.ob-icon-section` "resolves 30×, hidden") and, on the same signature, #188.

## Verification

CI on this PR is the gate — in particular each app's own e2e suite. `npm update … --package-lock-only` was used so nothing but the lock moves.
