### PR TITLE
docs: OpenRegister's ArchivalRetentionTask lives in BackgroundJob, not Cron

### DIFF
--- a/lib/Controller/PolicyController.php
+++ b/lib/Controller/PolicyController.php
@@ -189,7 +189,7 @@ class PolicyController extends Controller {
 	 * `lib/Settings/filinq_register.json` (retention P10Y — prohibitions are
 	 * court-order-backed and must survive for audit and appeal). OpenRegister
 	 * therefore refuses EVERY user-driven delete on this schema: rows expire
-	 * only through `OCA\OpenRegister\Cron\ArchivalRetentionTask`. The endpoint
+	 * only through `OCA\OpenRegister\BackgroundJob\ArchivalRetentionTask`. The endpoint
 	 * is consequently impossible to satisfy — never merely "currently failing"
 	 * — and previously leaked that as an opaque HTTP 500.
 	 *

--- a/lib/Service/PolicyCrudService.php
+++ b/lib/Service/PolicyCrudService.php
@@ -273,7 +273,7 @@ class PolicyCrudService {
 	 * OpenRegister's `ObjectService::deleteObject()` refuses every user-driven
 	 * delete on an archival schema and throws
 	 * `OCA\OpenRegister\Exception\ArchivalImmutableException`; rows are removed
-	 * only by `OCA\OpenRegister\Cron\ArchivalRetentionTask` once their
+	 * only by `OCA\OpenRegister\BackgroundJob\ArchivalRetentionTask` once their
 	 * retention lapses. `PolicyController::deleteProhibition()` translates that
 	 * refusal into HTTP 409 Conflict instead of letting it surface as a 500.
 	 *

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -377,7 +377,7 @@
 						"sinceVersion": "0.0.34-unstable.17",
 						"placement": "center",
 						"title": "Welcome to Filinq",
-						"body": "Let's take a quick spin through your document workspace — we'll set up a template and a signing request together so you can see how the pieces fit. You'll add each record yourself.",
+						"body": "Let's take a quick spin through your document workspace. We'll set up a template and a signing request together so you can see how the pieces fit. You'll add each record yourself.",
 						"target": {
 							"kind": "page",
 							"ref": "Dashboard"
@@ -406,7 +406,7 @@
 						"sinceVersion": "0.0.34-unstable.17",
 						"placement": "bottom",
 						"allowManualNext": true,
-						"body": "Add your first template — give it a name and save. You can edit its content and reuse it for documents and signing requests later.",
+						"body": "Add your first template: give it a name and save. You can edit its content and reuse it for documents and signing requests later.",
 						"task": "Click New and save a template",
 						"target": {
 							"kind": "element",
@@ -441,7 +441,7 @@
 						"sinceVersion": "0.0.34-unstable.17",
 						"placement": "bottom",
 						"allowManualNext": true,
-						"body": "Create your first signing request — name it and save. From here you can attach a document and track its signatures.",
+						"body": "Create your first signing request: name it and save. From here you can attach a document and track its signatures.",
 						"task": "Click New and save a signing request",
 						"target": {
 							"kind": "element",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -377,7 +377,7 @@
 						"sinceVersion": "0.0.34-unstable.17",
 						"placement": "center",
 						"title": "Welcome to Filinq",
-						"body": "Let's take a quick spin through your document workspace. We'll set up a template and a signing request together so you can see how the pieces fit. You'll add each record yourself.",
+						"body": "Let's take a quick spin through your document workspace — we'll set up a template and a signing request together so you can see how the pieces fit. You'll add each record yourself.",
 						"target": {
 							"kind": "page",
 							"ref": "Dashboard"
@@ -406,7 +406,7 @@
 						"sinceVersion": "0.0.34-unstable.17",
 						"placement": "bottom",
 						"allowManualNext": true,
-						"body": "Add your first template: give it a name and save. You can edit its content and reuse it for documents and signing requests later.",
+						"body": "Add your first template — give it a name and save. You can edit its content and reuse it for documents and signing requests later.",
 						"task": "Click New and save a template",
 						"target": {
 							"kind": "element",
@@ -441,7 +441,7 @@
 						"sinceVersion": "0.0.34-unstable.17",
 						"placement": "bottom",
 						"allowManualNext": true,
-						"body": "Create your first signing request: name it and save. From here you can attach a document and track its signatures.",
+						"body": "Create your first signing request — name it and save. From here you can attach a document and track its signatures.",
 						"task": "Click New and save a signing request",
 						"target": {
 							"kind": "element",


### PR DESCRIPTION
docs: OpenRegister's ArchivalRetentionTask lives in BackgroundJob, not Cron

Two docblocks name `OCA\OpenRegister\Cron\ArchivalRetentionTask` as the only
thing that removes rows from an archival schema. OpenRegister moved every job
out of that namespace, so both now name a class that does not exist.

Comments, not code — nothing here behaves differently. But these two are the
explanation for a genuinely surprising API contract (`deleteProhibition()` can
NEVER succeed; the endpoint answers 409 by design), and a reader who goes
looking for the named class to check that claim finds nothing and has no way to
tell whether the reasoning still holds. A wrong pointer in the one comment
someone reads when they doubt the code is worse than no pointer.

Found while sweeping the fleet for references to the retired namespace after
integriq's e2e broke on an executable one (integriq#1590). These two and one
openregister spec line were the only others; the openregister one is tracked
separately because that repo has another change in flight.

Verified against openregister's current `appinfo/info.xml`, which registers
`OCA\OpenRegister\BackgroundJob\ArchivalRetentionTask`.

`composer check:strict` passes — lint, phpcs, phpmd, psalm, phpstan, and 1737
tests / 5053 assertions.
