### PR TITLE
fix(manifest): drop 3 em-dashes from tour copy

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -377,7 +377,7 @@
 						"sinceVersion": "0.0.34-unstable.17",
 						"placement": "center",
 						"title": "Welcome to Filinq",
-						"body": "Let's take a quick spin through your document workspace — we'll set up a template and a signing request together so you can see how the pieces fit. You'll add each record yourself.",
+						"body": "Let's take a quick spin through your document workspace. We'll set up a template and a signing request together so you can see how the pieces fit, and you'll add each record yourself.",
 						"target": {
 							"kind": "page",
 							"ref": "Dashboard"
@@ -406,7 +406,7 @@
 						"sinceVersion": "0.0.34-unstable.17",
 						"placement": "bottom",
 						"allowManualNext": true,
-						"body": "Add your first template — give it a name and save. You can edit its content and reuse it for documents and signing requests later.",
+						"body": "Add your first template. Give it a name and save. You can edit its content and reuse it for documents and signing requests later.",
 						"task": "Click New and save a template",
 						"target": {
 							"kind": "element",
@@ -441,7 +441,7 @@
 						"sinceVersion": "0.0.34-unstable.17",
 						"placement": "bottom",
 						"allowManualNext": true,
-						"body": "Create your first signing request — name it and save. From here you can attach a document and track its signatures.",
+						"body": "Create your first signing request. Name it and save. From here you can attach a document and track its signatures.",
 						"task": "Click New and save a signing request",
 						"target": {
 							"kind": "element",


### PR DESCRIPTION
Found by **gate-96** (`manifest-copy-style`, ConductionNL/.github#581).

Three getting-started tour steps, all already real user copy, so the meaning is unchanged.

The welcome step also loses a **comma splice** the dash was covering for:

> **before** "…your document workspace **—** we'll set up a template and a signing request together so you can see how the pieces fit. You'll add each record yourself."
>
> **after** "…your document workspace**.** We'll set up a template and a signing request together so you can see how the pieces fit, **and** you'll add each record yourself."

## Checked, not assumed

The sibling fix in humaniq **broke `check:l10n`** — that app requires every manifest string to carry an `en`/`nl` key, so rewriting the English orphaned the Dutch. This app has no such coupling.

| check | result |
|---|---|
| gate-96 | **0 findings** over **50 strings** (was 3) |
| `check:manifest` | PASS |
| `test:l10n` | PASS |
| `check:schema-l10n` | PASS |

Those are every frontend check this repo's CI actually runs, per its `frontend-checks` list.