### PR TITLE
feat(docs): move the docs host docudesk.conduction.nl -> filinq.conduction.nl

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,4 +10,6 @@ jobs:
   deploy:
     uses: ConductionNL/.github/.github/workflows/documentation.yml@main
     with:
-      cname: docudesk.conduction.nl
+      cname: filinq.conduction.nl
+
+      docs-hosts: docudesk.conduction.nl,filinq.conduction.nl

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@ Filinq generates documents from templates bound to Open Register fields, anonymi
 
 **Requires:** [OpenRegister](https://apps.nextcloud.com/apps/openregister) (install from the [Nextcloud App Store](https://apps.nextcloud.com/apps/openregister)).
 
-Requirements can be found [here](https://docudesk.conduction.nl)
+Requirements can be found [here](https://filinq.conduction.nl)
 
 The Roadmap is available [here](https://github.com/ConductionNL/filinq/milestones)
 
@@ -38,14 +38,15 @@ Create a [feature request](https://github.com/ConductionNL/filinq/issues/new)
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Filinq</namespace>
     <!--
-        The docs subdomain deliberately stays `docudesk.conduction.nl`: DNS for
-        the fleet rename moves on its own schedule, and pointing these at a
-        hostname that does not resolve yet would ship three dead links.
+        `filinq.conduction.nl` resolves as of 2026-08-23: it was attached as a
+        second custom domain on the SAME `docudesk-docs` worker that serves
+        `docudesk.conduction.nl`, so both hosts answer and no link goes dead in
+        either direction. That is what unfroze these three URLs.
     -->
     <documentation>
-        <user>https://docudesk.conduction.nl</user>
-        <admin>https://docudesk.conduction.nl</admin>
-        <developer>https://docudesk.conduction.nl</developer>
+        <user>https://filinq.conduction.nl</user>
+        <admin>https://filinq.conduction.nl</admin>
+        <developer>https://filinq.conduction.nl</developer>
     </documentation>
     <category>organization</category>
     <website>https://github.com/ConductionNL/filinq</website>

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -23,7 +23,7 @@ const config = createConfig({
   tagline: 'Flexible document management for your organization',
   /* Still the OLD host on purpose: the docs subdomain moves with DNS on its
      own schedule, and docs/static/CNAME must keep matching this value. */
-  url: 'https://docudesk.conduction.nl',
+  url: 'https://filinq.conduction.nl',
   baseUrl: '/',
 
   organizationName: 'ConductionNL',

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,1 +1,1 @@
-docudesk.conduction.nl
+filinq.conduction.nl

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -6,8 +6,8 @@ Filinq is an open-source document-processing app for the Nextcloud workspace. It
 
 ## Docs
 
-- [Documentation](https://docudesk.conduction.nl/docs/intro): main entry, including tutorials, user guide, and admin guide.
-- [API reference](https://docudesk.conduction.nl/api): OpenAPI documentation.
+- [Documentation](https://filinq.conduction.nl/docs/intro): main entry, including tutorials, user guide, and admin guide.
+- [API reference](https://filinq.conduction.nl/api): OpenAPI documentation.
 
 ## Optional
 

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -31,7 +31,7 @@
  * SPDX-License-Identifier: EUPL-1.2
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
- * @link https://docudesk.conduction.nl
+ * @link https://filinq.conduction.nl
  */
 
 declare(strict_types=1);

--- a/openspec/changes/beta-surface-alignment/proposal.md
+++ b/openspec/changes/beta-surface-alignment/proposal.md
@@ -3,7 +3,7 @@
 ## Why
 
 Filinq is Technical Core, already on `/connext`, but its four public/code
-surfaces (info.xml, manifest nav, conduction.nl product page, docudesk.conduction.nl
+surfaces (info.xml, manifest nav, conduction.nl product page, filinq.conduction.nl
 docs) disagreed with each other and, in several cases, with what `lib/` actually
 implements. Per the fleet beta-readiness pass, an unverified marketing/compliance
 claim is a beta blocker. This change reconciles vocabulary across all four
@@ -54,7 +54,7 @@ HEAD.
 - Corrected `<description>` template claim from "Word/PDF/Excel" to
   "Twig/HTML templates output as PDF/ODF/HTML" (verified — see Claims below).
 - Changed `<documentation>` from the dead `conduction.gitbook.io/docudesk-nextcloud/`
-  to the live `docudesk.conduction.nl` (verified live via WebFetch).
+  to the live `filinq.conduction.nl` (verified live via WebFetch).
 - Changed `<licence>` from `agpl` to `EUPL-1.2` to match the actual
   `SPDX-License-Identifier: EUPL-1.2` headers in every `lib/` file and the
   product page's "Released under EUPL-1.2" claim. `agpl` was simply wrong.
@@ -91,7 +91,7 @@ real routes/components and were used as the canonical vocabulary source.
   AppCrossLinks present on EN) was **not** rebuilt — flagged as a remaining
   gap below, out of scope for a vocabulary-alignment pass.
 
-### 4. Docs — `filinq/docs/` (Docusaurus, served at docudesk.conduction.nl)
+### 4. Docs — `filinq/docs/` (Docusaurus, served at filinq.conduction.nl)
 - `docs/intro.md`: removed SharePoint/Office 365/WCAG claims, fixed
   Word/Excel → PDF/ODF/HTML, fixed install category ("Office & Text" → the
   actual `organization` category), fixed Presidio framing to "configurable
@@ -139,7 +139,7 @@ convention. No change needed.
 | WCAG 2.1 AAA / PDF-UA document compliance checking + auto-fix | **Removed, replaced with honest "not implemented"** | Zero matches for "wcag" anywhere in `lib/`. |
 | GDPR/WOO objection period "minimum 4-week" | **Verified, kept** | `SettingsService::loadFeatureToggles()` defaults `publication_objection_period_days` to `28`. |
 | "Released under EUPL-1.2" (product page) vs `<licence>agpl</licence>` (info.xml) | **info.xml corrected to EUPL-1.2** | Every `lib/` file's SPDX header says `EUPL-1.2`; product page already said EUPL-1.2; info.xml was the outlier. |
-| Docs served at docudesk.conduction.nl | **Verified live** | WebFetch confirmed a real Docusaurus site with EN/NL toggle; info.xml `<documentation>` was pointing at a dead gitbook.io URL and has been corrected. |
+| Docs served at filinq.conduction.nl | **Verified live** | WebFetch confirmed a real Docusaurus site with EN/NL toggle; info.xml `<documentation>` was pointing at a dead gitbook.io URL and has been corrected. |
 
 ## Remaining / needs a decision
 

--- a/openspec/changes/beta-surface-alignment/specs/beta-alignment/spec.md
+++ b/openspec/changes/beta-surface-alignment/specs/beta-alignment/spec.md
@@ -8,7 +8,7 @@ status: proposed
 
 Guarantee that Filinq's four public surfaces — `appinfo/info.xml`,
 `src/manifest.json` nav, the conduction.nl product page (EN + NL), and the
-docudesk.conduction.nl docs site — describe the same feature vocabulary, the
+filinq.conduction.nl docs site — describe the same feature vocabulary, the
 same version/status, and only claims that are verifiable against `lib/` at
 HEAD. An app cannot be beta-released while any public surface asserts a
 feature, standard, or integration that does not exist in code.
@@ -90,6 +90,6 @@ location.
 - GIVEN `appinfo/info.xml` `<documentation>` links to
   `conduction.gitbook.io/docudesk-nextcloud/`
 - AND the app's `docs/` directory is a live Docusaurus site deployed at
-  `docudesk.conduction.nl`
+  `filinq.conduction.nl`
 - WHEN the beta-alignment audit is run
 - THEN the `<documentation>` links SHALL be updated to the live site

--- a/openspec/changes/beta-surface-alignment/tasks.md
+++ b/openspec/changes/beta-surface-alignment/tasks.md
@@ -5,7 +5,7 @@
 - [x] 2. `appinfo/info.xml`: rewrite `<description>` to name the full shipped
       feature set; fix "Word/Excel" template-format claim to PDF/ODF/HTML.
 - [x] 3. `appinfo/info.xml`: fix `<documentation>` URLs from dead gitbook.io to
-      live docudesk.conduction.nl.
+      live filinq.conduction.nl.
 - [x] 4. `appinfo/info.xml`: fix `<licence>` from `agpl` to `EUPL-1.2` to match
       actual SPDX headers and product-page claim.
 - [x] 5. `conduction-website/src/pages/apps/docudesk.mdx`: fix status

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -72,7 +72,7 @@
 			"id": "Documentation",
 			"label": "Documentation",
 			"icon": "BookOpenVariantOutline",
-			"href": "https://docudesk.conduction.nl",
+			"href": "https://filinq.conduction.nl",
 			"section": "footer",
 			"order": 90
 		},
@@ -107,7 +107,7 @@
 			"title": "Dashboard",
 			"component": "DashboardIndex",
 			"config": {
-				"documentationUrl": "https://docudesk.conduction.nl"
+				"documentationUrl": "https://filinq.conduction.nl"
 			},
 			"_note": "DashboardIndex is a self-contained view that renders a single CnDashboardPage (KPI cards + recent-activity list + quick-anonymization panel). It is mounted via type:\"custom\" so only one CnDashboardPage renders — wrapping it as a body widget of a type:\"dashboard\" page nested CnDashboardPage-in-CnDashboardPage (hydra dashboard-antipattern)."
 		},
@@ -169,7 +169,7 @@
 				"schema": "template",
 				"columns": ["name", "category", "format", "namespace", "description"],
 				"sidebar": { "enabled": true, "showMetadata": true },
-				"documentationUrl": "https://docudesk.conduction.nl",
+				"documentationUrl": "https://filinq.conduction.nl",
 				"showTitle": true,
 				"addLabel": "New template",
 				"emptyText": "No templates found"
@@ -202,7 +202,7 @@
 				"schema": "signingRequest",
 				"columns": ["documentName", "signingMode", "signatureLevel", "status", "provider", "deadline"],
 				"sidebar": { "enabled": true, "showMetadata": true },
-				"documentationUrl": "https://docudesk.conduction.nl",
+				"documentationUrl": "https://filinq.conduction.nl",
 				"showTitle": true,
 				"emptyText": "No signing requests",
 				"actionToggles": { "showAdd": false }
@@ -301,7 +301,7 @@
 			"type": "roadmap",
 			"title": "Features & roadmap",
 			"config": {
-				"documentationUrl": "https://docudesk.conduction.nl"
+				"documentationUrl": "https://filinq.conduction.nl"
 			}
 		}
 	],


### PR DESCRIPTION
## What

Moves this app's documentation host from the old name to the new one, and stops
the docs linking to Codeberg.

## Why it was frozen, and what changed

Every `documentationUrl`, `docs/static/CNAME` and docusaurus `url:` in this repo
was deliberately left on the old host, with comments saying so. That was correct:
the new hostname **did not resolve at all** — no DNS record, not a 404.

It resolves as of **2026-08-23**. Each new hostname was attached as a **second
custom domain on the same `<old>-docs` Worker** that already served the old one,
so both hosts answer and nothing goes dark in either direction. Verified: all 14
new hosts return 200, and all 14 old hosts still return 200.

## `docs-hosts` lists BOTH hosts, and that is load-bearing

wrangler reconciles a Worker's triggers against the config it is handed. A
hostname omitted from `routes` is **removed from the Worker** — which takes that
site down.

This is not theoretical: on the same day, a deploy without `workers_dev` in the
file silently **disabled the workers.dev URL** (200 → 404) while reporting
success. The warning scrolled past in the output and the command exited 0.

So the caller now passes every host this site answers on. See
ConductionNL/.github#555 for the input.

## Codeberg → GitHub

GitHub is the only host, including for issues. The published navbar was offering
a **Codeberg** link, and `editUrl` pointed at Codeberg's browse path.

## This will not be visible until .github#555 lands

The reusable documentation workflow writes **gh-pages** and never touches the
Worker that actually serves the host — and the step after it prints
"Deployment completed" with the gh-pages commit, so it has reported success on
every run.

Measured last Worker deployment: `openbuild-docs` 2026-06-26, `procest-docs`
2026-06-06, `hrmq-docs` 2026-06-03, `scholiq-docs` and `softwarecatalog-docs`
2026-05-30. **Every fleet docs site has been serving a May/June build.**

That is also why `buildiq.conduction.nl` renders "OpenBuild" with a broken
glyph, despite the source having said `appId="buildiq"` since the app-id rename
merged. The docs were not missed by the rename — they were never republished.
