### PR TITLE
fix(specs): exclude the backend-only half of the remaining specs, correct stale registers

### DIFF
--- a/openspec/specs/anonymisation-prohibition-gate/spec.md
+++ b/openspec/specs/anonymisation-prohibition-gate/spec.md
@@ -14,7 +14,7 @@ When the anonymise endpoint is called, the controller / service MUST resolve eve
 #### Scenario: No prohibitions configured — gate is a no-op
 
 - **GIVEN** an anonymise request with a payload of detected entities
-- **AND** zero active `publicationProhibition` records exist in the consent register
+- **AND** zero active `publicationProhibition` records exist in the `filinq` register
 - **WHEN** the endpoint processes the request
 - **THEN** the gate runs but matches nothing
 - **AND** the request is forwarded to OpenRegister unchanged
@@ -170,7 +170,7 @@ When an override validates, the corresponding prohibition match is treated as "r
 
 ### Requirement: The gate MUST NOT create `publicationConsent` records
 
-This change is read-only with respect to the consent register. The gate consults `publicationProhibition` records but MUST NOT create, modify, or query `publicationConsent` records. Generic anonymisation flows continue to be outside the publication-clearance workflow.
+This change is read-only with respect to the `filinq` register. The gate consults `publicationProhibition` records but MUST NOT create, modify, or query `publicationConsent` records. Generic anonymisation flows continue to be outside the publication-clearance workflow.
 
 #### Scenario: Successful anonymise creates no publicationConsent
 

--- a/openspec/specs/consent-management/spec.md
+++ b/openspec/specs/consent-management/spec.md
@@ -602,6 +602,8 @@ when no contact is linked. The Twig merge engine, batch logic, and PDF output SH
 
 The schema MUST add a new property `scope` with enum values `document` and `entity`, default `document`. All existing records (which are implicitly per-document) MUST be valid under the new schema with `scope` defaulted to `document`. The discriminator gates which other fields are required and which are not used.
 
+@e2e exclude Stored-record shape (default-valued scope on pre-change records, field requiredness per discriminator) is a persistence claim with no rendered surface; asserted by PHPUnit tests/unit/Service/ConsentScopeValidatorTest.php — testDocumentScopeAcceptsValidPayload, testEntityScopeAcceptsValidPayload, testUnknownScopeIsRejected
+
 #### Scenario: Schema accepts existing records as scope=document by default
 
 - **GIVEN** a `publicationConsent` record stored before this change landed (no `scope` field present)
@@ -628,6 +630,8 @@ The schema MUST add a new property `scope` with enum values `document` and `enti
 ### Requirement: `documentId` MUST be required only for scope=document records
 
 The existing canonical requirement (CONS-002: "Each consent record links to a document via documentId") is refined: this requirement MUST continue to hold for `scope: "document"` records. For `scope: "entity"` records, `documentId` MUST NOT be required, and the consent service MUST reject writes that include a `documentId` on a `scope: "entity"` record (sanity check — entity-wide standing consent does not belong to a single document).
+
+@e2e exclude Server-side write validation on a field no Vue form exposes (neither src/dialogs/StandingConsentFormModal.vue nor src/modals/CreateStandingConsentModal.vue carries a documentId input, and there is no consent-creation UI per REQ-CONS-07); asserted by PHPUnit tests/unit/Service/ConsentScopeValidatorTest.php — testDocumentScopeRejectsMissingDocumentId, testEntityScopeRejectsDocumentId — and by Newman tests/integration/filinq-api.postman_collection.json "POST /api/policy/standing-consents (scope validation: documentId not allowed)"
 
 #### Scenario: scope=document write missing documentId is rejected
 
@@ -671,6 +675,8 @@ The schema MUST add the following properties, populated only when `scope: "entit
 
 The schema MUST add a new optional property `policyMatch`, valid only on `scope: "document"` records. This property MUST be a polymorphic reference constrained to point ONLY to a `publicationProhibition` record OR a `publicationConsent` record (with the latter expected to be `scope: "entity"`). Any UUID pointing to a different schema MUST be rejected by OpenRegister's `ValidateObject` pipeline at save time. The consent service MUST additionally enforce that a `publicationConsent` referent is in fact `scope: "entity"`.
 
+@e2e exclude Schema-definition shape and save-time referent validation; policyMatch is set by the detector and exposed on no create/edit form, so a browser cannot produce any of these writes. Asserted by PHPUnit tests/unit/Service/ConsentScopeValidatorTest.php (testEntityScopeRejectsPolicyMatch), tests/unit/Service/ConsentServiceTest.php (testValidateRejectsPolicyMatchOnScopeEntity) and tests/unit/Service/ConsentUpdateHandlerTest.php (testUnmatchedRecordRejectsPolicyMatchInjection, testProhibitionPolicyMatchUuidSwapRejected)
+
 #### Scenario: Schema definition uses items.oneOf for constraint
 
 - **GIVEN** the updated `publicationConsent` schema in `lib/Settings/filinq_register.json`
@@ -711,6 +717,8 @@ The schema MUST add a new optional property `policyMatch`, valid only on `scope:
 ### Requirement: `consentStatus` enum MUST remain unchanged
 
 This change MUST NOT add new values to the `consentStatus` enum. The discriminator for "this record was pre-empted by a policy" is the combination of `policyMatch` (non-null + which schema it references) and `notificationStatus: "skipped"`. The existing values (`pending`, `consent_given`, `objection_received`, `no_response`, `anonymized`) cover all outcomes — pre-empted records use the same terminal values as workflow-resolved records, with `policyMatch` and `notificationStatus` carrying the path-of-arrival information.
+
+@e2e exclude Field values written by the detector on a record no UI creates (consentStatus, notificationStatus, notificationSentAt, objectionDeadline, publicationDecision, policyMatch, and the absence of a dispatch); asserted by Newman tests/integration/filinq-api.postman_collection.json — "prohibition: POST /api/consent → prohibition rejects the request (403 + rule identity)", "standing-consent: POST /api/consent → consent_given + publish_with_consent", "both-match: POST /api/consent → prohibition wins over standing consent" — and by PHPUnit tests/unit/Service/ConsentServiceTest.php
 
 #### Scenario: Prohibition match resolves to existing 'anonymized' status
 

--- a/openspec/specs/document-creatie-sjablonen/spec.md
+++ b/openspec/specs/document-creatie-sjablonen/spec.md
@@ -12,6 +12,9 @@ status: in-progress
 
 ## Purpose
 Generates documents from templates by merging resolved data into a sandboxed Twig template. Merge data is resolved from OpenRegister objects by register, schema, and object UUID with nested resolution up to three levels deep, optional external data via OpenConnector, and ad-hoc JSON context, while rendering supports conditional sections, iteration, and per-field warnings for missing values. This enables automated creation of formal documents such as beschikkingen from structured case data.
+
+@e2e exclude API-only generation surface (POST /api/documents/generate, /generate/preview, /generate/bulk, GET /api/documents/jobs/{jobId}) reached by no Vue component; asserted below HTTP by PHPUnit — tests/unit/Controller/DocumentControllerTest.php, tests/unit/Service/DocumentServiceTest.php, tests/unit/BackgroundJob/BatchDocumentJobTest.php
+
 ## Requirements
 ### Requirement: REQ-DCS-01 Data Resolution from OpenRegister (Priority: Must)
 
@@ -66,7 +69,7 @@ The system MUST render templates by merging resolved data context using the exis
 - WHEN DocumentService::generateDocument() is called
 - THEN the Twig template is rendered with the merged data
 - AND conditional sections show/hide based on zaaktype
-- AND document metadata is stored in the document register
+- AND document metadata is stored in the `filinq` register
 
 #### Scenario: Conditional sections in template
 - GIVEN a template has `{% if zaaktype == 'omgevingsvergunning' %}` blocks
@@ -253,7 +256,7 @@ Generated documents MUST be linkable to cases in Procest and triggerable from wo
 - GIVEN a document is generated from a zaak's data
 - WHEN the generation completes
 - THEN the document can be automatically attached to the source zaak in Procest
-- AND document metadata is stored in the document register
+- AND document metadata is stored in the `filinq` register
 
 #### Scenario: Workflow-triggered generation
 - GIVEN an n8n workflow monitors zaak status changes
@@ -263,14 +266,14 @@ Generated documents MUST be linkable to cases in Procest and triggerable from wo
 
 #### Scenario: Audit trail
 - GIVEN a document is generated
-- WHEN the metadata is stored in the document register
+- WHEN the metadata is stored in the `filinq` register
 - THEN it includes: template ID, version, data sources, generation timestamp, generating user
 
 | ID | Requirement | Priority | Status |
 |----|------------|----------|--------|
 | DCS-070 | Generated documents can be attached to zaak in Procest | SHOULD | Planned |
 | DCS-071 | Document generation triggerable from n8n workflows | SHOULD | Planned |
-| DCS-072 | Generated document metadata stored in document register | MUST | Planned |
+| DCS-072 | Generated document metadata stored in the `filinq` register | MUST | Planned |
 
 ### Requirement: REQ-DCS-09 Mock Register Test Data (Priority: Should)
 

--- a/openspec/specs/document-editing/spec.md
+++ b/openspec/specs/document-editing/spec.md
@@ -23,6 +23,8 @@ byte-identical. ADR-087 §2 prefers this over parse-and-re-serialise because
 re-serialisation silently drops comments, tracked changes and styles that no test
 asserts on.
 
+@e2e exclude MCP JSON-RPC tool surface with no Filinq UI of its own; asserted by PHPUnit under tests/unit/Service/Editing/ — EditSessionServiceTest, GuardedWriterTest, DocumentGuardTest, DocumentGuardFormatTest, AgentArtefactMarkerTest, PackageCodecTest, PackagePartIoTest, RoundTripFidelityTest, EditSessionAgentSurfacesTest. NOT evidenced by tests/e2e/workflows/agent-document-editing.spec.ts: that suite carries no @e2e anchor by design and harness-skips whenever no cache backend serves MCP sessions (all six skipped in CI run 32777433490, entries 89-94).
+
 ## Requirements
 
 ### Requirement: Edits address stable anchors, never positional indexes
@@ -232,7 +234,7 @@ refusal MAY fail open, because its artefacts are identifiable from the file itse
 
 #### Scenario: An unreachable signing register refuses the edit
 
-- **GIVEN** the signing register cannot be reached
+- **GIVEN** the `filinq` register cannot be reached
 - **WHEN** an edit is attempted
 - **THEN** the edit MUST be refused, because absence of evidence is not evidence of absence
 

--- a/openspec/specs/entity-publication-policies/spec.md
+++ b/openspec/specs/entity-publication-policies/spec.md
@@ -5,17 +5,17 @@ status: done
 # entity-publication-policies Specification
 
 ## Purpose
-Defines the `publicationProhibition` schema in the consent register, an entity-level deny-list where each rule names a person or organisation that must always be anonymised when detected in a publication-bound document, regardless of any consent. Rules carry match criteria (exact, normalized, BSN, KVK), legal authority, severity, validity window, and active state, and are importable on app install and queryable via the OpenRegister API. This provides the policy data that anonymisation and publication-clearance flows match detected entities against.
+Defines the `publicationProhibition` schema in the `filinq` register, an entity-level deny-list where each rule names a person or organisation that must always be anonymised when detected in a publication-bound document, regardless of any consent. Rules carry match criteria (exact, normalized, BSN, KVK), legal authority, severity, validity window, and active state, and are importable on app install and queryable via the OpenRegister API. This provides the policy data that anonymisation and publication-clearance flows match detected entities against.
 ## Requirements
 ### Requirement: A `publicationProhibition` schema MUST exist in the consent register
 
-The `publicationProhibition` schema MUST be defined in the consent register and MUST be importable on app install. It represents an entity-level deny-list rule: each record describes one real-world person or organization that MUST always be anonymized when detected in a publication-bound document, regardless of any per-document consent process or any standing consent that might otherwise apply. A prohibition is not a consent — it asserts the absence of permission to publish unredacted, with prohibition-specific metadata.
+The `publicationProhibition` schema MUST be defined in the `filinq` register and MUST be importable on app install. It represents an entity-level deny-list rule: each record describes one real-world person or organization that MUST always be anonymized when detected in a publication-bound document, regardless of any per-document consent process or any standing consent that might otherwise apply. A prohibition is not a consent — it asserts the absence of permission to publish unredacted, with prohibition-specific metadata.
 
 #### Scenario: Schema is registered on app install
 
 - **GIVEN** a fresh Filinq install
 - **WHEN** the app's register configuration is imported
-- **THEN** the `consent` register contains a `publicationProhibition` schema with the documented properties: `primaryName`, `entityType`, `matchRules`, `reason`, `legalAuthority`, `caseReference`, `severity`, `jurisdiction`, `addedBy`, `validFrom`, `validUntil`, `active`, `notes`
+- **THEN** the `filinq` register contains a `publicationProhibition` schema with the documented properties: `primaryName`, `entityType`, `matchRules`, `reason`, `legalAuthority`, `caseReference`, `severity`, `jurisdiction`, `addedBy`, `validFrom`, `validUntil`, `active`, `notes`
 
 #### Scenario: Schema is queryable via OpenRegister API
 
@@ -107,6 +107,8 @@ When a detected entity matches BOTH a `publicationProhibition` rule and an activ
 
 The matching service MUST NOT issue a database query per detected entity. Instead, it MUST load all `active: true` `publicationProhibition` records and all `active: true` `scope: "entity"` `publicationConsent` records (with current time bounds open) into an in-memory lookup index at service init or on rule-mutation event. The lookup MUST be O(1) per `(matchType, entityType, value)` tuple.
 
+@e2e exclude In-memory rule-cache lifecycle (load, O(1) lookup, invalidation on rule mutation, scope-filtered publicationConsent events) has no rendered surface; asserted by PHPUnit tests/unit/Service/PolicyMatchServiceTest.php (testInvalidateCacheClearsLoadedRules, rulesCache seeding) and tests/unit/EventListener/FilinqEventHandlerTest.php (scope=entity vs scope=document event handling)
+
 #### Scenario: Page-level batch detection issues no per-entity rule queries
 
 - **GIVEN** a document with 30 detected entities and a combined prohibition + standing-consent set of 100 active records total
@@ -131,6 +133,8 @@ The matching service MUST NOT issue a database query per detected entity. Instea
 ### Requirement: Time bounds MUST be honored at match time
 
 A rule with `validFrom` in the future or `validUntil` in the past MUST NOT match, even if `active: true`. A rule with `active: false` MUST NOT match regardless of time bounds. This applies to both `publicationProhibition` records and `scope: "entity"` `publicationConsent` records.
+
+@e2e exclude Match-time evaluation of validFrom / validUntil / active; the outcome is a non-match inside the detector, never rendered (the Vue surfaces show the stored active flag, not the match decision). Asserted by PHPUnit tests/unit/Service/PolicyMatchServiceTest.php — testFutureValidFromDoesNotMatch, testExpiredValidUntilDoesNotMatch, testInactiveRulesAreSkipped
 
 #### Scenario: Rule with future validFrom does not match
 

--- a/openspec/specs/register-i18n/spec.md
+++ b/openspec/specs/register-i18n/spec.md
@@ -153,7 +153,7 @@ Filinq MUST have a small, well-defined translation surface limited to template m
 - THEN only template title, description, field label, and helpText are translatable
 - AND template content (HTML/Twig) is NOT translatable via this mechanism
 - AND consent records are NOT translatable
-- AND document register report data is NOT translatable
+- AND `filinq` register report data is NOT translatable
 
 #### Scenario: Template content language variants
 - GIVEN a template needs to generate documents in Dutch and English

--- a/openspec/specs/template-management/spec.md
+++ b/openspec/specs/template-management/spec.md
@@ -13,7 +13,7 @@ retrofit_extensions:
 **Status**: in-progress
 **OpenSpec changes**:
 - [office-template-authoring](../../changes/office-template-authoring/) _(active)_ — office-file-native templates: `templateType`/source-file data-model extension (REQ-DDOTA-006) and versioning/lock/preview/duplicate parity for office templates (REQ-DDOTA-007) (kind: code)
-- [guided-document-wizard](../../changes/guided-document-wizard/) _(active)_ — adds the `wizardDefinition` schema to the templates register (guided-interview definitions fronting a template by `templateId`; the `template`/`templateVersion` data model is unchanged) — full requirements live in the `guided-document-wizard` capability (REQ-DDGDW-*) (kind: code)
+- [guided-document-wizard](../../changes/guided-document-wizard/) _(active)_ — adds the `wizardDefinition` schema to the `filinq` register (guided-interview definitions fronting a template by `templateId`; the `template`/`templateVersion` data model is unchanged) — full requirements live in the `guided-document-wizard` capability (REQ-DDGDW-*) (kind: code)
 
 ## Purpose
 
@@ -210,10 +210,12 @@ TemplateService is injectable via DI, enabling other Nextcloud apps to manage te
 
 TemplateService resolves register and schema configuration via OpenRegisterResolver and uses ObjectService for all data operations.
 
+@e2e exclude Internal service wiring (resolver lookup, RuntimeException when OpenRegister is absent, namespace-validation delegation) with no rendered surface; asserted by PHPUnit tests/unit/Service/OpenRegisterResolverTest.php and tests/unit/Service/TemplateServiceTest.php
+
 #### Scenario: Register/schema resolution
 - GIVEN TemplateService needs to perform a CRUD operation
 - WHEN `OpenRegisterResolver::getRegisterAndSchema()` is called
-- THEN the configured template register and schema IDs are returned
+- THEN the configured `filinq` register and schema IDs are returned
 - AND these are used for all ObjectService calls
 
 #### Scenario: OpenRegister unavailable
@@ -268,6 +270,8 @@ Template listing supports search, filtering, and pagination via OpenRegister's q
 
 Template objects from OpenRegister are consistently serialized for API responses.
 
+@e2e exclude PHP serialization internals (jsonSerialize() dispatch, array cast of non-object results, results/total envelope) invisible above the API boundary; asserted by PHPUnit tests/unit/Service/TemplateServiceTest.php
+
 #### Scenario: JSON serialization of OpenRegister objects
 - GIVEN an OpenRegister object is returned from a query
 - WHEN the object has a jsonSerialize() method
@@ -306,7 +310,7 @@ Template objects from OpenRegister are consistently serialized for API responses
 
 ### Templates Register Schemas
 
-The `templates` register (`lib/Settings/filinq_register.json`) is the single
+The `filinq` register (`lib/Settings/filinq_register.json`) is the single
 source of truth for template-related schemas. It contains:
 
 | Schema | Owning capability | Purpose |
@@ -397,6 +401,8 @@ Snapshots are stored as OpenRegister objects in the version register/schema retu
 Filinq SHALL return both source and target version objects for client-side diff rendering, leaving the actual diff computation to the consumer.
 
 The diff endpoint is intentionally thin: the server fetches both versions and returns them under `from` / `to` keys; clients (e.g. the Filinq template editor UI) compute the visual diff against the two `content` blobs.
+
+@e2e exclude GET /api/templates/{id}/versions/diff has no frontend caller today (the only diff view, src/views/comparison/ComparisonView.vue, calls /api/comparison/compare instead); the response shape and its 400/404 paths are asserted by PHPUnit tests/unit/Controller/TemplateVersionsControllerTest.php and tests/unit/Service/TemplateVersionServiceTest.php
 
 #### Scenario: Diff requires both endpoints
 
@@ -502,6 +508,8 @@ A lock is represented by two fields on the template object: `lockedBy` (user id)
 Filinq SHALL centralise list-parameter parsing, body-parameter parsing, and exception-to-JSON conversion for template controllers in a single `TemplateRequestHandler` so every endpoint exposes consistent paging, filtering, and error semantics.
 
 `parseListParams(IRequest)` reads `namespace`, `_search`, `_limit` (default 20), `_offset` (default 0) and returns `{filters: {namespace?, _search?}, limit: int, offset: int}` — only non-empty filters are included. `parseBodyParams(IRequest, stripKeys?)` returns the request param bag with the framework's `_route` key always removed and any caller-listed keys also stripped (e.g. `id` on update). `buildErrorResponse(Exception, prefix)` logs the exception with the given prefix and returns a `JSONResponse` whose status code is the exception's code when it falls in `[400, 600)` and `500` otherwise; the body is `{"error":"<exception message>"}`.
+
+@e2e exclude PHP helper internals on TemplateRequestHandler (parseListParams, parseBodyParams, buildErrorResponse) with no rendered surface; asserted by PHPUnit tests/unit/Controller/TemplateRequestHandlerTest.php
 
 #### Scenario: List-params parser keeps only non-empty filters
 


### PR DESCRIPTION
## What

Clears the genuinely-backend half of #782 with truthful excludes and corrects the stale register references left behind by #771.

**83 scenarios newly excluded**, measured with gate-19's own parser (`check_e2e_coverage.parse_spec_scenarios`), 0 bare:

| Spec | Level | Scenarios |
|---|---|---|
| `document-creatie-sjablonen` | whole-spec | 31 / 31 |
| `document-editing` | whole-spec | 19 / 19 |
| `template-management` | requirement × 4 | 13 |
| `entity-publication-policies` | requirement × 2 | 7 |
| `consent-management` | requirement × 4 | 13 |

Every reason names a **test artefact that was opened and confirmed to exist**, per gate-19's doctrine that artefact-naming reasons hold and world-describing ones rot.

### `document-editing` deliberately does NOT cite its Playwright suite

`tests/e2e/workflows/agent-document-editing.spec.ts` carries **no `@e2e` anchor by design** and harness-skips whenever no cache backend serves MCP sessions — **all six skipped in CI run 32777433490, entries 89–94**. The exclude names PHPUnit `tests/unit/Service/Editing/` and states in-line that the Playwright leg is not the evidence. A reason naming a skipped suite is a lie with extra steps.

## Three requirement groups REFUSED

The issue misclassified these. Each has a live browser surface, so they are left **untagged and honestly failing gate-19** rather than excluded falsely:

- **`template-management` REQ-TMPL-06 (Search and Pagination)** — `src/views/templates/TemplateIndex.vue` binds a search box (`v-model="searchQuery"`) and sends the very `_search` filter the scenarios assert. A Playwright test can type "invoice" and assert the filtered rows.
- **`entity-publication-policies` match-rule types** — `src/dialogs/ProhibitionFormModal.vue:60` renders the closed v1 vocabulary as an `NcSelect` (`matchTypeOptions: ['exact','normalized','bsn','kvk']`). That select is where a user actually meets the "exactly these four types" constraint.
- **`consent-management` entity-scope fields** — `src/dialogs/StandingConsentFormModal.vue` gates submit on `consentMethod` and `matchRules` (`canSubmit`, L90–92 → `:disabled` L256) and renders the *"warn when `validUntil` omitted"* clause the requirement body itself calls for (L192).

## Register references (14 across 7 specs)

Register half only. **Schema slugs are unchanged** — `document`, `dossier`, `signing` and `consent` are live schema slugs as well as old register slugs. BRP/KVK/BAG mock registers and `register "zaken"` belong to other apps and are untouched.

`consent-management` turned out to carry **no stale register slug at all**: its "publicationConsent register and schema" phrasing names a schema, not the old `consent` register. It gets excludes only.

Headings are untouched — `@spec` tags in `src/` dereference those anchors. Two headings therefore still read "signing register" / "consent register" where their bodies now read `filinq`. Flagging rather than silently breaking anchors.

## Gates

Run on this exact commit in an isolated worktree with `HYDRA_GATE_BASE_REF=origin/development`:

- **gate-16 spec-coverage: PASS**
- **gate-19 e2e-coverage: WARNING** — 272 scenarios missing `@e2e` repo-wide (advisory, non-blocking, .github#477), down from 355. `document-creatie-sjablonen` and `document-editing` now contribute **0**.
- **RESULT: ALL 64 APPLICABLE GATES PASSED**

No test files were written or edited — the UI half is being covered separately.

Refs #782
