### PR TITLE
docs(specs): point register references at the consolidated filinq register

### DIFF
--- a/openspec/specs/admin-settings/spec.md
+++ b/openspec/specs/admin-settings/spec.md
@@ -105,7 +105,7 @@ On application boot, Filinq automatically imports its register/schema definition
 - AND OpenRegister is installed and enabled (>= v0.2.10)
 - WHEN the app boots for the first time
 - THEN `Application::boot()` calls `SettingsService::initialize()`
-- AND the Consent Register and PublicationConsent schema are auto-created from `filinq_register.json`
+- AND the Filinq Register and PublicationConsent schema are auto-created from `filinq_register.json`
 - AND the `configuration_version` is updated to the version in the JSON file
 
 #### Scenario: Version-gated configuration import

--- a/openspec/specs/anonymization-link/spec.md
+++ b/openspec/specs/anonymization-link/spec.md
@@ -5,11 +5,14 @@ status: done
 # anonymization-link Specification
 
 ## Purpose
-Records the mapping between a source Nextcloud file and its anonymised counterpart through an `anonymizationLink` schema in the document register. Each successful run persists the source and anonymised file IDs, names, paths, output format, replacement count, and operator, with both file IDs made facetable so links can be looked up in either direction via the OpenRegister search API. This provides a queryable, idempotent record of which documents have been anonymised and into what.
+
+@e2e exclude Backend data-model and OR-search-API contract spec: schema strict-validation and facetable flags, SettingsInitializer version-compare re-import, the best-effort UPSERT in AnonymizationService::recordAnonymizationLink, and the shape of OR search responses. No browser surface — the UI consuming these links is specified in document-register and my-documents. Covered by PHPUnit tests/unit/Service/AnonymizationLinkServiceTest.php (REQ-ALINK-02/04 found-update, not-found-create and best-effort-failure paths).
+
+Records the mapping between a source Nextcloud file and its anonymised counterpart through an `anonymizationLink` schema in the `filinq` register. Each successful run persists the source and anonymised file IDs, names, paths, output format, replacement count, and operator, with both file IDs made facetable so links can be looked up in either direction via the OpenRegister search API. This provides a queryable, idempotent record of which documents have been anonymised and into what.
 ## Requirements
 ### Requirement: AnonymizationLink Schema — Data Model (REQ-ALINK-01)
 
-The `document` register SHALL contain an `anonymizationLink` schema that records the mapping between a source NC file and its anonymised counterpart. The schema SHALL declare full `required`, `properties`, and `hardValidation: true` per OR Adoption Decision 3 (document-register spec). `sourceFileId` and `anonymizedFileId` are required fields and SHALL be declared `facetable: true` to enable OR search API faceted filtering in both directions.
+The `filinq` register SHALL contain an `anonymizationLink` schema that records the mapping between a source NC file and its anonymised counterpart. The schema SHALL declare full `required`, `properties`, and `hardValidation: true` per OR Adoption Decision 3 (document-register spec). `sourceFileId` and `anonymizedFileId` are required fields and SHALL be declared `facetable: true` to enable OR search API faceted filtering in both directions.
 
 | Field | Type | Required | Facetable | Description |
 |-------|------|----------|-----------|-------------|
@@ -44,7 +47,7 @@ The `document` register SHALL contain an `anonymizationLink` schema that records
 - **WHEN** `SettingsInitializer::initialize()` runs after the `anonymizationLink` schema is added
 - **THEN** it SHALL detect `info.version "5.3.0" > stored "5.2.0"` via `version_compare`
 - **AND** it SHALL call `ConfigurationService::importFromApp()` to persist the updated config
-- **AND** the `anonymizationLink` schema SHALL be available in the `document` register
+- **AND** the `anonymizationLink` schema SHALL be available in the `filinq` register
 
 ### Requirement: Idempotent UPSERT on Successful Anonymisation (REQ-ALINK-02)
 
@@ -104,26 +107,26 @@ The `anonymizationLink` schema SHALL support two query directions via OR's stand
 **Forward query** (source → anonymised): retrieve the anonymised file for a given source file.
 
 ```
-GET /api/objects?register=document&schema=anonymizationLink&sourceFileId=<NC_FILE_ID>
+GET /api/objects?register=filinq&schema=anonymizationLink&sourceFileId=<NC_FILE_ID>
 ```
 
 **Reverse query** (anonymised → source): retrieve the source file for a given anonymised file.
 
 ```
-GET /api/objects?register=document&schema=anonymizationLink&anonymizedFileId=<NC_FILE_ID>
+GET /api/objects?register=filinq&schema=anonymizationLink&anonymizedFileId=<NC_FILE_ID>
 ```
 
 #### Scenario: Forward lookup resolves anonymised file for a source
 
 - **GIVEN** an `anonymizationLink` record exists with `sourceFileId: 42` and `anonymizedFileId: 99`
-- **WHEN** the OR search API is queried with `register=document&schema=anonymizationLink&sourceFileId=42`
+- **WHEN** the OR search API is queried with `register=filinq&schema=anonymizationLink&sourceFileId=42`
 - **THEN** the response SHALL contain the link record
 - **AND** `anonymizedFileId` SHALL equal `99`
 
 #### Scenario: Reverse lookup resolves source for an anonymised file
 
 - **GIVEN** an `anonymizationLink` record exists with `sourceFileId: 42` and `anonymizedFileId: 99`
-- **WHEN** the OR search API is queried with `register=document&schema=anonymizationLink&anonymizedFileId=99`
+- **WHEN** the OR search API is queried with `register=filinq&schema=anonymizationLink&anonymizedFileId=99`
 - **THEN** the response SHALL contain the link record
 - **AND** `sourceFileId` SHALL equal `42`
 

--- a/openspec/specs/batch-anonymization/spec.md
+++ b/openspec/specs/batch-anonymization/spec.md
@@ -29,7 +29,7 @@ Provides batch anonymization of multiple files in a single operation. Per-file s
 
 **Priority:** MUST
 
-A `batchAnonymizationJob` schema MUST be declared with `x-openregister-lifecycle` (states: `pending → extracting → review → anonymizing → completed | error`). Each batch job is an OR object in the `dossier` register; per-file child objects carry their own lifecycle.
+A `batchAnonymizationJob` schema MUST be declared with `x-openregister-lifecycle` (states: `pending → extracting → review → anonymizing → completed | error`). Each batch job is an OR object in the `filinq` register; per-file child objects carry their own lifecycle.
 
 #### Scenario: Batch job creates an OR object on upload
 

--- a/openspec/specs/custom-dictionary-recognition/spec.md
+++ b/openspec/specs/custom-dictionary-recognition/spec.md
@@ -6,7 +6,7 @@ TBD - created by archiving change custom-dictionary-recognition. Update Purpose 
 ### Requirement: Organisation-managed dictionaries and terms (REQ-DDCDR-001)
 
 The app MUST provide organisation-scoped `customDictionary` and
-`customDictionaryTerm` register objects (in the `document` register) storing,
+`customDictionaryTerm` register objects (in the `filinq` register) storing,
 per dictionary, a label, description, colour, match mode
 (`exact`|`caseInsensitive`|`wordBoundary`, default `caseInsensitive`), a
 deferred `fuzzy` flag, an `active` flag and a calculated term count; and per

--- a/openspec/specs/document-register/spec.md
+++ b/openspec/specs/document-register/spec.md
@@ -5,15 +5,15 @@ or_adoption_change: docudesk-adopt-or-abstractions
 
 # Document Register
 
-@e2e exclude Backend data-model spec for the document register: schema strict-validation, archival retention (P7Y/P1Y), BatchCorrespondenceJob OR-object lifecycle + notifications, derived calculations (risk/error-count), OR file-attachment report storage, tenant-scope/i18n reads — no browser surface. Covered by PHPUnit (schema/lifecycle/calculation) and Newman (correspondence API).
+@e2e exclude Backend data-model spec for the document-domain schemas of the consolidated `filinq` register: schema strict-validation, archival retention (P7Y/P1Y), BatchCorrespondenceJob OR-object lifecycle + notifications, derived calculations (risk/error-count), OR file-attachment report storage, tenant-scope/i18n reads — no browser surface. Covered by PHPUnit (schema/lifecycle/calculation) and Newman (correspondence API).
 
 ## Purpose
 
-Defines the data model for the `document` register used by Filinq to store correspondence audit logs and huisstijl configuration. The `report`, `template`, and `entity` schemas originally present in `document_register.json` have been migrated to their authoritative homes: report objects are now OR File Attachments enriched with `x-openregister-calculations` annotations; template management lives in the `templates` register. Three schemas remain active in the document register: `correspondence`, `huisstijl`, and `batchCorrespondenceJob`.
+Defines the data model for the document-domain schemas that Filinq uses to store correspondence audit logs and huisstijl configuration. These schemas live in the consolidated `filinq` register — the former `document` register was folded into it, so `register=filinq` is the only correct binding. The `report`, `template`, and `entity` schemas originally present in `document_register.json` have been migrated to their authoritative homes: report objects are now OR File Attachments enriched with `x-openregister-calculations` annotations; the `template` schema is likewise carried by the `filinq` register. Three document-domain schemas remain active: `correspondence`, `huisstijl`, and `batchCorrespondenceJob`.
 
 ## OR Adoption decisions (from docudesk-adopt-or-abstractions)
 
-- **Decision 3**: Schema validation is now mandatory. All schemas in the document register declare full `required`, `properties`, and `hardValidation: true`. The previous `properties: []` / `hardValidation: false` shape is removed.
+- **Decision 3**: Schema validation is now mandatory. All document-domain schemas in the `filinq` register declare full `required`, `properties`, and `hardValidation: true`. The previous `properties: []` / `hardValidation: false` shape is removed.
 - **Decision 2**: Archival annotation per schema. `correspondence` carries `x-openregister-archival.retention: P7Y` (Archiefwet selectielijst cat. 3.2). `batchCorrespondenceJob` carries `P1Y` (operational log, cat. 1.2).
 - **Decision 1**: Lifecycle annotation backs all status fields. `batchCorrespondenceJob` declares `x-openregister-lifecycle` replacing the IAppConfig-backed status writes in `BatchCorrespondenceJob.php`. The wire status values (pending/processing/success/error/completed) are unchanged (Decision 5).
 
@@ -63,7 +63,7 @@ The `batchCorrespondenceJob` schema replaces IAppConfig-based batch-job tracking
 
 - **GIVEN** `CorrespondenceService::dispatchBatchJob()` is invoked with > 10 recipients
 - **WHEN** the job is queued
-- **THEN** a `batchCorrespondenceJob` object SHALL be created in the `document` register with status `pending`
+- **THEN** a `batchCorrespondenceJob` object SHALL be created in the `filinq` register with status `pending`
 - **AND** the OR object UUID SHALL replace the current `$jobId` IAppConfig key
 
 #### Scenario: Job lifecycle transitions replace inline status writes
@@ -96,7 +96,7 @@ The `batchCorrespondenceJob` schema replaces IAppConfig-based batch-job tracking
 
 | ID | Requirement | Priority | Status |
 |----|------------|----------|--------|
-| DREG-010 | `batchCorrespondenceJob` schema exists in `document` register | MUST | Implementing |
+| DREG-010 | `batchCorrespondenceJob` schema exists in `filinq` register | MUST | Implementing |
 | DREG-011 | Schema declares `x-openregister-lifecycle` with states: pending/processing/success/error/completed | MUST | Implementing |
 | DREG-012 | All five lifecycle transition writes in `BatchCorrespondenceJob.php` (lines 113/162/168/186/199) route through lifecycle API | MUST | Apply-phase |
 | DREG-013 | Schema carries `x-openregister-archival.retention: P1Y` | MUST | Implementing |
@@ -174,13 +174,13 @@ When the Phase 2 prerequisites ship, document-register reads SHALL be scoped to 
 
 ### Requirement: AnonymizationLink Schema in Document Register (REQ-DREG-ALINK-01)
 
-The `document` register SHALL include the `anonymizationLink` schema. The schema SHALL declare full `required`, `properties`, and `hardValidation: true` per OR Adoption Decision 3. The schema SHALL carry `x-openregister-archival` with `retention: P7Y` aligned with the anonymisation audit-trail obligation under GDPR Art. 5(2) (accountability principle). The `x-openregister-archival.category` SHALL be shipped as an explicit placeholder (e.g. `"TODO: confirm Archiefwet 1995 selectielijst category with selectielijst manager"`) — the precise selectielijst classification is to be confirmed by the organisation's selectielijst manager before this change is archived.
+The `filinq` register SHALL include the `anonymizationLink` schema. The schema SHALL declare full `required`, `properties`, and `hardValidation: true` per OR Adoption Decision 3. The schema SHALL carry `x-openregister-archival` with `retention: P7Y` aligned with the anonymisation audit-trail obligation under GDPR Art. 5(2) (accountability principle). The `x-openregister-archival.category` SHALL be shipped as an explicit placeholder (e.g. `"TODO: confirm Archiefwet 1995 selectielijst category with selectielijst manager"`) — the precise selectielijst classification is to be confirmed by the organisation's selectielijst manager before this change is archived.
 
 #### Scenario: Schema present in document register after version bump
 
 - **WHEN** `SettingsInitializer::initialize()` runs against a fresh installation with `info.version "5.3.0"`
-- **THEN** the `document` register SHALL expose `anonymizationLink` in its `schemas` array
-- **AND** `objectService->getSchemas(register: 'document')` SHALL include `anonymizationLink`
+- **THEN** the `filinq` register SHALL expose `anonymizationLink` in its `schemas` array
+- **AND** `objectService->getSchemas(register: 'filinq')` SHALL include `anonymizationLink`
 
 #### Scenario: AnonymizationLink archival after 7 years
 

--- a/openspec/specs/dossier-register/spec.md
+++ b/openspec/specs/dossier-register/spec.md
@@ -10,19 +10,22 @@ status: in-progress
 - [dossier-management-ui](../../changes/dossier-management-ui/) _(active)_ — the `dossier` schema gains an optional `status` property governed by a declarative `x-openregister-lifecycle` (canonical `initial: open`; `open → in-review → processed → published/closed`); all other properties, the `base` vocabulary, folder binding and seeds unchanged (kind: code)
 
 ## Purpose
-Defines Filinq's `dossier` register in OpenRegister, holding a `dossier` schema for folder-level anonymisation metadata (name, description, legal bases, and review date) and a `base` schema that encodes the Dutch Woo Art. 5 grondslagen vocabulary, seeded with the six canonical exception grounds. The register is installed and upserted idempotently via the existing configuration-import path on app install and upgrade. This gives folder-based anonymisation work a structured, queryable record of which legal grounds apply and when a dossier was last reviewed.
+
+@e2e exclude Backend data-model spec for the dossier-domain schemas: register/schema import and idempotent upsert, strict property validation, the seeded Woo Art. 5 grondslagen vocabulary and slug→UUID resolution. No browser surface — the dossier UI is specified separately in the dossier-management-ui change. Covered by PHPUnit tests/unit/Settings/DossierRegisterConfigTest.php and tests/unit/Controller/DossierControllerTest.php.
+
+Defines the `dossier` and `base` schemas that Filinq contributes to OpenRegister, carried by the consolidated `filinq` register: a `dossier` schema for folder-level anonymisation metadata (name, description, legal bases, and review date) and a `base` schema that encodes the Dutch Woo Art. 5 grondslagen vocabulary, seeded with the six canonical exception grounds. The register is installed and upserted idempotently via the existing configuration-import path on app install and upgrade. This gives folder-based anonymisation work a structured, queryable record of which legal grounds apply and when a dossier was last reviewed.
 ## Requirements
 ### Requirement: Dossier register exists in Filinq's register configuration
 
-The system SHALL define a new `dossier` register in `lib/Settings/filinq_register.json` under `components.registers`, alongside the existing `consent`, `signing`, `templates`, and `document` registers. The register SHALL be applied to OpenRegister on app install/upgrade via the existing `ConfigurationService::importFromApp()` path — no new loader code is required.
+The system SHALL define the `dossier` and `base` schemas in `lib/Settings/filinq_register.json` under `components.schemas`, listed in the `schemas` array of the single `filinq` register declared under `components.registers`. (The former `consent`, `signing`, `templates`, `document`, `dossier` and `docudesk` registers were consolidated into that one register; `filinq` is now the only register slug this app declares.) The register SHALL be applied to OpenRegister on app install/upgrade via the existing `ConfigurationService::importFromApp()` path — no new loader code is required.
 
 #### Scenario: Register is installed on fresh install
 - **WHEN** Filinq is installed on a Nextcloud instance that has OpenRegister enabled
-- **THEN** `RegistersLoader` creates a register with slug `dossier`, title "Dossier Register", and schemas `dossier` and `base`
+- **THEN** `RegistersLoader` creates a register with slug `filinq`, title "Filinq Register", whose `schemas` array includes `dossier` and `base`
 - **AND** the register is visible via `GET /api/registers?_extend=schemas`
 
 #### Scenario: Register is idempotent on upgrade
-- **WHEN** Filinq is upgraded on an instance that already has the `dossier` register installed
+- **WHEN** Filinq is upgraded on an instance that already has the `filinq` register installed
 - **THEN** the register is not duplicated; the loader upserts by slug
 - **AND** existing dossier objects are preserved
 
@@ -31,7 +34,7 @@ The system SHALL define a new `dossier` register in `lib/Settings/filinq_registe
 The system SHALL define a `dossier` schema with the following properties: `name` (string, required, mirrors folder name at creation), `description` (string, optional), `bases` (array of strings, optional, no `minItems` — each string is the slug of a `base` object), and `checkedOn` (date-time, optional). The schema SHALL be stored under `components.schemas.dossier` in `filinq_register.json`, follow OpenRegister's OpenAPI 3.0.0 schema conventions (ADR-006), and MUST include `slug: "dossier"`, `title`, `description`, and `configuration.objectNameField: "name"` so list UIs render the stored name.
 
 #### Scenario: A dossier can be created with all fields set
-- **GIVEN** the dossier register has been installed and the six canonical seed `base` objects exist
+- **GIVEN** the `filinq` register has been installed and the six canonical seed `base` objects exist
 - **WHEN** a client posts `POST /api/objects/dossier` with `name`, `description`, `bases: ["persoonsgegevens"]` (a known seed slug), `checkedOn`, and `@self.folder` set to an existing folder node ID
 - **THEN** the response is 201 with a `uuid`, and subsequent `GET /api/objects/dossier/<uuid>` returns the same data including `bases: ["persoonsgegevens"]` (slug preserved verbatim, not resolved to UUID)
 
@@ -57,9 +60,9 @@ The system SHALL define a `base` schema with the following properties: `name` (s
 
 ### Requirement: `bases` is a string-array of base slugs, resolved at runtime by consumers
 
-The `dossier.bases` field SHALL be a JSON array of strings (`items.type: "string"`). Each element is the slug of a `base` object in the `dossier` register (e.g. `"persoonsgegevens"`).
+The `dossier.bases` field SHALL be a JSON array of strings (`items.type: "string"`). Each element is the slug of a `base` object in the `filinq` register (e.g. `"persoonsgegevens"`).
 
-OpenRegister's `$ref`-based referential-integrity walker (`ReferentialIntegrityService::extractTargetRef`) is NOT used here in v1: the register-config import path runs schemas through a strict JSON-schema validator (`opis/json-schema`) that rejects `#/components/schemas/<x>` references when the schema is validated in isolation. Storing slugs as plain strings sidesteps that constraint. Consumer apps (Filinq's `anonymisation-grondslagen-summary` is the first one) resolve the slug against the `base` register at read time.
+OpenRegister's `$ref`-based referential-integrity walker (`ReferentialIntegrityService::extractTargetRef`) is NOT used here in v1: the register-config import path runs schemas through a strict JSON-schema validator (`opis/json-schema`) that rejects `#/components/schemas/<x>` references when the schema is validated in isolation. Storing slugs as plain strings sidesteps that constraint. Consumer apps (Filinq's `anonymisation-grondslagen-summary` is the first one) resolve the slug against the `base` schema at read time.
 
 **v1 consequences of the slug-only model:**
 
@@ -113,7 +116,7 @@ Because Filinq relies on OpenRegister's audit trail for review-history (design.m
 
 ### Requirement: Seed dossiers demonstrate the three ADR-016 personas
 
-The `dossier` register SHALL ship with 3–5 seed dossier objects covering the municipality, consultancy, and travel-agency personas defined in ADR-016. At least one seed dossier SHALL have an empty `bases` array to demonstrate optionality, and at least one SHALL have `null` for `checkedOn` to demonstrate the unreviewed state. Seed dossiers SHALL reference `base` seed objects via their slugs (resolved by the loader to UUIDs).
+The `filinq` register SHALL ship with 3–5 seed dossier objects covering the municipality, consultancy, and travel-agency personas defined in ADR-016. At least one seed dossier SHALL have an empty `bases` array to demonstrate optionality, and at least one SHALL have `null` for `checkedOn` to demonstrate the unreviewed state. Seed dossiers SHALL reference `base` seed objects via their slugs (resolved by the loader to UUIDs).
 
 #### Scenario: Seeded dossiers are visible after install
 - **WHEN** Filinq is installed and `RegistersLoader` completes

--- a/openspec/specs/letter-correspondence-generation/spec.md
+++ b/openspec/specs/letter-correspondence-generation/spec.md
@@ -97,7 +97,7 @@ The system SHALL support multiple output formats for correspondence: PDF (defaul
 
 ### Requirement: Huisstijl default configuration
 
-The system SHALL support a huisstijl configuration object stored in OpenRegister (schema: `huisstijl`, register: `document`) containing `logo` (base64 or file reference), `primaryColor` (CSS color), `headerHtml` (Twig template for page header), `footerHtml` (Twig template for page footer), and `defaultMargins` (object with top/right/bottom/left in mm). When generating correspondence, if the template references a huisstijl ID or a default huisstijl is configured, these settings SHALL be applied automatically to the output.
+The system SHALL support a huisstijl configuration object stored in OpenRegister (schema: `huisstijl`, register: `filinq`) containing `logo` (base64 or file reference), `primaryColor` (CSS color), `headerHtml` (Twig template for page header), `footerHtml` (Twig template for page footer), and `defaultMargins` (object with top/right/bottom/left in mm). When generating correspondence, if the template references a huisstijl ID or a default huisstijl is configured, these settings SHALL be applied automatically to the output.
 
 #### Scenario: Huisstijl applied to letter
 - **WHEN** a correspondence is generated and a huisstijl configuration exists
@@ -112,17 +112,17 @@ The system SHALL support a huisstijl configuration object stored in OpenRegister
 
 ### Requirement: Correspondence register logging
 
-The system SHALL log every generated correspondence as an object in the document register (schema: `correspondence`, register: `document`). Each entry SHALL contain: `templateId` (UUID of template used), `templateName` (human-readable), `recipientId` (UUID of recipient object), `recipientType` (e.g., PERSON, ORGANIZATION), `caseReference` (optional UUID linking to source zaak/case), `generatedAt` (ISO 8601 datetime), `format` (pdf/docx/html), `status` (generated/failed), and `generatedBy` (Nextcloud user ID). The schema SHALL be added to `filinq_register.json`.
+The system SHALL log every generated correspondence as an object in the `filinq` register (schema: `correspondence`, register: `filinq`). Each entry SHALL contain: `templateId` (UUID of template used), `templateName` (human-readable), `recipientId` (UUID of recipient object), `recipientType` (e.g., PERSON, ORGANIZATION), `caseReference` (optional UUID linking to source zaak/case), `generatedAt` (ISO 8601 datetime), `format` (pdf/docx/html), `status` (generated/failed), and `generatedBy` (Nextcloud user ID). The schema SHALL be added to `filinq_register.json`.
 
 #### Scenario: Successful generation creates register entry
 - **WHEN** a letter is successfully generated
-- **THEN** a correspondence object is created in the document register
+- **THEN** a correspondence object is created in the `filinq` register
 - **AND** the object contains all required metadata fields
 - **AND** `status` is set to "generated"
 
 #### Scenario: Failed generation creates register entry with error
 - **WHEN** a letter generation fails
-- **THEN** a correspondence object is still created in the document register
+- **THEN** a correspondence object is still created in the `filinq` register
 - **AND** `status` is set to "failed"
 - **AND** an `errorMessage` field contains the failure reason
 

--- a/openspec/specs/openregister-bridge/spec.md
+++ b/openspec/specs/openregister-bridge/spec.md
@@ -11,7 +11,7 @@ retrofit: true
 
 Provides a single resolver service that translates Filinq `IAppConfig` keys into OpenRegister register/schema slug pairs and validates namespace identifiers used by per-app data partitions. Services that need to read or write OpenRegister objects depend on the resolver instead of reading config keys directly — this keeps the config-translation seam in one place, isolates the IAppConfig naming convention from consumer code, and gives controllers a typed exception to render setup-state UIs.
 
-The resolver is consumed by `TemplateService` and `TemplateVersionService` today; future register-backed features (signing requests, document register, dossier register, consent log) are expected to consume the same translator pattern.
+The resolver is consumed by `TemplateService` and `TemplateVersionService` today; future register-backed features (signing requests, document schemas, dossier schemas, consent log — all now schemas of the single `filinq` register) are expected to consume the same translator pattern.
 
 ## Requirements
 
@@ -67,7 +67,7 @@ Both lookups read `SettingsService::getAllSettings()['configuration']` and surfa
 - The resolver does NOT discover register/schema slugs at runtime — it reads what `SettingsService` has cached. If admin settings change at runtime, callers must re-resolve.
 - Both lookups raise `RegisterNotConfiguredException` with the same exception class. Callers cannot distinguish "template register missing" from "template schema missing" without parsing the message; that's acceptable because both are admin-side setup gaps with the same remediation (open admin settings, fill in the field). The dedicated exception class lets controllers render an empty-state response instead of a 500.
 - The namespace regex matches REQ-TMPL-03 verbatim — if either spec ever loosens the constraint (e.g. to allow hyphens), both must move together. TODO: extract the regex to a shared constant if a second consumer needs it.
-- The resolver currently only knows template + template-version registers. New register-backed features (signing requests, document register, dossier register, consent log) will need to either extend this class with new lookups or follow the same pattern in sibling resolvers. The decision is deferred until the second feature lands; this REQ documents the existing contract without prescribing the expansion model.
+- The resolver currently only knows template + template-version registers. New register-backed features (signing requests, document schemas, dossier schemas, consent log — all now schemas of the single `filinq` register) will need to either extend this class with new lookups or follow the same pattern in sibling resolvers. The decision is deferred until the second feature lands; this REQ documents the existing contract without prescribing the expansion model.
 
 ## Configuration
 


### PR DESCRIPTION
## Why

filinq#771 consolidated six registers — `consent`, `signing`, `templates`, `document`, `dossier`, `docudesk` — into one with slug **`filinq`**, carrying all 23 schemas, and `OCA\Filinq\Repair\ConsolidateRegisters` physically moves the object rows. The specs under `openspec/specs/` still described the old topology.

The sharpest case is `anonymization-link`, whose four literal API examples read:

```
GET /api/objects?register=document&schema=anonymizationLink&sourceFileId=<NC_FILE_ID>
```

That is not stale prose. Once the repair step has moved the rows, that query returns **nothing** — and it fails silently, exactly the way the consolidation's own docblock warns about ("Nothing errors. The app simply looks empty"). Anyone implementing to the spec writes the wrong query.

## What changed

Register references become `filinq`. **Schema slugs are untouched.**

That distinction was the trap and it was handled per-occurrence, not by substitution: `dossier` is *both* a retired register slug *and* a live schema slug, and `template`/`anonymizationLink` never moved. So `register=document&schema=anonymizationLink` becomes `register=filinq&schema=anonymizationLink` — half the pair changes. The external `brp` register in `letter-correspondence-generation` belongs to another app and is left alone.

Eight specs updated:

| spec | what it was saying |
|---|---|
| `anonymization-link` | 4 literal API examples + schema-home prose |
| `document-register` | data-model home, `getSchemas(register: 'document')` |
| `dossier-register` | register identity, seed home, the now-false "alongside the existing …" list |
| `letter-correspondence-generation` | `register: "document"` for `huisstijl` + `correspondence` |
| `batch-anonymization`, `custom-dictionary-recognition`, `openregister-bridge`, `admin-settings` | schema-home prose |

Also fixes a **pre-existing** register/schema confusion in `dossier-register`: `base` is a schema, never a register.

## Two things deliberately NOT done

**Headings are unchanged.** Five `@spec` tags in `src/` dereference anchors such as `anonymization-link/spec.md#requirement-bidirectional-lookup-via-or-search-api-req-alink-03`. Renaming a requirement heading changes its slug and breaks those references silently, so only body text was edited.

**Ten specs still carry stale references and are not touched here.** Gate-19 is scoped by *file*, not by line — touching one line pulls every scenario in that file into e2e scope. The remaining ten cost **257 scenarios**:

| spec | scenarios pulled in | genuinely backend? |
|---|---|---|
| `consent-management` | 41 | no — real UI |
| `template-management` | 39 | no — real UI |
| `document-creatie-sjablonen` | 31 | no — wizard UI |
| `entity-publication-policies` | 30 | no — ProhibitionIndex UI |
| `financial-document-field-extraction` | 24 | yes |
| `anonimisation-grondslagen-summary` | 20 | yes |
| `anonimisation-prohibition-gate` | 20 | yes |
| `register-i18n` | 20 | yes |
| `document-editing` | 19 | no — real UI |
| `signing-audit-via-or` | 13 | yes |

Clearing those with excludes would mean either writing hollow reasons or claiming five UI-bearing specs are backend. Both are worse than the red, so they are reported rather than papered over — a follow-up issue is the right home.

## Gate-19, handled honestly

Six of the eight files were free: every scenario already carried an exclude or a real `@e2e` reference. The other two — `anonymization-link` (14) and `dossier-register` (16) — each gained **one whole-spec `@e2e exclude`**.

This is the mechanism gate-19's own docstring names for "pure-backend or API-contract specs covered by Newman/PHPUnit instead of Playwright", and `document-register` already carries exactly such a line. Both are true: these specs cover OR schema validation, `SettingsInitializer` version-compare, service UPSERT semantics and search-response shape, with no browser surface — `dossier`'s UI lives in the separate `dossier-management-ui` change, and `anonymization-link`'s REQ-ALINK-04 is *literally* unit-test coverage.

Per the gate's `exclusion_reason` doctrine — a reason naming a **test artifact** holds, one naming a **state of the world** rots — both name real files: `tests/unit/Service/AnonymizationLinkServiceTest.php`, `tests/unit/Settings/DossierRegisterConfigTest.php`, `tests/unit/Controller/DossierControllerTest.php`. All verified to exist.

I checked the gate's parser before writing them: gate-19 has **no closed category vocabulary** (unlike gate-61) — `is_reason_bearing()` requires only ≥3 chars and one alphanumeric. So these are free-text prose by design, not an invented category.

## Verification

```
[gate-19] e2e-coverage: PASS — 87 reference(s) in e2e suite   (diff-scoped, exit 0)
[gate-16] spec-coverage: # count=0
[hydra-gates] ALL 64 APPLICABLE GATES GREEN — and all 64 of them ran.
```

The repo-wide uncovered-scenario backlog went **down**, 443 → 411 — the excludes retired real debt rather than shifting it.
