### PR TITLE
fix(release): name docudesk as this app's previous App Store id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ concurrency:
   group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
+# `previous-app-id` is the App Store id this app shipped under before the
+# rename. The store keys everything on the id, so `filinq` is a brand new
+# entry starting from nothing -- without this the version line restarts
+# BELOW what the app already published as `docudesk`, and the store accepts
+# that with a 200 and then never offers it to anyone. Drop the input once
+# the `docudesk` entry is retired.
 jobs:
   unstable:
     if: github.ref == 'refs/heads/development'
@@ -34,6 +40,7 @@ jobs:
     with:
       release-type: unstable
       app-name: filinq
+      previous-app-id: docudesk
     secrets: inherit
 
   beta:
@@ -42,6 +49,7 @@ jobs:
     with:
       release-type: beta
       app-name: filinq
+      previous-app-id: docudesk
     secrets: inherit
 
   stable:
@@ -50,4 +58,5 @@ jobs:
     with:
       release-type: stable
       app-name: filinq
+      previous-app-id: docudesk
     secrets: inherit


### PR DESCRIPTION
Depends on ConductionNL/.github#593, which adds the `previous-app-id` input.

The App Store keys everything on the app id, so renaming `<id>` to `filinq` made it a **brand new store entry starting from nothing**. The release workflow derives its baseline from this repo's git tags and `appinfo/info.xml`, neither of which knows anything about what shipped as `docudesk`, so the version line restarts below it.

`docudesk` currently serves **0.1.0-beta.3** on the store.

The store has no version ordering rule — `_check_permission` validates existence and ownership only — so a lower version uploads with a 200 and is then never offered to anyone already on the higher one.

`previous-app-id` folds the old entry's published versions into the baseline, so the renamed app picks the line up instead of restarting it. Drop the input once the `docudesk` entry is retired.