### PR TITLE
docs: repoint stale Codeberg references to GitHub

### DIFF
--- a/docs/GOVERNMENT-FEATURES.md
+++ b/docs/GOVERNMENT-FEATURES.md
@@ -64,7 +64,7 @@
 | # | Eis | Status | Toelichting |
 |---|-----|--------|-------------|
 | T-01 | On-premise / self-hosted installatie | Beschikbaar | Nextcloud-app |
-| T-02 | Open source (broncode beschikbaar) | Beschikbaar | EUPL-1.2, Codeberg |
+| T-02 | Open source (broncode beschikbaar) | Beschikbaar | EUPL-1.2, GitHub |
 | T-03 | RESTful API | Via platform | OpenRegister REST API |
 | T-04 | Event-driven architectuur | Beschikbaar | Luistert op OpenRegister events |
 | T-05 | Database-onafhankelijkheid | Via platform | PostgreSQL, MySQL, SQLite |

--- a/docs/i18n/nl/docusaurus-theme-classic/footer.json
+++ b/docs/i18n/nl/docusaurus-theme-classic/footer.json
@@ -11,9 +11,9 @@
     "message": "Documentatie",
     "description": "The label of footer link with label=Documentation linking to /docs/intro"
   },
-  "link.item.label.Codeberg": {
-    "message": "Codeberg",
-    "description": "The label of footer link with label=Codeberg linking to https://github.com/ConductionNL/filinq"
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/ConductionNL/filinq"
   },
   "copyright": {
     "message": "Copyright © 2026 for <a href=\"https://openwebconcept.nl\">Open Webconcept</a> by <a href=\"https://conduction.nl\">Conduction B.V.</a>",

--- a/openspec/changes/archive/2026-06-14-anonymisation-prohibition-gate/design.md
+++ b/openspec/changes/archive/2026-06-14-anonymisation-prohibition-gate/design.md
@@ -1,4 +1,4 @@
-<!-- status: pr-created — PR #93 https://codeberg.org/Conduction/docudesk/pulls/93 -->
+<!-- status: pr-created — Codeberg PR docudesk#93 (pre-migration, not migrated to GitHub) -->
 
 ## Context
 

--- a/openspec/changes/archive/2026-06-14-anonymiser-backend-warning/design.md
+++ b/openspec/changes/archive/2026-06-14-anonymiser-backend-warning/design.md
@@ -1,4 +1,4 @@
-## Status: pr-created — PR #94 https://codeberg.org/Conduction/docudesk/pulls/94
+## Status: pr-created — Codeberg PR docudesk#94 (pre-migration, not migrated to GitHub)
 
 ## Context
 

--- a/openspec/changes/archive/2026-06-14-digital-signing-integration/design.md
+++ b/openspec/changes/archive/2026-06-14-digital-signing-integration/design.md
@@ -1,6 +1,6 @@
 ---
 status: pr-created
-pr: https://codeberg.org/Conduction/docudesk/pulls
+pr: https://github.com/ConductionNL/filinq/pulls
 ---
 
 ## Context

--- a/openspec/changes/archive/2026-06-14-enhanced-anonymization/design.md
+++ b/openspec/changes/archive/2026-06-14-enhanced-anonymization/design.md
@@ -1,6 +1,6 @@
 ---
 status: pr-created
-pr: https://codeberg.org/Conduction/docudesk/pulls/68
+pr: Codeberg PR docudesk#68 (pre-migration, not migrated to GitHub)
 ---
 
 ## Context


### PR DESCRIPTION
GitHub (`ConductionNL`) is the only host for this org; Codeberg was a mirror and is retired. Several references also still carried the **pre-rename repo name `docudesk`** (now `filinq`).

## Inventory

38 files contain the word `codeberg`. **6 changed, 32 deliberately kept.**

## Changed (6)

| Category | Count | Files |
|---|---|---|
| Stale factual claim about source host | 1 | `docs/GOVERNMENT-FEATURES.md` — T-02 said the source lives on Codeberg |
| Stale i18n label | 1 | `docs/i18n/nl/.../footer.json` — `link.item.label.Codeberg` |
| PR link, numbered → plain text (rule: never map the number) | 3 | archived `design.md` × 3 |
| PR list link, un-numbered → host-swapped | 1 | `archive/2026-06-14-digital-signing-integration/design.md` |

### The i18n one is a real user-facing miss
The rename PR (#753) updated `navbar.json` to `item.label.GitHub` and repointed the URL inside this key's `description`, but left the key name and message behind — so the Dutch docs footer rendered a link **labelled "Codeberg" pointing at GitHub**.

## Issue/PR numbers are NOT mapped across hosts

A Codeberg PR number is not a GitHub PR number. GitHub serves `/pulls/<N>` as the PR **list** page with **HTTP 200**, so a naive host swap passes any status-code check while pointing at the wrong page. The three numbered links are demoted to plain text that preserves the fact:

> `Codeberg PR docudesk#94 (pre-migration, not migrated to GitHub)`

Only the bare `/pulls` list link was host-swapped, since that mapping is unambiguous.

## Deliberately kept (32)

- **27 archived `hydra.json`** — each holds `"repo": "https://codeberg.org/Conduction/docudesk"` next to a separate `"issue": <N>` field. Verified: **all 27** have an `issue` field. Repointing `repo` alone would silently reattribute a Codeberg issue number to GitHub.
- **1 archived `design.md`** (`print-functionality`) — same split shape: `issue: 33` beside a `pr:` Codeberg URL.
- **`tests/schemas/app-manifest-v2.schema.json`** — the forge-type enum (`["codeberg","forgejo","gitea","github"]`) and `"default": "codeberg"` are live product configuration, not stale links. Inverting them would be a behaviour change.
- **`tests/e2e/visual/README.md`** — prose accurately recording the retired Forgejo/Codeberg CI wiring.
- **`openspec/changes/verapdf-validation/{tasks,proposal}.md`** — already correct plain text: "GitHub #315 (primary); mirrors the original Codeberg #182".

`.forgejo/` is left in place. Confirmed: no `CODEBERG_TOKEN` reference anywhere in the repo.

## Verification

- Plain `grep -ril codeberg` (not `git grep` — this repo is a submodule in the dev workspace and `git grep` can silently under-report): 38 before → 35 after; every remaining hit enumerated above as a deliberate keep. The 3 residual hits in edited `design.md` files are the intentional plain-text "Codeberg PR …" notes.
- `git grep` and plain `grep` cross-checked and agreed at 38 (no worktree aliasing).
- `footer.json` re-parsed with `JSON.parse` — OK.
- No PHP, JS or YAML files changed, so `php -l` / `node --check` are not applicable.
- URLs spot-checked with `curl -L -w '%{http_code}'`: `github.com/ConductionNL/filinq` → 200, `/pulls` → 200, `/edit/main/docs/` → 200.
- No badge URLs and no `raw/branch` or `src/branch` URLs existed in this repo, so those conversion rules did not apply.
