### PR TITLE
fix(l10n): add the Flow nav labels, which arrived untranslated

### DIFF
--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -926,7 +926,9 @@ OC.L10N.register(
         "Click New and save a signing request": "Klik op Nieuw en sla een ondertekenverzoek op",
         "Your first template is ready": "Je eerste sjabloon staat klaar",
         "You have a template and a signing request. The Dashboard tracks them as your document workspace grows, and the documentation covers the rest.": "Je hebt een sjabloon en een ondertekenverzoek. Het dashboard houdt ze bij naarmate je documentwerkomgeving groeit, en de documentatie behandelt de rest.",
-        "Open the documentation to keep going": "Open de documentatie om verder te gaan"
+        "Open the documentation to keep going": "Open de documentatie om verder te gaan",
+        "Flows": "Flows",
+        "Flow": "Flow"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -949,7 +949,9 @@
         "Click New and save a signing request": "Klik op Nieuw en sla een ondertekenverzoek op",
         "Your first template is ready": "Je eerste sjabloon staat klaar",
         "You have a template and a signing request. The Dashboard tracks them as your document workspace grows, and the documentation covers the rest.": "Je hebt een sjabloon en een ondertekenverzoek. Het dashboard houdt ze bij naarmate je documentwerkomgeving groeit, en de documentatie behandelt de rest.",
-        "Open the documentation to keep going": "Open de documentatie om verder te gaan"
+        "Open the documentation to keep going": "Open de documentatie om verder te gaan",
+        "Flows": "Flows",
+        "Flow": "Flow"
     },
     "pluralForm": "nplurals=2; plural=(n != 1);"
 }


### PR DESCRIPTION
A shared change added `Flows` and `Flow` to this app's manifest nav after the catalogue was last filled, so both rendered English for a Dutch user. The manifest is **data the renderer walks, not source the extractor scans**, so nothing flagged them.

## Both map to themselves, and that is correct here

Dutch Nextcloud keeps the product term. decidiq, dossiq and openregister already carry `Flows → "Flows"` and `Flow → "Flow"`, so this matches the fleet rather than inventing a Dutch word for a feature name nobody calls anything else.

An identical value is the right answer here — worth distinguishing from the case I unpicked on ConductionNL/pipelinq#1445, where **43 English strings had been copied into `nl.json`** to satisfy a parity check and read as translated while being nothing of the kind.

The test is whether the Dutch genuinely *is* the English, not whether the two strings happen to match.

## Verification

| | |
|---|---|
| manifest strings without Dutch | **0** |
| keys DROPPED vs pre-change | **0** |
| `check:l10n-js` | PASS |

Then `l10n:build`, because `nl.json` alone ships nothing — the frontend reads `OC.L10N` from `l10n/nl.js`.