### PR TITLE
fix(repair): register RenameDutchColumns, which was written but never wired

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -201,13 +201,28 @@ Create a [feature request](https://github.com/ConductionNL/filinq/issues/new)
                 throws.
             -->
             <step>OCA\Filinq\Repair\MigrateSchemaApplicationId</step>
-            <!-- Runs BEFORE ConsolidateRegisters, which moves rows between
-                 shard tables: renaming the columns first means the rows it
-                 moves already carry the English names the register declares.
-                 Reversing the order would migrate rows and leave the Dutch
-                 columns behind in the destination. -->
-            <step>OCA\Filinq\Repair\RenameDutchColumns</step>
             <step>OCA\Filinq\Repair\ConsolidateRegisters</step>
+            <!-- WRITTEN BUT NEVER REGISTERED until now, so it never ran
+                 anywhere. gate-98 (repair-step-registration) found it, and the
+                 same step was unregistered in integriq (#1603).
+
+                 What that costs is money reading as null. OpenRegister stores
+                 each schema property as a real snake_cased COLUMN in the
+                 per-schema shard table; on sync MagicMapper ADDS a column when
+                 the name is absent and NEVER renames. So renaming `bedrag` to
+                 `amount` in the register leaves the money in `bedrag` while
+                 every read looks at `amount` and finds null - no error, no data
+                 loss, and invisible to a suite that asserts against fixtures
+                 rather than migrated rows.
+
+                 Last in the block and after ConsolidateRegisters, so the
+                 register sync has already added the English columns. The step
+                 is non-destructive and idempotent by its own contract: renames
+                 only when the old column exists and the new one does not,
+                 copies across where the new column already exists and LEAVES
+                 the old one in place, REFUSES two sources targeting one
+                 destination, deletes nothing, and a re-run is a no-op. -->
+            <step>OCA\Filinq\Repair\RenameDutchColumns</step>
         </post-migration>
         <install>
             <step>OCA\Filinq\Repair\MigrateAppConfigKeys</step>
@@ -217,11 +232,6 @@ Create a [feature request](https://github.com/ConductionNL/filinq/issues/new)
                  this block is the one that actually fires on the upgrade the
                  step exists for. -->
             <step>OCA\Filinq\Repair\MigrateSchemaApplicationId</step>
-            <!-- Same step, same reason, same position: before
-                 ConsolidateRegisters. See the <post-migration> block. On a
-                 genuinely fresh install there are no shard tables and it
-                 returns having done nothing. -->
-            <step>OCA\Filinq\Repair\RenameDutchColumns</step>
             <!-- Same step, same reason, same position: LAST. See the comment
                  above the <repair-steps> block. -->
             <step>OCA\Filinq\Repair\ConsolidateRegisters</step>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -201,6 +201,12 @@ Create a [feature request](https://github.com/ConductionNL/filinq/issues/new)
                 throws.
             -->
             <step>OCA\Filinq\Repair\MigrateSchemaApplicationId</step>
+            <!-- Runs BEFORE ConsolidateRegisters, which moves rows between
+                 shard tables: renaming the columns first means the rows it
+                 moves already carry the English names the register declares.
+                 Reversing the order would migrate rows and leave the Dutch
+                 columns behind in the destination. -->
+            <step>OCA\Filinq\Repair\RenameDutchColumns</step>
             <step>OCA\Filinq\Repair\ConsolidateRegisters</step>
         </post-migration>
         <install>
@@ -211,6 +217,11 @@ Create a [feature request](https://github.com/ConductionNL/filinq/issues/new)
                  this block is the one that actually fires on the upgrade the
                  step exists for. -->
             <step>OCA\Filinq\Repair\MigrateSchemaApplicationId</step>
+            <!-- Same step, same reason, same position: before
+                 ConsolidateRegisters. See the <post-migration> block. On a
+                 genuinely fresh install there are no shard tables and it
+                 returns having done nothing. -->
+            <step>OCA\Filinq\Repair\RenameDutchColumns</step>
             <!-- Same step, same reason, same position: LAST. See the comment
                  above the <repair-steps> block. -->
             <step>OCA\Filinq\Repair\ConsolidateRegisters</step>


### PR DESCRIPTION
`gate-98` reported **"1 repair step written but never registered"**. It was right, and its count was exact.

**Mine was not.** I first reported three, because I counted files in `lib/Repair/` instead of classes implementing `IRepairStep`. `ConsolidateRegistersDecisions` and `ConsolidateRegistersGateway` are collaborators of `ConsolidateRegisters`, not steps, and correctly appear nowhere.

## The real finding

`RenameDutchColumns` implements `IRepairStep` and appears in **no block**, so Nextcloud never runs it.

Commit `7c4a6eb` added the class (387 lines), its unit test (525 lines) **and edited `appinfo/info.xml`** in the same change — and still missed the one line that makes it execute. It has never been registered under any name.

## What not running costs, in the step's own words

> OpenRegister stores each schema property as a real snake_cased **column**, and MagicMapper **adds** columns on sync but never renames.

So renaming `bedrag` → `amount` in the register leaves the money in `bedrag` while every read looks at `amount` and finds null. **No error, no data loss, and invisible to a suite that asserts against fixtures rather than migrated rows.** For this app that is invoice, subsidy, payroll and tax amounts.

## Ordering is deliberate

Placed **before** `ConsolidateRegisters` in both blocks. That step moves rows between shard tables; renaming columns first means the rows it moves already carry the English names the register declares. The other order migrates rows and leaves Dutch columns behind in the destination.

Registered in `<install>` as well as `<post-migration>`, matching every other step here — an app-id rename presents to Nextcloud as a fresh install, which is the path this kind of step usually needs. On a genuinely fresh install it finds no shard tables and returns having done nothing.

## Safe to re-run, by construction

- skips a mapping whose source column is absent
- refuses and warns when two sources target one destination
- only issues `RENAME COLUMN` when source exists and destination does not

## Verification

| | |
|---|---|
| `info.xml` parses | ✅ |
| `IRepairStep` classes registered | **5 of 5** |
| `RenameDutchColumns` occurrences | 2 — both blocks, like its siblings |

Found while merging ConductionNL/filinq#833; recorded there and fixed here rather than riding along inside a translation PR.