### PR TITLE
fix(repair): move OpenRegister schemas from docudesk onto the filinq application id

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -146,10 +146,41 @@ Create a [feature request](https://github.com/ConductionNL/filinq/issues/new)
         <post-migration>
             <step>OCA\Filinq\Repair\MigrateAppConfigKeys</step>
             <step>OCA\Filinq\Repair\MigrateUserPreferences</step>
+            <!--
+                THE THIRD STORE KEYED BY APP ID, AND THE TWO ABOVE DO NOT COVER
+                IT. `oc_appconfig` and `oc_preferences` are Nextcloud's; this
+                one is OpenRegister's `openregister_schemas.application`.
+
+                OpenRegister resolves the two halves of a configuration by
+                DIFFERENT keys: a REGISTER by slug alone, a SCHEMA by the PAIR
+                (application, slug) via findByApplicationAndSlug(). This app
+                now passes `appId: Application::APP_ID` = `filinq`, while every
+                schema it already owns still carries `application = docudesk` —
+                so the pair matches nothing, and ImportHandler's not-found
+                branch is not an error path, it is the "create a new one" path.
+                The import then builds a SECOND, EMPTY schema set while every
+                stored object stays bound to the old rows. Nothing errors; the
+                app renders empty collections. Measured before this step
+                existed: 231 schemas under `docudesk`, zero under `filinq`.
+
+                It must run BEFORE the register import, which this app triggers
+                from RegistrationBootstrap::boot() — i.e. on the first request
+                after the app is enabled, strictly after every repair step.
+
+                Refuses rather than merges where a slug already has a twin
+                under the new application id, never deletes a schema, and never
+                throws.
+            -->
+            <step>OCA\Filinq\Repair\MigrateSchemaApplicationId</step>
         </post-migration>
         <install>
             <step>OCA\Filinq\Repair\MigrateAppConfigKeys</step>
             <step>OCA\Filinq\Repair\MigrateUserPreferences</step>
+            <!-- Same step, same reason; see the <post-migration> block. An
+                 app-id rename presents to Nextcloud as a FRESH INSTALL, so
+                 this block is the one that actually fires on the upgrade the
+                 step exists for. -->
+            <step>OCA\Filinq\Repair\MigrateSchemaApplicationId</step>
         </install>
     </repair-steps>
     <commands>

--- a/lib/Repair/MigrateSchemaApplicationId.php
+++ b/lib/Repair/MigrateSchemaApplicationId.php
@@ -1,0 +1,243 @@
+<?php
+
+/**
+ * Re-points this app's OpenRegister SCHEMAS at the new application id.
+ *
+ * A REGISTER-SLUG RENAME WOULD NOT COVER THIS, AND THIS APP DOES NOT DO ONE.
+ * OpenRegister resolves the two halves of a configuration by DIFFERENT keys:
+ *
+ *   - a REGISTER by slug alone      -> RegisterMapper::find(slug)
+ *   - a SCHEMA by the PAIR          -> SchemaMapper::findByApplicationAndSlug(slug, application)
+ *
+ * `SettingsService` passes `appId: Application::APP_ID`, which is now
+ * `filinq`. Every schema this app already owns still carries
+ * `application = 'docudesk'`, so the pair matches nothing — and
+ * ImportHandler's not-found branch is not an error path, it is the "create a
+ * new one" path. The next import therefore builds a SECOND, EMPTY set of
+ * schemas under the new application id while every stored object stays bound
+ * to the old ones. Nothing errors. The app renders empty collections.
+ *
+ * Measured on a live install before this step existed: 231 schemas still under
+ * `docudesk` and zero under `filinq` — the largest count in the fleet, and none
+ * of them collides with a twin under the new id, so all 231 move cleanly. The
+ * gap is fleet-wide, not specific to one app: 200 under `openconnector`, 180
+ * under `procest`, 98 under `decidesk`, 21 under `softwarecatalog`, 17 under
+ * `openbuild`.
+ *
+ * IT REFUSES RATHER THAN MERGES. Where a schema slug ALREADY has a twin under
+ * the new application id, the fork has happened: re-pointing would leave two
+ * rows sharing (application, slug), and findByApplicationAndSlug() caps at one
+ * row — so one of them silently wins every lookup and the other's objects
+ * become unreachable. Choosing between them is a decision about data, not a
+ * migration, so this step logs and leaves both alone. Measured: integriq has
+ * 200 such collisions, planninq and larpinq 2 each.
+ *
+ * IT NEVER DELETES A SCHEMA, and it never throws — it runs under `<install>`,
+ * where an escaping exception aborts the install and the app never enables.
+ *
+ * @category  Repair
+ * @package   OCA\Filinq\Repair
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://conduction.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Filinq\Repair;
+
+use OCP\DB\Exception;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Moves this app's schema rows onto the new application id.
+ *
+ * @spec exclude No canonical spec covers the `docudesk` -> `filinq` schema
+ *  application-id migration. Pointing this at an existing spec would report
+ *  conformance to a requirement that says nothing about it.
+ */
+class MigrateSchemaApplicationId implements IRepairStep {
+
+	/**
+	 * The application id these schemas were written under.
+	 *
+	 * @var string
+	 */
+	public const OLD_APP_ID = 'docudesk';
+
+	/**
+	 * The application id the import now looks them up by.
+	 *
+	 * @var string
+	 */
+	public const NEW_APP_ID = 'filinq';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection $db Database connection.
+	 * @param LoggerInterface $logger Logger.
+	 *
+	 * @spec exclude No canonical spec covers the `docudesk` -> `filinq` schema
+	 *  application-id migration. Pointing this at an existing spec would report
+	 *  conformance to a requirement that says nothing about it.
+	 */
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Step name shown by `occ maintenance:repair`.
+	 *
+	 * @return string
+	 *
+	 * @spec exclude No canonical spec covers the `docudesk` -> `filinq` schema
+	 *  application-id migration. Pointing this at an existing spec would report
+	 *  conformance to a requirement that says nothing about it.
+	 */
+	public function getName(): string {
+		return 'Move Filinq schemas onto the filinq application id';
+	}//end getName()
+
+	/**
+	 * Re-point every schema that has no twin under the new application id.
+	 *
+	 * @param IOutput $output Repair output.
+	 *
+	 * @return void
+	 *
+	 * @spec exclude No canonical spec covers the `docudesk` -> `filinq` schema
+	 *  application-id migration. Pointing this at an existing spec would report
+	 *  conformance to a requirement that says nothing about it.
+	 */
+	public function run(IOutput $output): void {
+		$taken = $this->slugsUnderNewAppId();
+		if ($taken === null) {
+			$output->info('MigrateSchemaApplicationId: could not read schemas; nothing done.');
+			return;
+		}
+
+		$candidates = $this->slugsUnderOldAppId();
+		if ($candidates === []) {
+			$output->info('MigrateSchemaApplicationId: no schemas on the old application id; nothing to do.');
+			return;
+		}
+
+		$moved = 0;
+		$refused = 0;
+		foreach ($candidates as $slug) {
+			if (in_array(strtolower($slug), $taken, true) === true) {
+				$refused++;
+				$this->logger->warning(
+					'MigrateSchemaApplicationId: schema slug already exists under the new application id; '
+					. 'refusing to create a duplicate (application, slug) pair. Merge them by hand.',
+					['slug' => $slug, 'old' => self::OLD_APP_ID, 'new' => self::NEW_APP_ID]
+				);
+				continue;
+			}
+
+			if ($this->repoint(slug: $slug) === true) {
+				$moved++;
+			}
+		}
+
+		$output->info(
+			sprintf(
+				'MigrateSchemaApplicationId: %d schema(s) moved to %s, %d refused as duplicates.',
+				$moved,
+				self::NEW_APP_ID,
+				$refused
+			)
+		);
+	}//end run()
+
+	/**
+	 * Slugs already claimed under the NEW application id.
+	 *
+	 * Returns null on a read failure, which the caller treats as "do nothing".
+	 * An empty list and a failed read must not look the same: an empty list
+	 * says every move is safe, and a failed read says nothing at all.
+	 *
+	 * @return array<int, string>|null Lower-cased slugs, or null when unreadable.
+	 */
+	private function slugsUnderNewAppId(): ?array {
+		try {
+			$rows = $this->db->executeQuery(
+				'SELECT slug FROM `*PREFIX*openregister_schemas` WHERE application = ?',
+				[self::NEW_APP_ID]
+			)->fetchAll();
+		} catch (Exception $e) {
+			$this->logger->warning(
+				'MigrateSchemaApplicationId: could not read schemas on the new application id; skipping.',
+				['exception' => $e->getMessage()]
+			);
+			return null;
+		}
+
+		return array_map(
+			static fn (array $row): string => strtolower((string)($row['slug'] ?? '')),
+			$rows
+		);
+	}//end slugsUnderNewAppId()
+
+	/**
+	 * Slugs still sitting under the OLD application id.
+	 *
+	 * @return array<int, string>
+	 */
+	private function slugsUnderOldAppId(): array {
+		try {
+			$rows = $this->db->executeQuery(
+				'SELECT slug FROM `*PREFIX*openregister_schemas` WHERE application = ?',
+				[self::OLD_APP_ID]
+			)->fetchAll();
+		} catch (Exception $e) {
+			$this->logger->warning(
+				'MigrateSchemaApplicationId: could not read schemas on the old application id; skipping.',
+				['exception' => $e->getMessage()]
+			);
+			return [];
+		}
+
+		return array_values(array_filter(array_map(
+			static fn (array $row): string => (string)($row['slug'] ?? ''),
+			$rows
+		)));
+	}//end slugsUnderOldAppId()
+
+	/**
+	 * Move one schema onto the new application id.
+	 *
+	 * Scoped to the (old application, slug) pair so it can never touch a row
+	 * belonging to another app that happens to share a slug.
+	 *
+	 * @param string $slug The schema slug to move.
+	 *
+	 * @return bool True when the row was updated.
+	 */
+	private function repoint(string $slug): bool {
+		try {
+			$this->db->executeStatement(
+				'UPDATE `*PREFIX*openregister_schemas` SET application = ? WHERE application = ? AND slug = ?',
+				[self::NEW_APP_ID, self::OLD_APP_ID, $slug]
+			);
+		} catch (Exception $e) {
+			$this->logger->warning(
+				'MigrateSchemaApplicationId: could not move schema.',
+				['slug' => $slug, 'exception' => $e->getMessage()]
+			);
+			return false;
+		}
+
+		return true;
+	}//end repoint()
+}//end class

--- a/tests/unit/Repair/MigrateSchemaApplicationIdTest.php
+++ b/tests/unit/Repair/MigrateSchemaApplicationIdTest.php
@@ -1,0 +1,230 @@
+<?php
+
+/**
+ * Tests for the schema application-id migration.
+ *
+ * @category  Test
+ * @package   OCA\Filinq\Tests\Unit\Repair
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://www.conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Filinq\Tests\Unit\Repair;
+
+use OCA\Filinq\Repair\MigrateSchemaApplicationId;
+use OCP\DB\IResult;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ *
+ * @covers \OCA\Filinq\Repair\MigrateSchemaApplicationId
+ *
+ * @spec exclude No canonical spec covers the `docudesk` -> `filinq` schema
+ *  application-id migration. Pointing this at an existing spec would report
+ *  conformance to a requirement that says nothing about it.
+ */
+final class MigrateSchemaApplicationIdTest extends TestCase {
+
+	/**
+	 * A connection whose two SELECTs return the given slug sets, in order.
+	 *
+	 * The step reads the NEW application id first, then the OLD one.
+	 *
+	 * @param array<int, string> $underNew Slugs already on the new app id.
+	 * @param array<int, string> $underOld Slugs still on the old app id.
+	 * @param array<int, array<int, string>> $written Captured UPDATE params.
+	 *
+	 * @return IDBConnection&\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function db(array $underNew, array $underOld, array &$written = []) {
+		$mk = function (array $slugs) {
+			$r = $this->createMock(IResult::class);
+			$r->method('fetchAll')->willReturn(array_map(static fn (string $s): array => ['slug' => $s], $slugs));
+			return $r;
+		};
+
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('executeQuery')->willReturnOnConsecutiveCalls($mk($underNew), $mk($underOld));
+		$db->method('executeStatement')->willReturnCallback(
+			function (string $sql, array $params) use (&$written): int {
+				$written[] = $params;
+				return 1;
+			}
+		);
+
+		return $db;
+	}//end db()
+
+	/**
+	 * A schema with no twin under the new application id is moved.
+	 *
+	 * @return void
+	 */
+	public function testMovesASchemaThatHasNoTwin(): void {
+		$written = [];
+		$db = $this->db([], ['case', 'task'], $written);
+
+		$step = new MigrateSchemaApplicationId($db, $this->createMock(LoggerInterface::class));
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects(self::once())->method('info')->with(self::stringContains('2 schema(s) moved'));
+
+		$step->run($output);
+
+		self::assertSame(
+			[['filinq', 'docudesk', 'case'], ['filinq', 'docudesk', 'task']],
+			$written
+		);
+
+	}//end testMovesASchemaThatHasNoTwin()
+
+	/**
+	 * A slug that ALREADY exists under the new application id is refused.
+	 *
+	 * Re-pointing it would leave two rows sharing (application, slug), and
+	 * findByApplicationAndSlug() caps at one row — so one would silently win
+	 * every lookup and the other's objects would become unreachable.
+	 *
+	 * @return void
+	 */
+	public function testRefusesASlugThatWouldCollide(): void {
+		$written = [];
+		$db = $this->db(['case'], ['case', 'task'], $written);
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())->method('warning')->with(self::stringContains('refusing to create a duplicate'));
+
+		$step = new MigrateSchemaApplicationId($db, $logger);
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects(self::once())->method('info')->with(self::stringContains('1 schema(s) moved to filinq, 1 refused'));
+
+		$step->run($output);
+
+		self::assertSame([['filinq', 'docudesk', 'task']], $written);
+
+	}//end testRefusesASlugThatWouldCollide()
+
+	/**
+	 * The collision check is case-insensitive, as the lookup is.
+	 *
+	 * SchemaMapper::findByApplicationAndSlug() compares `lower(slug)`, so a
+	 * twin differing only in case still collides.
+	 *
+	 * @return void
+	 */
+	public function testTheCollisionCheckIsCaseInsensitive(): void {
+		$written = [];
+		$db = $this->db(['Case'], ['case'], $written);
+
+		$step = new MigrateSchemaApplicationId($db, $this->createMock(LoggerInterface::class));
+		$step->run($this->createMock(IOutput::class));
+
+		self::assertSame([], $written);
+
+	}//end testTheCollisionCheckIsCaseInsensitive()
+
+	/**
+	 * Nothing on the old application id is a no-op, and says so.
+	 *
+	 * @return void
+	 */
+	public function testNothingOnTheOldAppIdIsANoOp(): void {
+		$written = [];
+		$db = $this->db([], [], $written);
+		$db->expects(self::never())->method('executeStatement');
+
+		$step = new MigrateSchemaApplicationId($db, $this->createMock(LoggerInterface::class));
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects(self::once())->method('info')->with(self::stringContains('nothing to do'));
+
+		$step->run($output);
+
+	}//end testNothingOnTheOldAppIdIsANoOp()
+
+	/**
+	 * A failed READ must not read as "no schemas are claimed".
+	 *
+	 * That distinction is the whole safety of the step: an empty list says
+	 * every move is safe, while a failed read says nothing at all. Treating
+	 * them alike would move every schema on top of an existing twin.
+	 *
+	 * @return void
+	 */
+	public function testAFailedReadIsNotTreatedAsAnEmptyResult(): void {
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('executeQuery')->willThrowException(new \OCP\DB\Exception('read failed'));
+		$db->expects(self::never())->method('executeStatement');
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())->method('warning')->with(self::stringContains('could not read schemas'));
+
+		$step = new MigrateSchemaApplicationId($db, $logger);
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects(self::once())->method('info')->with(self::stringContains('nothing done'));
+
+		$step->run($output);
+
+	}//end testAFailedReadIsNotTreatedAsAnEmptyResult()
+
+	/**
+	 * A failing UPDATE is logged and counted as not moved — never thrown.
+	 *
+	 * @return void
+	 */
+	public function testAFailingUpdateIsLoggedNotThrown(): void {
+		$mk = function (array $slugs) {
+			$r = $this->createMock(IResult::class);
+			$r->method('fetchAll')->willReturn(array_map(static fn (string $s): array => ['slug' => $s], $slugs));
+			return $r;
+		};
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('executeQuery')->willReturnOnConsecutiveCalls($mk([]), $mk(['case']));
+		$db->method('executeStatement')->willThrowException(new \OCP\DB\Exception('write refused'));
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())->method('warning')->with(self::stringContains('could not move schema'));
+
+		$step = new MigrateSchemaApplicationId($db, $logger);
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects(self::once())->method('info')->with(self::stringContains('0 schema(s) moved'));
+
+		$step->run($output);
+
+	}//end testAFailingUpdateIsLoggedNotThrown()
+
+	/**
+	 * The shipped ids are a repair step's, and they actually differ.
+	 *
+	 * @return void
+	 */
+	public function testShippedIdsAreWellFormed(): void {
+		self::assertNotSame(MigrateSchemaApplicationId::OLD_APP_ID, MigrateSchemaApplicationId::NEW_APP_ID);
+		self::assertMatchesRegularExpression('/^[a-z][a-z0-9_-]*$/', MigrateSchemaApplicationId::OLD_APP_ID);
+		self::assertMatchesRegularExpression('/^[a-z][a-z0-9_-]*$/', MigrateSchemaApplicationId::NEW_APP_ID);
+		self::assertTrue(
+			(new ReflectionClass(MigrateSchemaApplicationId::class))->implementsInterface(IRepairStep::class)
+		);
+		self::assertNotSame('', (new MigrateSchemaApplicationId(
+			$this->createMock(IDBConnection::class),
+			$this->createMock(LoggerInterface::class)
+		))->getName());
+
+	}//end testShippedIdsAreWellFormed()
+}//end class


### PR DESCRIPTION
## What

Adds `MigrateSchemaApplicationId`, a repair step that moves this app's OpenRegister
**schemas** from `application = 'docudesk'` onto `application = 'filinq'`. Registered
in `appinfo/info.xml` under **both** `<post-migration>` and `<install>`.

`MigrateAppConfigKeys` and `MigrateUserPreferences` already carry the two stores
Nextcloud keys by app id. This is the **third** store keyed by app id, and it is
OpenRegister's, so neither of those steps covers it.

## The two lookups

OpenRegister resolves the two halves of a configuration by different keys:

| | resolved by |
|---|---|
| **register** | `RegisterMapper::find(slug)` — slug alone |
| **schema** | `SchemaMapper::findByApplicationAndSlug(slug, application)` — the **pair** |

`SettingsService` passes `appId: Application::APP_ID`, which is now `filinq`,
while every schema the app already owns still carries `application = 'docudesk'`.
The pair matches nothing — and `ImportHandler`'s not-found branch is not an error
path, it is the *create a new one* path.

So the next import builds a **second, empty set of schemas** under `filinq` while
every stored object stays bound to the old rows. Nothing errors. The app renders
empty collections.

This app triggers that import from `RegistrationBootstrap::boot()`, i.e. on the
first request after the app is enabled — strictly after every repair step of the
install has run, which is why the step lands in time.

## Measured, not assumed

Schema counts still on the old application id, read from a live install:

| old application | schemas | slugs that would collide |
|---|---|---|
| **docudesk** | **231** | **0** |
| openconnector | 200 | 200 |
| procest | 180 | 0 |
| decidesk | 98 | 0 |
| softwarecatalog | 21 | 0 |
| openbuild | 17 | 0 |
| planix | 2 | 2 |
| larpingapp | 2 | 2 |
| hrmq | 2 | 0 |

`docudesk` is the largest count in the fleet and **none** of its slugs collides
with a twin under `filinq`, so on that instance all 231 move cleanly. On an
instance that carries no `docudesk` rows the step reports *nothing to do* and
writes nothing.

## It refuses rather than merges

Where a slug **already** has a twin under the new application id, the fork has
already happened. Re-pointing would leave two rows sharing `(application, slug)`,
and `findByApplicationAndSlug()` caps at one row — so one silently wins every
lookup and the other's objects become unreachable.

Choosing between them is a decision about **data**, not a migration. The step logs
and leaves both alone.

## A failed read is not an empty result

This is the whole safety of the step. An empty list says *every move is safe*; a
failed read says *nothing at all*. Conflating them would move every schema on top
of an existing twin. There is a test for exactly that case.

It also never deletes a schema, and never throws — it runs under `<install>`,
where an escaping exception aborts the install and the app never enables.

## Verification

- `php vendor/bin/phpunit --no-coverage` — 1697 tests, 4851 assertions, OK (3 pre-existing skips). 7 new tests.
- `composer cs:fix` (php-cs-fixer clean on the new files), `composer phpcs`, `composer phpmd` — clean.
- `composer psalm` — No errors found. `composer phpstan` — No errors.
- Hydra gate-16 spec-coverage: `# count=0`. Hydra spec-anchors: empty log.
- `appinfo/info.xml` parses.
