### PR TITLE
test(e2e): cover template version restore + publication policy-match derivation

### DIFF
--- a/tests/e2e/workflows/publication-policy-toggle.spec.ts
+++ b/tests/e2e/workflows/publication-policy-toggle.spec.ts
@@ -86,7 +86,13 @@
 import { test, expect, type APIRequestContext } from '@playwright/test'
 import { harvestToken, jsonHeaders, API, TEST_PREFIX } from './_fixtures'
 
-test.describe.configure({ mode: 'serial' })
+// Deliberately NOT `test.describe.configure({ mode: 'serial' })`, unlike most
+// files in this directory. The two tests below share no state — each seeds its
+// own run-stamped entity and document id — and the config already pins
+// `workers: 1` / `fullyParallel: false`, so serial mode would buy no isolation
+// here. What it WOULD buy is a failure in the first test silently skipping the
+// second, which is how a single broken fixture turns into "one failure" in the
+// tally while a second, independent regression goes unreported.
 
 /**
  * Read back the `scope: "document"` consent record for one document id.

--- a/tests/e2e/workflows/publication-policy-toggle.spec.ts
+++ b/tests/e2e/workflows/publication-policy-toggle.spec.ts
@@ -221,7 +221,10 @@ test('A standing consent short-circuits detection: the per-document record is co
 			.catch(() => '')})`,
 	).toBe(201)
 	const standingId = (await standing.json()).id as string
-	expect(standingId, 'the standing consent must carry a persisted uuid').toBeTruthy()
+	expect(
+		standingId,
+		'the standing consent must carry a persisted uuid',
+	).toBeTruthy()
 
 	const created = await createDocumentConsent(req, token, entity, documentId)
 	// A prohibition match would have thrown PolicyRejectedException → 403. The

--- a/tests/e2e/workflows/publication-policy-toggle.spec.ts
+++ b/tests/e2e/workflows/publication-policy-toggle.spec.ts
@@ -1,0 +1,373 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Filinq Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Coverage for the `entity-publication-policies` policy-match derivation —
+ * the data contract the publication-prep anonymisation toggle is built on.
+ *
+ * WHY THIS IS A SEPARATE FILE FROM `entity-review.spec.ts`
+ * -------------------------------------------------------
+ * The work item asked for these tests to be appended to `entity-review.spec.ts`
+ * and driven through its `driveToReview()` helper. That helper opens the
+ * FOLDER-ANALYSIS review table (`/folder-anonymization`,
+ * `src/views/anonymization/EntityReviewTable.vue`), and the toggle that table
+ * carries is the anonymisation-gate "Skip" switch — gated on
+ * `prohibitionMatch.highConfidence`, a different mechanism with a different
+ * default (OFF) and no prohibition-list wording.
+ *
+ * The toggle the `entity-publication-policies` scenarios describe is the
+ * "Anonymise this entity in the published document" switch in
+ * `src/views/consent/ConsentDetail.vue`, driven by the `policyMatch`
+ * REFERENT TYPE, reached from the Consent Management list — a different page,
+ * a different store and a different fixture. Putting it in the entity-review
+ * file would have filed it under a spec it does not belong to.
+ *
+ * ⚠️ THE TWO TOGGLE SCENARIOS ARE UNREACHABLE AND ARE DELIBERATELY UNTAGGED
+ * -------------------------------------------------------------------------
+ * Neither `#toggle-is-locked-when-policymatch-references-a-prohibition` nor
+ * `#toggle-is-overridable-when-policymatch-references-a-standing-consent` is
+ * anchored anywhere in this suite, because the toggle they describe cannot
+ * render. Measured on a freshly `ci-seed.sh`-provisioned instance, 2026-08-25.
+ * Two independent blockers, either of which alone is sufficient:
+ *
+ *   1. `ConsentDetail.vue` puts the whole anonymisation section — toggle,
+ *      locked note, standing-consent note — in `CnDetailPage`'s DEFAULT slot,
+ *      while also supplying a `#stats-rows` slot. `CnDetailPage` renders those
+ *      two branches as `v-if` / `v-else`:
+ *
+ *          <div v-if="hasStats" class="cn-detail-page__stats"> … </div>
+ *          <div v-else class="cn-detail-page__content"><slot /></div>
+ *
+ *          hasStats() { return this.statsColumns.length > 0
+ *              && (this.statsRows.length > 0 || !!this.$slots['stats-rows']) }
+ *
+ *      `statsColumns` and `#stats-rows` are both present whenever
+ *      `consentItem` is set — and `consentItem` must be set for the toggle to
+ *      exist at all. So the stats table always wins and the default slot NEVER
+ *      renders. The rendered page stops after the Entity Information table:
+ *      no toggle, no consent-status form, no Save Changes button.
+ *
+ *   2. `/consent/:id` does not deep-link. The manifest route declares the
+ *      param as `:id`, `ConsentDetail` declares the prop as `consentId`, and
+ *      its `created()` hook fetches only `if (this.consentId)`. The names
+ *      never meet, so a direct navigation renders the error state
+ *      "No consent record selected." The only hydrating path is a row click
+ *      on `/consent` (`ConsentIndex::viewConsent` → `setConsentItem`).
+ *
+ * A test tagged against either scenario would be green over a UI that does
+ * not exist — the `.github#345` defect. So the UI halves are left UNCOVERED.
+ *
+ * WHAT IS COVERED HERE INSTEAD
+ * ----------------------------
+ * The DATA contract both toggle scenarios sit on: that a `scope: "document"`
+ * `publicationConsent` really does end up carrying a `policyMatch` pointing at
+ * a prohibition (retroactively) or at a `scope: "entity"` standing consent (at
+ * detection time). That half works end-to-end and is measured below, so the
+ * report on the toggle can say "the blocker is the render path, not the data"
+ * as an executable fact rather than a claim.
+ *
+ * ⚠️ NOTE ON THE ORIGINAL REACHABILITY WARNING. The work item flagged the
+ * standing-consent scenario as possibly unreachable because
+ * `prohibition-override-audit-schema.spec.ts` records that the regex-only
+ * backend emits `CUSTOM_DICTIONARY` at confidence 1.00 and the 0.85 override
+ * threshold is not in `SettingsService::WRITABLE_KEYS`. That constraint is
+ * real but belongs to a DIFFERENT mechanism — the anonymisation prohibition
+ * GATE (`ProhibitionOverrideCommitter`,
+ * `filinq.prohibition.high_confidence_threshold`). `PolicyMatchService::match()`
+ * is rule-based (`exact` / `normalized` / `bsn` / `kvk`) and never reads a
+ * detection confidence, so the policy-match path below is fully reachable and
+ * is exercised for real here.
+ *
+ * Cleanup: `publicationConsent` exposes no DELETE (measured: 405) and
+ * prohibitions are retention-protected (409), so every fixture is stamped with
+ * `TEST_PREFIX` and every assertion names only this run's strings.
+ */
+
+import { test, expect, type APIRequestContext } from '@playwright/test'
+import { harvestToken, jsonHeaders, API, TEST_PREFIX } from './_fixtures'
+
+test.describe.configure({ mode: 'serial' })
+
+/**
+ * Read back the `scope: "document"` consent record for one document id.
+ *
+ * ⚠️ Keyed on `documentId`, NOT on `entityText`, and that is load-bearing.
+ * `GET /api/consents` returns EVERY publicationConsent object — the
+ * `scope: "entity"` standing consents included — and a standing consent
+ * carries the SAME `entityText` as the per-document record it matched. A
+ * lookup by entity text therefore returns whichever of the two the store
+ * happens to list first, and the standing consent legitimately has
+ * `policyMatch: null` (a scope=entity row must not carry one — see
+ * `ConsentScopeValidator::assertEntityHasNoPolicyMatch()`). That read the
+ * first time round as "the reference was never persisted".
+ *
+ * `scope` is asserted too, so a future change that starts stamping
+ * `documentId` on standing consents fails here rather than silently
+ * reintroducing the same ambiguity.
+ *
+ * The list endpoint answers with a bare array (not `{results}`), and the
+ * Consent Management table pages it CLIENT-side, so reading the API directly
+ * is the only way to see a record that is not on the table's first page.
+ *
+ * @param req   The request context.
+ * @param token The CSRF request-token.
+ * @param doc   The exact `documentId` to look for.
+ * @return The matching scope=document record, or undefined.
+ */
+async function consentFor(
+	req: APIRequestContext,
+	token: string,
+	doc: string,
+): Promise<Record<string, unknown> | undefined> {
+	const res = await req.get(`${API}/consents`, { headers: jsonHeaders(token) })
+	expect(res.status(), `GET ${API}/consents must answer 200`).toBe(200)
+	const body = await res.json()
+	const rows = (Array.isArray(body) ? body : (body.results ?? [])) as Array<
+		Record<string, unknown>
+	>
+	const matches = rows.filter(
+		(r) => r.documentId === doc && r.scope === 'document',
+	)
+	expect(
+		matches.length,
+		`exactly one scope=document record must carry documentId "${doc}" `
+			+ `(found ${matches.length})`,
+	).toBeLessThanOrEqual(1)
+	return matches[0]
+}
+
+/**
+ * Create a `scope: "document"` publicationConsent for one entity.
+ *
+ * @param req   The request context.
+ * @param token The CSRF request-token.
+ * @param text  The entity text.
+ * @param doc   The document id to attach it to.
+ * @return The HTTP status and parsed body.
+ */
+async function createDocumentConsent(
+	req: APIRequestContext,
+	token: string,
+	text: string,
+	doc: string,
+) {
+	const res = await req.post(`${API}/consents`, {
+		headers: jsonHeaders(token),
+		data: { documentId: doc, entityType: 'PERSON', entityText: text },
+	})
+	return { status: res.status(), body: await res.json().catch(() => ({})) }
+}
+
+// ---------------------------------------------------------------------------
+// Standing-consent match at detection time
+// ---------------------------------------------------------------------------
+
+// @e2e openspec/specs/entity-publication-policies/spec.md#standing-consent-match-short-circuits-when-no-prohibition-match
+//
+// Every clause of the scenario has an assertion below:
+//
+//   GIVEN "an entity matching an active scope:'entity' publicationConsent with
+//          UUID R-STANDING-1 and matching no publicationProhibition rule"
+//       → the standing consent is created here and its uuid is captured; the
+//         entity text is `TEST_PREFIX`-stamped so no prohibition seeded by any
+//         other spec in this suite can match it. The "no prohibition" half is
+//         asserted positively rather than assumed: a prohibition match would
+//         make POST /api/consents answer 403 (PolicyRejectedException), so the
+//         201 below IS the proof that the prohibition pass found nothing.
+//
+//   THEN scope:'document', consentStatus:'consent_given',
+//        notificationStatus:'skipped', publicationDecision:'publish_with_consent',
+//        policyMatch referencing R-STANDING-1
+//       → asserted field by field, and re-asserted against a fresh list read so
+//         the claim is about what was PERSISTED, not about the create echo.
+//
+//   AND "no notification is sent"
+//       → `notificationSentAt` must be empty. `notificationStatus: 'skipped'`
+//         is asserted separately above; on its own it is the workflow's own
+//         label for its intent, not evidence that nothing went out.
+test('A standing consent short-circuits detection: the per-document record is consent_given and points at the standing consent', async ({
+	page,
+}) => {
+	const token = await harvestToken(page)
+	const req = page.request
+
+	const entity = `${TEST_PREFIX} Standing Subject`
+	const documentId = `${TEST_PREFIX}-doc-standing`
+
+	const standing = await req.post(`${API}/policy/standing-consents`, {
+		headers: jsonHeaders(token),
+		data: {
+			entityText: entity,
+			entityType: 'PERSON',
+			consentMethod: 'opt_in_form',
+			consentScope: `${TEST_PREFIX} publication-policy fixture`,
+			matchRules: [{ type: 'exact', value: entity }],
+			active: true,
+			consentStatus: 'consent_given',
+			publicationDecision: 'publish_with_consent',
+			notificationStatus: 'skipped',
+		},
+	})
+	expect(
+		standing.status(),
+		`POST ${API}/policy/standing-consents must answer 201 (body: ${await standing
+			.text()
+			.catch(() => '')})`,
+	).toBe(201)
+	const standingId = (await standing.json()).id as string
+	expect(standingId, 'the standing consent must carry a persisted uuid').toBeTruthy()
+
+	const created = await createDocumentConsent(req, token, entity, documentId)
+	// A prohibition match would have thrown PolicyRejectedException → 403. The
+	// 201 is therefore the positive control for "matching no prohibition rule".
+	expect(
+		created.status,
+		'POST /api/consents must answer 201. A 403 here would mean a prohibition '
+			+ 'matched first, which is a DIFFERENT scenario (#prohibition-match-short-circuits) '
+			+ `and would invalidate every assertion below. Body: ${JSON.stringify(created.body).slice(0, 300)}`,
+	).toBe(201)
+
+	expect(created.body.scope, 'the created record is scope=document').toBe(
+		'document',
+	)
+	expect(
+		created.body.policyMatch,
+		'policyMatch must reference the standing consent that matched',
+	).toBe(standingId)
+	expect(
+		created.body.consentStatus,
+		'a standing-consent match resolves the record to consent_given',
+	).toBe('consent_given')
+	expect(
+		created.body.notificationStatus,
+		'the WOO notification workflow must be skipped, not started',
+	).toBe('skipped')
+	expect(
+		created.body.publicationDecision,
+		'the decision defaults to publish_with_consent under a standing consent',
+	).toBe('publish_with_consent')
+	expect(
+		created.body.notificationSentAt ?? null,
+		'"no notification is sent" — nothing may have been stamped as sent',
+	).toBeFalsy()
+
+	// Persistence, not the create echo.
+	const persisted = await consentFor(req, token, documentId)
+	expect(
+		persisted,
+		`the seeded scope=document record for "${documentId}" must be readable back from the list`,
+	).toBeDefined()
+	expect(
+		persisted!.policyMatch,
+		'the policyMatch reference must have PERSISTED, not just been echoed',
+	).toBe(standingId)
+	expect(persisted!.consentStatus).toBe('consent_given')
+})
+
+// ---------------------------------------------------------------------------
+// Retroactive prohibition resolution
+// ---------------------------------------------------------------------------
+
+// DELIBERATELY CARRIES NO `@e2e` ANCHOR.
+//
+// The nearest scenario is
+// `#new-prohibition-retroactively-resolves-matching-in-flight-records`, and
+// this test does assert three of its four THEN clauses (consentStatus,
+// notificationStatus, publicationDecision, policyMatch). It does NOT assert
+// the remaining two:
+//
+//   "AND any pending notification for that record is canceled"
+//   "AND the audit log records the retroactive update with timestamp and
+//    triggering rule UUID"
+//
+// Filinq exposes no read surface for either from an e2e context — there is no
+// notification-queue endpoint and no retroactive-audit endpoint in
+// `appinfo/routes.php`. Anchoring here would credit those two clauses to a
+// test that cannot evaluate them, which is exactly the false-green this suite
+// is trying not to add to. The scenario stays uncovered until a read surface
+// exists; this test still earns its place as the executable proof that the
+// DATA precondition for the locked-toggle UI is satisfied — i.e. that the
+// toggle's blocker is the render path, not the policy engine.
+test('Creating a prohibition retroactively resolves an in-flight consent record and points it at the new rule', async ({
+	page,
+}) => {
+	const token = await harvestToken(page)
+	const req = page.request
+
+	const entity = `${TEST_PREFIX} Prohibited Subject`
+	const documentId = `${TEST_PREFIX}-doc-prohibited`
+
+	// In-flight FIRST, prohibition second: that ordering is the whole point.
+	// Creating the prohibition first would make POST /api/consents answer 403
+	// and there would be no in-flight record to resolve.
+	const created = await createDocumentConsent(req, token, entity, documentId)
+	expect(
+		created.status,
+		`POST ${API}/consents must answer 201 while no rule matches (body: ${JSON.stringify(created.body).slice(0, 300)})`,
+	).toBe(201)
+	expect(
+		created.body.consentStatus,
+		'the record must start in-flight (pending) for the retroactive pass to have anything to do',
+	).toBe('pending')
+	expect(
+		created.body.policyMatch ?? null,
+		'no rule matches yet, so policyMatch must start null',
+	).toBeNull()
+
+	const rule = await req.post(`${API}/policy/prohibitions`, {
+		headers: jsonHeaders(token),
+		data: {
+			primaryName: entity,
+			entityType: 'PERSON',
+			matchRules: [{ type: 'exact', value: entity }],
+			reason: `${TEST_PREFIX} publication-policy fixture`,
+			active: true,
+		},
+	})
+	expect(
+		rule.status(),
+		`POST ${API}/policy/prohibitions must answer 201 (body: ${await rule
+			.text()
+			.catch(() => '')})`,
+	).toBe(201)
+	const ruleId = (await rule.json()).id as string
+	expect(ruleId, 'the prohibition must carry a persisted uuid').toBeTruthy()
+
+	const resolved = await consentFor(req, token, documentId)
+	expect(
+		resolved,
+		`the in-flight record for "${documentId}" must still be readable after the retroactive pass`,
+	).toBeDefined()
+
+	expect(
+		resolved!.policyMatch,
+		'the in-flight record must now reference the prohibition that was just created. '
+			+ 'A null here means the retroactive listener did not fire — the record would '
+			+ 'stay published-eligible while an active prohibition names its entity.',
+	).toBe(ruleId)
+	expect(
+		resolved!.consentStatus,
+		'a retroactively prohibited record is force-resolved to anonymized',
+	).toBe('anonymized')
+	expect(
+		resolved!.notificationStatus,
+		'the WOO notification workflow must be marked skipped once the rule pre-empts it',
+	).toBe('skipped')
+
+	// `publicationDecision` is declared `"translatable": true` in
+	// lib/Settings/filinq_register.json, so OpenRegister's i18n layer reads it
+	// back as `{ "<lang>": "<value>" }` rather than as the bare string the
+	// service wrote. Assert the VALUE through either shape: pinning the string
+	// alone would fail on a translated instance, and pinning the object alone
+	// would fail on an untranslated one — and neither failure would be about
+	// the policy engine this test is measuring.
+	const decision = resolved!.publicationDecision
+	const decisionValues =
+		decision !== null && typeof decision === 'object'
+			? Object.values(decision as Record<string, unknown>)
+			: [decision]
+	expect(
+		decisionValues,
+		`the retroactive pass must set publicationDecision to "anonymize" (read back as ${JSON.stringify(decision)})`,
+	).toContain('anonymize')
+})

--- a/tests/e2e/workflows/template-detail.spec.ts
+++ b/tests/e2e/workflows/template-detail.spec.ts
@@ -66,7 +66,11 @@ import {
 	TEST_FAMILY,
 } from './_fixtures'
 
-test.describe.configure({ mode: 'serial' })
+// Deliberately NOT `test.describe.configure({ mode: 'serial' })`. The two
+// tests seed and delete their own run-stamped templates and share no state,
+// and the config already pins `workers: 1` / `fullyParallel: false`. Serial
+// mode would only add "a failure in the first silently skips the second",
+// which turns two independent results into one.
 
 test.afterAll(async ({ request }) => {
 	const res = await request.get(`${API}/templates`)

--- a/tests/e2e/workflows/template-detail.spec.ts
+++ b/tests/e2e/workflows/template-detail.spec.ts
@@ -1,0 +1,301 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Filinq Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Coverage for the template DETAIL surface — `src/views/templates/TemplateDetail.vue`
+ * and the version-history endpoints it drives.
+ *
+ * WHY THIS FILE EXISTS SEPARATELY FROM `templates-crud.spec.ts`
+ * ------------------------------------------------------------
+ * That file covers the list surface and the create/read/update/delete legs.
+ * `/templates/:id` had ZERO coverage of any kind, and the reason it was
+ * skipped over is recorded — wrongly — in that file's own header, which
+ * called `TemplateDetail.vue` "a STUB ('Template editor' heading +
+ * descriptive paragraph) with no name/content fields and no save button".
+ * That description is stale: the component is an 806-line registered editor
+ * with metadata fields, a WYSIWYG surface, a preview tab, a versions tab, a
+ * restore-confirmation dialog and a lock banner. The header has been
+ * corrected; `mountsTheEditor` below is the executable form of that
+ * correction, so the claim cannot silently go stale again.
+ *
+ * ⚠️ WHAT IS *NOT* COVERED HERE, AND WHY — READ BEFORE ADDING A TEST
+ * ------------------------------------------------------------------
+ * `TemplateDetail.vue` never hydrates from the route. Its `mounted()` reads
+ * `templateStore.templateItem` and nothing else:
+ *
+ *     isNew() { return this.templateStore.templateItem === null }
+ *     async mounted() { if (!this.isNew) { …hydrate, acquireLock… } }
+ *
+ * `templateItem` is set in exactly one place in the whole app —
+ * `TemplateIndex.vue::openTemplate()` — and `TemplateIndex` is NOT registered
+ * in `src/registry.js` (removed by openspec/changes/orphaned-surface-restoration
+ * when the Templates page was decomposed to `type:"index"`; see the comment
+ * at the top of registry.js). The live Templates page is CnIndexPage, whose
+ * manifest entry declares no `actions` / `headerActions`, so nothing in the
+ * shipped UI ever navigates to `TemplateDetail` with `templateItem` set.
+ *
+ * Consequence: on every reachable navigation the component mounts with
+ * `isNew === true`. That means
+ *
+ *   - the Versions tab is `v-if="!isNew"` → it does not render at all,
+ *   - `lockOwner` stays null → the "Locked by {user}" banner cannot appear
+ *     and Save is never disabled by a lock.
+ *
+ * So the UI halves of the versions/restore and lock-banner journeys are
+ * UNREACHABLE, not merely untested. They are left UNCOVERED and UNTAGGED
+ * rather than covered by a test that drives an unreachable state, or by a
+ * `test.skip()` that gate-19's dead-test parser would count as live. See the
+ * report on ConductionNL/filinq#782.
+ *
+ * The restore SCENARIO itself is not lost to that gap: it is written as an
+ * HTTP contract ("WHEN `POST /api/templates/{id}/versions/{versionId}/restore`
+ * is called"), and every one of its THEN clauses is asserted below at exactly
+ * that level.
+ */
+
+import { test, expect, type APIRequestContext } from '@playwright/test'
+import { appUrl, dismissOverlays, waitForAppReady } from '../spec-coverage/_helpers'
+import {
+	harvestToken,
+	jsonHeaders,
+	API,
+	createTemplate,
+	getTemplate,
+	deleteTemplate,
+	TEST_PREFIX,
+	TEST_FAMILY,
+} from './_fixtures'
+
+test.describe.configure({ mode: 'serial' })
+
+test.afterAll(async ({ request }) => {
+	const res = await request.get(`${API}/templates`)
+	const body = await res.json().catch(() => ({ results: [] }))
+	for (const t of body.results ?? []) {
+		if (String(t.name ?? '').startsWith(TEST_FAMILY) && t.id) {
+			await request.delete(`${API}/templates/${t.id}`).catch(() => {})
+		}
+	}
+})
+
+/** One entry of the paginated version-history payload. */
+interface VersionRow {
+	id: string
+	version: number
+	content?: string
+	changelog?: string
+	editor?: string
+}
+
+/**
+ * Read the version history for a template.
+ *
+ * @param req   The Playwright request context.
+ * @param token The CSRF request-token.
+ * @param id    The template id.
+ * @return The parsed `{results, total}` payload.
+ */
+async function versions(
+	req: APIRequestContext,
+	token: string,
+	id: string,
+): Promise<{ results: VersionRow[]; total: number }> {
+	const url = `${API}/templates/${id}/versions`
+	const res = await req.get(url, { headers: jsonHeaders(token) })
+	expect(res.status(), `GET ${url} must answer 200`).toBe(200)
+	const body = await res.json()
+	return { results: (body.results ?? []) as VersionRow[], total: body.total ?? 0 }
+}
+
+// ---------------------------------------------------------------------------
+// Version restore — REQ-TMPL-08
+// ---------------------------------------------------------------------------
+
+// @e2e openspec/specs/template-management/spec.md#restore-writes-auto-snapshot-then-overwrites-template
+//
+// Every THEN clause of the scenario has an assertion below:
+//
+//   "the current template state is saved as a new version with
+//    changelog = 'Auto-saved before restore to version <targetVersion>'"
+//        → the auto-snapshot is located BY that exact changelog string and its
+//          `content` is asserted to be the pre-restore (V2) body. Matching on
+//          the string alone would pass on an empty snapshot.
+//
+//   "…overwritten with the target version's values via
+//    updateTemplateWithoutVersion() so no second snapshot is produced"
+//        → the history count is asserted to grow by EXACTLY ONE. This is the
+//          clause that fails if the restore path is ever re-pointed at
+//          `updateTemplate()`: the restore would then snapshot a second time
+//          and the count would grow by two while every other assertion here
+//          still passed.
+//
+//   "the restored template object is returned"
+//        → the POST response body's `content` is asserted, and a follow-up GET
+//          proves the overwrite persisted rather than only being echoed back.
+test('Restoring a version writes the auto-snapshot first and then overwrites the template', async ({
+	page,
+}) => {
+	const token = await harvestToken(page)
+	const req = page.request
+
+	const V1 = 'V1 — original body for {{recipient}}.'
+	const V2 = 'V2 — revised body for {{recipient}}.'
+
+	const tmpl = await createTemplate(req, token, {
+		name: `${TEST_PREFIX}-restore`,
+		content: V1,
+	})
+
+	// One content change, so the history holds a snapshot of V1 to restore to.
+	const upd = await req.put(`${API}/templates/${tmpl.id}`, {
+		headers: jsonHeaders(token),
+		data: { name: tmpl.name, content: V2 },
+	})
+	expect(
+		upd.status(),
+		`PUT ${API}/templates/${tmpl.id} must answer 200 (body: ${await upd
+			.text()
+			.catch(() => '')})`,
+	).toBe(200)
+
+	// POSITIVE CONTROL. Everything below counts versions and searches the
+	// history; on an empty history the "+1" and "no second snapshot"
+	// assertions are satisfiable for the wrong reason.
+	const before = await versions(req, token, tmpl.id)
+	expect(
+		before.results.length,
+		'one content change must have produced exactly one snapshot before anything is restored',
+	).toBe(1)
+	const target = before.results[0]
+	expect(
+		target.content,
+		'the snapshot taken on update captures the PRE-update state, so it must hold V1',
+	).toBe(V1)
+
+	const restoreUrl = `${API}/templates/${tmpl.id}/versions/${target.id}/restore`
+	const restored = await req.post(restoreUrl, { headers: jsonHeaders(token) })
+	expect(
+		restored.status(),
+		`POST ${restoreUrl} must answer 200 (body: ${await restored
+			.text()
+			.catch(() => '')})`,
+	).toBe(200)
+
+	// "AND the restored template object is returned"
+	const restoredBody = await restored.json()
+	expect(
+		restoredBody.content,
+		'the restore response must carry the target version content',
+	).toBe(V1)
+
+	const after = await versions(req, token, tmpl.id)
+
+	// "…so no second snapshot is produced" — exactly one new row, not two.
+	expect(
+		after.results.length,
+		'restore must add exactly ONE history row (the auto-snapshot). Two rows here '
+			+ 'means the overwrite went through updateTemplate() instead of '
+			+ `updateTemplateWithoutVersion(). Changelogs seen: ${after.results
+				.map((v) => JSON.stringify(v.changelog))
+				.join(', ')}`,
+	).toBe(before.results.length + 1)
+
+	// "the current template state is saved as a new version with
+	//  changelog = 'Auto-saved before restore to version <targetVersion>'"
+	const expectedChangelog = `Auto-saved before restore to version ${target.version}`
+	const auto = after.results.find((v) => v.changelog === expectedChangelog)
+	expect(
+		auto,
+		`the auto-snapshot must carry the changelog "${expectedChangelog}". `
+			+ `Changelogs seen: ${after.results
+				.map((v) => JSON.stringify(v.changelog))
+				.join(', ')}`,
+	).toBeDefined()
+	expect(
+		auto!.content,
+		'the auto-snapshot must capture the state as it was JUST BEFORE the restore (V2). '
+			+ 'A snapshot carrying V1 would mean the overwrite happened first and the '
+			+ 'pre-restore body is gone — the exact history loss this scenario exists to prevent.',
+	).toBe(V2)
+
+	// "the template's content … overwritten with the target version's values" —
+	// asserted against a fresh read, not the echoed response.
+	const reread = await getTemplate(req, token, tmpl.id)
+	expect(reread.status, 'GET the template after restore').toBe(200)
+	expect(
+		reread.body.content,
+		'the persisted template content must be the restored version',
+	).toBe(V1)
+
+	await deleteTemplate(req, token, tmpl.id)
+})
+
+// ---------------------------------------------------------------------------
+// The detail route itself
+// ---------------------------------------------------------------------------
+
+// DELIBERATELY CARRIES NO `@e2e` ANCHOR.
+//
+// This asserts that `/templates/:id` is routed and mounts the real editor —
+// which is what refutes the stale "STUB … no name/content fields and no save
+// button" claim this file's header describes. It is NOT a scenario: no
+// `template-management` scenario says anything about the detail route
+// rendering, and anchoring it to one of the CRUD scenarios would credit a
+// clause it never evaluates (the `.github#345` defect — a green gate-19 row
+// over a UI that does not do what the scenario says).
+test('The /templates/:id route mounts the real TemplateDetail editor, not a stub', async ({
+	page,
+}) => {
+	const token = await harvestToken(page)
+	const req = page.request
+
+	const tmpl = await createTemplate(req, token, {
+		name: `${TEST_PREFIX}-detail-route`,
+	})
+
+	await page.goto(await appUrl(page, `templates/${tmpl.id}`), {
+		waitUntil: 'domcontentloaded',
+	})
+	await waitForAppReady(page)
+	await dismissOverlays(page)
+
+	const detail = page.locator('.template-detail')
+	await expect(
+		detail,
+		'the detail route must mount TemplateDetail.vue — a redirect to the list, or an '
+			+ 'empty <main>, means the manifest page or its registry entry has been lost',
+	).toBeVisible({ timeout: 30_000 })
+
+	// The three fields the stale header said did not exist.
+	for (const label of ['Name', 'Namespace', 'Description']) {
+		await expect(
+			detail.getByLabel(label, { exact: false }).first(),
+			`the editor must render a "${label}" field`,
+		).toBeVisible()
+	}
+
+	// The save button the stale header said did not exist.
+	await expect(
+		detail.getByRole('button', { name: 'Save', exact: true }),
+		'the editor must render a Save button',
+	).toBeVisible()
+
+	// The content surface. `contenteditable` is the WYSIWYG area; its
+	// aria-label is the only stable handle on it.
+	await expect(
+		detail.locator('[contenteditable="true"]'),
+		'the editor must render an editable content surface',
+	).toBeVisible()
+
+	// The Editor and Preview tabs are unconditional. The Versions tab is
+	// `v-if="!isNew"` and is NOT asserted here — see this file's header for
+	// why it cannot render on a reachable navigation.
+	for (const tab of ['Editor', 'Preview']) {
+		await expect(
+			detail.getByRole('button', { name: tab, exact: true }),
+			`the "${tab}" tab must render`,
+		).toBeVisible()
+	}
+
+	await deleteTemplate(req, token, tmpl.id)
+})

--- a/tests/e2e/workflows/templates-crud.spec.ts
+++ b/tests/e2e/workflows/templates-crud.spec.ts
@@ -10,18 +10,37 @@
  * lifecycle PERSISTS, and that the persisted state surfaces in the
  * read-only Templates list UI.
  *
- * Why the create/edit/delete legs are API-driven: the Filinq Templates
- * UI is read-only. `TemplateIndex.vue` renders a non-interactive table;
- * its "New template" button routes to `TemplateDetail.vue`, which is a
- * STUB ("Template editor" heading + descriptive paragraph) with no name/
- * content fields and no save button. There is no edit or delete control
- * on a row. So the writes go through the documented REST endpoints
- * (`TemplatesController` / `templateStore`) and persistence is asserted
- * BOTH through follow-up API reads AND through the real UI list — which
- * is exactly the OpenRegister-backed data path the UI itself consumes.
+ * Why the create/edit/delete legs are API-driven: the live Templates list
+ * is read-only. The `Templates` manifest page is `type:"index"`, so it is
+ * rendered by CnIndexPage, and its manifest entry declares no `actions`
+ * or `headerActions` — there is no create, edit or delete control on the
+ * page or on a row. So the writes go through the documented REST
+ * endpoints (`TemplatesController` / `templateStore`) and persistence is
+ * asserted BOTH through follow-up API reads AND through the real UI list
+ * — which is exactly the OpenRegister-backed data path the UI consumes.
  *
- * The missing create/edit/delete UI is flagged as a product gap in the
- * run report; a `test.fixme` below documents it as an executable TODO.
+ * ⚠️ CORRECTED 2026-08-25. This header used to say the "New template"
+ * button routes to `TemplateDetail.vue`, "which is a STUB ('Template
+ * editor' heading + descriptive paragraph) with no name/content fields
+ * and no save button". Both halves were wrong, and that description is
+ * what steered every later pass away from the detail surface:
+ *
+ *   - `TemplateDetail.vue` is an 806-line registered editor with Name /
+ *     Namespace / Category / Tags / Description / Change-note fields, a
+ *     WYSIWYG content surface with a raw-HTML toggle, a Save button, a
+ *     preview tab, a versions tab, a restore-confirmation dialog and a
+ *     "Locked by {user}" banner. `tests/e2e/workflows/template-detail.spec.ts`
+ *     asserts the fields and the Save button so this cannot go stale again.
+ *   - The button that routes to it lives on `TemplateIndex.vue`, which is
+ *     no longer registered in `src/registry.js` and therefore renders
+ *     nowhere. It is not the page a user sees.
+ *
+ * The real gap is narrower and is documented in `template-detail.spec.ts`:
+ * `TemplateDetail` hydrates only from `templateStore.templateItem`, never
+ * from `$route.params`, so on any reachable navigation it mounts in
+ * new-template mode and its Versions tab and lock banner cannot render.
+ * A `test.fixme` below documents the missing list-level CRUD controls as
+ * an executable TODO.
  *
  * @spec openspec/specs/template-management/spec.md#create-a-template
  * @spec openspec/specs/template-management/spec.md#list-templates-with-namespace-filter


### PR DESCRIPTION
Refs #782.

Real Playwright coverage for two of the six identified gaps, plus the correction of the stale comment that steered earlier passes away from one of them. **No spec file is touched** — this is `tests/e2e/**` only.

## What landed

### `tests/e2e/workflows/template-detail.spec.ts` (new)

| Test | Tag | Why the tag is honest |
|---|---|---|
| Restoring a version writes the auto-snapshot first and then overwrites the template | `@e2e template-management#restore-writes-auto-snapshot-then-overwrites-template` | Every THEN clause is asserted. The auto-snapshot is located **by** its `Auto-saved before restore to version <N>` changelog *and* its `content` is asserted to be the pre-restore body (matching the string alone would pass on an empty snapshot). The history is asserted to grow by **exactly one** — that is the clause that fails if the overwrite is ever re-pointed at `updateTemplate()` and snapshots twice. The overwrite is checked against a fresh `GET`, not the response echo. |
| The `/templates/:id` route mounts the real TemplateDetail editor, not a stub | **none** | No `template-management` scenario claims anything about the detail route rendering. Anchoring it to a CRUD scenario would credit a clause it never evaluates. |

### `tests/e2e/workflows/templates-crud.spec.ts` (header corrected)

The header called `TemplateDetail.vue` *"a STUB ('Template editor' heading + descriptive paragraph) with no name/content fields and no save button"*. It is an 806-line registered editor with metadata fields, a WYSIWYG surface with a raw-HTML toggle, a preview tab, a versions tab, a restore dialog and a lock banner. The new spec asserts the fields and the Save button so the claim cannot go stale again.

### `tests/e2e/workflows/publication-policy-toggle.spec.ts` (new)

| Test | Tag | Why |
|---|---|---|
| A standing consent short-circuits detection | `@e2e entity-publication-policies#standing-consent-match-short-circuits-when-no-prohibition-match` | All clauses asserted: `scope=document`, `consentStatus=consent_given`, `notificationStatus=skipped`, `publicationDecision=publish_with_consent`, `policyMatch` → the standing consent, and `notificationSentAt` empty for *"no notification is sent"*. The `201` on create is used as the positive control for *"matching no prohibition rule"* — a prohibition match answers `403`. Re-asserted against a fresh list read. |
| Creating a prohibition retroactively resolves an in-flight consent record | **none** | It asserts four of the six clauses of `#new-prohibition-retroactively-resolves-matching-in-flight-records`, but the app exposes no read surface for *"any pending notification is canceled"* or *"the audit log records the retroactive update"*. Anchoring would credit clauses the test cannot evaluate. |

## The two toggle scenarios are UNCOVERED and UNTAGGED — the toggle cannot render

Measured on a freshly `ci-seed.sh`-provisioned NC 34 instance running this branch, 2026-08-25. **Two independent blockers**, either sufficient on its own:

1. **`ConsentDetail.vue` puts the whole anonymisation section in `CnDetailPage`'s default slot while also supplying `#stats-rows`.** `CnDetailPage` renders those two as `v-if` / `v-else`:

   ```
   <div v-if="hasStats" class="cn-detail-page__stats"> … </div>
   <div v-else class="cn-detail-page__content"><slot /></div>

   hasStats() { return this.statsColumns.length > 0
       && (this.statsRows.length > 0 || !!this.$slots['stats-rows']) }
   ```

   `statsColumns` and `#stats-rows` are both present whenever `consentItem` is set — and `consentItem` **must** be set for the toggle to exist. The stats table always wins. Live DOM: the page stops after the Entity Information table. No toggle, no consent-status form, no **Save Changes** button.

2. **`/consent/:id` does not deep-link.** Route param `:id`, prop `consentId`, `created()` fetches only `if (this.consentId)`. Direct navigation renders *"No consent record selected."* The only hydrating path is a row click on `/consent`.

The **data** half works end-to-end and is now measured by the two tests above, so the diagnosis is executable rather than asserted: the blocker is the render path, not the policy engine.

> The original reachability warning (regex-only backend → `CUSTOM_DICTIONARY` at 1.00, and the 0.85 threshold not in `SettingsService::WRITABLE_KEYS`) turned out to belong to a **different mechanism** — the anonymisation prohibition *gate*. `PolicyMatchService::match()` is rule-based and never reads a detection confidence, so the policy-match path is fully reachable and is exercised for real here.

## `TemplateDetail`'s versions tab and lock banner are also unreachable

`TemplateDetail.vue` hydrates only from `templateStore.templateItem`, never from `$route.params`. The one place that sets it — `TemplateIndex.vue::openTemplate()` — is no longer registered in `src/registry.js`, and the live `Templates` page is `CnIndexPage` with no `actions`/`headerActions` pointing at the detail route (its row menu's **Edit** opens a generic object modal instead).

Live result of navigating to `/templates/<real-uuid>`:

```
title:      "New template"
tabs:       ["Editor", "Preview"]      ← Versions is v-if="!isNew"
nameValue:  ""
lockBanner: null
saveDisabled: false
```

So the versions/restore UI and the "Locked by {user}" banner cannot render. The restore **scenario** is not lost to that gap — it is written as an HTTP contract and is covered at exactly that level. The lock-banner UI is left uncovered; per the brief it is deliberately **not** tagged against REQ-TMPL-10/11, which are about status codes.

## Verification

- **Gate:** `HYDRA_GATE_BASE_REF=origin/development vendor/bin/hydra-gates .` → base resolved to `2f5fe079`, 3 changed files. **All 64 applicable gates green**, all 64 ran. gate-19 is `WARNING` on 352 pre-existing untagged scenarios (advisory, `.github#477`), unchanged by this PR.
- **Tags machine-verified** against gate-19's own parser (`collect_ref_status` / `parse_spec_scenarios`): both anchors resolve to real scenarios and are recognised as covered; neither toggle scenario, nor the retroactive scenario, is claimed.
- **Suite:** run against a dedicated NC 34 instance provisioned from this branch. The four new tests pass. See the PR discussion for the full tally and the pre-existing failures unrelated to this change.
