### PR TITLE
fix(docs): publish from development, and pin the worker that serves this site

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,9 +2,9 @@ name: Documentation
 
 on:
   push:
-    branches: [documentation]
+    branches: [development]
   pull_request:
-    branches: [documentation]
+    branches: [development]
 
 jobs:
   deploy:
@@ -12,4 +12,10 @@ jobs:
     with:
       cname: filinq.conduction.nl
 
+      # PINNED, not derived. The callee defaults worker-name to the first label
+      # of `cname` + "-docs" — which since the app-id rename would be
+      # `filinq-docs`, a worker that does not exist. wrangler would CREATE it
+      # and deploy there, while both custom domains keep routing to
+      # `docudesk-docs`. Green every time, reaching nobody.
+      worker-name: docudesk-docs
       docs-hosts: docudesk.conduction.nl,filinq.conduction.nl


### PR DESCRIPTION
## What

Two edits to `.github/workflows/documentation.yml`.

**Trigger.** It fired on `push: branches: [documentation]` — a branch that *exists*, which is why nothing looked broken, but that nobody updates. The pipeline faithfully republished a stale snapshot and reported success every time. That is why `filinq.conduction.nl` still serves **"DocuDesk"** while `docs/docusaurus.config.js` has said Filinq since the app-id rename.

**Worker name — this is the one that would have bitten after the trigger fix.** The reusable workflow *derives* `worker-name` from `cname` when it isn't given: first label + `-docs`. Since the rename, `cname` is the **new** host — so the derived name is `filinq-docs`, **a worker that does not exist**.

wrangler doesn't fail on that. It **creates** the worker and deploys there, while both custom domains keep routing to `docudesk-docs`. Every run green, every byte delivered to nobody.

Pinning it also decouples the worker from the hostname, so a future host move can't silently fork the deployment again.

## Unchanged, deliberately

`docs-hosts` already lists **both** hosts. It must: wrangler *reconciles* a worker's triggers against the config it is handed, so a host omitted there is **removed from the worker** — fixing only the trigger would have turned a stale site into a dark one.

## Context

Same fix landed across the other eleven fleet apps. This repo was left out of that sweep because its checkout was held by the register-consolidation work (#771).