### PR TITLE
fix(ci): give dispatched runs their own concurrency lane

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -61,7 +61,29 @@ on:
 # (`quality-feature/x` for both events, exactly as before) and gives the two
 # default branches' push runs a lane of their own.
 concurrency:
-  group: quality-${{ github.head_ref || github.ref_name }}${{ (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'development')) && '-push' || '' }}
+  # SUFFIXED BY EVENT NAME, not just by `-push`.
+  #
+  # The previous expression gave a push on `development` its own lane
+  # (`-push`) but left EVERYTHING ELSE sharing `quality-development` — and
+  # that is not a quiet lane: `Sync to Beta` keeps a PR open whose head_ref
+  # IS `development`, so its run computes the same group and is re-triggered
+  # on every merge.
+  #
+  # A `workflow_dispatch` therefore shared a group with that PR and was
+  # cancelled by it. Measured on shillinq 2026-08-21: dispatch 32487948678
+  # cancelled by pull_request run 32490160836 (head_branch `development`).
+  # A run someone deliberately asked for could essentially never complete.
+  #
+  # That reaches past ad-hoc verification: the fleet gate-drift sweep
+  # (.github#523) dispatches per app with `--ref development`, because
+  # `schedule:` cannot choose a branch. Under the old group those runs are
+  # cancelled and report neither pass nor fail — and a routine that produces
+  # no verdict is indistinguishable from one that never ran.
+  #
+  # This is hermiq's form, already live there. Pull requests keep the bare
+  # group (so a PR still supersedes its own earlier run); push, dispatch and
+  # schedule each get their own lane.
+  group: quality-${{ github.head_ref || github.ref_name }}${{ (github.event_name != 'pull_request' && (github.ref_name == 'main' || github.ref_name == 'development')) && format('-{0}', github.event_name) || '' }}
   cancel-in-progress: true
 
 # Permission CEILING for the called quality pipeline. GitHub statically


### PR DESCRIPTION
A `workflow_dispatch` on `development` cannot complete on this repo — it is cancelled by the `Sync to Beta` pull request.

## The mechanism

The group suffixed only pushes, leaving everything else in `quality-development`:

- push on `development` → `quality-development-push` ✅ own lane
- **workflow_dispatch** → `quality-development`
- **pull_request whose head_ref is `development`** → `quality-development`

`Sync to Beta` keeps exactly such a PR open and it is re-triggered on every merge, so a dispatched run shares a group with a PR that fires constantly.

Measured on shillinq 2026-08-21 (same expression):

```
dispatch      32487948678  development  13:39Z  ->  cancelled
pull_request  32490160836  development  14:04Z   (the Sync-to-Beta run)
```

## Why it matters

The fleet gate-drift sweep (ConductionNL/.github#523) dispatches per app with `--ref development`, because `schedule:` cannot choose a branch. Under the old group those runs are cancelled and report **neither pass nor fail** — a routine that produces no verdict is indistinguishable from one that never ran.

## The change

One line, adopting **hermiq's form verbatim** (already live there — an existing in-fleet pattern, not a new invention). PRs keep the bare group so a PR still supersedes its own earlier run; push, dispatch and schedule each get a lane.

Part of a 12-repo sweep; ConductionNL/.github#540 fixed the shared workflow, but a caller-level `concurrency:` governs the calling job and takes effect regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)