### PR TITLE
chore(ci): take the canonical coverage-guard from ConductionNL/.github

### DIFF
--- a/scripts/coverage-guard.php
+++ b/scripts/coverage-guard.php
@@ -5,6 +5,8 @@
  *
  * Usage:
  *   php scripts/coverage-guard.php <clover.xml> [--against=<clover.xml>]
+ *   php scripts/coverage-guard.php <clover.xml> --against=<clover.xml> --changed-files=<list>
+ *   php scripts/coverage-guard.php <clover.xml> --against=<clover.xml> --changed-files=<list> --deletion-neutral
  *   php scripts/coverage-guard.php <clover.xml> [--update-baseline]
  *   php scripts/coverage-guard.php --capabilities
  *
@@ -53,7 +55,16 @@ const CG_INPUT   = 2;
  * check that did not run looking exactly like one that passed. The probe turns
  * that into a loud failure.
  */
-const CG_CAPABILITIES = ['against', 'update-baseline', 'capabilities', 'changed-files'];
+const CG_CAPABILITIES = ['against', 'update-baseline', 'capabilities', 'changed-files', 'deletion-neutral'];
+
+/**
+ * Bucket key used for statements that could not be attributed to a method.
+ *
+ * It is a real key, present on both sides, so a file that falls back is compared
+ * exactly as it is today — conservatively, deletions included. It is never a way
+ * for a file to disappear from the comparison.
+ */
+const CG_WHOLE_FILE = '<whole file>';
 
 /**
  * Sum clover metrics for a named subset of files.
@@ -137,6 +148,242 @@ function cgMeasureFiles(string $file, string $label, array $only): array
 
     return [$statements, $covered, $percentage];
 }
+
+/**
+ * Attribute every statement in the named files to the METHOD it sits in.
+ *
+ * WHY BY METHOD NAME, AND WHY NOT BY LINE NUMBER.
+ *
+ * Clover identifies a statement only by its `num` — the line it sits on — and a
+ * deletion shifts every line after the cut. On launchpad#128's file, 117 of the
+ * 254 surviving statements (46%) sit at or after the deletion site, so matching
+ * base statement `num=310` to head statement `num=310` compares two unrelated
+ * lines across half the file and returns a confident, meaningless verdict. The
+ * test suite measures that directly on its fixture: a line-number intersection
+ * there reports 182/234 head against 189/234 base, i.e. a fabricated regression,
+ * where method-name attribution reconciles exactly at 183/254 on both sides.
+ * Method names survive the shift; line numbers do not.
+ *
+ * THE SHAPE CLOVER ACTUALLY EMITS, verified against 2 608 file entries in four
+ * real PHPUnit artifacts from this fleet:
+ *
+ *     <file name="/abs/path/Foo.php">
+ *       <class name="Foo"><metrics .../></class>
+ *       <line num="44" type="method" name="__construct" count="6"/>
+ *       <line num="48" type="stmt" count="6"/>
+ *       ...
+ *       <metrics statements="9" coveredstatements="9" methods="7" .../>
+ *     </file>
+ *
+ * `<line>` elements are FLAT and in document order; a `type="method"` line opens
+ * a method and every `type="stmt"` line after it belongs to that method until the
+ * next one. `metrics/@statements` counts the `stmt` lines only — methods are
+ * counted separately and `elements` is their sum — so summing attributed
+ * statements reproduces the file metric wherever the line data is complete.
+ *
+ * The bucket key is the REPO-RELATIVE path that matched, never the clover
+ * `name`. The two reports are produced from two different checkouts and their
+ * absolute paths differ, so keying on `name` would put every head bucket and
+ * every base bucket in disjoint namespaces and the intersection would be empty —
+ * which reads as "nothing to compare", i.e. a pass.
+ *
+ * TWO DEGENERATE SHAPES, BOTH HANDLED FAIL-CLOSED:
+ *
+ *  - A file whose metrics declare statements but which carries NO usable line
+ *    data (the `processUncoveredFiles` shape: PHPUnit counts a file it never
+ *    loaded). Attribution would measure it as 0/0 — an invisible pass on exactly
+ *    the file most likely to be untested. Such a file falls back to a single
+ *    CG_WHOLE_FILE bucket carrying its file-level metrics, the fallback is
+ *    printed by name, and cgCollapseFiles() then puts BOTH sides on the same
+ *    footing so the fallback cannot be mistaken for a deletion.
+ *  - Two methods of the same name in one file (two classes in one file, in
+ *    principle). Their statements are SUMMED into one bucket rather than
+ *    disambiguated by ordinal, because ordinals shift when one of them is
+ *    deleted. Summing keeps the bucket in the intersection, so deleting one of a
+ *    same-named pair is still charged against the change. Not seen in any of the
+ *    2 608 entries surveyed; handled so it cannot become a silent hole.
+ *
+ * @param string            $file  Clover report to read.
+ * @param string            $label Human label for error messages.
+ * @param array<int,string> $only  Repo-relative paths to include.
+ *
+ * @return array{0: array<string,array{0:int,1:int}>, 1: array<int,string>, 2: array<int,string>}
+ *         buckets keyed "<path>::<method>", the repo-relative paths this report
+ *         matched, and the paths that had to fall back to file-level metrics.
+ */
+function cgAttributeMethods(string $file, string $label, array $only): array
+{
+    if (file_exists($file) === false) {
+        fwrite(STDERR, "Error: {$label} clover file not found: {$file}\n");
+        exit(CG_INPUT);
+    }
+
+    $xml = @simplexml_load_file($file);
+    if ($xml === false) {
+        fwrite(STDERR, "Error: could not parse {$label} report {$file}\n");
+        exit(CG_INPUT);
+    }
+
+    $buckets  = [];
+    $matched  = [];
+    $fellBack = [];
+
+    foreach ($xml->xpath('//file') as $entry) {
+        $name = (string) $entry['name'];
+        if ($name === '') {
+            continue;
+        }
+
+        $path = null;
+        foreach ($only as $wanted) {
+            if (str_ends_with($name, $wanted) === true) {
+                $path = $wanted;
+                break;
+            }
+        }
+
+        if ($path === null) {
+            continue;
+        }
+
+        $matched[] = $path;
+
+        $method     = CG_WHOLE_FILE;
+        $statements = 0;
+        $covered    = 0;
+        $local      = [];
+
+        foreach ($entry->line as $line) {
+            $type = (string) $line['type'];
+
+            if ($type === 'method') {
+                $named  = (string) $line['name'];
+                $method = ($named === '' ? CG_WHOLE_FILE : $named);
+                continue;
+            }
+
+            if ($type !== 'stmt') {
+                continue;
+            }
+
+            $key = ($path . '::' . $method);
+            if (isset($local[$key]) === false) {
+                $local[$key] = [0, 0];
+            }
+
+            $local[$key][0]++;
+            $statements++;
+
+            if (((int) $line['count']) > 0) {
+                $local[$key][1]++;
+                $covered++;
+            }
+        }
+
+        $declared = (int) $entry->metrics['statements'];
+
+        if ($statements === 0 && $declared > 0) {
+            // No usable line data. Measuring 0/0 here would drop the file out of
+            // the comparison entirely, so fall back to the file metric and say so.
+            $fellBack[] = $path;
+            $local      = [
+                ($path . '::' . CG_WHOLE_FILE) => [$declared, (int) $entry->metrics['coveredstatements']],
+            ];
+            echo "    note: {$label} report carries no line data for {$path}; "
+                . "falling back to its file-level metric ({$entry->metrics['coveredstatements']}/{$declared}).\n";
+        } else if ($statements !== $declared) {
+            echo "    note: {$label} report declares {$declared} statement(s) for {$path} but emits "
+                . "{$statements} attributable line(s); the attributable ones are what is compared.\n";
+        }
+
+        foreach ($local as $key => $pair) {
+            if (isset($buckets[$key]) === false) {
+                $buckets[$key] = [0, 0];
+            }
+
+            $buckets[$key][0] += $pair[0];
+            $buckets[$key][1] += $pair[1];
+        }
+    }//end foreach
+
+    return [$buckets, array_values(array_unique($matched)), array_values(array_unique($fellBack))];
+}//end cgAttributeMethods()
+
+/**
+ * Collapse every bucket belonging to the named files into one per file.
+ *
+ * THIS IS THE HOLE THAT WRITING THE TESTS FOUND, and it is worth naming because
+ * it is the invisible-pass shape in its purest form. If one side of the
+ * comparison cannot be attributed to methods it falls back to a single
+ * CG_WHOLE_FILE bucket — but that bucket's key then exists on ONE side only, so
+ * the asymmetric rule classifies the entire base-side file as "deleted", drops
+ * it, finds nothing left to compare, and reports:
+ *
+ *     OK: none of the changed PHP existed at the merge base
+ *
+ * A file the guard could not read would have passed every possible drop. So when
+ * EITHER side falls back for a file, BOTH sides are collapsed to that file's
+ * single bucket: the key then exists on both sides, the file is compared exactly
+ * as the file-scoped mode compares it today, and the deletion penalty applies to
+ * it. Conservative, and visible in the output.
+ *
+ * @param array<string,array{0:int,1:int}> $buckets
+ * @param array<int,string>                $paths
+ *
+ * @return array<string,array{0:int,1:int}>
+ */
+function cgCollapseFiles(array $buckets, array $paths): array
+{
+    if (empty($paths) === true) {
+        return $buckets;
+    }
+
+    $collapse = array_fill_keys($paths, true);
+    $out      = [];
+
+    foreach ($buckets as $key => $pair) {
+        $split = strrpos($key, '::');
+        $path  = ($split === false ? $key : substr($key, 0, $split));
+
+        if (isset($collapse[$path]) === true) {
+            $key = ($path . '::' . CG_WHOLE_FILE);
+        }
+
+        if (isset($out[$key]) === false) {
+            $out[$key] = [0, 0];
+        }
+
+        $out[$key][0] += $pair[0];
+        $out[$key][1] += $pair[1];
+    }
+
+    return $out;
+}//end cgCollapseFiles()
+
+/**
+ * Sum a bucket map, optionally restricted to a set of keys.
+ *
+ * @param array<string,array{0:int,1:int}> $buckets
+ * @param array<string,bool>|null          $keep    Keys to include, or null for all.
+ *
+ * @return array{0:int,1:int} statements, covered
+ */
+function cgSumBuckets(array $buckets, ?array $keep = null): array
+{
+    $statements = 0;
+    $covered    = 0;
+
+    foreach ($buckets as $key => $pair) {
+        if ($keep !== null && isset($keep[$key]) === false) {
+            continue;
+        }
+
+        $statements += $pair[0];
+        $covered    += $pair[1];
+    }
+
+    return [$statements, $covered];
+}//end cgSumBuckets()
 
 /**
  * Read the changed-file list, keeping only PHP files the guard can measure.
@@ -299,6 +546,15 @@ $cloverFile   = ($positional[0] ?? 'coverage/clover.xml');
 $baselineFile = (__DIR__ . '/../.coverage-baseline');
 $against      = ($options['against'] ?? null);
 $changedList  = ($options['changed-files'] ?? null);
+$deletionFree = isset($options['deletion-neutral']);
+
+// A flag that is accepted and ignored is the silent-downgrade shape this script's
+// `--capabilities` probe exists to prevent, so refuse rather than fall through to
+// a comparison the caller did not ask for.
+if ($deletionFree === true && (is_string($changedList) === false || $changedList === '')) {
+    fwrite(STDERR, "Error: --deletion-neutral requires --changed-files (and therefore --against). It refines the file-scoped comparison; it has no meaning against the whole project.\n");
+    exit(CG_INPUT);
+}
 
 // ── scoped mode: compare ONLY the PHP the change touched ────────────────────
 //
@@ -320,6 +576,153 @@ if (is_string($changedList) === true && $changedList !== '') {
     }
 
     echo 'Scoped to ' . count($changed) . " changed PHP file(s).\n";
+
+    // ── deletion-neutral mode ───────────────────────────────────────────────
+    //
+    // WHAT THIS FIXES. `cgRatioDropped()` is a single integer cross-product with
+    // no tolerance, so the file-scoped ratchet demands, exactly:
+    //
+    //     the code you touched must be at least as well covered as the code you
+    //     did not.
+    //
+    // For ADDITIONS that is right, and it earns its keep: openconnector#1265
+    // covered 27 of 54 new statements against a 61.86% floor, needed 34, and
+    // writing the missing seven is what exposed a cascade that deleted nothing
+    // and reported success.
+    //
+    // For DELETIONS it INVERTS. Removing `d` statements of which `c` were covered
+    // lowers the ratio whenever c/d exceeds the ratio of what remains — i.e.
+    // whenever the deleted code was better tested than average. And dead code is
+    // dead because nothing CALLS it, not because nothing TESTED it: gate-57
+    // (orphaned-write-capability) exists to find precisely that code, so gate-57
+    // and this ratchet are in arithmetic opposition, not tension. Such a pull
+    // request cannot satisfy the ratchet from inside its own subject at all —
+    // the only moves are delete less, add filler, or delete additional
+    // *uncovered* statements until it balances. The gate can be satisfied by
+    // deleting more code and cannot be satisfied by testing anything.
+    //
+    // Measured, both blocked by the file-scoped rule:
+    //   opencatalogi#895  head 112/115 (97.39%)  base 148/151 (98.01%)  -0.62%
+    //   launchpad#128     head 183/254 (72.05%)  base 220/304 (72.37%)  -0.32%
+    //
+    // THE RULE, AND IT IS ASYMMETRIC ON PURPOSE:
+    //
+    //     drop BASE-ONLY methods (deletions) from the base side;
+    //     KEEP HEAD-ONLY methods (additions) on the head side.
+    //
+    // The symmetric version — "compare over statements present in both reports" —
+    // is the obvious one and it is broken. It also drops head-only statements, so
+    // a change adding 40 new statements with 0 of them covered compares an empty
+    // set to an empty set and PASSES. That is the openconnector#1265 shape, and
+    // the symmetric rule would have retired the half of this ratchet that works.
+    // A mutant reintroducing it is in the test suite and must stay there.
+    //
+    // Consequences, all four measured in quality-config/tests/test-coverage-guard.py:
+    //   pure deletion (opencatalogi) PASS  112/115 vs 112/115 — exactly neutral
+    //   pure deletion (launchpad)    PASS  183/254 vs 183/254
+    //   regression in survivors      FAIL  180/254 vs 183/254
+    //   new untested code            FAIL  183/294 (62.24%) vs 183/254 (72.05%)
+    //
+    // KNOWN RESIDUAL, stated rather than discovered: a RENAME reads as a delete
+    // plus an add. The old name leaves the base side, the new name arrives on the
+    // head side and must be covered. That is the right incentive — a renamed
+    // method is new code as far as the test suite is concerned — but it means a
+    // pure rename of a well-covered method is not free, and an author who did not
+    // expect it will read the failure as noise. It is documented here and in the
+    // failure message so it is legible when it happens.
+    if ($deletionFree === true) {
+        [$headBuckets, $headFiles, $headFellBack] = cgAttributeMethods($cloverFile, 'current', $changed);
+        [$baseBuckets, $baseFiles, $baseFellBack] = cgAttributeMethods($against, 'merge-base', $changed);
+
+        // Either side falling back forces BOTH sides to file level for that file —
+        // see cgCollapseFiles() for why anything else is an invisible pass.
+        $collapse = array_values(array_unique(array_merge($headFellBack, $baseFellBack)));
+        if (empty($collapse) === false) {
+            echo 'Falling back to file-level metrics on both sides for: ' . implode(', ', $collapse) . "\n";
+            $headBuckets = cgCollapseFiles($headBuckets, $collapse);
+            $baseBuckets = cgCollapseFiles($baseBuckets, $collapse);
+        }
+
+        echo 'Deletion-neutral: attributed by method name (head ' . count($headFiles) . ' file(s), '
+            . 'base ' . count($baseFiles) . ' file(s), ' . count($headBuckets) . ' head method(s), '
+            . count($baseBuckets) . " base method(s)).\n";
+
+        // A changed file the base measured and the head did not is normally a
+        // DELETED file, and treating it as deleted is the point of this mode. But
+        // it is also what an accidental coverage exclusion looks like, and the two
+        // are indistinguishable from here — so it is said out loud rather than
+        // absorbed silently.
+        $goneFiles = array_values(array_diff($baseFiles, $headFiles));
+        if (empty($goneFiles) === false) {
+            echo 'Measured at the merge base and absent from the head report: '
+                . implode(', ', $goneFiles) . "\n";
+            echo "    Treated as deleted. If one of those files still exists, it has been dropped from\n";
+            echo "    coverage measurement and that is the thing to fix, not this guard.\n";
+        }
+
+        if (empty($headBuckets) === true && empty($baseBuckets) === true) {
+            echo "OK: none of the changed PHP files appear in either coverage report.\n";
+            echo "    Nothing was measured, so nothing is claimed about them.\n";
+            exit(CG_OK);
+        }
+
+        $keep = [];
+        foreach ($headBuckets as $key => $unused) {
+            $keep[$key] = true;
+        }
+
+        $dropped = [];
+        foreach ($baseBuckets as $key => $pair) {
+            if (isset($keep[$key]) === false) {
+                $dropped[$key] = $pair;
+            }
+        }
+
+        [$statements, $covered]         = cgSumBuckets($headBuckets);
+        [$baseStatements, $baseCovered] = cgSumBuckets($baseBuckets, $keep);
+
+        $current = ($statements > 0 ? round((($covered / $statements) * 100), 2) : 0.0);
+        $base    = ($baseStatements > 0 ? round((($baseCovered / $baseStatements) * 100), 2) : 0.0);
+
+        if (empty($dropped) === false) {
+            [$droppedStatements, $droppedCovered] = cgSumBuckets($dropped);
+            echo 'Removed from the base side: ' . count($dropped)
+                . " method(s) absent from head, {$droppedCovered}/{$droppedStatements} statements.\n";
+            echo "    A method that no longer exists is not a coverage regression; it is deleted code.\n";
+        }
+
+        cgReport('Surviving code, head:', $statements, $covered, $current);
+        cgReport('Surviving code, base:', $baseStatements, $baseCovered, $base);
+
+        if ($baseStatements === 0) {
+            echo "OK: none of the changed PHP existed at the merge base, so there is no prior figure to drop below.\n";
+            exit(CG_OK);
+        }
+
+        if (cgRatioDropped($covered, $statements, $baseCovered, $baseStatements) === true) {
+            $delta = round(($base - $current), 2);
+            echo($delta > 0
+                ? "FAIL: coverage of the code this change KEEPS or ADDS dropped by {$delta}%.\n"
+                : "FAIL: coverage of the code this change KEEPS or ADDS dropped by less than 0.01% — too "
+                . "little to show in the percentage, but a real loss in the counts below.\n");
+            echo "      base {$baseCovered}/{$baseStatements} -> head {$covered}/{$statements} statements, "
+                . "comparing only methods that exist on BOTH sides plus everything new on this branch.\n";
+
+            if ($statements > $baseStatements) {
+                $added = ($statements - $baseStatements);
+                echo "      This change adds {$added} statements to those files. Adding code without tests drops coverage.\n";
+            }
+
+            echo "      Deleted methods were already excluded, so this is not a deletion penalty. If you\n";
+            echo "      RENAMED a method, note that a rename reads as a delete plus an add: the new name is\n";
+            echo "      new code here and has to be covered.\n";
+
+            exit(CG_DROPPED);
+        }
+
+        echo "OK: coverage of the surviving and added code did not drop.\n";
+        exit(CG_OK);
+    }//end if
 
     [$statements, $covered, $current]             = cgMeasureFiles($cloverFile, 'current', $changed);
     [$baseStatements, $baseCovered, $base]        = cgMeasureFiles($against, 'merge-base', $changed);


### PR DESCRIPTION
chore(ci): take the canonical coverage-guard from ConductionNL/.github

The PHPUnit cell that runs the coverage ratchet fails with "scripts/coverage-guard.php predates merge-base comparison (it does not report the 'against' capability)". That message names a plausible cause rather than the measured one, but the underlying fact is simple: this copy is the 17,288-byte version and the workflow is written against the 35,733-byte canonical one, which additionally reports `deletion-neutral`. Without that capability, deleting well-tested dead code still reads as a coverage drop.

Measured across the 21-app fleet: 8 apps already carry the canonical copy and their ratchets run and report normally; 11 carry a stale variant. This is vendored-copy drift, the same shape as the six drifted app-manifest schemas.

Copied verbatim from ConductionNL/.github at quality-config/coverage-guard.php rather than patched locally. Reimplementing a gate has cost us before: a hand-rolled version found 1 finding where the real gate found 13.
