### PR TITLE
fix(repair): register RenameDutchColumns so it actually runs

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -202,6 +202,15 @@ Create a [feature request](https://github.com/ConductionNL/filinq/issues/new)
             -->
             <step>OCA\Filinq\Repair\MigrateSchemaApplicationId</step>
             <step>OCA\Filinq\Repair\ConsolidateRegisters</step>
+            <!-- Written but never registered, so it had never run once: a
+                 class that exists is not a class that runs. It moves filinq
+                 data out of the Dutch columns into the English ones, so any
+                 instance predating the column rename still holds its data
+                 where nothing reads it.
+
+                 post-migration only: a fresh install has no Dutch columns to
+                 move, and the step is idempotent either way. -->
+            <step>OCA\Filinq\Repair\RenameDutchColumns</step>
         </post-migration>
         <install>
             <step>OCA\Filinq\Repair\MigrateAppConfigKeys</step>


### PR DESCRIPTION
The step exists in `lib/Repair/` and was never named in `appinfo/info.xml`, so Nextcloud has never run it once — a class that exists is not a class that runs.

Its `getName()` states the stakes: *'Move filinq data from the Dutch columns to the English ones'*. Any instance predating the column rename still holds that data where the English-column readers do not look.

Registered post-migration only: a fresh install has no Dutch columns to move, and the step is idempotent either way.

Verified: `info.xml` parses and the registered FQCN matches the class's namespace and name exactly.

Part of a fleet-wide sweep for this defect class — 4 apps affected: opencatalogi, integriq, filinq, shillinq.