### PR TITLE
fix(lint): let prettier have the last word after eslint --fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "NODE_ENV=development webpack --config webpack.config.js --progress",
     "watch": "NODE_ENV=development webpack --config webpack.config.js --progress --watch",
     "lint": "eslint src",
-    "lint-fix": "npm run lint -- --fix",
+    "lint-fix": "npm run lint -- --fix && npm run format:fix",
     "test": "jest --silent",
     "test-coverage": "jest --silent --coverage",
     "test:unit": "vitest run",


### PR DESCRIPTION
Same fix as ConductionNL/stackiq#744 — this repo has the identical shape.

## The problem

`lint-fix` ran eslint's fixer and stopped, so any autofixer that **constructs** source could leave the tree failing `format`.

`eslint-config-prettier` cannot prevent this. It only turns rules **off**, and the offenders are not formatting rules — `import-extensions/ban-inline-type-imports` and friends rewrite an import and emit their own text, which prettier then rejects.

## The fix

```
"lint-fix": "npm run lint -- --fix && npm run format:fix"
```

The two tools become **ordered rather than competing**: eslint decides what the code *says*, prettier decides how it *looks*, in that order, always.

## Why this keeps biting — it is structural

| script | scope |
|---|---|
| `lint` | `eslint src` — **src only** |
| `format` | `prettier "**/*.{js,ts,vue,css,scss}"` — everything, **including `tests/`** |

A new file under `tests/e2e/**` is format-checked in CI but **never linted**, and nothing local warns you before you push.

Measured today on #796: a new Playwright spec went red on `Frontend Check (format)` alone, while all 42 other checks passed. Not the author's mistake — the local workflow cannot surface it.

Whether to widen eslint's scope to `tests/` is a separate decision with a findings backlog behind it, and is deliberately not settled here.