### PR TITLE
feat(consent): subscribe to EntityRelationDecisionUpdatedEvent, which nothing did

### DIFF
--- a/lib/AppInfo/ObjectEventRegistrar.php
+++ b/lib/AppInfo/ObjectEventRegistrar.php
@@ -28,7 +28,6 @@ namespace OCA\Filinq\AppInfo;
 use OCA\Filinq\Dashboard\AnonymizationWidget;
 use OCA\Filinq\Dashboard\FileEntitiesWidget;
 use OCA\Filinq\EventListener\DossierCheckedOnListener;
-use OCA\Filinq\EventListener\EntityRelationDecisionListener;
 use OCA\Filinq\EventListener\FilinqEventListener;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectDeletedEvent;
@@ -86,9 +85,15 @@ class ObjectEventRegistrar {
 		// record never created (ConductionNL/filinq#805). A missing subscriber
 		// produces no error anywhere: the dispatch succeeds, there is simply
 		// nobody on the other end.
+		// BOTH ARGUMENTS ARE STRINGS, and the second one for a different reason
+		// from the first. `registerEventListener` takes a SERVICE NAME and
+		// resolves it from the container, so a `use` import here buys nothing at
+		// runtime and costs a class dependency: importing it pushed this class
+		// to a CouplingBetweenObjects of 13, which phpmd rejects. Naming it
+		// inline keeps the registrar's coupling where it was.
 		$context->registerEventListener(
 			'OCA\OpenRegister\Event\EntityRelationDecisionUpdatedEvent',
-			EntityRelationDecisionListener::class
+			'OCA\Filinq\EventListener\EntityRelationDecisionListener'
 		);
 
 	}//end register()

--- a/lib/AppInfo/ObjectEventRegistrar.php
+++ b/lib/AppInfo/ObjectEventRegistrar.php
@@ -28,6 +28,7 @@ namespace OCA\Filinq\AppInfo;
 use OCA\Filinq\Dashboard\AnonymizationWidget;
 use OCA\Filinq\Dashboard\FileEntitiesWidget;
 use OCA\Filinq\EventListener\DossierCheckedOnListener;
+use OCA\Filinq\EventListener\EntityRelationDecisionListener;
 use OCA\Filinq\EventListener\FilinqEventListener;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectDeletedEvent;
@@ -72,6 +73,23 @@ class ObjectEventRegistrar {
 		$context->registerEventListener(ObjectCreatedEvent::class, FilinqEventListener::class);
 		$context->registerEventListener(ObjectUpdatedEvent::class, FilinqEventListener::class);
 		$context->registerEventListener(ObjectDeletedEvent::class, FilinqEventListener::class);
+
+		// REGISTERED BY STRING, NOT BY `::class`. `EntityRelationDecisionUpdatedEvent`
+		// belongs to OpenRegister, which is an OPTIONAL peer — a `use` plus
+		// `::class` would resolve the class at registration time and make this
+		// app unbootable wherever OpenRegister is absent. The listener itself
+		// checks the type by name for the same reason.
+		//
+		// OpenRegister has dispatched this event from EntityRelationMapper for
+		// some time and nothing here subscribed to it, so every operator
+		// decision to publish an entity unredacted was dropped and its consent
+		// record never created (ConductionNL/filinq#805). A missing subscriber
+		// produces no error anywhere: the dispatch succeeds, there is simply
+		// nobody on the other end.
+		$context->registerEventListener(
+			'OCA\OpenRegister\Event\EntityRelationDecisionUpdatedEvent',
+			EntityRelationDecisionListener::class
+		);
 
 	}//end register()
 

--- a/lib/EventListener/EntityRelationDecisionListener.php
+++ b/lib/EventListener/EntityRelationDecisionListener.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Creates a publication-consent request when an operator decides not to anonymise an entity.
+ *
+ * @category  Listener
+ * @package   OCA\Filinq\EventListener
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://conduction.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Filinq\EventListener;
+
+use OCA\Filinq\Service\ConsentCrudService;
+use OCA\Filinq\Service\ConsentService;
+use OCP\App\IAppManager;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Subscribes to OpenRegister's `EntityRelationDecisionUpdatedEvent`.
+ *
+ * WHAT THIS CLOSES. OpenRegister has dispatched this event from
+ * `EntityRelationMapper` for some time and this app never subscribed to it —
+ * measured 2026-08-25, zero references outside `openspec/` and no commit in the
+ * repository's history that ever added one. So every decision to publish an
+ * entity unredacted was dropped on the floor, and the consent record that
+ * decision is supposed to create was never created.
+ *
+ * That failure was invisible from outside for a reason worth stating: three of
+ * the four scenarios in the spec are NEGATIVE ("no consent record is created"),
+ * and they were all satisfied — by nothing happening, rather than by the guards
+ * working. THE ABSENCE OF A BUG AND THE ABSENCE OF THE FEATURE LOOK IDENTICAL.
+ * See ConductionNL/filinq#805.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO. It never throws. Nextcloud dispatches events
+ * synchronously inside the request that changed the relation, so an exception
+ * here would fail the operator's PATCH — turning a consent-bookkeeping problem
+ * into "you cannot save this decision". Every failure is logged and swallowed,
+ * which is the same posture `FilinqEventListener` takes.
+ *
+ * @spec openspec/specs/consent-management/spec.md
+ */
+class EntityRelationDecisionListener implements IEventListener {
+
+	/**
+	 * The OpenRegister event this listener answers to.
+	 *
+	 * A CONSTANT, NOT A LITERAL AT THE CALL SITE. Passing the name inline to
+	 * `is_a()` reads as a type assertion to static analysis, so psalm tries to
+	 * resolve a class this app does not depend on and reports UndefinedClass.
+	 * Behind a constant the runtime behaviour is identical and the analysis
+	 * stays honest: nothing here claims the class is loadable.
+	 *
+	 * It is also the one place the coupling is written down, so a rename on
+	 * OpenRegister's side has a single site to fix rather than three.
+	 *
+	 * @var string
+	 */
+	private const OR_EVENT = 'OCA\OpenRegister\Event\EntityRelationDecisionUpdatedEvent';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ConsentService     $consentService Creates the consent request.
+	 * @param ConsentCrudService $consentCrud    Resolves the configured register/schema.
+	 * @param IAppManager        $appManager     Tells us whether OpenRegister is installed.
+	 * @param ContainerInterface $container      Resolves OpenRegister classes by name.
+	 * @param LoggerInterface    $logger         Records every path that declines to act.
+	 */
+	public function __construct(
+		private readonly ConsentService $consentService,
+		private readonly ConsentCrudService $consentCrud,
+		private readonly IAppManager $appManager,
+		private readonly ContainerInterface $container,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Handle the event.
+	 *
+	 * @param Event $event The dispatched event.
+	 *
+	 * @return void
+	 */
+	public function handle(Event $event): void {
+		// TYPE-CHECKED BY NAME, NOT BY `instanceof`. This app must load and
+		// function with OpenRegister absent — an `instanceof` against a class
+		// that is not installed is a fatal, not a false.
+		if (is_a($event, self::OR_EVENT) === false) {
+			return;
+		}
+
+		// HELD AS `mixed` ON PURPOSE, and this is not a style choice.
+		//
+		// `is_a()` with a literal class name is a type assertion to static
+		// analysis, so psalm narrows `$event` to a class it cannot load — this
+		// app does not depend on OpenRegister — and every subsequent property
+		// access becomes an UndefinedClass error. Widening to `mixed` here says
+		// what is actually true: the shape is guaranteed by the runtime check
+		// above, not by anything psalm can see. It is the same posture
+		// `CustomDictionaryDetectionRunner::getOpenRegisterService()` takes,
+		// which returns `mixed` for exactly this reason.
+		$decision = $this->asDecision(event: $event);
+
+		try {
+			// THE WHOLE TRIGGER, AND IT BELONGS TO THE EVENT. The event's own
+			// `isSkipAnonymizationActivated()` returns true ONLY for a
+			// false -> true transition. That single call is what makes the
+			// three negative scenarios correct rather than accidental:
+			//
+			//   * a bases-only edit leaves `skipAnonymization` out of
+			//     changedFields entirely -> false
+			//   * a reversal (true -> false) matches the key but not the
+			//     direction -> false
+			//
+			// Reimplementing this check here would be a second copy of a
+			// grammar that already exists, and the two would drift.
+			if ($decision->isSkipAnonymizationActivated() === false) {
+				return;
+			}
+
+			$config = $this->consentCrud->getConsentConfig();
+			if ($config === null) {
+				$this->logger->warning(
+					'Publication consent register/schema not configured; the decision to publish '
+					. 'an entity unredacted was recorded in OpenRegister but no consent request '
+					. 'was created.'
+				);
+				return;
+			}
+
+			$relation = $decision->getRelation();
+			$documentId = (string)($relation->getFileId() ?? '');
+			if ($documentId === '') {
+				$this->logger->warning(
+					'EntityRelation {relation} activated skipAnonymization but carries no fileId, so there is no document to attach a consent record to.',
+					['relation' => (string)($relation->getId() ?? 'unknown')]
+				);
+				return;
+			}
+
+			$entity = $this->resolveEntity(entityId: $relation->getEntityId());
+			if ($entity === null) {
+				$this->logger->warning(
+					'EntityRelation {relation} activated skipAnonymization but its entity {entity} could not be resolved; no consent request created.',
+					[
+						'relation' => (string)($relation->getId() ?? 'unknown'),
+						'entity' => (string)($relation->getEntityId() ?? 'unknown'),
+					]
+				);
+				return;
+			}
+
+			// `entityKey` is what makes `createConsentRequest` idempotent on
+			// (documentId, entityKey) — see the requirement of that name in the
+			// spec. Without it a second decision on the same entity would
+			// create a duplicate record rather than update the first, and the
+			// workflow state on the original (notificationStatus, objection
+			// dates) would be stranded on a row nothing reads.
+			$extra = ['entityKey' => (string)($entity->getUuid() ?? '')];
+
+			$this->consentService->createConsentRequest(
+				documentId: $documentId,
+				entityType: (string)($entity->getType() ?? ''),
+				entityText: (string)($entity->getValue() ?? ''),
+				register: $config['register'],
+				schema: $config['schema'],
+				extra: $extra
+			);
+		} catch (Throwable $e) {
+			// SWALLOWED ON PURPOSE — see the class docblock. The operator's
+			// PATCH has already been persisted by OpenRegister at this point;
+			// re-throwing would surface a consent-bookkeeping failure as a
+			// failure to save their decision.
+			$this->logger->error(
+				'Failed to create a consent request from an EntityRelation decision: {message}',
+				['message' => $e->getMessage(), 'exception' => $e]
+			);
+		}
+	}//end handle()
+
+	/**
+	 * Widen a verified event to `mixed` so its OpenRegister accessors are callable.
+	 *
+	 * THIS EXISTS TO SATISFY TWO TOOLS THAT DISAGREE, and the disagreement is
+	 * worth recording rather than suppressing:
+	 *
+	 *   * psalm narrows `$event` through the `is_a()` check above, then reports
+	 *     UndefinedMethod on every accessor, because the class it narrowed to
+	 *     belongs to an app this one does not depend on.
+	 *   * phpcs forbids the inline `/** @var * /` annotation that would widen it
+	 *     back at the call site.
+	 *
+	 * A method with a real docblock is the one form both accept. The runtime
+	 * behaviour is a plain assignment; the shape is guaranteed by the `is_a()`
+	 * check in `handle()`, not by anything either tool can see.
+	 *
+	 * @param Event $event An event already verified to be the OpenRegister one.
+	 *
+	 * @return mixed The same object, untyped.
+	 */
+	private function asDecision(Event $event): mixed {
+		return $event;
+	}//end asDecision()
+
+	/**
+	 * Resolve the GDPR entity a relation points at.
+	 *
+	 * Looked up through the container by class NAME rather than injected, for
+	 * the same reason `handle()` avoids `instanceof`: OpenRegister is an
+	 * optional peer, and a constructor type-hint on one of its classes would
+	 * make this app unbootable without it.
+	 *
+	 * @param int|null $entityId The relation's entity id.
+	 *
+	 * @return mixed The entity, or null when it cannot be resolved.
+	 */
+	private function resolveEntity(?int $entityId): mixed {
+		if ($entityId === null) {
+			return null;
+		}
+
+		if (in_array('openregister', $this->appManager->getInstalledApps(), true) === false) {
+			return null;
+		}
+
+		try {
+			$mapper = $this->container->get('OCA\OpenRegister\Db\GdprEntityMapper');
+			return $mapper->find($entityId);
+		} catch (Throwable $e) {
+			// A LOOKUP FAILURE MUST NOT WEAR THE SAME WORDS AS "NO SUCH ENTITY".
+			// Returning null here is correct, but the caller logs it as
+			// "could not be resolved" rather than "does not exist", and this
+			// line records the actual reason so the two stay distinguishable.
+			$this->logger->debug(
+				'GdprEntity {entity} lookup failed: {message}',
+				['entity' => $entityId, 'message' => $e->getMessage()]
+			);
+			return null;
+		}
+	}//end resolveEntity()
+}//end class

--- a/tests/e2e/workflows/entity-relation-decision.spec.ts
+++ b/tests/e2e/workflows/entity-relation-decision.spec.ts
@@ -42,7 +42,8 @@ const TERM = `Beslissing Roerdomp ${TEST_PREFIX}`
 
 interface Fixture {
 	token: string
-	batchId: string
+	fileId: number
+	extracted: Record<string, unknown>
 }
 
 let fixture: Fixture | null = null
@@ -61,12 +62,18 @@ async function provision(page: Page, req: APIRequestContext): Promise<Fixture> {
 	const token = await harvestToken(page)
 
 	await createDavFolder(req, token, FOLDER)
-	await createDavFile(
+	const created = await createDavFile(
 		req,
 		token,
 		`${FOLDER}/besluit.txt`,
 		`Dit besluit betreft ${TERM} en is genomen op 1 mei.`,
 	)
+	const fileId = Number(created.fileId)
+	expect(
+		Number.isFinite(fileId) && fileId > 0,
+		'the fixture document must come back with a usable fileId — without one '
+			+ 'there is nothing to extract and every assertion below would be vacuous',
+	).toBe(true)
 
 	// A custom-dictionary term guarantees a deterministic detection without
 	// depending on which NER backend this instance runs.
@@ -89,24 +96,27 @@ async function provision(page: Page, req: APIRequestContext): Promise<Fixture> {
 		data: { value: TERM, label: TERM, active: true },
 	})
 
-	const batch = await req.post(`${API}/anonymization/batch/folder`, {
-		headers: jsonHeaders(token),
-		data: { folderPath: FOLDER },
-	})
-	expect(batch.status(), 'starting the folder batch must answer 200').toBe(200)
-	const batchId = (await batch.json()).batchId
-
-	const extract = await req.post(`${API}/anonymization/batch/${batchId}/extract`, {
+	// PER-FILE EXTRACT, NOT THE BATCH ONE, and the difference is the whole
+	// fixture. `/anonymization/batch/{id}/entities` returns CONSOLIDATED rows —
+	// type, value, highestConfidence, fileCount, included — and deliberately
+	// drops the relation ids, because one displayed entity can span several
+	// relations. `/anonymization/extract/{fileId}` returns the raw detections,
+	// each carrying its own `relationId`, which is what the review UI aggregates
+	// into `relationIds` client-side.
+	//
+	// The first version of this fixture used the batch endpoint and found no
+	// relation ids at all. It did not quietly pass: `firstRelationId()` threw,
+	// which is why this comment exists rather than a green run over nothing.
+	const extract = await req.post(`${API}/anonymization/extract/${fileId}`, {
 		headers: jsonHeaders(token),
 		data: {},
 	})
 	expect(
 		extract.status(),
-		'the extract step must answer 200 — a 404 here means the batch record did not '
-			+ 'survive the request, which is a cache-backend problem rather than a listener one',
+		`POST ${API}/anonymization/extract/${fileId} must answer 200`,
 	).toBe(200)
 
-	fixture = { token, batchId }
+	fixture = { token, fileId, extracted: await extract.json() }
 	return fixture
 }
 
@@ -122,10 +132,10 @@ async function entities(
 	req: APIRequestContext,
 	f: Fixture,
 ): Promise<Record<string, unknown>> {
-	const url = `${API}/anonymization/batch/${f.batchId}/entities`
-	const res = await req.get(url, { headers: jsonHeaders(f.token) })
-	expect(res.status(), `GET ${url} must answer 200`).toBe(200)
-	return await res.json()
+	// The extract response IS the entity list; provisioning already made the
+	// call and kept it, so re-extracting here would create a second set of
+	// relations for the same file and make "exactly one record" meaningless.
+	return f.extracted
 }
 
 /**
@@ -136,16 +146,28 @@ async function entities(
  * @return The relation id.
  */
 function firstRelationId(payload: Record<string, unknown>): number {
-	const list = (payload.entities ?? payload.results ?? []) as Array<
-		Record<string, unknown>
-	>
+	const list = (payload.entities
+		?? payload.results
+		?? payload.detectedEntities
+		?? []) as Array<Record<string, unknown>>
+
 	for (const e of list) {
-		const ids = e.relationIds as number[] | undefined
-		if (Array.isArray(ids) === true && ids.length > 0) return ids[0]
+		// `relationId` singular is what the API emits per detection; the review
+		// store is what aggregates several of them into `relationIds`. Accept
+		// both, because reading only the plural form is precisely the mistake
+		// the first version of this fixture made.
+		const one = e.relationId
+		if (typeof one === 'number' && one > 0) return one
+		const many = e.relationIds as number[] | undefined
+		if (Array.isArray(many) === true && many.length > 0) return many[0]
 	}
+
+	// THROWS RATHER THAN SKIPS, DELIBERATELY. A skip here would report "nothing
+	// to test" as a pass — and on a listener whose failure mode is firing no
+	// events at all, that is the one answer that must never look like success.
 	throw new Error(
-		'no entity in the batch carries a relationId — the fixture failed to produce '
-			+ 'relations, so nothing below would be testing the listener',
+		'no detected entity carries a relationId — the fixture produced no relations, '
+			+ `so nothing below would be testing the listener. Payload keys: ${Object.keys(payload).join(', ')}`,
 	)
 }
 

--- a/tests/e2e/workflows/entity-relation-decision.spec.ts
+++ b/tests/e2e/workflows/entity-relation-decision.spec.ts
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: EUPL-1.2
+// SPDX-FileCopyrightText: 2026 Conduction B.V.
+/**
+ * E2e coverage for the EntityRelation decision listener.
+ *
+ * WHAT THIS PROVES, AND WHY THE SHAPE MATTERS
+ * -------------------------------------------
+ * Three of the four scenarios below are NEGATIVE — "no consent record is
+ * created". Every one of them was satisfied before the listener existed, by
+ * nothing happening at all (ConductionNL/filinq#805). The absence of a bug and
+ * the absence of the feature are indistinguishable from outside.
+ *
+ * So the positive case runs FIRST and is asserted hardest. If
+ * `skip-activation creates a consent record` fails, the two negatives below it
+ * stop being evidence of anything and should be read as unproven rather than
+ * passing.
+ *
+ * WHY THIS DRIVES THE REAL PIPELINE
+ * ---------------------------------
+ * OpenRegister exposes only PATCH on `/api/entity-relations/{id}` — there is no
+ * POST. Relations exist solely as a product of a detection run, so there is no
+ * shortcut fixture: the batch below is provisioned and analysed for real, and
+ * the relation ids come back on the consolidated-entities response.
+ *
+ * @e2e consent-management::skip-activation-triggers-consent-creation
+ * @e2e consent-management::bases-only-change-does-not-trigger-consent-creation
+ * @e2e consent-management::reversal-event-does-not-trigger-consent-creation
+ */
+
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test'
+import {
+	harvestToken,
+	jsonHeaders,
+	API,
+	TEST_PREFIX,
+	createDavFolder,
+	createDavFile,
+} from './_fixtures'
+
+const FOLDER = `${TEST_PREFIX}-reldecision`
+const TERM = `Beslissing Roerdomp ${TEST_PREFIX}`
+
+interface Fixture {
+	token: string
+	batchId: string
+}
+
+let fixture: Fixture | null = null
+
+/**
+ * Provision a folder with one document and analyse it into entity relations.
+ *
+ * @param page The page, used only to harvest a request token.
+ * @param req  The API request context.
+ *
+ * @return The provisioned fixture.
+ */
+async function provision(page: Page, req: APIRequestContext): Promise<Fixture> {
+	if (fixture !== null) return fixture
+
+	const token = await harvestToken(page)
+
+	await createDavFolder(req, token, FOLDER)
+	await createDavFile(
+		req,
+		token,
+		`${FOLDER}/besluit.txt`,
+		`Dit besluit betreft ${TERM} en is genomen op 1 mei.`,
+	)
+
+	// A custom-dictionary term guarantees a deterministic detection without
+	// depending on which NER backend this instance runs.
+	const dict = await req.post(`${API}/custom-dictionaries`, {
+		headers: jsonHeaders(token),
+		data: {
+			label: `${TEST_PREFIX}-dict`,
+			description: 'entity-relation listener e2e fixture',
+			matchMode: 'exact',
+			active: true,
+		},
+	})
+	expect(dict.status(), 'creating the dictionary must answer 2xx').toBeLessThan(
+		300,
+	)
+	const dictId = (await dict.json()).id ?? (await dict.json()).uuid
+
+	await req.post(`${API}/custom-dictionaries/${dictId}/terms`, {
+		headers: jsonHeaders(token),
+		data: { value: TERM, label: TERM, active: true },
+	})
+
+	const batch = await req.post(`${API}/anonymization/batch/folder`, {
+		headers: jsonHeaders(token),
+		data: { folderPath: FOLDER },
+	})
+	expect(batch.status(), 'starting the folder batch must answer 200').toBe(200)
+	const batchId = (await batch.json()).batchId
+
+	const extract = await req.post(`${API}/anonymization/batch/${batchId}/extract`, {
+		headers: jsonHeaders(token),
+		data: {},
+	})
+	expect(
+		extract.status(),
+		'the extract step must answer 200 — a 404 here means the batch record did not '
+			+ 'survive the request, which is a cache-backend problem rather than a listener one',
+	).toBe(200)
+
+	fixture = { token, batchId }
+	return fixture
+}
+
+/**
+ * Read the consolidated entities for the batch, which carry their relation ids.
+ *
+ * @param req The API request context.
+ * @param f   The provisioned fixture.
+ *
+ * @return The parsed response.
+ */
+async function entities(
+	req: APIRequestContext,
+	f: Fixture,
+): Promise<Record<string, unknown>> {
+	const url = `${API}/anonymization/batch/${f.batchId}/entities`
+	const res = await req.get(url, { headers: jsonHeaders(f.token) })
+	expect(res.status(), `GET ${url} must answer 200`).toBe(200)
+	return await res.json()
+}
+
+/**
+ * Pull the first usable relation id out of a consolidated-entities payload.
+ *
+ * @param payload The entities response.
+ *
+ * @return The relation id.
+ */
+function firstRelationId(payload: Record<string, unknown>): number {
+	const list = (payload.entities ?? payload.results ?? []) as Array<
+		Record<string, unknown>
+	>
+	for (const e of list) {
+		const ids = e.relationIds as number[] | undefined
+		if (Array.isArray(ids) === true && ids.length > 0) return ids[0]
+	}
+	throw new Error(
+		'no entity in the batch carries a relationId — the fixture failed to produce '
+			+ 'relations, so nothing below would be testing the listener',
+	)
+}
+
+/**
+ * Count publication-consent records whose entity text matches the fixture term.
+ *
+ * @param req The API request context.
+ * @param f   The provisioned fixture.
+ *
+ * @return How many records match.
+ */
+async function consentCount(req: APIRequestContext, f: Fixture): Promise<number> {
+	const res = await req.get(`${API}/consents`, { headers: jsonHeaders(f.token) })
+	expect(res.status(), `GET ${API}/consents must answer 200`).toBe(200)
+	const body = await res.json()
+	const rows = (body.results ?? body.consents ?? body ?? []) as Array<
+		Record<string, unknown>
+	>
+	if (Array.isArray(rows) === false) return 0
+	return rows.filter((r) => String(r.entityText ?? '').includes(TERM)).length
+}
+
+/**
+ * PATCH a relation the way the review UI does.
+ *
+ * @param req     The API request context.
+ * @param f       The provisioned fixture.
+ * @param id      The relation id.
+ * @param payload The fields to send.
+ *
+ * @return The response status.
+ */
+async function patchRelation(
+	req: APIRequestContext,
+	f: Fixture,
+	id: number,
+	payload: Record<string, unknown>,
+): Promise<number> {
+	const res = await req.patch(
+		`/index.php/apps/openregister/api/entity-relations/${id}`,
+		{ headers: jsonHeaders(f.token), data: payload },
+	)
+	return res.status()
+}
+
+test.describe('entity-relation decision listener', () => {
+	test.slow()
+
+	// ---------------------------------------------------------------------
+	// THE POSITIVE CONTROL. Runs first, deliberately.
+	// @e2e consent-management::skip-activation-triggers-consent-creation
+	// ---------------------------------------------------------------------
+	test('skip activation creates a consent record for the entity', async ({
+		page,
+		request,
+	}) => {
+		const f = await provision(page, request)
+		const relationId = firstRelationId(await entities(request, f))
+
+		const before = await consentCount(request, f)
+
+		const status = await patchRelation(request, f, relationId, {
+			skipAnonymization: true,
+		})
+		expect(status, 'the relation PATCH must succeed').toBeLessThan(300)
+
+		// POLLED, BUT ON A SHORT LEASH. The listener runs synchronously inside
+		// the PATCH, so the record should already exist when the response
+		// returns; the 15s window covers OpenRegister's own write settling, not
+		// an asynchronous listener. Keeping it short matters — a generous
+		// timeout here would let a listener that never fires look merely slow.
+		await expect
+			.poll(async () => await consentCount(request, f), {
+				message:
+					'activating skipAnonymization must create a publicationConsent record; '
+					+ 'if this count never rises, nothing is subscribed to '
+					+ 'EntityRelationDecisionUpdatedEvent (see #805)',
+				timeout: 15_000,
+			})
+			.toBeGreaterThan(before)
+	})
+
+	// ---------------------------------------------------------------------
+	// @e2e consent-management::bases-only-change-does-not-trigger-consent-creation
+	// ---------------------------------------------------------------------
+	test('a bases-only change creates no consent record', async ({
+		page,
+		request,
+	}) => {
+		const f = await provision(page, request)
+		const relationId = firstRelationId(await entities(request, f))
+
+		const before = await consentCount(request, f)
+
+		const status = await patchRelation(request, f, relationId, {
+			bases: ['persoonsgegevens'],
+		})
+		expect(status, 'the relation PATCH must succeed').toBeLessThan(300)
+
+		await page.waitForTimeout(2000)
+		expect(
+			await consentCount(request, f),
+			'a bases-only edit must not create a consent record — skipAnonymization is '
+				+ 'absent from the diff, so isSkipAnonymizationActivated() is false',
+		).toBe(before)
+	})
+
+	// ---------------------------------------------------------------------
+	// @e2e consent-management::reversal-event-does-not-trigger-consent-creation
+	// ---------------------------------------------------------------------
+	test('a reversal creates no consent record and leaves the existing one alone', async ({
+		page,
+		request,
+	}) => {
+		const f = await provision(page, request)
+		const relationId = firstRelationId(await entities(request, f))
+
+		// Establish the true -> false direction this scenario is about.
+		await patchRelation(request, f, relationId, { skipAnonymization: true })
+		await page.waitForTimeout(2000)
+		const afterActivation = await consentCount(request, f)
+
+		const status = await patchRelation(request, f, relationId, {
+			skipAnonymization: false,
+		})
+		expect(status, 'the reversal PATCH must succeed').toBeLessThan(300)
+
+		await page.waitForTimeout(2000)
+		expect(
+			await consentCount(request, f),
+			'a reversal must neither create a record nor remove the one the activation '
+				+ 'created — the listener takes no action in this direction',
+		).toBe(afterActivation)
+	})
+})

--- a/tests/unit/EventListener/EntityRelationDecisionListenerTest.php
+++ b/tests/unit/EventListener/EntityRelationDecisionListenerTest.php
@@ -1,0 +1,303 @@
+<?php
+/**
+ * Tests for the EntityRelation decision listener.
+ *
+ * @category  Test
+ * @package   OCA\Filinq\Tests\Unit\EventListener
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://conduction.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Filinq\Tests\Unit\EventListener;
+
+// REQUIRED EXPLICITLY, not autoloaded. This file's `class_alias` must run
+// BEFORE the listener's `is_a($event, 'OCA\OpenRegister\Event\...')` check is
+// reached, and `tests/` is not on the PSR-4 map, so leaving it to the
+// autoloader would mean the alias never executes and every case fails on a
+// class that "does not exist".
+require_once __DIR__ . '/FakeEntityRelationDecisionUpdatedEvent.php';
+
+use OCA\Filinq\EventListener\EntityRelationDecisionListener;
+use OCA\Filinq\Service\ConsentCrudService;
+use OCA\Filinq\Service\ConsentService;
+use OCP\App\IAppManager;
+use OCP\EventDispatcher\Event;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * THE THREE NEGATIVE SCENARIOS NEED A POSITIVE CONTROL, and that is the whole
+ * point of this file's shape.
+ *
+ * "A bases-only change does not create a consent record" and "a reversal does
+ * not create a consent record" were both SATISFIED before this listener
+ * existed — by nothing happening at all. A test suite that only asserted the
+ * negatives would have passed against an app with no listener, which is exactly
+ * the state ConductionNL/filinq#805 describes.
+ *
+ * So `testSkipActivationCreatesAConsentRequest` is not merely one more case: it
+ * is the control that gives the other three meaning. If it ever fails, the
+ * negatives below stop being evidence of anything.
+ *
+ * @spec openspec/specs/consent-management/spec.md
+ */
+class EntityRelationDecisionListenerTest extends TestCase {
+
+	private ConsentService $consentService;
+
+	private ConsentCrudService $consentCrud;
+
+	private IAppManager $appManager;
+
+	private ContainerInterface $container;
+
+	private EntityRelationDecisionListener $listener;
+
+	/**
+	 * Build the listener with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->consentService = $this->createMock(ConsentService::class);
+		$this->consentCrud = $this->createMock(ConsentCrudService::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->container = $this->createMock(ContainerInterface::class);
+
+		$this->listener = new EntityRelationDecisionListener(
+			$this->consentService,
+			$this->consentCrud,
+			$this->appManager,
+			$this->container,
+			$this->createMock(LoggerInterface::class)
+		);
+	}//end setUp()
+
+	/**
+	 * A stand-in for OpenRegister's event, matched by class name.
+	 *
+	 * The listener checks `is_a($event, '...EntityRelationDecisionUpdatedEvent')`
+	 * by NAME rather than `instanceof`, because OpenRegister is an optional peer
+	 * and an `instanceof` against an absent class is a fatal. That means a test
+	 * double must genuinely carry that class name — hence `class_alias` onto a
+	 * local fake rather than a PHPUnit mock of a class this suite cannot load.
+	 *
+	 * @param bool  $activated What `isSkipAnonymizationActivated()` returns.
+	 * @param mixed $relation  The relation the event carries.
+	 *
+	 * @return Event
+	 */
+	private function makeEvent(bool $activated, mixed $relation): Event {
+		return new FakeEntityRelationDecisionUpdatedEvent($activated, $relation);
+	}//end makeEvent()
+
+	/**
+	 * A relation double exposing only what the listener reads.
+	 *
+	 * @param int|null $fileId   The document the relation sits on.
+	 * @param int|null $entityId The entity it points at.
+	 *
+	 * @return object
+	 */
+	private function makeRelation(?int $fileId, ?int $entityId): object {
+		return new class($fileId, $entityId) {
+			public function __construct(private ?int $fileId, private ?int $entityId) {
+			}
+
+			public function getFileId(): ?int {
+				return $this->fileId;
+			}
+
+			public function getEntityId(): ?int {
+				return $this->entityId;
+			}
+
+			public function getId(): ?int {
+				return 1;
+			}
+		};
+	}//end makeRelation()
+
+	/**
+	 * Wire the container to return an entity mapper yielding this entity.
+	 *
+	 * @param string $type  The entity type.
+	 * @param string $value The entity text.
+	 * @param string $uuid  The entity uuid, used as the idempotency key.
+	 *
+	 * @return void
+	 */
+	private function withEntity(string $type, string $value, string $uuid): void {
+		$entity = new class($type, $value, $uuid) {
+			public function __construct(
+				private string $type,
+				private string $value,
+				private string $uuid
+			) {
+			}
+
+			public function getType(): string {
+				return $this->type;
+			}
+
+			public function getValue(): string {
+				return $this->value;
+			}
+
+			public function getUuid(): string {
+				return $this->uuid;
+			}
+		};
+
+		$mapper = new class($entity) {
+			public function __construct(private object $entity) {
+			}
+
+			public function find(int $id): object {
+				return $this->entity;
+			}
+		};
+
+		$this->appManager->method('getInstalledApps')->willReturn(['openregister', 'filinq']);
+		$this->container->method('get')->willReturn($mapper);
+	}//end withEntity()
+
+	/**
+	 * THE POSITIVE CONTROL. Activation creates a consent request.
+	 *
+	 * @spec openspec/specs/consent-management/spec.md
+	 *
+	 * @return void
+	 */
+	public function testSkipActivationCreatesAConsentRequest(): void {
+		$this->consentCrud->method('getConsentConfig')
+			->willReturn(['register' => 'filinq', 'schema' => 'publicationConsent']);
+		$this->withEntity('PERSON', 'Anneke Jansen', 'entity-uuid-1');
+
+		$this->consentService->expects($this->once())
+			->method('createConsentRequest')
+			->with(
+				'42',
+				'PERSON',
+				'Anneke Jansen',
+				'filinq',
+				'publicationConsent',
+				$this->callback(
+					static function (array $extra): bool {
+						// The idempotency key is the point: without it a second
+						// decision on the same entity duplicates the record and
+						// strands the first one's workflow state.
+						return ($extra['entityKey'] ?? null) === 'entity-uuid-1';
+					}
+				)
+			)
+			->willReturn(['id' => 'consent-1', 'wasUpdated' => false]);
+
+		$this->listener->handle($this->makeEvent(true, $this->makeRelation(42, 7)));
+	}//end testSkipActivationCreatesAConsentRequest()
+
+	/**
+	 * A bases-only edit leaves skipAnonymization out of the diff entirely.
+	 *
+	 * @spec openspec/specs/consent-management/spec.md
+	 *
+	 * @return void
+	 */
+	public function testBasesOnlyChangeCreatesNothing(): void {
+		$this->consentService->expects($this->never())->method('createConsentRequest');
+		$this->listener->handle($this->makeEvent(false, $this->makeRelation(42, 7)));
+	}//end testBasesOnlyChangeCreatesNothing()
+
+	/**
+	 * A reversal matches the field but not the direction.
+	 *
+	 * @spec openspec/specs/consent-management/spec.md
+	 *
+	 * @return void
+	 */
+	public function testReversalCreatesNothing(): void {
+		$this->consentService->expects($this->never())->method('createConsentRequest');
+		$this->listener->handle($this->makeEvent(false, $this->makeRelation(42, 7)));
+	}//end testReversalCreatesNothing()
+
+	/**
+	 * An unrelated event is ignored without touching anything.
+	 *
+	 * @spec exclude The name-based type check is a defensive guard for the case
+	 *  where OpenRegister is absent; no spec scenario describes dispatching an
+	 *  unrelated event at this listener.
+	 *
+	 * @return void
+	 */
+	public function testAnUnrelatedEventIsIgnored(): void {
+		$this->consentService->expects($this->never())->method('createConsentRequest');
+		$this->listener->handle(new Event());
+	}//end testAnUnrelatedEventIsIgnored()
+
+	/**
+	 * With no consent register configured the listener declines rather than throws.
+	 *
+	 * @spec exclude No scenario covers the unconfigured-register path; it is an
+	 *  operational guard, and its contract is that the operator's PATCH still
+	 *  succeeds.
+	 *
+	 * @return void
+	 */
+	public function testUnconfiguredRegisterDeclinesQuietly(): void {
+		$this->consentCrud->method('getConsentConfig')->willReturn(null);
+		$this->consentService->expects($this->never())->method('createConsentRequest');
+
+		$this->listener->handle($this->makeEvent(true, $this->makeRelation(42, 7)));
+	}//end testUnconfiguredRegisterDeclinesQuietly()
+
+	/**
+	 * A failure inside consent creation MUST NOT propagate.
+	 *
+	 * Nextcloud dispatches synchronously inside the request that changed the
+	 * relation, so a throw here would fail the operator's PATCH — turning a
+	 * bookkeeping problem into "you cannot save this decision".
+	 *
+	 * @spec exclude Describes the listener's error posture rather than a
+	 *  behaviour any scenario states; asserted here so the posture cannot
+	 *  regress silently.
+	 *
+	 * @return void
+	 */
+	public function testAFailureNeverEscapes(): void {
+		$this->consentCrud->method('getConsentConfig')
+			->willReturn(['register' => 'filinq', 'schema' => 'publicationConsent']);
+		$this->withEntity('PERSON', 'Anneke Jansen', 'entity-uuid-1');
+		$this->consentService->method('createConsentRequest')
+			->willThrowException(new RuntimeException('OpenRegister unavailable'));
+
+		$this->listener->handle($this->makeEvent(true, $this->makeRelation(42, 7)));
+
+		$this->addToAssertionCount(1);
+	}//end testAFailureNeverEscapes()
+
+	/**
+	 * A relation with no fileId has no document to attach a record to.
+	 *
+	 * @spec exclude Guard for malformed input; no scenario describes a relation
+	 *  without a fileId.
+	 *
+	 * @return void
+	 */
+	public function testARelationWithoutAFileIdCreatesNothing(): void {
+		$this->consentCrud->method('getConsentConfig')
+			->willReturn(['register' => 'filinq', 'schema' => 'publicationConsent']);
+		$this->consentService->expects($this->never())->method('createConsentRequest');
+
+		$this->listener->handle($this->makeEvent(true, $this->makeRelation(null, 7)));
+	}//end testARelationWithoutAFileIdCreatesNothing()
+}//end class

--- a/tests/unit/EventListener/FakeEntityRelationDecisionUpdatedEvent.php
+++ b/tests/unit/EventListener/FakeEntityRelationDecisionUpdatedEvent.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * A stand-in carrying OpenRegister's event class name.
+ *
+ * @category  Test
+ * @package   OCA\Filinq\Tests\Unit\EventListener
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://conduction.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Filinq\Tests\Unit\EventListener;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * WHY THIS EXISTS RATHER THAN A PHPUNIT MOCK.
+ *
+ * The listener identifies its event with `is_a($event, 'OCA\OpenRegister\Event\
+ * EntityRelationDecisionUpdatedEvent')` — by NAME, because OpenRegister is an
+ * optional peer and `instanceof` against a class that is not installed is a
+ * fatal error rather than a false.
+ *
+ * That means the double must genuinely answer to that name. This unit suite
+ * runs without OpenRegister on the autoloader, so the class cannot be mocked
+ * directly; instead this local fake is aliased onto the real name below, which
+ * makes `is_a()` true for exactly the reason it would be true in production.
+ *
+ * The alias is guarded: where OpenRegister IS loadable (in-container runs), the
+ * real class wins and this file changes nothing.
+ */
+class FakeEntityRelationDecisionUpdatedEvent extends Event {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param bool  $activated What `isSkipAnonymizationActivated()` reports.
+	 * @param mixed $relation  The relation carried by the event.
+	 */
+	public function __construct(
+		private readonly bool $activated,
+		private readonly mixed $relation,
+	) {
+		parent::__construct();
+	}//end __construct()
+
+	/**
+	 * Whether skipAnonymization went false -> true in this change.
+	 *
+	 * @return bool
+	 */
+	public function isSkipAnonymizationActivated(): bool {
+		return $this->activated;
+	}//end isSkipAnonymizationActivated()
+
+	/**
+	 * The relation in its post-update state.
+	 *
+	 * @return mixed
+	 */
+	public function getRelation(): mixed {
+		return $this->relation;
+	}//end getRelation()
+}//end class
+
+if (class_exists('OCA\OpenRegister\Event\EntityRelationDecisionUpdatedEvent') === false) {
+	class_alias(
+		FakeEntityRelationDecisionUpdatedEvent::class,
+		'OCA\OpenRegister\Event\EntityRelationDecisionUpdatedEvent'
+	);
+}


### PR DESCRIPTION
Implements the requirement in `openspec/specs/consent-management/spec.md`:

> ### Requirement: A listener MUST subscribe to `EntityRelationDecisionUpdatedEvent`

**Nothing ever did.** Measured on `development`: zero references to that event
outside `openspec/`, and `git log --all -S` finds no commit that ever added one
to `lib/`. OpenRegister has been dispatching it from `EntityRelationMapper:843`
throughout — so every operator decision to publish an entity unredacted was
dispatched to nobody, and the consent record it is supposed to create was never
created. Closes #805.

## Why it stayed invisible for so long

Three of the four scenarios are **negative** — "no consent record is created"
for a bases-only edit, for a reversal, for a rejected prohibition.

All three were satisfied. By **nothing happening**, rather than by the guards
working.

> The absence of a bug and the absence of the feature look identical from
> outside.

A test suite asserting only those negatives would have passed against an app with
no listener at all. That is why the unit suite leads with the **positive
control**: if `testSkipActivationCreatesAConsentRequest` ever fails, the three
negatives stop being evidence of anything.

**Verified by mutation**: inverting the trigger makes exactly that test fail and
leaves the negatives green — which is the failure mode this shape exists to
catch.

## The trigger belongs to the event

`isSkipAnonymizationActivated()` already distinguishes a `false → true`
activation from a bases-only edit (key absent from `changedFields`) and from a
reversal (present, wrong direction). Reimplementing that check here would be a
second copy of a grammar that already exists, and the two would drift.

## Three things shaped by OpenRegister being optional

| decision | why |
|---|---|
| registered by **string**, not `::class` | a `use` resolves at registration time and makes the app unbootable without OpenRegister |
| `is_a()` by name, not `instanceof` | `instanceof` against an absent class is **fatal**, not false |
| mapper resolved from the container, guarded on `getInstalledApps()` | matches `CustomDictionaryDetectionRunner` |

## It never throws

Nextcloud dispatches synchronously inside the request that changed the relation,
so an exception here would fail the operator's PATCH — turning consent
bookkeeping into *"you cannot save this decision"*. Every failure is logged and
swallowed, the same posture `FilinqEventListener` takes. Asserted by
`testAFailureNeverEscapes`.

## Idempotency

`entityKey` is passed so `createConsentRequest` stays idempotent on
`(documentId, entityKey)` per the requirement directly below this one in the same
spec. Without it, a second decision on the same entity duplicates the record and
strands the first one's workflow state — `notificationStatus`, objection dates —
on a row nothing reads.

## Verification

- **1737 tests pass** (+7), 5053 assertions
- psalm, phpstan, phpcs, phpmd — **all clean**
- `ALL 65 APPLICABLE GATES PASSED — and all 65 of them ran`, gate-16 `PASS`

One note on a tooling conflict resolved rather than suppressed: psalm narrows
`$event` through the `is_a()` check and then reports UndefinedMethod on a class
it cannot load, while phpcs forbids the inline `@var` that would widen it back.
A small `asDecision()` method with a real docblock is the one form both accept —
no suppressions added.
