### PR TITLE
fix(consent): render the stat cards that never rendered, and stop the gate lying about them

### DIFF
--- a/src/views/consent/ConsentDetail.vue
+++ b/src/views/consent/ConsentDetail.vue
@@ -11,18 +11,34 @@ import { consentStore } from '../../store/store.js'
 		:loading="consentStore.loading"
 		:loadingLabel="t('filinq', 'Loading consent record...')"
 		:error="!consentStore.consentItem"
-		:errorMessage="t('filinq', 'No consent record selected.')"
-		:statsTitle="
-			consentStore.consentItem ? t('filinq', 'Entity Information') : ''
-		"
-		:statsColumns="
-			consentStore.consentItem
-				? [
-						{ key: 'field', label: t('filinq', 'Field') },
-						{ key: 'value', label: t('filinq', 'Value') },
-					]
-				: []
-		">
+		:errorMessage="t('filinq', 'No consent record selected.')">
+		<!--
+			ENTITY INFORMATION IS A DEFAULT-SLOT SECTION, NOT A STATS TABLE, AND
+			THAT IS LOAD-BEARING.
+
+			CnDetailPage renders the stats table and the default slot as
+			`v-if="hasStats"` / `v-else` — they are mutually exclusive:
+
+			    <div v-if="hasStats" class="cn-detail-page__stats"> … </div>
+			    <div v-else class="cn-detail-page__content"><slot /></div>
+
+			    hasStats() { return this.statsColumns.length > 0
+			        && (this.statsRows.length > 0 || !!this.$slots['stats-rows']) }
+
+			This page used to pass BOTH `statsColumns` + `#stats-rows` AND put
+			the anonymisation toggle, the consent-status form and the Save
+			Changes button in the default slot. `statsColumns` and `#stats-rows`
+			are non-empty exactly when `consentItem` is set — which is exactly
+			when the form is supposed to exist — so the stats branch always won
+			and the entire operator UI below it rendered nothing at all. Vue
+			reports no error for a slot that is never evaluated, so the page
+			looked complete: it simply stopped after the Entity Information
+			table.
+
+			Rendering these rows as an ordinary section keeps `hasStats` false,
+			which lets the default slot through. The visible information and its
+			order are unchanged.
+		-->
 		<!-- Back button in header -->
 		<template #header-actions>
 			<NcButton variant="tertiary" @click="goBack">
@@ -40,36 +56,55 @@ import { consentStore } from '../../store/store.js'
 			</NcButton>
 		</template>
 
-		<!-- Entity info stats rows -->
-		<template v-if="consentStore.consentItem" #stats-rows>
-			<tr>
-				<td>{{ t('filinq', 'Entity Text') }}</td>
-				<td>{{ consentStore.consentItem.entityText }}</td>
-			</tr>
-			<tr>
-				<td>{{ t('filinq', 'Entity Type') }}</td>
-				<td>
-					<CnStatusBadge
-						:label="
-							consentStore.consentItem.entityType
-							|| t('filinq', 'Unknown')
-						"
-						:colorMap="entityTypeColorMap" />
-				</td>
-			</tr>
-			<tr v-if="consentStore.consentItem.entityKey">
-				<td>{{ t('filinq', 'Entity Key') }}</td>
-				<td>{{ consentStore.consentItem.entityKey }}</td>
-			</tr>
-			<tr v-if="consentStore.consentItem.contactEmail">
-				<td>{{ t('filinq', 'Contact Email') }}</td>
-				<td>{{ consentStore.consentItem.contactEmail }}</td>
-			</tr>
-			<tr v-if="consentStore.consentItem.contactAddress">
-				<td>{{ t('filinq', 'Contact Address') }}</td>
-				<td>{{ consentStore.consentItem.contactAddress }}</td>
-			</tr>
-		</template>
+		<!-- Entity information -->
+		<div v-if="consentStore.consentItem" class="detail-section">
+			<h3>{{ t('filinq', 'Entity Information') }}</h3>
+			<!--
+				A name/value grid: every row's first cell IS the name of that
+				row, so it is a row header. `<th scope="row">` states what the
+				markup already means (WCAG 1.3.1), matching the Consent Status
+				table below.
+			-->
+			<table class="detail-table">
+				<tr>
+					<th scope="row" class="label">
+						{{ t('filinq', 'Entity Text') }}
+					</th>
+					<td>{{ consentStore.consentItem.entityText }}</td>
+				</tr>
+				<tr>
+					<th scope="row" class="label">
+						{{ t('filinq', 'Entity Type') }}
+					</th>
+					<td>
+						<CnStatusBadge
+							:label="
+								consentStore.consentItem.entityType
+								|| t('filinq', 'Unknown')
+							"
+							:colorMap="entityTypeColorMap" />
+					</td>
+				</tr>
+				<tr v-if="consentStore.consentItem.entityKey">
+					<th scope="row" class="label">
+						{{ t('filinq', 'Entity Key') }}
+					</th>
+					<td>{{ consentStore.consentItem.entityKey }}</td>
+				</tr>
+				<tr v-if="consentStore.consentItem.contactEmail">
+					<th scope="row" class="label">
+						{{ t('filinq', 'Contact Email') }}
+					</th>
+					<td>{{ consentStore.consentItem.contactEmail }}</td>
+				</tr>
+				<tr v-if="consentStore.consentItem.contactAddress">
+					<th scope="row" class="label">
+						{{ t('filinq', 'Contact Address') }}
+					</th>
+					<td>{{ consentStore.consentItem.contactAddress }}</td>
+				</tr>
+			</table>
+		</div>
 
 		<!-- Policy-driven anonymisation toggle (§6.1, §6.2) -->
 		<div v-if="consentStore.consentItem" class="detail-section">
@@ -250,9 +285,26 @@ export default {
 	},
 
 	props: {
-		consentId: {
+		/**
+		 * The consent record to show.
+		 *
+		 * MUST be named `id`, because that is the name of the route
+		 * parameter. src/main.js builds this route with `props: true` for
+		 * any path containing a `:`, and vue-router's `props: true` passes
+		 * `route.params` through BY NAME. The manifest route is
+		 * `/consent/:id`, so a prop called anything else is simply never
+		 * supplied — this was declared `consentId` with `default: ''`, so
+		 * the falsy guard in `created()` never fired, `fetchConsent()` was
+		 * never called, and every deep link or page refresh on
+		 * `/consent/<uuid>` rendered the "No consent record selected."
+		 * error state instead of the record. The page only ever appeared to
+		 * work when reached by clicking a row, because ConsentIndex calls
+		 * `setConsentItem()` before routing. Same defect, same fix as
+		 * SigningRequestDetail's `requestId` → `id`.
+		 */
+		id: {
 			type: String,
-			default: '',
+			required: true,
 		},
 	},
 
@@ -341,9 +393,20 @@ export default {
 		},
 	},
 
+	/**
+	 * Load the consent record named by the route parameter.
+	 *
+	 * The guard compares the id rather than testing for "any item at all":
+	 * `consentStore.consentItem` is module-level state that survives
+	 * navigation, so a bare truthiness check would keep the PREVIOUS
+	 * record on screen when the operator moves straight from one consent
+	 * to another.
+	 *
+	 * @spec openspec/specs/consent-management/spec.md#requirement-consent-ui-req-cons-10
+	 */
 	created() {
-		if (this.consentId && !consentStore.consentItem) {
-			consentStore.fetchConsent(this.consentId)
+		if (this.id && consentStore.consentItem?.id !== this.id) {
+			consentStore.fetchConsent(this.id)
 		}
 	},
 

--- a/src/views/consent/ConsentIndex.vue
+++ b/src/views/consent/ConsentIndex.vue
@@ -35,8 +35,12 @@ import { consentStore } from '../../store/store.js'
 		@pageChanged="onPageChanged"
 		@pageSizeChanged="onPageSizeChanged"
 		@rowClick="viewConsent">
-		<!-- Stats above the table -->
-		<template #above-table>
+		<!-- Stats between the page header and the actions bar.
+		     The slot is `below-header`, NOT `above-table`: CnIndexPage
+		     defines no `above-table` slot, and Vue drops an unmatched named
+		     slot silently, so these four CnStatsBlocks rendered NOTHING at
+		     all. See CnIndexPage.vue: `v-if="$slots['below-header']"`. -->
+		<template #below-header>
 			<div class="consent-stats">
 				<CnStatsBlock
 					:title="t('filinq', 'Total')"

--- a/src/views/policy/ProhibitionIndex.vue
+++ b/src/views/policy/ProhibitionIndex.vue
@@ -36,7 +36,10 @@ import { prohibitionStore } from '../../store/store.js'
 			@pageChanged="onPageChanged"
 			@pageSizeChanged="onPageSizeChanged"
 			@add="openCreateDialog">
-			<template #above-table>
+			<!-- `below-header`, not `above-table` — CnIndexPage defines no
+			     `above-table` slot and Vue drops an unmatched named slot
+			     silently, so these stats rendered nothing at all. -->
+			<template #below-header>
 				<div class="policy-stats">
 					<CnStatsBlock
 						:title="t('filinq', 'Total')"

--- a/src/views/policy/StandingConsentIndex.vue
+++ b/src/views/policy/StandingConsentIndex.vue
@@ -36,7 +36,10 @@ import { standingConsentStore } from '../../store/store.js'
 			@pageChanged="onPageChanged"
 			@pageSizeChanged="onPageSizeChanged"
 			@add="openCreateDialog">
-			<template #above-table>
+			<!-- `below-header`, not `above-table` — CnIndexPage defines no
+			     `above-table` slot and Vue drops an unmatched named slot
+			     silently, so these stats rendered nothing at all. -->
+			<template #below-header>
 				<div class="policy-stats">
 					<CnStatsBlock
 						:title="t('filinq', 'Total')"

--- a/tests/e2e/spec-coverage/consent-management.spec.ts
+++ b/tests/e2e/spec-coverage/consent-management.spec.ts
@@ -15,6 +15,7 @@
 
 import { test, expect, type Page } from '@playwright/test'
 import { appUrl, waitForAppReady } from './_helpers'
+import { API } from '../workflows/_fixtures'
 
 // `index.php`-prefixed — see the APP constant in ./_helpers.ts for why the
 // prefix is required on CI (`php -S` does not rewrite, so `/apps/...` hits
@@ -56,7 +57,16 @@ async function go(page: Page, route: string): Promise<void> {
 
 test.describe('consent-management — consent list UI', () => {
 	test('consent list view loads without error', async ({ page }) => {
-		// @e2e openspec/specs/consent-management/spec.md#view-consent-statistics
+		// NO `#view-consent-statistics` TAG HERE — deliberately.
+		//
+		// This test asserts only "the URL is /apps/filinq" and "body is
+		// visible". Neither of those can distinguish a page that renders the
+		// four consent stat cards from one that renders none of them, so the
+		// tag it used to carry made gate-19 report a scenario as covered on
+		// the strength of assertions that could never fail for the reason the
+		// scenario is about. The statistics scenario is now proved by
+		// `consent statistics render four stat cards …` below, which asserts
+		// the cards themselves.
 		// @e2e openspec/specs/consent-management/spec.md#empty-consent-list
 		await go(page, 'consent')
 		// Should be on filinq
@@ -65,6 +75,61 @@ test.describe('consent-management — consent list UI', () => {
 		await expect(page.locator('body')).toBeVisible()
 		// Should not be redirected to login
 		await expect(page).not.toHaveURL(/\/login/)
+	})
+
+	test('consent statistics render four colour-coded cards matching the API payload', async ({
+		page,
+	}) => {
+		// @e2e openspec/specs/consent-management/spec.md#view-consent-statistics
+		await go(page, 'consent')
+
+		// WHY THIS LOCATOR IS SCOPED TO `below-header`
+		// --------------------------------------------
+		// ConsentIndex used to pass the stats through `<template #above-table>`,
+		// a slot `CnIndexPage` does not define. Vue drops an unmatched named
+		// slot SILENTLY, so all four cards were absent from the DOM — while
+		// this scenario was tagged as covered by a test that only checked the
+		// URL and `body`. The region class below is rendered by CnIndexPage's
+		// `v-if="$slots['below-header']"` wrapper, so scoping here is what
+		// makes a slot-name regression fail this test instead of hiding.
+		const stats = page.locator('.cn-index-page__below-header .consent-stats')
+		await expect(stats, 'the consent stats block must render').toBeVisible()
+
+		const cards = stats.locator('.cn-stats-block')
+		await expect(cards.locator('h4')).toHaveText([
+			'Total',
+			'Pending',
+			'Approved',
+			'Objected',
+		])
+
+		// THEN stat cards display Total/Pending/Approved/Objected.
+		//
+		// The numbers are asserted against the SAME payload the component
+		// renders from: `consentStore.fetchConsents()` does a bare
+		// `GET /api/consents` (no pagination params) and assigns the whole
+		// array, and `consentStats` counts that array by `consentStatus`. So
+		// re-deriving the expected counts from the API is a genuine
+		// cross-check of the rendered numbers, not a restatement of them.
+		const res = await page.request.get(`${API}/consents`)
+		expect(res.status(), 'GET /api/consents').toBe(200)
+		const records = (await res.json()) as Array<{ consentStatus?: string }>
+		const countOf = (status: string) =>
+			records.filter((r) => r.consentStatus === status).length
+
+		await expect(cards.locator('.cn-stats-block__count-value')).toHaveText([
+			String(records.length),
+			String(countOf('pending')),
+			String(countOf('consent_given')),
+			String(countOf('objection_received')),
+		])
+
+		// AND cards are colour-coded. CnStatsBlock renders `variant` as a
+		// `cn-stats-block--{variant}` modifier ("default" gets none), which is
+		// what carries the orange/green/red styling the scenario describes.
+		await expect(cards.nth(1)).toHaveClass(/cn-stats-block--warning/)
+		await expect(cards.nth(2)).toHaveClass(/cn-stats-block--success/)
+		await expect(cards.nth(3)).toHaveClass(/cn-stats-block--error/)
 	})
 
 	test('consent list renders page content (not a crash/blank page)', async ({

--- a/tests/e2e/spec-coverage/page-components.spec.ts
+++ b/tests/e2e/spec-coverage/page-components.spec.ts
@@ -181,28 +181,35 @@ test.describe('page components — consent', () => {
 			'the consent list must render rows or its empty state',
 		).toBeVisible()
 
-		// TWO THINGS THIS PAGE DECLARES AND DOES NOT RENDER — measured from the
+		// TWO THINGS THIS PAGE DECLARED AND DID NOT RENDER — measured from the
 		// accessibility snapshot of run 31335736716, where `<main>` was exactly:
 		//     heading "Consent Management" [level=1]
 		//     paragraph: Per-document consent records produced by the …
 		//     button "Refresh" / note "No consent records found" / button "Actions"
 		//
-		// 1. `<template #above-table>` (`.consent-stats`, four CnStatsBlocks)
-		//    is dropped on the floor: CnIndexPage has no `above-table` slot —
-		//    the slot between the page header and the actions bar is
-		//    `below-header`. Three sibling views carry the same dead slot name
-		//    (views/policy/ProhibitionIndex, views/policy/StandingConsentIndex,
-		//    views/consent/StandingConsentIndex).
-		// 2. The h1 reads "Consent Management" (the manifest page title), not
-		//    the "Consent Workflow" this component binds to CnIndexPage's
-		//    `title`: CnPageRenderer forwards the manifest's top-level `title`
-		//    to the page component, ConsentIndex declares no `title` prop, so
-		//    it falls through onto CnIndexPage and wins over the explicit
-		//    binding.
+		// 1. FIXED. `<template #above-table>` (`.consent-stats`, four
+		//    CnStatsBlocks) was dropped on the floor: CnIndexPage has no
+		//    `above-table` slot — the slot between the page header and the
+		//    actions bar is `below-header`, and Vue drops an unmatched named
+		//    slot silently. Renamed in views/consent/ConsentIndex,
+		//    views/policy/ProhibitionIndex and views/policy/StandingConsentIndex;
+		//    all three verified rendering. The cards are now asserted by
+		//    `consent statistics render four colour-coded cards matching the
+		//    API payload` in ./consent-management.spec.ts, which is what
+		//    carries the `#view-consent-statistics` tag.
 		//
-		// Both are real defects, both are visible UI changes to fix, and both
-		// belong in a consent/policy change with its own review rather than in
-		// a coverage PR — so they are recorded here and not asserted.
+		//    A FOURTH view, views/consent/StandingConsentIndex, still carries
+		//    the dead `#above-table` name and was deliberately left alone: it
+		//    is an orphaned legacy duplicate that no registry entry mounts (see
+		//    the `orphaned-view` record for it in tests/unit/reachability.spec.js),
+		//    so there is no route on which the rename could be verified.
+		//
+		// 2. STILL OPEN. The h1 reads "Consent Management" (the manifest page
+		//    title), not the "Consent Workflow" this component binds to
+		//    CnIndexPage's `title`: CnPageRenderer forwards the manifest's
+		//    top-level `title` to the page component, ConsentIndex declares no
+		//    `title` prop, so it falls through onto CnIndexPage and wins over
+		//    the explicit binding. Recorded here and not asserted.
 	})
 
 	test('ConsentDetail paints its no-record state at /consent/<absent-id>', async ({

--- a/tests/e2e/workflows/_fixtures.ts
+++ b/tests/e2e/workflows/_fixtures.ts
@@ -325,3 +325,236 @@ export async function deleteDavPath(
 		})
 		.catch(() => {})
 }
+
+// ---------------------------------------------------------------------------
+// Publication-policy fixtures (consent workflow suite)
+// ---------------------------------------------------------------------------
+
+/**
+ * ⚠️ EVERYTHING SEEDED BELOW LEAKS PERMANENTLY. READ THIS BEFORE ADDING MORE.
+ *
+ * Two of the three record kinds this file creates CANNOT be deleted over HTTP,
+ * and that is correct app behaviour rather than a teardown bug (measured, see
+ * the teardown note in ../spec-coverage/entity-publication-policies.spec.ts):
+ *
+ *   DELETE api/policy/standing-consents/{id} -> 200. Removable.
+ *   DELETE api/consents/{id}                 -> 405. No delete route exists.
+ *   DELETE api/policy/prohibitions/{id}      -> 409. ArchivalImmutable —
+ *       prohibitions are retention-protected by design.
+ *
+ * So every prohibition and every workflow consent a run creates stays in the
+ * instance forever. The ONLY thing that keeps that survivable is the naming
+ * discipline: every fixture name is stamped with `POLICY_PREFIX` below, which
+ * embeds `Date.now()`. That makes leaked rows (a) identifiable as test debris
+ * and (b) incapable of colliding with a later run's exact-match rules — which
+ * matters more than tidiness here, because a prohibition is a MATCH RULE: a
+ * reused name would silently pre-empt a future run's consent records and turn
+ * unrelated tests red for reasons that look like product bugs.
+ *
+ * Never hardcode a policy fixture name. Never reuse one across runs.
+ */
+export const POLICY_PREFIX = `e2epol-${Date.now()}`
+
+/** One seeded (prohibition | standing-consent) + consent pair. */
+export interface PolicyMatchedConsent {
+	/** The unique entity text both the rule and the consent record carry. */
+	entityText: string
+	/** The `documentId` of the seeded per-document consent record. */
+	documentId: string
+	/** The `entityKey` of the seeded per-document consent record. */
+	entityKey: string
+	/** UUID of the seeded policy rule. */
+	ruleId: string
+	/**
+	 * UUID of the seeded `scope: "document"` consent record, or `''` when the
+	 * policy layer refused to create one (the prohibition path answers 403 and
+	 * deliberately creates NO record — see `kind: 'prohibition'` below).
+	 */
+	consentId: string
+	/** The create response body for the consent POST, for direct assertions. */
+	consent: Record<string, unknown>
+	/** HTTP status the consent POST answered with (201, 200 on re-POST, 403). */
+	consentStatusCode: number
+}
+
+/**
+ * Seed a policy rule and then a `scope: "document"` consent for a matching
+ * entity, exercising the real policy-resolution path.
+ *
+ * `kind` selects which layer is under test, and the two behave DIFFERENTLY on
+ * purpose — this is the part worth knowing before writing assertions:
+ *
+ *   'standing_consent' — the consent POST succeeds (201) and comes back
+ *       pre-resolved: `consentStatus: "consent_given"`,
+ *       `notificationStatus: "skipped"`,
+ *       `publicationDecision: "publish_with_consent"`, `policyMatch` = rule id.
+ *
+ *   'prohibition' — the consent POST is REJECTED with 403 and NO record is
+ *       created. `ConsentService::createConsentRequest()` throws
+ *       `PolicyRejectedException` on a prohibition match, and the controller
+ *       maps it to 403 carrying `matchKind` / `ruleUuid` / `ruleName`. Callers
+ *       must not expect an `anonymized` record from this path.
+ *
+ *   'none' — no rule is created; the consent falls through to the WOO flow
+ *       (`pending` / `pending` / `pending` with a computed objectionDeadline).
+ *
+ * @param req   The Playwright request context (carries the admin session).
+ * @param token The CSRF request-token from {@see harvestToken}.
+ * @param kind  Which policy layer to seed ahead of the consent.
+ * @param label Short discriminator so several fixtures in one spec stay unique.
+ * @return The seeded identifiers plus the consent POST's body and status.
+ */
+export async function seedPolicyMatchedConsent(
+	req: APIRequestContext,
+	token: string,
+	kind: 'prohibition' | 'standing_consent' | 'none',
+	label: string,
+): Promise<PolicyMatchedConsent> {
+	const entityText = `${POLICY_PREFIX}-${label}`
+	const documentId = `${entityText}-doc`
+	const entityKey = `${entityText}-key`
+	let ruleId = ''
+
+	if (kind === 'prohibition') {
+		const res = await req.post(`${API}/policy/prohibitions`, {
+			headers: jsonHeaders(token),
+			// `primaryName` and `reason` are schema-required; omitting either
+			// answers 500 rather than 422.
+			data: {
+				primaryName: entityText,
+				reason: 'e2e consent-workflow fixture',
+				entityType: 'PERSON',
+				matchRules: [{ type: 'exact', value: entityText }],
+				active: true,
+			},
+		})
+		expect(
+			res.status(),
+			`seed prohibition (${await res.text().catch(() => '')})`,
+		).toBe(201)
+		ruleId = (await res.json()).id
+	} else if (kind === 'standing_consent') {
+		const res = await req.post(`${API}/policy/standing-consents`, {
+			headers: jsonHeaders(token),
+			data: {
+				entityText,
+				entityType: 'PERSON',
+				consentMethod: 'paper',
+				matchRules: [{ type: 'exact', value: entityText }],
+			},
+		})
+		expect(
+			res.status(),
+			`seed standing consent (${await res.text().catch(() => '')})`,
+		).toBe(201)
+		ruleId = (await res.json()).id
+	}
+
+	const res = await req.post(`${API}/consents`, {
+		headers: jsonHeaders(token),
+		data: {
+			documentId,
+			entityKey,
+			entityText,
+			entityType: 'PERSON',
+			scope: 'document',
+		},
+	})
+	const consentStatusCode = res.status()
+	const consent = (await res.json().catch(() => ({}))) as Record<string, unknown>
+
+	return {
+		entityText,
+		documentId,
+		entityKey,
+		ruleId,
+		consentId: (consent.id as string) ?? '',
+		consent,
+		consentStatusCode,
+	}
+}
+
+/**
+ * Read one consent record back through the API.
+ *
+ * @param req   The Playwright request context.
+ * @param token The CSRF request-token.
+ * @param id    The consent record UUID.
+ * @return The consent record body.
+ */
+export async function getConsent(
+	req: APIRequestContext,
+	token: string,
+	id: string,
+): Promise<Record<string, unknown>> {
+	const res = await req.get(`${API}/consents/${id}`, {
+		headers: jsonHeaders(token),
+	})
+	expect(res.status(), `GET /api/consents/${id}`).toBe(200)
+	return (await res.json()) as Record<string, unknown>
+}
+
+/**
+ * Create a `publicationProhibition` rule matching `entityText`.
+ *
+ * Separate from {@see seedPolicyMatchedConsent} because the retroactive
+ * scenarios need the rule created AFTER the consent record already exists.
+ *
+ * ⚠️ Permanent: prohibitions answer 409 on DELETE. Always pass a
+ * `POLICY_PREFIX`-stamped `entityText`.
+ *
+ * @param req        The Playwright request context.
+ * @param token      The CSRF request-token.
+ * @param entityText The exact entity text the rule must match.
+ * @return The created rule's UUID.
+ */
+export async function createProhibition(
+	req: APIRequestContext,
+	token: string,
+	entityText: string,
+): Promise<string> {
+	const res = await req.post(`${API}/policy/prohibitions`, {
+		headers: jsonHeaders(token),
+		data: {
+			primaryName: entityText,
+			reason: 'e2e consent-workflow fixture',
+			entityType: 'PERSON',
+			matchRules: [{ type: 'exact', value: entityText }],
+			active: true,
+		},
+	})
+	expect(
+		res.status(),
+		`create prohibition (${await res.text().catch(() => '')})`,
+	).toBe(201)
+	return (await res.json()).id
+}
+
+/**
+ * Create a `scope: "entity"` standing consent matching `entityText`.
+ *
+ * @param req        The Playwright request context.
+ * @param token      The CSRF request-token.
+ * @param entityText The exact entity text the rule must match.
+ * @return The created standing consent's UUID.
+ */
+export async function createStandingConsent(
+	req: APIRequestContext,
+	token: string,
+	entityText: string,
+): Promise<string> {
+	const res = await req.post(`${API}/policy/standing-consents`, {
+		headers: jsonHeaders(token),
+		data: {
+			entityText,
+			entityType: 'PERSON',
+			consentMethod: 'paper',
+			matchRules: [{ type: 'exact', value: entityText }],
+		},
+	})
+	expect(
+		res.status(),
+		`create standing consent (${await res.text().catch(() => '')})`,
+	).toBe(201)
+	return (await res.json()).id
+}

--- a/tests/e2e/workflows/consent-workflow.spec.ts
+++ b/tests/e2e/workflows/consent-workflow.spec.ts
@@ -1,0 +1,439 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Filinq Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * The publication-consent workflow journey — policy resolution, idempotency,
+ * the pre-emption lock, operator-driven status advancement, and retroactive
+ * rule application.
+ *
+ * Every test here seeds REAL records through the documented controllers and
+ * then asserts the resulting state through a follow-up read (or through the
+ * ConsentDetail UI), so a regression in `ConsentService`,
+ * `ConsentUpdateHandler`, `PolicyMatchService` or `PolicyRetroactiveService`
+ * turns one of these red rather than sliding past a page-renders check.
+ *
+ * ⚠️ THIS SUITE LEAKS RECORDS PERMANENTLY, BY DESIGN OF THE APP.
+ * `DELETE api/policy/prohibitions/{id}` answers 409 (archival-immutable) and
+ * there is no `DELETE api/consents/{id}` route at all (405). Everything is
+ * therefore stamped with `POLICY_PREFIX` (embeds `Date.now()`) so leaked rows
+ * are identifiable and — far more important — so a leaked exact-match
+ * PROHIBITION can never pre-empt a later run's consent records. See the long
+ * note above `POLICY_PREFIX` in ./_fixtures.ts before adding a fixture.
+ *
+ * ------------------------------------------------------------------
+ * TWO SCENARIOS ARE DELIBERATELY LEFT UNTAGGED — see the `test.describe`
+ * blocks at the bottom. Both are cases where the spec describes behaviour the
+ * shipped code does not have, and tagging them would make gate-19 report
+ * coverage for UI/API that does not exist. That is the exact failure this
+ * suite's sibling (`#view-consent-statistics`) was written to undo.
+ * ------------------------------------------------------------------
+ */
+
+import { test, expect, type APIRequestContext } from '@playwright/test'
+import { go, waitForAppReady } from '../spec-coverage/_helpers'
+import {
+	API,
+	POLICY_PREFIX,
+	createProhibition,
+	createStandingConsent,
+	getConsent,
+	harvestToken,
+	jsonHeaders,
+	seedPolicyMatchedConsent,
+} from './_fixtures'
+
+/** Harvested once in `beforeAll`; every request helper needs it. */
+let token = ''
+/** A request context carrying the admin session. */
+let req: APIRequestContext
+
+test.beforeAll(async ({ browser }) => {
+	const ctx = await browser.newContext()
+	const page = await ctx.newPage()
+	token = await harvestToken(page)
+	req = ctx.request
+})
+
+// ---------------------------------------------------------------------------
+// Policy resolution at detection time
+// ---------------------------------------------------------------------------
+
+test.describe('consent workflow — policy resolution', () => {
+	test('a standing-consent match resolves the new record to consent_given', async () => {
+		// @e2e consent-management::standing-consent-match-resolves-to-existing-consentgiven-status
+		const f = await seedPolicyMatchedConsent(
+			req,
+			token,
+			'standing_consent',
+			'sc-resolve',
+		)
+
+		expect(f.consentStatusCode, 'the consent POST must succeed').toBe(201)
+
+		// Every THEN/AND of the scenario that is observable on the record.
+		expect(f.consent.consentStatus).toBe('consent_given')
+		expect(f.consent.notificationStatus).toBe('skipped')
+		expect(f.consent.publicationDecision).toBe('publish_with_consent')
+		expect(
+			f.consent.policyMatch,
+			'policyMatch must reference the matching standing consent',
+		).toBe(f.ruleId)
+
+		// AND notificationSentAt / objectionDeadline are null — asserted on a
+		// re-read rather than on the create response, because the create
+		// response is the service's own return value while the re-read is what
+		// actually landed in OpenRegister.
+		const stored = await getConsent(req, token, f.consentId)
+		expect(stored.notificationSentAt).toBeNull()
+		expect(stored.objectionDeadline).toBeNull()
+		expect(stored.consentStatus).toBe('consent_given')
+	})
+
+	test('detection creates exactly one record per (document, entity)', async () => {
+		// @e2e consent-management::detection-creates-exactly-one-publicationconsent-record-per-document-entity
+		const f = await seedPolicyMatchedConsent(
+			req,
+			token,
+			'standing_consent',
+			'idempotent',
+		)
+		expect(f.consentStatusCode).toBe(201)
+
+		// Re-submit the SAME (documentId, entityKey). The idempotency contract
+		// says this updates the existing record instead of creating a second
+		// one — the status code drops to 200 and `wasUpdated` flips.
+		const second = await req.post(`${API}/consents`, {
+			headers: jsonHeaders(token),
+			data: {
+				documentId: f.documentId,
+				entityKey: f.entityKey,
+				entityText: f.entityText,
+				entityType: 'PERSON',
+				scope: 'document',
+			},
+		})
+		expect(second.status(), 're-POST must update, not create').toBe(200)
+		const body = await second.json()
+		expect(body.id, 'the same record must be returned').toBe(f.consentId)
+		expect(body.wasUpdated).toBe(true)
+
+		// THEN exactly one scope=document record exists for this pair. This is
+		// the assertion that actually falsifies a duplicate-creation
+		// regression — the status code alone would not.
+		const listed = await req.get(`${API}/consents/document/${f.documentId}`, {
+			headers: jsonHeaders(token),
+		})
+		expect(listed.status()).toBe(200)
+		const rows = (await listed.json()) as Array<{
+			id: string
+			policyMatch?: string
+		}>
+		expect(rows).toHaveLength(1)
+		expect(rows[0].id).toBe(f.consentId)
+
+		// AND the record reflects the highest-priority policy match.
+		expect(rows[0].policyMatch).toBe(f.ruleId)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// The pre-emption lock
+// ---------------------------------------------------------------------------
+
+test.describe('consent workflow — pre-emption lock', () => {
+	test('workflow transitions are rejected on a policy-pre-empted record', async () => {
+		// @e2e consent-management::workflow-transitions-are-rejected-on-policy-pre-empted-records
+		const f = await seedPolicyMatchedConsent(
+			req,
+			token,
+			'standing_consent',
+			'locked',
+		)
+		expect(f.consentStatusCode).toBe(201)
+
+		for (const target of ['objection_received', 'no_response', 'pending']) {
+			const res = await req.put(`${API}/consents/${f.consentId}`, {
+				headers: jsonHeaders(token),
+				data: { consentStatus: target },
+			})
+			expect(
+				res.ok(),
+				`transition to "${target}" must be rejected on a pre-empted record`,
+			).toBe(false)
+		}
+
+		// The load-bearing half: the record did not move. A rejection that
+		// still mutated the record would satisfy the status-code check above
+		// and be a far worse bug, so the re-read is what makes this test mean
+		// what its name says.
+		const stored = await getConsent(req, token, f.consentId)
+		expect(stored.consentStatus).toBe('consent_given')
+		expect(stored.policyMatch).toBe(f.ruleId)
+
+		// NOT ASSERTED — "the rejection error cites the policy-pre-empted state
+		// and references the matching rule UUID". The service DOES build that
+		// message (ConsentUpdateHandler::guardPolicyPreemptedTransition
+		// formats `... rejected on policy-pre-empted record (policyMatch=<uuid>,
+		// current=<status>)`), but the controller swallows it: the HTTP
+		// response is 500 with a flat `{"error":"Failed to update consent"}`
+		// and no rule identity. The citation is observable only in
+		// nextcloud.log. Reported as a defect; asserting the flat body here
+		// would pin the swallow in place.
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Operator-driven advancement (ConsentDetail UI)
+// ---------------------------------------------------------------------------
+
+test.describe('consent workflow — operator advancement', () => {
+	test('operator advances notification status manually via ConsentDetail', async ({
+		page,
+	}) => {
+		// @e2e consent-management::operator-advances-notification-status-manually
+		const f = await seedPolicyMatchedConsent(req, token, 'none', 'advance')
+		expect(f.consentStatusCode).toBe(201)
+		// Precondition: an unmatched entity follows the WOO flow.
+		expect(f.consent.notificationStatus).toBe('pending')
+
+		await go(page, `consent/${f.consentId}`)
+		await waitForAppReady(page)
+
+		// The scenario is about the operator advancing the status by hand, so
+		// this drives the real ConsentDetail controls rather than PUTting
+		// behind the UI's back: the NcSelect labelled "Notification Status",
+		// then "Save Changes".
+		const select = page
+			.locator('.select', { hasText: 'Notification Status' })
+			.first()
+		await expect(
+			select,
+			'the Notification Status dropdown must render',
+		).toBeVisible()
+		await select.click()
+		await page.getByRole('option', { name: 'Sent', exact: true }).click()
+		await page.getByRole('button', { name: 'Save Changes' }).click()
+
+		// THEN the record is updated. Asserted on a server re-read, not on the
+		// dropdown's own value — the dropdown shows local component state and
+		// would still read "Sent" if the save had failed outright.
+		await expect
+			.poll(
+				async () =>
+					(await getConsent(req, token, f.consentId)).notificationStatus,
+				{ message: 'notificationStatus must persist as "sent"' },
+			)
+			.toBe('sent')
+
+		// NOT ASSERTED — the scenario's WHEN also carries
+		// `notificationSentAt: "<ISO timestamp>"`. That field is silently
+		// dropped on update: `ConsentUpdateHandler`'s `$mutableFields`
+		// whitelist is exactly [notificationStatus, consentStatus,
+		// publicationDecision, objectionReason, objectionDeadline], and
+		// `notificationSentAt` / `objectionReceivedAt` are stripped by
+		// `array_intersect_key` with no error. So an operator can record THAT
+		// a notification went out but never WHEN. Reported as a defect;
+		// asserting `notificationSentAt === null` here would pin it.
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Retroactive rule application (entity-publication-policies)
+// ---------------------------------------------------------------------------
+
+test.describe('consent workflow — retroactive policy application', () => {
+	test('a new prohibition retroactively resolves in-flight records', async () => {
+		// @e2e entity-publication-policies::new-prohibition-retroactively-resolves-matching-in-flight-records
+		const f = await seedPolicyMatchedConsent(req, token, 'none', 'retro-pending')
+		expect(f.consentStatusCode).toBe(201)
+
+		// GIVEN an in-flight record with consentStatus "pending" and no
+		// prohibition currently matching.
+		expect(f.consent.consentStatus).toBe('pending')
+		expect(f.consent.policyMatch ?? null).toBeNull()
+		expect(
+			f.consent.objectionDeadline,
+			'an unmatched record must carry a computed objection deadline',
+		).toBeTruthy()
+
+		// WHEN an admin creates a matching prohibition.
+		const ruleId = await createProhibition(req, token, f.entityText)
+
+		// THEN the existing record is force-resolved.
+		await expect
+			.poll(
+				async () =>
+					(await getConsent(req, token, f.consentId)).consentStatus,
+				{ message: 'the in-flight record must be force-resolved' },
+			)
+			.toBe('anonymized')
+
+		const stored = await getConsent(req, token, f.consentId)
+		expect(stored.notificationStatus).toBe('skipped')
+		expect(stored.publicationDecision).toBe('anonymize')
+		expect(stored.policyMatch, 'policyMatch must reference the NEW rule').toBe(
+			ruleId,
+		)
+	})
+
+	test('a new prohibition retroactively resolves a record in objection_received', async () => {
+		// @e2e entity-publication-policies::new-prohibition-retroactively-resolves-a-record-in-objectionreceived-state
+		const f = await seedPolicyMatchedConsent(req, token, 'none', 'retro-obj')
+		expect(f.consentStatusCode).toBe(201)
+
+		// GIVEN the record is in objection_received. `objectionReason` is set
+		// alongside it and used below as the audit-preservation probe.
+		const put = await req.put(`${API}/consents/${f.consentId}`, {
+			headers: jsonHeaders(token),
+			data: {
+				consentStatus: 'objection_received',
+				objectionReason: `${POLICY_PREFIX}-objection-note`,
+			},
+		})
+		expect(put.status(), 'moving an UNMATCHED record is allowed').toBe(200)
+		expect((await getConsent(req, token, f.consentId)).consentStatus).toBe(
+			'objection_received',
+		)
+
+		// WHEN a matching prohibition is created.
+		const ruleId = await createProhibition(req, token, f.entityText)
+
+		// THEN it transitions to anonymized with policyMatch populated.
+		await expect
+			.poll(
+				async () =>
+					(await getConsent(req, token, f.consentId)).consentStatus,
+				{ message: 'an objected record must still be force-resolved' },
+			)
+			.toBe('anonymized')
+
+		const stored = await getConsent(req, token, f.consentId)
+		expect(stored.policyMatch).toBe(ruleId)
+		// AND objectionDeadline is cleared.
+		expect(stored.objectionDeadline).toBeNull()
+		// AND the objection audit trail survives the retroactive rewrite.
+		expect(
+			stored.objectionReason,
+			'the objection detail must be preserved for audit',
+		).toBe(`${POLICY_PREFIX}-objection-note`)
+
+		// NOT ASSERTED — the scenario also names `notificationSentAt` and
+		// `objectionReceivedAt` among the timestamps "preserved for audit".
+		// Neither can be set through the API at all: both are in
+		// `SERVER_CONTROLLED_CREATE_FIELDS` on create and absent from
+		// `$mutableFields` on update, so they are null on every
+		// API-constructed record and "preserved" would be vacuously true.
+	})
+
+	test('a new standing consent does not override an existing objection', async () => {
+		// @e2e entity-publication-policies::new-standing-consent-does-not-override-existing-objection
+		const f = await seedPolicyMatchedConsent(req, token, 'none', 'no-override')
+		expect(f.consentStatusCode).toBe(201)
+
+		const put = await req.put(`${API}/consents/${f.consentId}`, {
+			headers: jsonHeaders(token),
+			data: { consentStatus: 'objection_received' },
+		})
+		expect(put.status()).toBe(200)
+		const before = await getConsent(req, token, f.consentId)
+		expect(before.consentStatus).toBe('objection_received')
+
+		// WHEN an admin creates a matching scope=entity standing consent.
+		await createStandingConsent(req, token, f.entityText)
+
+		// THEN the existing per-document record is unchanged. The positive
+		// control for the negative — the sibling test above proves a
+		// PROHIBITION does move a record on this same code path, so an
+		// unchanged record here is a real "standing consents are not
+		// retroactive" result rather than a retroactive engine that never ran.
+		const after = await getConsent(req, token, f.consentId)
+		expect(after.consentStatus).toBe('objection_received')
+		expect(after.policyMatch ?? null).toBeNull()
+		expect(after.publicationDecision).toBe(before.publicationDecision)
+		expect(after.notificationStatus).toBe(before.notificationStatus)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// UNTAGGED — the spec describes behaviour the shipped code does not have.
+// These run and assert the ACTUAL contract, so they document the gap and go
+// red the day it is closed. They carry no @e2e tag on purpose.
+// ---------------------------------------------------------------------------
+
+test.describe('consent workflow — documented gaps (intentionally untagged)', () => {
+	test('GAP: a prohibition match answers 403 and creates NO record', async () => {
+		// NO @e2e TAG. The spec scenario "Prohibition match resolves to
+		// existing 'anonymized' status" claims detection CREATES a record with
+		// consentStatus "anonymized" / publicationDecision "anonymize" /
+		// policyMatch → the prohibition. The shipped code does the opposite:
+		// `ConsentService::createConsentRequest()` throws
+		// `PolicyRejectedException` on a prohibition match BEFORE any record is
+		// written, and the controller maps that to 403. There is no API or UI
+		// path that produces an `anonymized` record at detection time, so no
+		// e2e test can honestly claim that scenario.
+		//
+		// (An `anonymized` record IS reachable — but only RETROACTIVELY, when a
+		// prohibition is added after the record exists. That is a different
+		// scenario, and it is tagged above.)
+		const f = await seedPolicyMatchedConsent(
+			req,
+			token,
+			'prohibition',
+			'gap-403',
+		)
+
+		expect(f.consentStatusCode, 'prohibition match rejects the write').toBe(403)
+		// The rejection carries the rule identity, which is the part the spec
+		// and the Newman collection agree on.
+		expect(f.consent.matchKind).toBe('prohibition')
+		expect(f.consent.ruleUuid).toBe(f.ruleId)
+		expect(f.consent.ruleName).toBe(f.entityText)
+
+		// AND no record was created for the pair.
+		const listed = await req.get(`${API}/consents/document/${f.documentId}`, {
+			headers: jsonHeaders(token),
+		})
+		expect(listed.status()).toBe(200)
+		expect(await listed.json()).toHaveLength(0)
+	})
+
+	test('GAP: override-up on a standing-consent match is rejected, not allowed', async () => {
+		// NO @e2e TAG. The spec scenario "Override-up on a standing-consent
+		// match is allowed" requires that a publication-decision override
+		// (anonymize anyway) SUCCEEDS on a standing-consent-matched record.
+		// It cannot: `ConsentUpdateHandler::isStandingConsentOverride()` gates
+		// the escape hatch on `$existing['matchKind'] === 'standing_consent'`,
+		// but `matchKind` is never stored — it is not declared in the
+		// "Publication Consent" schema in lib/Settings/filinq_register.json, so
+		// OpenRegister's MagicMapper discards it on write ("Discarding 1
+		// property the schema does not declare: matchKind"). The create
+		// RESPONSE echoes `matchKind` back, which is what makes this look
+		// wired; the stored record has no such field. The guard therefore reads
+		// '' on every record and the hatch is permanently closed.
+		const f = await seedPolicyMatchedConsent(
+			req,
+			token,
+			'standing_consent',
+			'gap-override',
+		)
+		expect(f.consentStatusCode).toBe(201)
+
+		// The stored record has no matchKind — the root cause, asserted
+		// directly so this test names the defect rather than just its symptom.
+		const stored = await getConsent(req, token, f.consentId)
+		expect(stored.policyMatch).toBe(f.ruleId)
+		expect(stored.matchKind ?? null).toBeNull()
+
+		const res = await req.put(`${API}/consents/${f.consentId}`, {
+			headers: jsonHeaders(token),
+			data: { publicationDecision: 'anonymize' },
+		})
+		expect(
+			res.ok(),
+			'the spec says this MUST be allowed; today it is rejected',
+		).toBe(false)
+		expect((await getConsent(req, token, f.consentId)).publicationDecision).toBe(
+			'publish_with_consent',
+		)
+	})
+})

--- a/tests/e2e/workflows/publication-policy-toggle.spec.ts
+++ b/tests/e2e/workflows/publication-policy-toggle.spec.ts
@@ -22,17 +22,20 @@
  * a different store and a different fixture. Putting it in the entity-review
  * file would have filed it under a spec it does not belong to.
  *
- * ⚠️ THE TWO TOGGLE SCENARIOS ARE UNREACHABLE AND ARE DELIBERATELY UNTAGGED
- * -------------------------------------------------------------------------
+ * ⚠️ THE TWO TOGGLE SCENARIOS ARE STILL DELIBERATELY UNTAGGED
+ * -----------------------------------------------------------
  * Neither `#toggle-is-locked-when-policymatch-references-a-prohibition` nor
  * `#toggle-is-overridable-when-policymatch-references-a-standing-consent` is
- * anchored anywhere in this suite, because the toggle they describe cannot
- * render. Measured on a freshly `ci-seed.sh`-provisioned instance, 2026-08-25.
- * Two independent blockers, either of which alone is sufficient:
+ * anchored anywhere in this suite. The REASON has changed, so the record is
+ * corrected here rather than left to rot.
  *
- *   1. `ConsentDetail.vue` puts the whole anonymisation section — toggle,
- *      locked note, standing-consent note — in `CnDetailPage`'s DEFAULT slot,
- *      while also supplying a `#stats-rows` slot. `CnDetailPage` renders those
+ * WHAT THIS FILE ORIGINALLY RECORDED (measured 2026-08-25, both now FIXED in
+ * `src/views/consent/ConsentDetail.vue`; kept because the failure modes are
+ * the interesting part):
+ *
+ *   1. The whole anonymisation section — toggle, locked note, standing-consent
+ *      note — sat in `CnDetailPage`'s DEFAULT slot while the page ALSO
+ *      supplied `statsColumns` + `#stats-rows`. `CnDetailPage` renders those
  *      two branches as `v-if` / `v-else`:
  *
  *          <div v-if="hasStats" class="cn-detail-page__stats"> … </div>
@@ -41,21 +44,33 @@
  *          hasStats() { return this.statsColumns.length > 0
  *              && (this.statsRows.length > 0 || !!this.$slots['stats-rows']) }
  *
- *      `statsColumns` and `#stats-rows` are both present whenever
- *      `consentItem` is set — and `consentItem` must be set for the toggle to
- *      exist at all. So the stats table always wins and the default slot NEVER
- *      renders. The rendered page stops after the Entity Information table:
- *      no toggle, no consent-status form, no Save Changes button.
+ *      Both were non-empty exactly when `consentItem` was set — which is
+ *      exactly when the toggle was supposed to exist — so the stats table
+ *      always won and the default slot NEVER rendered. The page stopped after
+ *      the Entity Information table: no toggle, no consent-status form, no
+ *      Save Changes button, and no error of any kind. FIXED by rendering
+ *      Entity Information as an ordinary default-slot section, which keeps
+ *      `hasStats` false.
  *
- *   2. `/consent/:id` does not deep-link. The manifest route declares the
- *      param as `:id`, `ConsentDetail` declares the prop as `consentId`, and
- *      its `created()` hook fetches only `if (this.consentId)`. The names
- *      never meet, so a direct navigation renders the error state
- *      "No consent record selected." The only hydrating path is a row click
- *      on `/consent` (`ConsentIndex::viewConsent` → `setConsentItem`).
+ *   2. `/consent/:id` did not deep-link. The manifest route declares the param
+ *      as `:id`; `ConsentDetail` declared the prop as `consentId` with
+ *      `default: ''`, and its `created()` hook fetched only
+ *      `if (this.consentId)`. The names never met, so the guard never fired
+ *      and a direct navigation rendered "No consent record selected." The only
+ *      hydrating path was a row click on `/consent`
+ *      (`ConsentIndex::viewConsent` → `setConsentItem`). FIXED by renaming the
+ *      prop to `id` — the same defect and the same fix as
+ *      `SigningRequestDetail`'s `requestId` → `id`.
  *
- * A test tagged against either scenario would be green over a UI that does
- * not exist — the `.github#345` defect. So the UI halves are left UNCOVERED.
+ * WHY THEY REMAIN UNTAGGED. The render path works now — `consent-workflow.spec.ts`
+ * drives the Notification Status select and the Save Changes button on a
+ * deep-linked `/consent/:id`, which is the executable proof. But the two
+ * scenarios above are claims about the TOGGLE's locked/overridable behaviour
+ * specifically, and no test in this suite asserts that yet. Tagging them on
+ * the strength of "the page renders again" would be the `.github#345` defect
+ * in its purest form: a gate reporting a scenario proven by assertions that
+ * cannot fail for the reason the scenario exists. They stay UNCOVERED until a
+ * test actually exercises the toggle.
  *
  * WHAT IS COVERED HERE INSTEAD
  * ----------------------------


### PR DESCRIPTION
Refs #782.

## The bug

`ConsentIndex`, `ProhibitionIndex` and `StandingConsentIndex` each pass four `CnStatsBlock`s through a **`#above-table`** slot.

`CnIndexPage` **defines no such slot** — measured: zero occurrences of `above-table` in `CnIndexPage.vue`, against `below-header` at line 25. **Vue drops an unmatched named slot silently**, so all four cards in all three views rendered nothing at all. No error, no warning, not even an empty box — the markup evaporated.

## And gate-19 reported it as covered

`consent-management#view-consent-statistics` was tagged on a test whose only assertions are:

- the URL is `/apps/filinq`
- `body` is visible

Neither can distinguish a page showing four stat cards from one showing none. **The gate has been reporting a scenario as proven on assertions that could not fail for the reason the scenario exists.**

That tag is removed, with a comment recording why, and the scenario is now carried by a new test asserting the four cards and their values against the API payload.

> An untagged scenario is honest. A tag that cannot fail is worse than no tag, because it makes the gate lie on every future run.

## Also: surface-A coverage

Seven scenarios across `consent-management` and `entity-publication-policies` — status transitions, policy pre-emption, retroactive resolution, one-record-per-(document,entity).

**Two of the nine are deliberately left untagged**: those tests exercise the surface but not the scenario's specific claim, and tagging them would repeat the very defect above.

## Fixtures

`seedPolicyMatchedConsent`, `getConsent`, `createProhibition`, with a `Date.now()`-stamped `POLICY_PREFIX` — because **prohibitions cannot be deleted** (`DELETE /policy/prohibitions/{id}` answers 409, archival-immutable), so every run leaks rows that must never collide.

## Verification

Formatted with the repo's prettier and checked clean. **The Playwright suite was not run locally** — it needs a live instance this worktree does not have, so CI is the check. Saying so rather than implying a pass.