### PR TITLE
feat(demo): generated demo data for every schema (ADR-111)

### DIFF
--- a/lib/Settings/docudesk_mock_register.json
+++ b/lib/Settings/docudesk_mock_register.json
@@ -1,0 +1,6928 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "docudesk demo data",
+    "version": "1.0.0",
+    "description": "Demo data covering every schema this app supplies, offered as the first step of the app's setup walkthrough. Generated from the schemas themselves, so every object satisfies the schema that will validate it."
+  },
+  "x-openregister": {
+    "type": "mock",
+    "app": "docudesk",
+    "description": "Demo data for docudesk. NOT installed automatically — a mock register is imported on demand, from the setup walkthrough or `occ openregister:descriptors:list --app=docudesk --import=<slug>`."
+  },
+  "paths": {},
+  "components": {
+    "registers": {
+      "consent": {
+        "slug": "consent",
+        "title": "Consent Register (demo)",
+        "version": "2.0.0",
+        "description": "Demo data for Consent Register. Generated from the register's own schemas — see hydra-gates/scripts/lib/generate_mock_register.py."
+      },
+      "signing": {
+        "slug": "signing",
+        "title": "Signing Register (demo)",
+        "version": "1.1.0",
+        "description": "Demo data for Signing Register. Generated from the register's own schemas — see hydra-gates/scripts/lib/generate_mock_register.py."
+      },
+      "templates": {
+        "slug": "templates",
+        "title": "Template Register (demo)",
+        "version": "2.0.0",
+        "description": "Demo data for Template Register. Generated from the register's own schemas — see hydra-gates/scripts/lib/generate_mock_register.py."
+      },
+      "document": {
+        "slug": "document",
+        "title": "Document Register (demo)",
+        "version": "2.0.0",
+        "description": "Demo data for Document Register. Generated from the register's own schemas — see hydra-gates/scripts/lib/generate_mock_register.py."
+      },
+      "dossier": {
+        "slug": "dossier",
+        "title": "Dossier Register (demo)",
+        "version": "1.0.0",
+        "description": "Demo data for Dossier Register. Generated from the register's own schemas — see hydra-gates/scripts/lib/generate_mock_register.py."
+      }
+    },
+    "schemas": {
+      "anonymizationLink": {
+        "x-openregister-processing": {
+          "code": "docudesk-anonymisation",
+          "naam": "Anonymisation of documents",
+          "doelbinding": "Pseudonymise / redact personal data detected in documents so they can be shared or published under the Wet Open Overheid without disclosing identifiable persons.",
+          "rechtsgrond": "public-task",
+          "grondslagSource": "EntityRelation.bases",
+          "dataCategories": [
+            "PERSON",
+            "LOCATION",
+            "ORGANIZATION",
+            "IBAN",
+            "EMAIL",
+            "PHONE_NUMBER",
+            "BSN"
+          ],
+          "backend": "docudesk.anonymiser",
+          "retentionReference": "anonymizationLink/x-openregister-archival (P7Y; selectielijst category to be confirmed)",
+          "lifecycle": "draft",
+          "logReads": true,
+          "attribution": {
+            "default": "docudesk-anonymisation"
+          },
+          "subjectIdFields": {}
+        },
+        "uri": null,
+        "slug": "anonymizationLink",
+        "title": "Anonymisation Link",
+        "description": "Koppeling tussen een bronbestand (niet-geanonimiseerd) en zijn geanonimiseerde tegenhanger. Eén record per bronbestand (idempotent op sourceFileId); her-anonimisering werkt hetzelfde record bij. Zowel sourceFileId als anonymizedFileId zijn facetable zodat de OpenRegister zoek-API de koppeling in beide richtingen oplost.",
+        "version": "1.0.0",
+        "summary": "",
+        "icon": "FileLinkOutline",
+        "required": [
+          "sourceFileId",
+          "anonymizedFileId"
+        ],
+        "properties": {
+          "sourceFileId": {
+            "description": "Nextcloud bestands-ID van het originele (niet-geanonimiseerde) document — idempotentiesleutel",
+            "type": "integer",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Bron bestands-ID"
+          },
+          "sourceFileName": {
+            "description": "Bestandsnaam van het brondocument",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Bron bestandsnaam",
+            "maxLength": 255
+          },
+          "sourceFilePath": {
+            "description": "Volledig pad van het brondocument binnen Nextcloud",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Bron pad",
+            "maxLength": 4096
+          },
+          "anonymizedFileId": {
+            "description": "Nextcloud bestands-ID van het geanonimiseerde resultaat — sleutel voor de omgekeerde zoekopdracht",
+            "type": "integer",
+            "required": true,
+            "visible": true,
+            "order": 4,
+            "facetable": true,
+            "title": "Geanonimiseerd bestands-ID"
+          },
+          "anonymizedFileName": {
+            "description": "Bestandsnaam van het geanonimiseerde resultaat",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 5,
+            "facetable": true,
+            "title": "Geanonimiseerde bestandsnaam",
+            "maxLength": 255
+          },
+          "anonymizedFilePath": {
+            "description": "Volledig (stabiel) pad van het geanonimiseerde resultaat binnen Nextcloud",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Geanonimiseerd pad",
+            "maxLength": 4096
+          },
+          "outputFormat": {
+            "description": "Uitvoerformaat van het geanonimiseerde document",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Formaat",
+            "enum": [
+              "pdf",
+              "docx",
+              "odt",
+              "txt",
+              "html"
+            ]
+          },
+          "status": {
+            "description": "Uitkomst van de anonimiseringsrun. Alleen succesvolle runs worden vastgelegd, dus de waarde is altijd 'anonymized'.",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "anonymized"
+            ],
+            "default": "anonymized"
+          },
+          "replacementCount": {
+            "description": "Aantal toegepaste entiteitsvervangingen in deze run",
+            "type": "integer",
+            "required": false,
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Vervangingen"
+          },
+          "runCount": {
+            "description": "Hoe vaak dit bronbestand is geanonimiseerd (opgehoogd bij elke her-anonimisering)",
+            "type": "integer",
+            "required": false,
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Aantal runs",
+            "default": 1
+          },
+          "anonymizedAt": {
+            "description": "Datum/tijd van de anonimiseringsrun (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 11,
+            "facetable": false,
+            "title": "Geanonimiseerd op"
+          },
+          "anonymizedBy": {
+            "description": "Nextcloud gebruikers-ID dat de anonimisering heeft gestart",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 12,
+            "facetable": true,
+            "title": "Geanonimiseerd door",
+            "maxLength": 64
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-06-09T00:00:00+00:00",
+        "created": "2026-06-09T00:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "sourceFileName",
+          "objectDescriptionField": "status",
+          "autoPublish": false
+        },
+        "searchable": true,
+        "x-openregister-archival": {
+          "retention": {
+            "default": "P7Y"
+          },
+          "category": "TODO: confirm Archiefwet 1995 selectielijst category with selectielijst manager",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        }
+      },
+      "base": {
+        "x-openregister-processing": {
+          "code": "docudesk-metadata-enrichment",
+          "naam": "Document metadata enrichment",
+          "doelbinding": "Automatically enrich documents with language detection, keyword extraction, and topic classification to support findability and records management.",
+          "rechtsgrond": "public-task",
+          "grondslagSource": "EntityRelation.bases",
+          "dataCategories": [
+            "PERSON",
+            "LOCATION",
+            "ORGANIZATION"
+          ],
+          "backend": "docudesk.metadata.enricher",
+          "retentionReference": "not declared (base carries no x-openregister-archival annotation)",
+          "lifecycle": "draft",
+          "logReads": true,
+          "attribution": {
+            "default": "docudesk-metadata-enrichment"
+          },
+          "subjectIdFields": {}
+        },
+        "uri": null,
+        "slug": "base",
+        "title": "Grondslag",
+        "description": "Een Woo Art. 5 uitzonderingsgrond waaronder gegevens geanonimiseerd worden voordat een document wordt gepubliceerd. OpenRegister bewaart de UUID's; de zes canonieke grondslagen worden meegeleverd als seed-data.",
+        "version": "1.1.0",
+        "summary": "Legal basis (grondslag) for anonymisation under Woo Art. 5",
+        "icon": "Gavel",
+        "required": [
+          "name",
+          "description"
+        ],
+        "properties": {
+          "name": {
+            "title": "Naam",
+            "description": "Korte Nederlandstalige naam van de grondslag (zichtbaar in de operator-UI).",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "maxLength": 100,
+            "translatable": true
+          },
+          "description": {
+            "title": "Omschrijving",
+            "description": "Toelichting op de grondslag, met verwijzing naar Woo Art. 5 en waar relevant AVG-artikelen.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "maxLength": 1000,
+            "translatable": true
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-05-12T12:00:00+00:00",
+        "created": "2026-05-12T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "name",
+          "objectDescriptionField": "description",
+          "autoPublish": false
+        },
+        "searchable": true
+      },
+      "batchCorrespondenceJob": {
+        "uri": null,
+        "slug": "batchCorrespondenceJob",
+        "title": "Batch Correspondence Job",
+        "description": "Bijhouding van een batch-correspondentieopdracht. Vervangt IAppConfig-gebaseerde statusopslag. Lifecycle-transitiebeheer via x-openregister-lifecycle.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "EmailMultipleOutline",
+        "required": [
+          "templateId",
+          "recipientCount",
+          "status",
+          "initiatedBy"
+        ],
+        "properties": {
+          "templateId": {
+            "description": "UUID van het gebruikte template",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Template"
+          },
+          "templateName": {
+            "description": "Naam van het template (denormalized)",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Template naam",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "recipientCount": {
+            "description": "Totaal aantal ontvangers in de batch",
+            "type": "integer",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Ontvangers"
+          },
+          "completedCount": {
+            "description": "Aantal succesvol gegenereerde brieven",
+            "type": "integer",
+            "required": false,
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Geslaagd"
+          },
+          "errorCount": {
+            "description": "Aantal mislukte generaties",
+            "type": "integer",
+            "required": false,
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Mislukt"
+          },
+          "status": {
+            "description": "Batchstatus",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "pending",
+              "processing",
+              "success",
+              "error",
+              "completed"
+            ],
+            "default": "pending"
+          },
+          "initiatedBy": {
+            "description": "Nextcloud gebruiker die de batch heeft gestart",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Gestart door",
+            "maxLength": 64
+          },
+          "startedAt": {
+            "description": "Start van verwerking (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 8,
+            "facetable": false,
+            "title": "Gestart"
+          },
+          "completedAt": {
+            "description": "Voltooiing (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Afgerond"
+          },
+          "errorMessage": {
+            "description": "Foutmelding bij volledig mislukte batch",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Foutmelding",
+            "maxLength": 2000
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-06-01T00:00:00+00:00",
+        "created": "2026-06-01T00:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "templateName",
+          "objectDescriptionField": "status",
+          "autoPublish": false
+        },
+        "searchable": true,
+        "x-openregister-archival": {
+          "retention": "P1Y",
+          "category": "Archiefwet 1995 selectielijst — cat. 1.2: operationele verwerkingslogboeken, korte bewaarplicht",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        },
+        "x-openregister-lifecycle": {
+          "field": "status",
+          "initial": "pending",
+          "states": {
+            "pending": {
+              "label": "Wachtend",
+              "terminal": false
+            },
+            "processing": {
+              "label": "Verwerken",
+              "terminal": false
+            },
+            "success": {
+              "label": "Geslaagd",
+              "terminal": true
+            },
+            "error": {
+              "label": "Mislukt",
+              "terminal": true
+            },
+            "completed": {
+              "label": "Voltooid",
+              "terminal": true
+            }
+          },
+          "transitions": {
+            "start": {
+              "from": "pending",
+              "to": "processing",
+              "label": "Start verwerking",
+              "requiresRole": "system",
+              "description": "BatchCorrespondenceJob::run() begint."
+            },
+            "succeed": {
+              "from": "processing",
+              "to": "success",
+              "label": "Geslaagd",
+              "requiresRole": "system",
+              "description": "Alle ontvangers verwerkt zonder fouten."
+            },
+            "fail": {
+              "from": "processing",
+              "to": "error",
+              "label": "Mislukt",
+              "requiresRole": "system",
+              "description": "Fatale fout, batch afgebroken."
+            },
+            "complete": {
+              "from": [
+                "success",
+                "error"
+              ],
+              "to": "completed",
+              "label": "Afronden",
+              "requiresRole": "system",
+              "description": "Definitieve afsluiting na verwerking."
+            }
+          }
+        },
+        "x-openregister-notifications": {
+          "batchCompleted": {
+            "trigger": {
+              "type": "lifecycle",
+              "transition": "complete"
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "field",
+                "field": "initiatedBy"
+              }
+            ],
+            "subject": {
+              "nl": "Batchcorrespondentie voltooid: {{templateName}}",
+              "en": "Batch correspondence completed: {{templateName}}"
+            },
+            "body": {
+              "nl": "{{completedCount}} van {{recipientCount}} brieven gegenereerd. Fouten: {{errorCount}}.",
+              "en": "{{completedCount}} of {{recipientCount}} letters generated. Errors: {{errorCount}}."
+            }
+          },
+          "batchFailed": {
+            "trigger": {
+              "type": "lifecycle",
+              "transition": "fail"
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "field",
+                "field": "initiatedBy"
+              }
+            ],
+            "subject": {
+              "nl": "Batchcorrespondentie mislukt: {{templateName}}",
+              "en": "Batch correspondence failed: {{templateName}}"
+            }
+          }
+        },
+        "x-openregister-calculations": {
+          "errorRate": {
+            "expression": "errorCount / recipientCount",
+            "type": "number",
+            "format": "float",
+            "description": "Ratio of failed generations over total recipients (0.0 – 1.0)",
+            "readOnly": true
+          },
+          "successRate": {
+            "expression": "completedCount / recipientCount",
+            "type": "number",
+            "format": "float",
+            "description": "Ratio of successfully generated letters over total recipients",
+            "readOnly": true
+          }
+        }
+      },
+      "correspondence": {
+        "x-openregister-notifications": {
+          "correspondenceFailed": {
+            "trigger": {
+              "type": "created"
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "field",
+                "field": "generatedBy"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "docudesk-woo-officers"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Documentgeneratie mislukt: {{templateName}}",
+              "en": "Document generation failed: {{templateName}}"
+            }
+          }
+        },
+        "uri": null,
+        "slug": "correspondence",
+        "title": "Correspondence",
+        "description": "Audit log voor gegenereerde correspondentie. Bevat metadata over welk template is gebruikt, voor welke ontvanger, en het resultaat.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "EmailOutline",
+        "required": [
+          "templateId",
+          "recipientId",
+          "generatedAt",
+          "format",
+          "status",
+          "generatedBy"
+        ],
+        "properties": {
+          "templateId": {
+            "description": "UUID van het gebruikte template",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Template ID"
+          },
+          "templateName": {
+            "description": "Naam van het gebruikte template",
+            "type": "string",
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Template naam",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "recipientId": {
+            "description": "UUID van het ontvangerobject in OpenRegister",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Ontvanger ID"
+          },
+          "recipientType": {
+            "description": "Type ontvanger",
+            "type": "string",
+            "visible": true,
+            "order": 4,
+            "facetable": true,
+            "title": "Ontvanger type",
+            "enum": [
+              "PERSON",
+              "ORGANIZATION"
+            ]
+          },
+          "caseReference": {
+            "description": "UUID verwijzing naar de bron zaak/case",
+            "type": "string",
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Zaak referentie"
+          },
+          "generatedAt": {
+            "description": "Datum/tijd van generatie (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Gegenereerd op"
+          },
+          "format": {
+            "description": "Uitvoerformaat van het document",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Formaat",
+            "enum": [
+              "pdf",
+              "docx",
+              "html",
+              "email"
+            ]
+          },
+          "status": {
+            "description": "Status van de generatie",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "generated",
+              "failed"
+            ]
+          },
+          "generatedBy": {
+            "description": "Nextcloud gebruikers-ID die de generatie heeft gestart",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 9,
+            "facetable": true,
+            "title": "Gegenereerd door",
+            "maxLength": 64
+          },
+          "errorMessage": {
+            "description": "Foutmelding bij mislukte generatie",
+            "type": "string",
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Foutmelding",
+            "maxLength": 2000
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-03-22T12:00:00+00:00",
+        "created": "2026-03-22T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "templateName",
+          "objectDescriptionField": "status",
+          "autoPublish": false
+        },
+        "searchable": true,
+        "x-openregister-archival": {
+          "retention": "P7Y",
+          "category": "Archiefwet 1995 selectielijst — cat. 3.2: zakelijke correspondentie voor organisatorische continuïteit",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        }
+      },
+      "dossier": {
+        "uri": null,
+        "slug": "dossier",
+        "title": "Dossier",
+        "description": "Een dossier representeert een Nextcloud-map (`@self.folder`) waarvan de inhoud onder één of meer Woo Art. 5 grondslagen geanonimiseerd wordt. Het dossier registreert wie het heeft beoordeeld (`checkedOn`) en welke grondslagen van toepassing zijn (`bases[]`).",
+        "version": "1.1.0",
+        "summary": "Anonymisation dossier — folder + grondslagen + review timestamp",
+        "icon": "FolderAccount",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "title": "Naam",
+            "description": "Naam van het dossier — komt overeen met de naam van de gekoppelde Nextcloud-map op het moment van aanmaken.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "maxLength": 200,
+            "translatable": true
+          },
+          "description": {
+            "title": "Omschrijving",
+            "description": "Vrije tekst die het doel van het dossier toelicht (bijv. \"Woo-verzoek Subsidietoekenningen cultuur\").",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "maxLength": 1000,
+            "translatable": true
+          },
+          "bases": {
+            "title": "Grondslagen",
+            "description": "Array van slugs die verwijzen naar `base`-objecten — de Woo Art. 5 uitzonderingsgronden op basis waarvan het dossier geanonimiseerd wordt. Consumer-side resolution (DocuDesk's anonymisation-grondslagen-summary) zoekt de slug op in het `base`-register.",
+            "type": "array",
+            "required": false,
+            "visible": true,
+            "order": 3,
+            "facetable": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "checkedOn": {
+            "title": "Beoordeeld op",
+            "description": "Tijdstempel waarop het dossier door een operator is beoordeeld; lege waarde betekent nog niet beoordeeld.",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 4,
+            "facetable": true
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-05-12T12:00:00+00:00",
+        "created": "2026-05-12T12:00:00+00:00",
+        "maxDepth": 1,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "name",
+          "objectDescriptionField": "description",
+          "autoPublish": false
+        },
+        "searchable": true
+      },
+      "generatedDocument": {
+        "x-openregister-processing": {
+          "code": "docudesk-ocr",
+          "naam": "OCR text extraction",
+          "doelbinding": "Extract machine-readable text from scanned documents and images (Tesseract OCR) for downstream metadata enrichment, search, and anonymisation.",
+          "rechtsgrond": "public-task",
+          "grondslagSource": "EntityRelation.bases",
+          "dataCategories": [
+            "PERSON",
+            "LOCATION",
+            "ORGANIZATION",
+            "EMAIL",
+            "PHONE_NUMBER"
+          ],
+          "backend": "docudesk.ocr.tesseract",
+          "retentionReference": "not declared (generatedDocument carries no x-openregister-archival annotation)",
+          "lifecycle": "draft",
+          "logReads": true,
+          "attribution": {
+            "default": "docudesk-ocr"
+          },
+          "subjectIdFields": {}
+        },
+        "x-openregister-calculations": {
+          "validationStatus": {
+            "backend": "docudesk.validation",
+            "type": "string",
+            "enum": [
+              "passed",
+              "warnings",
+              "failed"
+            ],
+            "description": "Document quality-control verdict computed by DocumentValidationService (passed | warnings | failed). Absent until the document is validated.",
+            "readOnly": true
+          },
+          "validationFindings": {
+            "backend": "docudesk.validation",
+            "type": "array",
+            "description": "Per-check findings (checkId, severity, message, optional field, optional suggestedAction) computed by DocumentValidationService. Never embeds document content.",
+            "readOnly": true
+          }
+        },
+        "uri": null,
+        "slug": "generatedDocument",
+        "title": "Generated Document",
+        "description": "Audit trail voor documenten gegenereerd via DocumentService. Bevat metadata inclusief template UUID, versie, databronnen en resultaat.",
+        "version": "1.0.0",
+        "summary": "",
+        "icon": "FileDocument",
+        "required": [
+          "templateId",
+          "templateVersion",
+          "generatedAt",
+          "format",
+          "status",
+          "generatedBy"
+        ],
+        "properties": {
+          "templateId": {
+            "description": "UUID van het gebruikte template",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Template ID"
+          },
+          "templateVersion": {
+            "description": "Versienummer van het gebruikte template (DCS-051)",
+            "type": "integer",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Template versie"
+          },
+          "templateName": {
+            "description": "Naam van het gebruikte template",
+            "type": "string",
+            "visible": true,
+            "order": 3,
+            "facetable": true,
+            "title": "Template naam",
+            "maxLength": 255
+          },
+          "dataRefs": {
+            "description": "Databronnen gebruikt voor het genereren van het document",
+            "type": "array",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Databronnen"
+          },
+          "format": {
+            "description": "Uitvoerformaat van het document",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 5,
+            "facetable": true,
+            "title": "Formaat",
+            "enum": [
+              "pdf",
+              "odf",
+              "html"
+            ]
+          },
+          "status": {
+            "description": "Status van de documentgeneratie",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "generated",
+              "failed"
+            ]
+          },
+          "generatedAt": {
+            "description": "Datum/tijd van generatie (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": true,
+            "visible": true,
+            "order": 7,
+            "facetable": false,
+            "title": "Gegenereerd op"
+          },
+          "generatedBy": {
+            "description": "Nextcloud gebruikers-ID die de generatie heeft gestart",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Gegenereerd door",
+            "maxLength": 64
+          },
+          "zaakId": {
+            "description": "UUID van de gekoppelde zaak in Procest (optioneel)",
+            "type": "string",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Zaak ID"
+          },
+          "warnings": {
+            "description": "Waarschuwingen opgetreden tijdens generatie",
+            "type": "array",
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Waarschuwingen"
+          },
+          "errorMessage": {
+            "description": "Foutmelding bij mislukte generatie",
+            "type": "string",
+            "visible": true,
+            "order": 11,
+            "facetable": false,
+            "title": "Foutmelding",
+            "maxLength": 2000
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-06-01T00:00:00+00:00",
+        "created": "2026-06-01T00:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "templateName",
+          "objectDescriptionField": "status",
+          "autoPublish": false
+        },
+        "searchable": true
+      },
+      "huisstijl": {
+        "uri": null,
+        "slug": "huisstijl",
+        "title": "Huisstijl Configuration",
+        "description": "Configuratie voor organisatie huisstijl: logo, kleuren, kop-/voetteksten en standaard marges voor correspondentie.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "Palette",
+        "required": [],
+        "properties": {
+          "name": {
+            "description": "Naam van de huisstijl configuratie",
+            "type": "string",
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Naam",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "logo": {
+            "description": "Logo als base64-gecodeerde string of bestandsreferentie",
+            "type": "string",
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "title": "Logo"
+          },
+          "primaryColor": {
+            "description": "Primaire kleur in CSS-formaat (bijv. #154273)",
+            "type": "string",
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Primaire kleur",
+            "maxLength": 25
+          },
+          "headerHtml": {
+            "description": "Twig template voor de paginakoptekst",
+            "type": "string",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Koptekst HTML",
+            "format": "html"
+          },
+          "footerHtml": {
+            "description": "Twig template voor de paginavoettekst",
+            "type": "string",
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Voettekst HTML",
+            "format": "html"
+          },
+          "defaultMargins": {
+            "description": "Standaard marges in mm (object met top, right, bottom, left)",
+            "type": "object",
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Standaard marges"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-03-22T12:00:00+00:00",
+        "created": "2026-03-22T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "name",
+          "objectDescriptionField": "primaryColor",
+          "autoPublish": false
+        },
+        "searchable": false
+      },
+      "publicationConsent": {
+        "x-openregister-notifications": {
+          "objectionDeadline": {
+            "trigger": {
+              "type": "scheduled",
+              "intervalSec": 86400,
+              "filter": {
+                "consentStatus": "pending"
+              }
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "groups",
+                "groups": [
+                  "docudesk-woo-officers"
+                ]
+              },
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              }
+            ],
+            "subject": {
+              "nl": "Bezwaartermijn verloopt binnenkort voor een publicatie",
+              "en": "Objection deadline is approaching for a publication"
+            }
+          }
+        },
+        "uri": null,
+        "slug": "publicationConsent",
+        "title": "Publication Consent",
+        "description": "Schema voor het beheren van publicatie toestemmingen volgens GDPR en Nederlandse Wet Open Overheid. Bevat informatie over entiteiten (personen/organisaties) die geïnformeerd moeten worden voordat een document wordt gepubliceerd, en hun reactie daarop.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "AccountCheck",
+        "required": [
+          "documentId",
+          "entityType",
+          "entityText"
+        ],
+        "properties": {
+          "scope": {
+            "description": "Discriminator: `document` = per-document/per-entity consent in the WOO workflow; `entity` = standing consent for a recurring entity (mayor, council member, etc.). Default `document` preserves backward compatibility — existing rows automatically load as `document`.",
+            "type": "string",
+            "enum": [
+              "document",
+              "entity"
+            ],
+            "required": false,
+            "visible": true,
+            "order": 0,
+            "facetable": true,
+            "title": "Scope",
+            "default": "document"
+          },
+          "documentId": {
+            "description": "Verwijzing naar het document dat gepubliceerd moet worden",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Document ID"
+          },
+          "entityType": {
+            "description": "Type entiteit (PERSON of ORGANIZATION) (Legacy/fallback: populated denormalised when no contactRef is set; once contactRef is linked, the contacts-leaf vCard is the source of truth for this field.)",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Entiteitstype",
+            "enum": [
+              "PERSON",
+              "ORGANIZATION"
+            ]
+          },
+          "entityText": {
+            "description": "Tekst van de gedetecteerde entiteit (Legacy/fallback: populated denormalised when no contactRef is set; once contactRef is linked, the contacts-leaf vCard is the source of truth for this field.)",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Entiteit tekst",
+            "maxLength": 500
+          },
+          "entityKey": {
+            "description": "Unieke key van de entiteit (gebruikt voor anonymisatie)",
+            "type": "string",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Entiteit key",
+            "maxLength": 50
+          },
+          "contactEmail": {
+            "description": "E-mailadres voor notificatie (indien bekend) (Legacy/fallback: populated denormalised when no contactRef is set; once contactRef is linked, the contacts-leaf vCard is the source of truth for this field.)",
+            "type": "string",
+            "format": "email",
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Contact e-mail",
+            "maxLength": 255
+          },
+          "contactAddress": {
+            "description": "Postadres voor notificatie (indien bekend) (Legacy/fallback: populated denormalised when no contactRef is set; once contactRef is linked, the contacts-leaf vCard is the source of truth for this field.)",
+            "type": "string",
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Contact adres",
+            "maxLength": 500
+          },
+          "contactRef": {
+            "description": "Linkage pointer to the canonical NC Contact record for this affected entity. When set, the contacts-leaf link table on the publicationConsent object is the source of truth for identity + channel; entityType/entityText/contactEmail/contactAddress are legacy/fallback denormalised copies used when no contact is linked.",
+            "type": "string",
+            "format": "uri",
+            "required": false,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Contact reference"
+          },
+          "notificationStatus": {
+            "description": "Status van de notificatie",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Notificatiestatus",
+            "enum": [
+              "pending",
+              "sent",
+              "delivered",
+              "failed",
+              "skipped"
+            ],
+            "default": "pending"
+          },
+          "notificationSentAt": {
+            "description": "Datum/tijd waarop de notificatie is verzonden",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 8,
+            "facetable": false,
+            "title": "Notificatie verzonden op"
+          },
+          "consentStatus": {
+            "description": "Status van de toestemming/bezwaar",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 9,
+            "facetable": true,
+            "title": "Toestemmingsstatus",
+            "enum": [
+              "pending",
+              "consent_given",
+              "objection_received",
+              "no_response",
+              "anonymized"
+            ],
+            "default": "pending"
+          },
+          "objectionDeadline": {
+            "description": "Deadline voor bezwaar indienen (volgens Wet Open Overheid: minimaal 4 weken)",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Bezwaar deadline"
+          },
+          "objectionReceivedAt": {
+            "description": "Datum/tijd waarop bezwaar is ontvangen",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 11,
+            "facetable": false,
+            "title": "Bezwaar ontvangen op"
+          },
+          "objectionReason": {
+            "description": "Reden voor bezwaar (indien ingediend)",
+            "type": "string",
+            "format": "markdown",
+            "visible": true,
+            "order": 12,
+            "facetable": false,
+            "title": "Bezwaarreden",
+            "maxLength": 2000,
+            "translatable": true
+          },
+          "publicationDecision": {
+            "description": "Beslissing over publicatie",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 13,
+            "facetable": true,
+            "title": "Publicatiebeslissing",
+            "enum": [
+              "pending",
+              "anonymize",
+              "publish_with_consent",
+              "publish_anonymized",
+              "reject"
+            ],
+            "default": "pending",
+            "translatable": true
+          },
+          "legalBasis": {
+            "description": "Juridische grondslag voor publicatie (bijv. Wet Open Overheid, AVG artikel 6)",
+            "type": "string",
+            "visible": true,
+            "order": 14,
+            "facetable": true,
+            "title": "Juridische grondslag",
+            "maxLength": 500,
+            "example": "Wet Open Overheid art. 3.1"
+          },
+          "notes": {
+            "description": "Interne notities over het proces",
+            "type": "string",
+            "format": "markdown",
+            "visible": true,
+            "order": 15,
+            "facetable": false,
+            "title": "Notities",
+            "maxLength": 2000,
+            "translatable": true
+          },
+          "matchRules": {
+            "description": "Array of `{type, value}` entries (same enum as `publicationProhibition`: `exact` / `normalized` / `bsn` / `kvk`). Only used on `scope=entity` records; service-level validation rejects `scope=entity` writes without at least one matchRule.",
+            "type": "array",
+            "required": false,
+            "visible": true,
+            "order": 100,
+            "items": {
+              "type": "object",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "exact",
+                    "normalized",
+                    "bsn",
+                    "kvk"
+                  ]
+                },
+                "value": {
+                  "type": "string",
+                  "maxLength": 255
+                }
+              }
+            },
+            "title": "Matchregels"
+          },
+          "validFrom": {
+            "description": "Standing-consent validity start (inclusive). Only honoured on `scope=entity` records.",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 101,
+            "facetable": true,
+            "title": "Geldig vanaf"
+          },
+          "validUntil": {
+            "description": "Standing-consent validity end (inclusive); `null` means open-ended. Service-level validation surfaces a non-blocking warning when blank.",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 102,
+            "facetable": true,
+            "title": "Geldig tot"
+          },
+          "active": {
+            "description": "Master kill-switch on standing consents (`scope=entity`). Only `active=true` records participate in matching.",
+            "type": "boolean",
+            "required": false,
+            "visible": true,
+            "order": 103,
+            "facetable": true,
+            "title": "Actief",
+            "default": true
+          },
+          "consentMethod": {
+            "description": "How consent was captured. Required at service-level on `scope=entity` writes.",
+            "type": "string",
+            "enum": [
+              "paper",
+              "digital_signature",
+              "verbal_recorded",
+              "opt_in_form"
+            ],
+            "required": false,
+            "visible": true,
+            "order": 104,
+            "facetable": true,
+            "title": "Toestemmingsmethode"
+          },
+          "consentDocument": {
+            "description": "Reference to the captured consent document (signed PDF / form upload).",
+            "type": "string",
+            "format": "uri",
+            "required": false,
+            "visible": true,
+            "order": 105,
+            "facetable": true,
+            "title": "Toestemmingsdocument"
+          },
+          "consentScope": {
+            "description": "Free-text limitation describing the scope of the standing consent (e.g. 'all publications referencing the position of burgemeester').",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 106,
+            "title": "Toestemmingsbereik",
+            "maxLength": 1024
+          },
+          "policyMatch": {
+            "description": "Polymorphic reference: when set on a `scope=document` record, points to the `publicationProhibition` UUID (prohibition pre-emption) OR to a `publicationConsent` UUID with `scope=entity` (standing-consent match). Service-level validation rejects polymorphic violations and rejects `policyMatch` on `scope=entity` records.",
+            "type": "string",
+            "format": "uri",
+            "required": false,
+            "visible": true,
+            "order": 107,
+            "facetable": true,
+            "title": "Policy match",
+            "x-openregister-handling": "related-object"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2025-12-08T12:00:00+00:00",
+        "created": "2025-12-08T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "entityText",
+          "objectDescriptionField": "consentStatus",
+          "autoPublish": false
+        },
+        "searchable": true
+      },
+      "publicationProhibition": {
+        "uri": null,
+        "slug": "publicationProhibition",
+        "title": "Publication Prohibition",
+        "description": "Court order, minor-protection, undercover-officer or categorical privacy-board prohibition on publishing personally-identifying information. When an active rule matches, the WOO objection workflow is pre-empted and the affected entity is forcibly anonymised. Time-bound (validFrom / validUntil) and rule-typed (exact / normalized / bsn / kvk) so the cache can resolve a match in O(1) per entity.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "ShieldLockOutline",
+        "required": [
+          "primaryName",
+          "entityType",
+          "matchRules",
+          "reason",
+          "active"
+        ],
+        "properties": {
+          "primaryName": {
+            "description": "Human-readable primary identifier — the name on the court order or the categorical exemption title.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Primaire naam",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "entityType": {
+            "description": "Entity category the rule applies to.",
+            "type": "string",
+            "enum": [
+              "PERSON",
+              "ORGANIZATION",
+              "OTHER"
+            ],
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Entiteittype"
+          },
+          "matchRules": {
+            "description": "Array of {type, value} entries; type is one of `exact` (literal), `normalized` (case+accent strip), `bsn` (BSN identifier), `kvk` (KvK identifier).",
+            "type": "array",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "items": {
+              "type": "object",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "exact",
+                    "normalized",
+                    "bsn",
+                    "kvk"
+                  ]
+                },
+                "value": {
+                  "type": "string",
+                  "maxLength": 255
+                }
+              }
+            },
+            "title": "Matchregels"
+          },
+          "reason": {
+            "description": "Short justification — gerechtelijk bevel, minderjarige bescherming, undercover, categorical privacy-board.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 4,
+            "title": "Reden",
+            "maxLength": 1024,
+            "translatable": true
+          },
+          "legalAuthority": {
+            "description": "Wettelijke grondslag of besluitnummer (e.g. AVG art. 17, Rechtbank Den Haag KG ZA 24/123).",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 5,
+            "title": "Juridische grondslag",
+            "maxLength": 512
+          },
+          "caseReference": {
+            "description": "Zaaknummer / dossiernummer voor traceability.",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Zaakreferentie",
+            "maxLength": 128
+          },
+          "severity": {
+            "description": "Urgentieklasse: critical (per direct effectief), high, normal.",
+            "type": "string",
+            "enum": [
+              "critical",
+              "high",
+              "normal"
+            ],
+            "required": false,
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Ernst",
+            "default": "normal"
+          },
+          "jurisdiction": {
+            "description": "Geografische/juridische scope (e.g. NL, EU, gemeente-specifiek).",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Jurisdictie",
+            "maxLength": 128
+          },
+          "addedBy": {
+            "description": "Nextcloud user die de regel heeft toegevoegd (UUID/UID).",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 9,
+            "facetable": true,
+            "title": "Toegevoegd door",
+            "maxLength": 255
+          },
+          "validFrom": {
+            "description": "Begindatum (inclusief) waarop de regel matched.",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 10,
+            "facetable": true,
+            "title": "Geldig vanaf"
+          },
+          "validUntil": {
+            "description": "Einddatum (inclusief) waarop de regel matched; null = onbeperkt.",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 11,
+            "facetable": true,
+            "title": "Geldig tot"
+          },
+          "active": {
+            "description": "Master kill-switch; alleen `active: true` regels matchen.",
+            "type": "boolean",
+            "required": true,
+            "visible": true,
+            "order": 12,
+            "facetable": true,
+            "title": "Actief",
+            "default": true
+          },
+          "notes": {
+            "description": "Markdown-vrije tekst voor extra context.",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 13,
+            "title": "Notities",
+            "translatable": true
+          }
+        },
+        "x-openregister-archival": {
+          "retention": "P10Y",
+          "reason": "Privacy-prohibitions are court-order-backed; retain at least 10 years for audit + appeal per Archiefwet selectielijst."
+        },
+        "authorization": {
+          "read": [
+            "consent"
+          ],
+          "write": [
+            "docudesk-policy-admins"
+          ]
+        }
+      },
+      "signerRecord": {
+        "x-openregister-notifications": {
+          "signingRequested": {
+            "trigger": {
+              "type": "created"
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "field",
+                "field": "userId"
+              }
+            ],
+            "subject": {
+              "nl": "Je moet een document ondertekenen",
+              "en": "You have a document to sign"
+            }
+          },
+          "signingDeadline": {
+            "trigger": {
+              "type": "scheduled",
+              "intervalSec": 86400,
+              "filter": {
+                "status": "PENDING"
+              }
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "field",
+                "field": "userId"
+              }
+            ],
+            "subject": {
+              "nl": "Herinnering: een document wacht op je handtekening",
+              "en": "Reminder: a document is awaiting your signature"
+            }
+          }
+        },
+        "uri": null,
+        "slug": "signerRecord",
+        "title": "Signer Record",
+        "description": "Individueel ondertekeningsrecord",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "AccountEdit",
+        "required": [
+          "signingRequestId",
+          "userId",
+          "displayName",
+          "status"
+        ],
+        "properties": {
+          "signingRequestId": {
+            "description": "Ondertekeningsverzoek UUID",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Verzoek ID"
+          },
+          "userId": {
+            "description": "Gebruikers-ID",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Gebruiker"
+          },
+          "displayName": {
+            "description": "Weergavenaam",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Naam",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "email": {
+            "description": "E-mailadres",
+            "type": "string",
+            "format": "email",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "E-mail",
+            "maxLength": 255
+          },
+          "order": {
+            "description": "Volgorde",
+            "type": "integer",
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Volgorde",
+            "default": 0
+          },
+          "status": {
+            "description": "Status",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "PENDING",
+              "SIGNED",
+              "DECLINED",
+              "EXPIRED",
+              "CANCELLED"
+            ],
+            "default": "PENDING"
+          },
+          "signedAt": {
+            "description": "Datum ondertekening",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 7,
+            "facetable": false,
+            "title": "Ondertekend op"
+          },
+          "declineReason": {
+            "description": "Reden weigering",
+            "type": "string",
+            "visible": true,
+            "order": 8,
+            "facetable": false,
+            "title": "Reden weigering",
+            "maxLength": 2000,
+            "translatable": true
+          },
+          "ipAddress": {
+            "description": "IP-adres",
+            "type": "string",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "IP-adres",
+            "maxLength": 45
+          },
+          "signatureData": {
+            "description": "Handtekeninggegevens (base64)",
+            "type": "string",
+            "visible": false,
+            "order": 10,
+            "facetable": false,
+            "title": "Handtekeninggegevens"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-03-22T12:00:00+00:00",
+        "created": "2026-03-22T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "displayName",
+          "objectDescriptionField": "status",
+          "autoPublish": false
+        },
+        "searchable": true,
+        "x-openregister-archival": {
+          "retention": "P10Y",
+          "category": "Archiefwet 1995 selectielijst — cat. 5.1.3: ondertekeningsbewijsmiddelen",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        }
+      },
+      "signingAuditEntry": {
+        "x-openregister-processing": {
+          "code": "docudesk-signing",
+          "naam": "Digital document signing",
+          "doelbinding": "Create and maintain a tamper-evident audit trail of electronic signing activities (eIDAS SES/AdES/QES) as legal evidence.",
+          "rechtsgrond": "legal-obligation",
+          "grondslagSource": "EntityRelation.bases",
+          "dataCategories": [
+            "PERSON",
+            "EMAIL",
+            "IP_ADDRESS"
+          ],
+          "backend": "docudesk.signing",
+          "retentionReference": "signingAuditEntry/x-openregister-archival (P10Y; Archiefwet 1995 selectielijst cat. 5.1.3)",
+          "lifecycle": "draft",
+          "logReads": true,
+          "attribution": {
+            "default": "docudesk-signing"
+          },
+          "subjectIdFields": {
+            "ncUserId": "actorUserId"
+          }
+        },
+        "uri": null,
+        "slug": "signingAuditEntry",
+        "title": "Signing Audit Entry",
+        "description": "DEPRECATED as of migrate-signing-audit-to-or-audit: new events are routed to OR audit trail (docudesk.signing.*). Existing records remain readable read-only for one major release. Onveranderbaar auditlogrecord voor digitale ondertekeningsacties. Retentie gedeclareerd via x-openregister-archival (P10Y).",
+        "deprecated": true,
+        "x-deprecated-since": "migrate-signing-audit-to-or-audit",
+        "x-sunset": "one major release after migrate-signing-audit-to-or-audit",
+        "version": "1.0.0",
+        "summary": "",
+        "icon": "ShieldCheck",
+        "required": [
+          "signingRequestId",
+          "action",
+          "actorUserId",
+          "actorDisplayName",
+          "timestamp"
+        ],
+        "properties": {
+          "signingRequestId": {
+            "description": "Ondertekeningsverzoek UUID",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Verzoek ID"
+          },
+          "action": {
+            "description": "Actie",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Actie",
+            "enum": [
+              "CREATED",
+              "SIGNED",
+              "DECLINED",
+              "CANCELLED",
+              "EXPIRED",
+              "COMPLETED",
+              "VIEWED"
+            ]
+          },
+          "actorUserId": {
+            "description": "Actor gebruikers-ID",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": true,
+            "title": "Actor"
+          },
+          "actorDisplayName": {
+            "description": "Actornaam",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Actornaam",
+            "maxLength": 255
+          },
+          "timestamp": {
+            "description": "Tijdstip (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": true,
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Tijdstip"
+          },
+          "ipAddress": {
+            "description": "IP-adres",
+            "type": "string",
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "IP-adres",
+            "maxLength": 45
+          },
+          "signatureLevel": {
+            "description": "eIDAS niveau",
+            "type": "string",
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Niveau",
+            "enum": [
+              "SES",
+              "AdES",
+              "QES"
+            ]
+          },
+          "provider": {
+            "description": "Provider",
+            "type": "string",
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Provider"
+          },
+          "metadata": {
+            "description": "Metadata (JSON)",
+            "type": "object",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Metadata"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": true,
+        "appendOnly": true,
+        "updated": "2026-03-22T12:00:00+00:00",
+        "created": "2026-03-22T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "action",
+          "objectDescriptionField": "actorDisplayName",
+          "autoPublish": false
+        },
+        "searchable": true,
+        "x-openregister-archival": {
+          "retention": "P10Y",
+          "category": "Archiefwet 1995 selectielijst — cat. 5.1.3: ondertekeningsauditverslagen als juridisch bewijsmiddel",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        }
+      },
+      "signingRequest": {
+        "deprecated": true,
+        "deprecatedSince": "5.6.0",
+        "deprecationNote": "The bespoke signing approval-chain (signingRequest + signerRecord step state) is being migrated to OpenRegister's canonical ApprovalChain / ApprovalStep abstraction per openspec/changes/migrate-signing-to-or-approval-workflow. Existing rows remain readable for the transition window; new sign-requests go through OR's ApprovalService and react to ApprovalStep*Event via lib/EventListener/ApprovalStepListener.php. Do not introduce new write-path callers — extend the ApprovalChain side instead.",
+        "x-openregister-notifications": {
+          "signingCompleted": {
+            "trigger": {
+              "type": "scheduled",
+              "intervalSec": 86400,
+              "filter": {
+                "status": "COMPLETED"
+              }
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "field",
+                "field": "initiatorUserId"
+              }
+            ],
+            "subject": {
+              "nl": "Ondertekeningsverzoek '{{documentName}}' is voltooid",
+              "en": "Signing request '{{documentName}}' is complete"
+            }
+          }
+        },
+        "uri": null,
+        "slug": "signingRequest",
+        "title": "Signing Request",
+        "description": "Ondertekeningsverzoek voor een document. DEPRECATED v1.2.0: bespoke signing approval-chain superseded by OR ApprovalChain/Step abstractions per openspec/changes/migrate-signing-to-or-approval-workflow.",
+        "version": "1.2.0",
+        "summary": "",
+        "icon": "FileSign",
+        "required": [
+          "documentFileId",
+          "documentName",
+          "initiatorUserId",
+          "signatureLevel",
+          "signingMode",
+          "status",
+          "provider"
+        ],
+        "properties": {
+          "documentFileId": {
+            "description": "Nextcloud bestand-ID",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Document ID"
+          },
+          "documentName": {
+            "description": "Naam document",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "title": "Documentnaam",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "initiatorUserId": {
+            "description": "Initiator gebruikers-ID",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": true,
+            "title": "Initiator"
+          },
+          "signatureLevel": {
+            "description": "eIDAS niveau",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 4,
+            "facetable": true,
+            "title": "Niveau",
+            "enum": [
+              "SES",
+              "AdES",
+              "QES"
+            ],
+            "default": "SES"
+          },
+          "signingMode": {
+            "description": "Ondertekeningsvolgorde",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 5,
+            "facetable": true,
+            "title": "Modus",
+            "enum": [
+              "sequential",
+              "parallel"
+            ],
+            "default": "sequential"
+          },
+          "status": {
+            "description": "Status",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "DRAFT",
+              "PENDING",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "DECLINED",
+              "EXPIRED",
+              "CANCELLED"
+            ],
+            "default": "DRAFT"
+          },
+          "provider": {
+            "description": "Provider",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Provider",
+            "enum": [
+              "native",
+              "validsign",
+              "docusign",
+              "adobesign",
+              "libresign"
+            ],
+            "default": "native"
+          },
+          "deadline": {
+            "description": "Deadline (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 8,
+            "facetable": false,
+            "title": "Deadline"
+          },
+          "signerIds": {
+            "description": "SignerRecord UUID's",
+            "type": "array",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Ondertekenaars"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-03-22T12:00:00+00:00",
+        "created": "2026-03-22T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "documentName",
+          "objectDescriptionField": "status",
+          "autoPublish": false
+        },
+        "searchable": true,
+        "x-openregister-lifecycle": {
+          "field": "status",
+          "initialState": "DRAFT",
+          "states": {
+            "DRAFT": {
+              "label": "Draft",
+              "description": "Signing request is being assembled by the initiator; not yet sent to signers."
+            },
+            "PENDING": {
+              "label": "Pending",
+              "description": "Request has been sent and is awaiting signer action."
+            },
+            "IN_PROGRESS": {
+              "label": "In progress",
+              "description": "At least one signer has started; the request is being signed."
+            },
+            "COMPLETED": {
+              "label": "Completed",
+              "description": "All signers have signed. Terminal state."
+            },
+            "DECLINED": {
+              "label": "Declined",
+              "description": "A signer declined; the request is terminated. Terminal."
+            },
+            "EXPIRED": {
+              "label": "Expired",
+              "description": "The deadline passed before completion. Terminal."
+            },
+            "CANCELLED": {
+              "label": "Cancelled",
+              "description": "The initiator cancelled the request. Terminal."
+            }
+          },
+          "transitions": {
+            "send": {
+              "from": "DRAFT",
+              "to": "PENDING",
+              "label": "Send for signing",
+              "description": "Notify the configured signers and start collecting signatures."
+            },
+            "start": {
+              "from": "PENDING",
+              "to": "IN_PROGRESS",
+              "label": "Start signing",
+              "description": "A signer has opened the request; mark the request as in progress."
+            },
+            "complete": {
+              "from": "IN_PROGRESS",
+              "to": "COMPLETED",
+              "label": "Complete signing",
+              "description": "All signers have signed; finalise the request. Terminal."
+            },
+            "decline": {
+              "from": "IN_PROGRESS",
+              "to": "DECLINED",
+              "label": "Decline",
+              "description": "A signer declined; terminate the request. Terminal."
+            },
+            "expire": {
+              "from": "PENDING",
+              "to": "EXPIRED",
+              "label": "Expire",
+              "description": "Deadline passed before completion. Terminal."
+            },
+            "cancel": {
+              "from": "PENDING",
+              "to": "CANCELLED",
+              "label": "Cancel",
+              "description": "Initiator cancels the request before completion. Terminal."
+            }
+          }
+        },
+        "x-openregister-archival": {
+          "retention": "P10Y",
+          "category": "Archiefwet 1995 selectielijst — cat. 5.1.3: ondertekeningsverzoeken als juridisch bewijsmiddel",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        }
+      },
+      "signingSession": {
+        "uri": null,
+        "slug": "signingSession",
+        "title": "Signing Session",
+        "description": "Persistente sessie voor de native SES signing-provider. Houdt de status van een ondertekeningssessie tussen HTTP-requests bij (issue #287). Wordt geschreven door NativeSigningProvider via OpenRegister zodat checkStatus/cancel/download na een fresh request de sessie kunnen terugvinden.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "FileSign",
+        "required": [
+          "externalId",
+          "documentPath",
+          "documentName",
+          "status"
+        ],
+        "properties": {
+          "externalId": {
+            "description": "Identifier van de signing-sessie (natuurlijke sleutel binnen de native provider)",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Sessie ID",
+            "maxLength": 128
+          },
+          "documentPath": {
+            "description": "Pad naar het bron-document binnen Nextcloud",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "title": "Documentpad",
+            "maxLength": 4000
+          },
+          "documentName": {
+            "description": "Naam van het document",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Documentnaam",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "signers": {
+            "description": "Array van ondertekenaars die in deze sessie betrokken zijn",
+            "type": "array",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Ondertekenaars"
+          },
+          "level": {
+            "description": "Handtekeningsniveau (alleen SES voor de native provider)",
+            "type": "string",
+            "visible": true,
+            "order": 5,
+            "facetable": true,
+            "title": "Niveau",
+            "enum": [
+              "SES"
+            ],
+            "default": "SES"
+          },
+          "status": {
+            "description": "Sessie-status",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "pending",
+              "in_progress",
+              "completed",
+              "cancelled",
+              "expired"
+            ],
+            "default": "pending"
+          },
+          "signatures": {
+            "description": "Lijst van toegevoegde handtekeningen",
+            "type": "array",
+            "visible": true,
+            "order": 7,
+            "facetable": false,
+            "title": "Handtekeningen"
+          },
+          "createdAt": {
+            "description": "Aangemaakt (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 8,
+            "facetable": false,
+            "title": "Aangemaakt"
+          },
+          "completedAt": {
+            "description": "Afgerond (ISO 8601), null tot completion",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Afgerond"
+          },
+          "signedDocumentPath": {
+            "description": "Pad naar het ondertekende document (kan gelijk zijn aan documentPath totdat SES-marker geschreven is)",
+            "type": "string",
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Ondertekend pad",
+            "maxLength": 4000
+          },
+          "markerEmbedded": {
+            "description": "Of de SES-marker (HMAC-blob) in het document is geschreven",
+            "type": "boolean",
+            "visible": true,
+            "order": 11,
+            "facetable": true,
+            "title": "Marker ingebed",
+            "default": false
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-05-27T12:00:00+00:00",
+        "created": "2026-05-27T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "documentName",
+          "objectDescriptionField": "status",
+          "autoPublish": false
+        },
+        "searchable": false,
+        "x-openregister-lifecycle": {
+          "field": "status",
+          "initial": "pending",
+          "states": {
+            "pending": {
+              "label": "Wachtend",
+              "terminal": false
+            },
+            "in_progress": {
+              "label": "Bezig",
+              "terminal": false
+            },
+            "completed": {
+              "label": "Voltooid",
+              "terminal": true
+            },
+            "cancelled": {
+              "label": "Geannuleerd",
+              "terminal": true
+            },
+            "expired": {
+              "label": "Verlopen",
+              "terminal": true
+            }
+          },
+          "transitions": {
+            "start": {
+              "from": "pending",
+              "to": "in_progress",
+              "label": "Start sessie",
+              "description": "Eerste signer heeft de sessie geopend."
+            },
+            "complete": {
+              "from": "in_progress",
+              "to": "completed",
+              "label": "Voltooi sessie",
+              "description": "Alle handtekeningen zijn verzameld. Terminal."
+            },
+            "cancel": {
+              "from": [
+                "pending",
+                "in_progress"
+              ],
+              "to": "cancelled",
+              "label": "Annuleer sessie",
+              "description": "Sessie geannuleerd door initiator of provider."
+            },
+            "expire": {
+              "from": [
+                "pending",
+                "in_progress"
+              ],
+              "to": "expired",
+              "label": "Sessie verlopen",
+              "description": "TTL verstreken — sessie automatisch verlopen."
+            }
+          }
+        }
+      },
+      "template": {
+        "uri": null,
+        "slug": "template",
+        "title": "Document Template",
+        "description": "Herbruikbare Twig/HTML templates voor PDF-generatie. Templates zijn gescoped per app via het namespace-veld.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "FileDocument",
+        "required": [
+          "name",
+          "content",
+          "namespace"
+        ],
+        "properties": {
+          "name": {
+            "description": "Naam van het template",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Naam",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "description": {
+            "description": "Beschrijving van het doel van het template",
+            "type": "string",
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "title": "Beschrijving",
+            "maxLength": 2000,
+            "translatable": true
+          },
+          "content": {
+            "description": "Twig/HTML template content voor PDF-rendering",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Template inhoud",
+            "format": "html",
+            "translatable": true
+          },
+          "namespace": {
+            "description": "App-identifier die eigenaar is van dit template (bijv. larpingapp, opencatalogi)",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 4,
+            "facetable": true,
+            "title": "Namespace",
+            "maxLength": 64
+          },
+          "format": {
+            "description": "Standaard paginaformaat voor PDF-uitvoer",
+            "type": "string",
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Paginaformaat",
+            "default": "A4",
+            "enum": [
+              "A4",
+              "A3",
+              "Letter",
+              "Legal"
+            ]
+          },
+          "orientation": {
+            "description": "Standaard pagina-oriëntatie",
+            "type": "string",
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Oriëntatie",
+            "default": "P",
+            "enum": [
+              "P",
+              "L"
+            ]
+          },
+          "category": {
+            "description": "Categorie van het template (bijv. beschikkingen, brieven, notities)",
+            "type": "string",
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Categorie",
+            "maxLength": 128,
+            "translatable": true
+          },
+          "tags": {
+            "description": "Vrije tags voor zoeken en filteren",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 64
+            },
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Tags"
+          },
+          "lockedBy": {
+            "description": "Nextcloud gebruikers-ID van de gebruiker die het template momenteel bewerkt",
+            "type": "string",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Vergrendeld door",
+            "maxLength": 64
+          },
+          "lockedAt": {
+            "description": "Tijdstip waarop de bewerkvergrendeling is verkregen (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Vergrendeld op"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-05-18T12:00:00+00:00",
+        "created": "2026-03-01T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "name",
+          "objectDescriptionField": "description",
+          "autoPublish": false
+        },
+        "searchable": true
+      },
+      "templateVersion": {
+        "uri": null,
+        "slug": "templateVersion",
+        "title": "Template Version",
+        "description": "Historische versie van een template. Wordt aangemaakt bij elke bewerking als snapshot van de vorige staat.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "History",
+        "required": [
+          "templateId",
+          "version",
+          "content",
+          "editor"
+        ],
+        "properties": {
+          "templateId": {
+            "description": "UUID van het bovenliggende template",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Template ID"
+          },
+          "version": {
+            "description": "Volgnummer van de versie (oplopend)",
+            "type": "integer",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "title": "Versienummer"
+          },
+          "content": {
+            "description": "HTML/Twig templateinhoud op het moment van de snapshot",
+            "type": "string",
+            "required": true,
+            "visible": false,
+            "order": 3,
+            "facetable": false,
+            "title": "Inhoud",
+            "format": "html"
+          },
+          "name": {
+            "description": "Naam van het template op het moment van de snapshot",
+            "type": "string",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Naam",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "description": {
+            "description": "Beschrijving van het template op het moment van de snapshot",
+            "type": "string",
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Beschrijving",
+            "maxLength": 2000,
+            "translatable": true
+          },
+          "format": {
+            "description": "Paginaformaat op het moment van de snapshot",
+            "type": "string",
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Formaat",
+            "default": "A4"
+          },
+          "orientation": {
+            "description": "Pagina-oriëntatie op het moment van de snapshot",
+            "type": "string",
+            "visible": true,
+            "order": 7,
+            "facetable": false,
+            "title": "Oriëntatie",
+            "default": "P"
+          },
+          "editor": {
+            "description": "Nextcloud gebruikers-ID van de gebruiker die de bewerking uitvoerde",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Bewerker",
+            "maxLength": 64
+          },
+          "changelog": {
+            "description": "Optionele notitie met beschrijving van de wijziging",
+            "type": "string",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Wijzigingsnotitie",
+            "maxLength": 2000,
+            "translatable": true
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": true,
+        "updated": "2026-05-18T12:00:00+00:00",
+        "created": "2026-05-18T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "name",
+          "objectDescriptionField": "changelog",
+          "autoPublish": false
+        },
+        "searchable": false
+      }
+    },
+    "objects": [
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-1-1"
+        },
+        "sourceFileId": 1,
+        "anonymizedFileId": 1,
+        "sourceFileName": "Voorbeeld Sourcefilename 1",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 1",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 1",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 1",
+        "outputFormat": "pdf",
+        "status": "anonymized",
+        "replacementCount": 1,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-01T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 1"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-2-2"
+        },
+        "sourceFileId": 2,
+        "anonymizedFileId": 2,
+        "sourceFileName": "Voorbeeld Sourcefilename 2",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 2",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 2",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 2",
+        "outputFormat": "docx",
+        "status": "anonymized",
+        "replacementCount": 2,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-02T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 2"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-3-3"
+        },
+        "sourceFileId": 3,
+        "anonymizedFileId": 3,
+        "sourceFileName": "Voorbeeld Sourcefilename 3",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 3",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 3",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 3",
+        "outputFormat": "odt",
+        "status": "anonymized",
+        "replacementCount": 3,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-03T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 3"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "recipientCount": 1,
+        "status": "pending",
+        "initiatedBy": "Voorbeeld Initiatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "completedCount": 1,
+        "errorCount": 1,
+        "startedAt": "2026-03-01T09:00:00+00:00",
+        "completedAt": "2026-03-01T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "recipientCount": 2,
+        "status": "processing",
+        "initiatedBy": "Voorbeeld Initiatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "completedCount": 2,
+        "errorCount": 2,
+        "startedAt": "2026-03-02T09:00:00+00:00",
+        "completedAt": "2026-03-02T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "recipientCount": 3,
+        "status": "success",
+        "initiatedBy": "Voorbeeld Initiatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "completedCount": 3,
+        "errorCount": 3,
+        "startedAt": "2026-03-03T09:00:00+00:00",
+        "completedAt": "2026-03-03T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "recipientId": "Voorbeeld Recipientid 1",
+        "generatedAt": "2026-03-01T09:00:00+00:00",
+        "format": "pdf",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "recipientType": "PERSON",
+        "caseReference": "Voorbeeld Casereference 1",
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "recipientId": "Voorbeeld Recipientid 2",
+        "generatedAt": "2026-03-02T09:00:00+00:00",
+        "format": "docx",
+        "status": "failed",
+        "generatedBy": "Voorbeeld Generatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "recipientType": "ORGANIZATION",
+        "caseReference": "Voorbeeld Casereference 2",
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "recipientId": "Voorbeeld Recipientid 3",
+        "generatedAt": "2026-03-03T09:00:00+00:00",
+        "format": "html",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "recipientType": "PERSON",
+        "caseReference": "Voorbeeld Casereference 3",
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1",
+        "bases": [
+          "Voorbeeld Bases 1"
+        ],
+        "checkedOn": "2026-03-01T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2",
+        "bases": [
+          "Voorbeeld Bases 2"
+        ],
+        "checkedOn": "2026-03-02T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3",
+        "bases": [
+          "Voorbeeld Bases 3"
+        ],
+        "checkedOn": "2026-03-03T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "templateVersion": 1,
+        "generatedAt": "2026-03-01T09:00:00+00:00",
+        "format": "pdf",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "dataRefs": [
+          "Voorbeeld Datarefs 1"
+        ],
+        "zaakId": "Voorbeeld Zaakid 1",
+        "warnings": [
+          "Voorbeeld Warnings 1"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "templateVersion": 2,
+        "generatedAt": "2026-03-02T09:00:00+00:00",
+        "format": "odf",
+        "status": "failed",
+        "generatedBy": "Voorbeeld Generatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "dataRefs": [
+          "Voorbeeld Datarefs 2"
+        ],
+        "zaakId": "Voorbeeld Zaakid 2",
+        "warnings": [
+          "Voorbeeld Warnings 2"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "templateVersion": 3,
+        "generatedAt": "2026-03-03T09:00:00+00:00",
+        "format": "html",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "dataRefs": [
+          "Voorbeeld Datarefs 3"
+        ],
+        "zaakId": "Voorbeeld Zaakid 3",
+        "warnings": [
+          "Voorbeeld Warnings 3"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "logo": "Voorbeeld Logo 1",
+        "primaryColor": "Voorbeeld Primarycolor 1",
+        "headerHtml": "Voorbeeld html 0",
+        "footerHtml": "Voorbeeld html 0",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "logo": "Voorbeeld Logo 2",
+        "primaryColor": "Voorbeeld Primarycolor 2",
+        "headerHtml": "Voorbeeld html 1",
+        "footerHtml": "Voorbeeld html 1",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "logo": "Voorbeeld Logo 3",
+        "primaryColor": "Voorbeeld Primarycolor 3",
+        "headerHtml": "Voorbeeld html 2",
+        "footerHtml": "Voorbeeld html 2",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-1-1"
+        },
+        "documentId": "Voorbeeld Documentid 1",
+        "entityType": "PERSON",
+        "entityText": "Voorbeeld Entitytext 1",
+        "scope": "document",
+        "entityKey": "Voorbeeld Entitykey 1",
+        "contactEmail": "voorbeeld0@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 1",
+        "contactRef": "https://example.invalid/resource/0",
+        "notificationStatus": "pending",
+        "notificationSentAt": "2026-03-01T09:00:00+00:00",
+        "consentStatus": "pending",
+        "objectionDeadline": "2026-03-01T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-01T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 0",
+        "publicationDecision": "pending",
+        "legalBasis": "Voorbeeld Legalbasis 1",
+        "notes": "Voorbeeld markdown 0",
+        "matchRules": [
+          {
+            "type": "exact",
+            "value": "Voorbeeld Value 1"
+          }
+        ],
+        "validFrom": "2026-03-01T09:00:00+00:00",
+        "validUntil": "2026-03-01T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "paper",
+        "consentDocument": "https://example.invalid/resource/0",
+        "consentScope": "Voorbeeld Consentscope 1"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-2-2"
+        },
+        "documentId": "Voorbeeld Documentid 2",
+        "entityType": "ORGANIZATION",
+        "entityText": "Voorbeeld Entitytext 2",
+        "scope": "entity",
+        "entityKey": "Voorbeeld Entitykey 2",
+        "contactEmail": "voorbeeld1@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 2",
+        "contactRef": "https://example.invalid/resource/1",
+        "notificationStatus": "sent",
+        "notificationSentAt": "2026-03-02T09:00:00+00:00",
+        "consentStatus": "consent_given",
+        "objectionDeadline": "2026-03-02T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-02T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 1",
+        "publicationDecision": "anonymize",
+        "legalBasis": "Voorbeeld Legalbasis 2",
+        "notes": "Voorbeeld markdown 1",
+        "matchRules": [
+          {
+            "type": "normalized",
+            "value": "Voorbeeld Value 2"
+          }
+        ],
+        "validFrom": "2026-03-02T09:00:00+00:00",
+        "validUntil": "2026-03-02T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "digital_signature",
+        "consentDocument": "https://example.invalid/resource/1",
+        "consentScope": "Voorbeeld Consentscope 2"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-3-3"
+        },
+        "documentId": "Voorbeeld Documentid 3",
+        "entityType": "PERSON",
+        "entityText": "Voorbeeld Entitytext 3",
+        "scope": "document",
+        "entityKey": "Voorbeeld Entitykey 3",
+        "contactEmail": "voorbeeld2@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 3",
+        "contactRef": "https://example.invalid/resource/2",
+        "notificationStatus": "delivered",
+        "notificationSentAt": "2026-03-03T09:00:00+00:00",
+        "consentStatus": "objection_received",
+        "objectionDeadline": "2026-03-03T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-03T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 2",
+        "publicationDecision": "publish_with_consent",
+        "legalBasis": "Voorbeeld Legalbasis 3",
+        "notes": "Voorbeeld markdown 2",
+        "matchRules": [
+          {
+            "type": "bsn",
+            "value": "Voorbeeld Value 3"
+          }
+        ],
+        "validFrom": "2026-03-03T09:00:00+00:00",
+        "validUntil": "2026-03-03T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "verbal_recorded",
+        "consentDocument": "https://example.invalid/resource/2",
+        "consentScope": "Voorbeeld Consentscope 3"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-1-1"
+        },
+        "primaryName": "Voorbeeld Primaryname 1",
+        "entityType": "PERSON",
+        "matchRules": [
+          {
+            "type": "exact",
+            "value": "Voorbeeld Value 1"
+          }
+        ],
+        "reason": "Voorbeeld Reason 1",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 1",
+        "caseReference": "Voorbeeld Casereference 1",
+        "severity": "critical",
+        "jurisdiction": "Voorbeeld Jurisdiction 1",
+        "addedBy": "Voorbeeld Addedby 1",
+        "validFrom": "2026-03-01T09:00:00+00:00",
+        "validUntil": "2026-03-01T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 1"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-2-2"
+        },
+        "primaryName": "Voorbeeld Primaryname 2",
+        "entityType": "ORGANIZATION",
+        "matchRules": [
+          {
+            "type": "normalized",
+            "value": "Voorbeeld Value 2"
+          }
+        ],
+        "reason": "Voorbeeld Reason 2",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 2",
+        "caseReference": "Voorbeeld Casereference 2",
+        "severity": "high",
+        "jurisdiction": "Voorbeeld Jurisdiction 2",
+        "addedBy": "Voorbeeld Addedby 2",
+        "validFrom": "2026-03-02T09:00:00+00:00",
+        "validUntil": "2026-03-02T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 2"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-3-3"
+        },
+        "primaryName": "Voorbeeld Primaryname 3",
+        "entityType": "OTHER",
+        "matchRules": [
+          {
+            "type": "bsn",
+            "value": "Voorbeeld Value 3"
+          }
+        ],
+        "reason": "Voorbeeld Reason 3",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 3",
+        "caseReference": "Voorbeeld Casereference 3",
+        "severity": "normal",
+        "jurisdiction": "Voorbeeld Jurisdiction 3",
+        "addedBy": "Voorbeeld Addedby 3",
+        "validFrom": "2026-03-03T09:00:00+00:00",
+        "validUntil": "2026-03-03T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 3"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-1-1"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 1",
+        "userId": "Voorbeeld Userid 1",
+        "displayName": "Voorbeeld Displayname 1",
+        "status": "PENDING",
+        "email": "voorbeeld0@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-01T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 1",
+        "ipAddress": "Voorbeeld Ipaddress 1",
+        "signatureData": "Voorbeeld Signaturedata 1"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-2-2"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 2",
+        "userId": "Voorbeeld Userid 2",
+        "displayName": "Voorbeeld Displayname 2",
+        "status": "SIGNED",
+        "email": "voorbeeld1@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-02T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 2",
+        "ipAddress": "Voorbeeld Ipaddress 2",
+        "signatureData": "Voorbeeld Signaturedata 2"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-3-3"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 3",
+        "userId": "Voorbeeld Userid 3",
+        "displayName": "Voorbeeld Displayname 3",
+        "status": "DECLINED",
+        "email": "voorbeeld2@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-03T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 3",
+        "ipAddress": "Voorbeeld Ipaddress 3",
+        "signatureData": "Voorbeeld Signaturedata 3"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-1-1"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 1",
+        "action": "CREATED",
+        "actorUserId": "Voorbeeld Actoruserid 1",
+        "actorDisplayName": "Voorbeeld Actordisplayname 1",
+        "timestamp": "2026-03-01T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 1",
+        "signatureLevel": "SES",
+        "provider": "Voorbeeld Provider 1",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-2-2"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 2",
+        "action": "SIGNED",
+        "actorUserId": "Voorbeeld Actoruserid 2",
+        "actorDisplayName": "Voorbeeld Actordisplayname 2",
+        "timestamp": "2026-03-02T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 2",
+        "signatureLevel": "AdES",
+        "provider": "Voorbeeld Provider 2",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-3-3"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 3",
+        "action": "DECLINED",
+        "actorUserId": "Voorbeeld Actoruserid 3",
+        "actorDisplayName": "Voorbeeld Actordisplayname 3",
+        "timestamp": "2026-03-03T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 3",
+        "signatureLevel": "QES",
+        "provider": "Voorbeeld Provider 3",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-1-1"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 1",
+        "documentName": "Voorbeeld Documentname 1",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 1",
+        "signatureLevel": "SES",
+        "signingMode": "sequential",
+        "status": "DRAFT",
+        "provider": "native",
+        "deadline": "2026-03-01T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 1"
+        ]
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-2-2"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 2",
+        "documentName": "Voorbeeld Documentname 2",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 2",
+        "signatureLevel": "AdES",
+        "signingMode": "parallel",
+        "status": "PENDING",
+        "provider": "validsign",
+        "deadline": "2026-03-02T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 2"
+        ]
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-3-3"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 3",
+        "documentName": "Voorbeeld Documentname 3",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 3",
+        "signatureLevel": "QES",
+        "signingMode": "sequential",
+        "status": "IN_PROGRESS",
+        "provider": "docusign",
+        "deadline": "2026-03-03T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 3"
+        ]
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-1-1"
+        },
+        "externalId": "Voorbeeld Externalid 1",
+        "documentPath": "Voorbeeld Documentpath 1",
+        "documentName": "Voorbeeld Documentname 1",
+        "status": "pending",
+        "signers": [
+          "Voorbeeld Signers 1"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 1"
+        ],
+        "createdAt": "2026-03-01T09:00:00+00:00",
+        "completedAt": "2026-03-01T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 1",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-2-2"
+        },
+        "externalId": "Voorbeeld Externalid 2",
+        "documentPath": "Voorbeeld Documentpath 2",
+        "documentName": "Voorbeeld Documentname 2",
+        "status": "in_progress",
+        "signers": [
+          "Voorbeeld Signers 2"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 2"
+        ],
+        "createdAt": "2026-03-02T09:00:00+00:00",
+        "completedAt": "2026-03-02T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 2",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-3-3"
+        },
+        "externalId": "Voorbeeld Externalid 3",
+        "documentPath": "Voorbeeld Documentpath 3",
+        "documentName": "Voorbeeld Documentname 3",
+        "status": "completed",
+        "signers": [
+          "Voorbeeld Signers 3"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 3"
+        ],
+        "createdAt": "2026-03-03T09:00:00+00:00",
+        "completedAt": "2026-03-03T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 3",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "content": "Voorbeeld html 0",
+        "namespace": "Voorbeeld Namespace 1",
+        "description": "Voorbeeld Description 1",
+        "format": "A4",
+        "orientation": "P",
+        "category": "Voorbeeld Category 1",
+        "tags": [
+          "Voorbeeld Tags 1"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 1",
+        "lockedAt": "2026-03-01T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "content": "Voorbeeld html 1",
+        "namespace": "Voorbeeld Namespace 2",
+        "description": "Voorbeeld Description 2",
+        "format": "A3",
+        "orientation": "L",
+        "category": "Voorbeeld Category 2",
+        "tags": [
+          "Voorbeeld Tags 2"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 2",
+        "lockedAt": "2026-03-02T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "content": "Voorbeeld html 2",
+        "namespace": "Voorbeeld Namespace 3",
+        "description": "Voorbeeld Description 3",
+        "format": "Letter",
+        "orientation": "P",
+        "category": "Voorbeeld Category 3",
+        "tags": [
+          "Voorbeeld Tags 3"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 3",
+        "lockedAt": "2026-03-03T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "version": 1,
+        "content": "Voorbeeld html 0",
+        "editor": "Voorbeeld Editor 1",
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 1"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "version": 2,
+        "content": "Voorbeeld html 1",
+        "editor": "Voorbeeld Editor 2",
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 2"
+      },
+      {
+        "@self": {
+          "register": "consent",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "version": 3,
+        "content": "Voorbeeld html 2",
+        "editor": "Voorbeeld Editor 3",
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 3"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-1-1"
+        },
+        "sourceFileId": 1,
+        "anonymizedFileId": 1,
+        "sourceFileName": "Voorbeeld Sourcefilename 1",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 1",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 1",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 1",
+        "outputFormat": "pdf",
+        "status": "anonymized",
+        "replacementCount": 1,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-01T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 1"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-2-2"
+        },
+        "sourceFileId": 2,
+        "anonymizedFileId": 2,
+        "sourceFileName": "Voorbeeld Sourcefilename 2",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 2",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 2",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 2",
+        "outputFormat": "docx",
+        "status": "anonymized",
+        "replacementCount": 2,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-02T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 2"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-3-3"
+        },
+        "sourceFileId": 3,
+        "anonymizedFileId": 3,
+        "sourceFileName": "Voorbeeld Sourcefilename 3",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 3",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 3",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 3",
+        "outputFormat": "odt",
+        "status": "anonymized",
+        "replacementCount": 3,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-03T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 3"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "recipientCount": 1,
+        "status": "pending",
+        "initiatedBy": "Voorbeeld Initiatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "completedCount": 1,
+        "errorCount": 1,
+        "startedAt": "2026-03-01T09:00:00+00:00",
+        "completedAt": "2026-03-01T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "recipientCount": 2,
+        "status": "processing",
+        "initiatedBy": "Voorbeeld Initiatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "completedCount": 2,
+        "errorCount": 2,
+        "startedAt": "2026-03-02T09:00:00+00:00",
+        "completedAt": "2026-03-02T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "recipientCount": 3,
+        "status": "success",
+        "initiatedBy": "Voorbeeld Initiatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "completedCount": 3,
+        "errorCount": 3,
+        "startedAt": "2026-03-03T09:00:00+00:00",
+        "completedAt": "2026-03-03T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "recipientId": "Voorbeeld Recipientid 1",
+        "generatedAt": "2026-03-01T09:00:00+00:00",
+        "format": "pdf",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "recipientType": "PERSON",
+        "caseReference": "Voorbeeld Casereference 1",
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "recipientId": "Voorbeeld Recipientid 2",
+        "generatedAt": "2026-03-02T09:00:00+00:00",
+        "format": "docx",
+        "status": "failed",
+        "generatedBy": "Voorbeeld Generatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "recipientType": "ORGANIZATION",
+        "caseReference": "Voorbeeld Casereference 2",
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "recipientId": "Voorbeeld Recipientid 3",
+        "generatedAt": "2026-03-03T09:00:00+00:00",
+        "format": "html",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "recipientType": "PERSON",
+        "caseReference": "Voorbeeld Casereference 3",
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1",
+        "bases": [
+          "Voorbeeld Bases 1"
+        ],
+        "checkedOn": "2026-03-01T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2",
+        "bases": [
+          "Voorbeeld Bases 2"
+        ],
+        "checkedOn": "2026-03-02T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3",
+        "bases": [
+          "Voorbeeld Bases 3"
+        ],
+        "checkedOn": "2026-03-03T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "templateVersion": 1,
+        "generatedAt": "2026-03-01T09:00:00+00:00",
+        "format": "pdf",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "dataRefs": [
+          "Voorbeeld Datarefs 1"
+        ],
+        "zaakId": "Voorbeeld Zaakid 1",
+        "warnings": [
+          "Voorbeeld Warnings 1"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "templateVersion": 2,
+        "generatedAt": "2026-03-02T09:00:00+00:00",
+        "format": "odf",
+        "status": "failed",
+        "generatedBy": "Voorbeeld Generatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "dataRefs": [
+          "Voorbeeld Datarefs 2"
+        ],
+        "zaakId": "Voorbeeld Zaakid 2",
+        "warnings": [
+          "Voorbeeld Warnings 2"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "templateVersion": 3,
+        "generatedAt": "2026-03-03T09:00:00+00:00",
+        "format": "html",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "dataRefs": [
+          "Voorbeeld Datarefs 3"
+        ],
+        "zaakId": "Voorbeeld Zaakid 3",
+        "warnings": [
+          "Voorbeeld Warnings 3"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "logo": "Voorbeeld Logo 1",
+        "primaryColor": "Voorbeeld Primarycolor 1",
+        "headerHtml": "Voorbeeld html 0",
+        "footerHtml": "Voorbeeld html 0",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "logo": "Voorbeeld Logo 2",
+        "primaryColor": "Voorbeeld Primarycolor 2",
+        "headerHtml": "Voorbeeld html 1",
+        "footerHtml": "Voorbeeld html 1",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "logo": "Voorbeeld Logo 3",
+        "primaryColor": "Voorbeeld Primarycolor 3",
+        "headerHtml": "Voorbeeld html 2",
+        "footerHtml": "Voorbeeld html 2",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-1-1"
+        },
+        "documentId": "Voorbeeld Documentid 1",
+        "entityType": "PERSON",
+        "entityText": "Voorbeeld Entitytext 1",
+        "scope": "document",
+        "entityKey": "Voorbeeld Entitykey 1",
+        "contactEmail": "voorbeeld0@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 1",
+        "contactRef": "https://example.invalid/resource/0",
+        "notificationStatus": "pending",
+        "notificationSentAt": "2026-03-01T09:00:00+00:00",
+        "consentStatus": "pending",
+        "objectionDeadline": "2026-03-01T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-01T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 0",
+        "publicationDecision": "pending",
+        "legalBasis": "Voorbeeld Legalbasis 1",
+        "notes": "Voorbeeld markdown 0",
+        "matchRules": [
+          {
+            "type": "exact",
+            "value": "Voorbeeld Value 1"
+          }
+        ],
+        "validFrom": "2026-03-01T09:00:00+00:00",
+        "validUntil": "2026-03-01T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "paper",
+        "consentDocument": "https://example.invalid/resource/0",
+        "consentScope": "Voorbeeld Consentscope 1"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-2-2"
+        },
+        "documentId": "Voorbeeld Documentid 2",
+        "entityType": "ORGANIZATION",
+        "entityText": "Voorbeeld Entitytext 2",
+        "scope": "entity",
+        "entityKey": "Voorbeeld Entitykey 2",
+        "contactEmail": "voorbeeld1@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 2",
+        "contactRef": "https://example.invalid/resource/1",
+        "notificationStatus": "sent",
+        "notificationSentAt": "2026-03-02T09:00:00+00:00",
+        "consentStatus": "consent_given",
+        "objectionDeadline": "2026-03-02T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-02T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 1",
+        "publicationDecision": "anonymize",
+        "legalBasis": "Voorbeeld Legalbasis 2",
+        "notes": "Voorbeeld markdown 1",
+        "matchRules": [
+          {
+            "type": "normalized",
+            "value": "Voorbeeld Value 2"
+          }
+        ],
+        "validFrom": "2026-03-02T09:00:00+00:00",
+        "validUntil": "2026-03-02T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "digital_signature",
+        "consentDocument": "https://example.invalid/resource/1",
+        "consentScope": "Voorbeeld Consentscope 2"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-3-3"
+        },
+        "documentId": "Voorbeeld Documentid 3",
+        "entityType": "PERSON",
+        "entityText": "Voorbeeld Entitytext 3",
+        "scope": "document",
+        "entityKey": "Voorbeeld Entitykey 3",
+        "contactEmail": "voorbeeld2@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 3",
+        "contactRef": "https://example.invalid/resource/2",
+        "notificationStatus": "delivered",
+        "notificationSentAt": "2026-03-03T09:00:00+00:00",
+        "consentStatus": "objection_received",
+        "objectionDeadline": "2026-03-03T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-03T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 2",
+        "publicationDecision": "publish_with_consent",
+        "legalBasis": "Voorbeeld Legalbasis 3",
+        "notes": "Voorbeeld markdown 2",
+        "matchRules": [
+          {
+            "type": "bsn",
+            "value": "Voorbeeld Value 3"
+          }
+        ],
+        "validFrom": "2026-03-03T09:00:00+00:00",
+        "validUntil": "2026-03-03T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "verbal_recorded",
+        "consentDocument": "https://example.invalid/resource/2",
+        "consentScope": "Voorbeeld Consentscope 3"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-1-1"
+        },
+        "primaryName": "Voorbeeld Primaryname 1",
+        "entityType": "PERSON",
+        "matchRules": [
+          {
+            "type": "exact",
+            "value": "Voorbeeld Value 1"
+          }
+        ],
+        "reason": "Voorbeeld Reason 1",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 1",
+        "caseReference": "Voorbeeld Casereference 1",
+        "severity": "critical",
+        "jurisdiction": "Voorbeeld Jurisdiction 1",
+        "addedBy": "Voorbeeld Addedby 1",
+        "validFrom": "2026-03-01T09:00:00+00:00",
+        "validUntil": "2026-03-01T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 1"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-2-2"
+        },
+        "primaryName": "Voorbeeld Primaryname 2",
+        "entityType": "ORGANIZATION",
+        "matchRules": [
+          {
+            "type": "normalized",
+            "value": "Voorbeeld Value 2"
+          }
+        ],
+        "reason": "Voorbeeld Reason 2",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 2",
+        "caseReference": "Voorbeeld Casereference 2",
+        "severity": "high",
+        "jurisdiction": "Voorbeeld Jurisdiction 2",
+        "addedBy": "Voorbeeld Addedby 2",
+        "validFrom": "2026-03-02T09:00:00+00:00",
+        "validUntil": "2026-03-02T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 2"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-3-3"
+        },
+        "primaryName": "Voorbeeld Primaryname 3",
+        "entityType": "OTHER",
+        "matchRules": [
+          {
+            "type": "bsn",
+            "value": "Voorbeeld Value 3"
+          }
+        ],
+        "reason": "Voorbeeld Reason 3",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 3",
+        "caseReference": "Voorbeeld Casereference 3",
+        "severity": "normal",
+        "jurisdiction": "Voorbeeld Jurisdiction 3",
+        "addedBy": "Voorbeeld Addedby 3",
+        "validFrom": "2026-03-03T09:00:00+00:00",
+        "validUntil": "2026-03-03T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 3"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-1-1"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 1",
+        "userId": "Voorbeeld Userid 1",
+        "displayName": "Voorbeeld Displayname 1",
+        "status": "PENDING",
+        "email": "voorbeeld0@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-01T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 1",
+        "ipAddress": "Voorbeeld Ipaddress 1",
+        "signatureData": "Voorbeeld Signaturedata 1"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-2-2"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 2",
+        "userId": "Voorbeeld Userid 2",
+        "displayName": "Voorbeeld Displayname 2",
+        "status": "SIGNED",
+        "email": "voorbeeld1@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-02T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 2",
+        "ipAddress": "Voorbeeld Ipaddress 2",
+        "signatureData": "Voorbeeld Signaturedata 2"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-3-3"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 3",
+        "userId": "Voorbeeld Userid 3",
+        "displayName": "Voorbeeld Displayname 3",
+        "status": "DECLINED",
+        "email": "voorbeeld2@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-03T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 3",
+        "ipAddress": "Voorbeeld Ipaddress 3",
+        "signatureData": "Voorbeeld Signaturedata 3"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-1-1"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 1",
+        "action": "CREATED",
+        "actorUserId": "Voorbeeld Actoruserid 1",
+        "actorDisplayName": "Voorbeeld Actordisplayname 1",
+        "timestamp": "2026-03-01T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 1",
+        "signatureLevel": "SES",
+        "provider": "Voorbeeld Provider 1",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-2-2"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 2",
+        "action": "SIGNED",
+        "actorUserId": "Voorbeeld Actoruserid 2",
+        "actorDisplayName": "Voorbeeld Actordisplayname 2",
+        "timestamp": "2026-03-02T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 2",
+        "signatureLevel": "AdES",
+        "provider": "Voorbeeld Provider 2",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-3-3"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 3",
+        "action": "DECLINED",
+        "actorUserId": "Voorbeeld Actoruserid 3",
+        "actorDisplayName": "Voorbeeld Actordisplayname 3",
+        "timestamp": "2026-03-03T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 3",
+        "signatureLevel": "QES",
+        "provider": "Voorbeeld Provider 3",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-1-1"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 1",
+        "documentName": "Voorbeeld Documentname 1",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 1",
+        "signatureLevel": "SES",
+        "signingMode": "sequential",
+        "status": "DRAFT",
+        "provider": "native",
+        "deadline": "2026-03-01T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 1"
+        ]
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-2-2"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 2",
+        "documentName": "Voorbeeld Documentname 2",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 2",
+        "signatureLevel": "AdES",
+        "signingMode": "parallel",
+        "status": "PENDING",
+        "provider": "validsign",
+        "deadline": "2026-03-02T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 2"
+        ]
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-3-3"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 3",
+        "documentName": "Voorbeeld Documentname 3",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 3",
+        "signatureLevel": "QES",
+        "signingMode": "sequential",
+        "status": "IN_PROGRESS",
+        "provider": "docusign",
+        "deadline": "2026-03-03T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 3"
+        ]
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-1-1"
+        },
+        "externalId": "Voorbeeld Externalid 1",
+        "documentPath": "Voorbeeld Documentpath 1",
+        "documentName": "Voorbeeld Documentname 1",
+        "status": "pending",
+        "signers": [
+          "Voorbeeld Signers 1"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 1"
+        ],
+        "createdAt": "2026-03-01T09:00:00+00:00",
+        "completedAt": "2026-03-01T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 1",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-2-2"
+        },
+        "externalId": "Voorbeeld Externalid 2",
+        "documentPath": "Voorbeeld Documentpath 2",
+        "documentName": "Voorbeeld Documentname 2",
+        "status": "in_progress",
+        "signers": [
+          "Voorbeeld Signers 2"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 2"
+        ],
+        "createdAt": "2026-03-02T09:00:00+00:00",
+        "completedAt": "2026-03-02T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 2",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-3-3"
+        },
+        "externalId": "Voorbeeld Externalid 3",
+        "documentPath": "Voorbeeld Documentpath 3",
+        "documentName": "Voorbeeld Documentname 3",
+        "status": "completed",
+        "signers": [
+          "Voorbeeld Signers 3"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 3"
+        ],
+        "createdAt": "2026-03-03T09:00:00+00:00",
+        "completedAt": "2026-03-03T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 3",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "content": "Voorbeeld html 0",
+        "namespace": "Voorbeeld Namespace 1",
+        "description": "Voorbeeld Description 1",
+        "format": "A4",
+        "orientation": "P",
+        "category": "Voorbeeld Category 1",
+        "tags": [
+          "Voorbeeld Tags 1"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 1",
+        "lockedAt": "2026-03-01T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "content": "Voorbeeld html 1",
+        "namespace": "Voorbeeld Namespace 2",
+        "description": "Voorbeeld Description 2",
+        "format": "A3",
+        "orientation": "L",
+        "category": "Voorbeeld Category 2",
+        "tags": [
+          "Voorbeeld Tags 2"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 2",
+        "lockedAt": "2026-03-02T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "content": "Voorbeeld html 2",
+        "namespace": "Voorbeeld Namespace 3",
+        "description": "Voorbeeld Description 3",
+        "format": "Letter",
+        "orientation": "P",
+        "category": "Voorbeeld Category 3",
+        "tags": [
+          "Voorbeeld Tags 3"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 3",
+        "lockedAt": "2026-03-03T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "version": 1,
+        "content": "Voorbeeld html 0",
+        "editor": "Voorbeeld Editor 1",
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 1"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "version": 2,
+        "content": "Voorbeeld html 1",
+        "editor": "Voorbeeld Editor 2",
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 2"
+      },
+      {
+        "@self": {
+          "register": "signing",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "version": 3,
+        "content": "Voorbeeld html 2",
+        "editor": "Voorbeeld Editor 3",
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 3"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-1-1"
+        },
+        "sourceFileId": 1,
+        "anonymizedFileId": 1,
+        "sourceFileName": "Voorbeeld Sourcefilename 1",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 1",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 1",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 1",
+        "outputFormat": "pdf",
+        "status": "anonymized",
+        "replacementCount": 1,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-01T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 1"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-2-2"
+        },
+        "sourceFileId": 2,
+        "anonymizedFileId": 2,
+        "sourceFileName": "Voorbeeld Sourcefilename 2",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 2",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 2",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 2",
+        "outputFormat": "docx",
+        "status": "anonymized",
+        "replacementCount": 2,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-02T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 2"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-3-3"
+        },
+        "sourceFileId": 3,
+        "anonymizedFileId": 3,
+        "sourceFileName": "Voorbeeld Sourcefilename 3",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 3",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 3",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 3",
+        "outputFormat": "odt",
+        "status": "anonymized",
+        "replacementCount": 3,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-03T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 3"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "recipientCount": 1,
+        "status": "pending",
+        "initiatedBy": "Voorbeeld Initiatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "completedCount": 1,
+        "errorCount": 1,
+        "startedAt": "2026-03-01T09:00:00+00:00",
+        "completedAt": "2026-03-01T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "recipientCount": 2,
+        "status": "processing",
+        "initiatedBy": "Voorbeeld Initiatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "completedCount": 2,
+        "errorCount": 2,
+        "startedAt": "2026-03-02T09:00:00+00:00",
+        "completedAt": "2026-03-02T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "recipientCount": 3,
+        "status": "success",
+        "initiatedBy": "Voorbeeld Initiatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "completedCount": 3,
+        "errorCount": 3,
+        "startedAt": "2026-03-03T09:00:00+00:00",
+        "completedAt": "2026-03-03T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "recipientId": "Voorbeeld Recipientid 1",
+        "generatedAt": "2026-03-01T09:00:00+00:00",
+        "format": "pdf",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "recipientType": "PERSON",
+        "caseReference": "Voorbeeld Casereference 1",
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "recipientId": "Voorbeeld Recipientid 2",
+        "generatedAt": "2026-03-02T09:00:00+00:00",
+        "format": "docx",
+        "status": "failed",
+        "generatedBy": "Voorbeeld Generatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "recipientType": "ORGANIZATION",
+        "caseReference": "Voorbeeld Casereference 2",
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "recipientId": "Voorbeeld Recipientid 3",
+        "generatedAt": "2026-03-03T09:00:00+00:00",
+        "format": "html",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "recipientType": "PERSON",
+        "caseReference": "Voorbeeld Casereference 3",
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1",
+        "bases": [
+          "Voorbeeld Bases 1"
+        ],
+        "checkedOn": "2026-03-01T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2",
+        "bases": [
+          "Voorbeeld Bases 2"
+        ],
+        "checkedOn": "2026-03-02T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3",
+        "bases": [
+          "Voorbeeld Bases 3"
+        ],
+        "checkedOn": "2026-03-03T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "templateVersion": 1,
+        "generatedAt": "2026-03-01T09:00:00+00:00",
+        "format": "pdf",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "dataRefs": [
+          "Voorbeeld Datarefs 1"
+        ],
+        "zaakId": "Voorbeeld Zaakid 1",
+        "warnings": [
+          "Voorbeeld Warnings 1"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "templateVersion": 2,
+        "generatedAt": "2026-03-02T09:00:00+00:00",
+        "format": "odf",
+        "status": "failed",
+        "generatedBy": "Voorbeeld Generatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "dataRefs": [
+          "Voorbeeld Datarefs 2"
+        ],
+        "zaakId": "Voorbeeld Zaakid 2",
+        "warnings": [
+          "Voorbeeld Warnings 2"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "templateVersion": 3,
+        "generatedAt": "2026-03-03T09:00:00+00:00",
+        "format": "html",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "dataRefs": [
+          "Voorbeeld Datarefs 3"
+        ],
+        "zaakId": "Voorbeeld Zaakid 3",
+        "warnings": [
+          "Voorbeeld Warnings 3"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "logo": "Voorbeeld Logo 1",
+        "primaryColor": "Voorbeeld Primarycolor 1",
+        "headerHtml": "Voorbeeld html 0",
+        "footerHtml": "Voorbeeld html 0",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "logo": "Voorbeeld Logo 2",
+        "primaryColor": "Voorbeeld Primarycolor 2",
+        "headerHtml": "Voorbeeld html 1",
+        "footerHtml": "Voorbeeld html 1",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "logo": "Voorbeeld Logo 3",
+        "primaryColor": "Voorbeeld Primarycolor 3",
+        "headerHtml": "Voorbeeld html 2",
+        "footerHtml": "Voorbeeld html 2",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-1-1"
+        },
+        "documentId": "Voorbeeld Documentid 1",
+        "entityType": "PERSON",
+        "entityText": "Voorbeeld Entitytext 1",
+        "scope": "document",
+        "entityKey": "Voorbeeld Entitykey 1",
+        "contactEmail": "voorbeeld0@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 1",
+        "contactRef": "https://example.invalid/resource/0",
+        "notificationStatus": "pending",
+        "notificationSentAt": "2026-03-01T09:00:00+00:00",
+        "consentStatus": "pending",
+        "objectionDeadline": "2026-03-01T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-01T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 0",
+        "publicationDecision": "pending",
+        "legalBasis": "Voorbeeld Legalbasis 1",
+        "notes": "Voorbeeld markdown 0",
+        "matchRules": [
+          {
+            "type": "exact",
+            "value": "Voorbeeld Value 1"
+          }
+        ],
+        "validFrom": "2026-03-01T09:00:00+00:00",
+        "validUntil": "2026-03-01T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "paper",
+        "consentDocument": "https://example.invalid/resource/0",
+        "consentScope": "Voorbeeld Consentscope 1"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-2-2"
+        },
+        "documentId": "Voorbeeld Documentid 2",
+        "entityType": "ORGANIZATION",
+        "entityText": "Voorbeeld Entitytext 2",
+        "scope": "entity",
+        "entityKey": "Voorbeeld Entitykey 2",
+        "contactEmail": "voorbeeld1@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 2",
+        "contactRef": "https://example.invalid/resource/1",
+        "notificationStatus": "sent",
+        "notificationSentAt": "2026-03-02T09:00:00+00:00",
+        "consentStatus": "consent_given",
+        "objectionDeadline": "2026-03-02T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-02T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 1",
+        "publicationDecision": "anonymize",
+        "legalBasis": "Voorbeeld Legalbasis 2",
+        "notes": "Voorbeeld markdown 1",
+        "matchRules": [
+          {
+            "type": "normalized",
+            "value": "Voorbeeld Value 2"
+          }
+        ],
+        "validFrom": "2026-03-02T09:00:00+00:00",
+        "validUntil": "2026-03-02T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "digital_signature",
+        "consentDocument": "https://example.invalid/resource/1",
+        "consentScope": "Voorbeeld Consentscope 2"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-3-3"
+        },
+        "documentId": "Voorbeeld Documentid 3",
+        "entityType": "PERSON",
+        "entityText": "Voorbeeld Entitytext 3",
+        "scope": "document",
+        "entityKey": "Voorbeeld Entitykey 3",
+        "contactEmail": "voorbeeld2@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 3",
+        "contactRef": "https://example.invalid/resource/2",
+        "notificationStatus": "delivered",
+        "notificationSentAt": "2026-03-03T09:00:00+00:00",
+        "consentStatus": "objection_received",
+        "objectionDeadline": "2026-03-03T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-03T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 2",
+        "publicationDecision": "publish_with_consent",
+        "legalBasis": "Voorbeeld Legalbasis 3",
+        "notes": "Voorbeeld markdown 2",
+        "matchRules": [
+          {
+            "type": "bsn",
+            "value": "Voorbeeld Value 3"
+          }
+        ],
+        "validFrom": "2026-03-03T09:00:00+00:00",
+        "validUntil": "2026-03-03T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "verbal_recorded",
+        "consentDocument": "https://example.invalid/resource/2",
+        "consentScope": "Voorbeeld Consentscope 3"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-1-1"
+        },
+        "primaryName": "Voorbeeld Primaryname 1",
+        "entityType": "PERSON",
+        "matchRules": [
+          {
+            "type": "exact",
+            "value": "Voorbeeld Value 1"
+          }
+        ],
+        "reason": "Voorbeeld Reason 1",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 1",
+        "caseReference": "Voorbeeld Casereference 1",
+        "severity": "critical",
+        "jurisdiction": "Voorbeeld Jurisdiction 1",
+        "addedBy": "Voorbeeld Addedby 1",
+        "validFrom": "2026-03-01T09:00:00+00:00",
+        "validUntil": "2026-03-01T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 1"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-2-2"
+        },
+        "primaryName": "Voorbeeld Primaryname 2",
+        "entityType": "ORGANIZATION",
+        "matchRules": [
+          {
+            "type": "normalized",
+            "value": "Voorbeeld Value 2"
+          }
+        ],
+        "reason": "Voorbeeld Reason 2",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 2",
+        "caseReference": "Voorbeeld Casereference 2",
+        "severity": "high",
+        "jurisdiction": "Voorbeeld Jurisdiction 2",
+        "addedBy": "Voorbeeld Addedby 2",
+        "validFrom": "2026-03-02T09:00:00+00:00",
+        "validUntil": "2026-03-02T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 2"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-3-3"
+        },
+        "primaryName": "Voorbeeld Primaryname 3",
+        "entityType": "OTHER",
+        "matchRules": [
+          {
+            "type": "bsn",
+            "value": "Voorbeeld Value 3"
+          }
+        ],
+        "reason": "Voorbeeld Reason 3",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 3",
+        "caseReference": "Voorbeeld Casereference 3",
+        "severity": "normal",
+        "jurisdiction": "Voorbeeld Jurisdiction 3",
+        "addedBy": "Voorbeeld Addedby 3",
+        "validFrom": "2026-03-03T09:00:00+00:00",
+        "validUntil": "2026-03-03T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 3"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-1-1"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 1",
+        "userId": "Voorbeeld Userid 1",
+        "displayName": "Voorbeeld Displayname 1",
+        "status": "PENDING",
+        "email": "voorbeeld0@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-01T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 1",
+        "ipAddress": "Voorbeeld Ipaddress 1",
+        "signatureData": "Voorbeeld Signaturedata 1"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-2-2"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 2",
+        "userId": "Voorbeeld Userid 2",
+        "displayName": "Voorbeeld Displayname 2",
+        "status": "SIGNED",
+        "email": "voorbeeld1@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-02T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 2",
+        "ipAddress": "Voorbeeld Ipaddress 2",
+        "signatureData": "Voorbeeld Signaturedata 2"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-3-3"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 3",
+        "userId": "Voorbeeld Userid 3",
+        "displayName": "Voorbeeld Displayname 3",
+        "status": "DECLINED",
+        "email": "voorbeeld2@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-03T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 3",
+        "ipAddress": "Voorbeeld Ipaddress 3",
+        "signatureData": "Voorbeeld Signaturedata 3"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-1-1"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 1",
+        "action": "CREATED",
+        "actorUserId": "Voorbeeld Actoruserid 1",
+        "actorDisplayName": "Voorbeeld Actordisplayname 1",
+        "timestamp": "2026-03-01T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 1",
+        "signatureLevel": "SES",
+        "provider": "Voorbeeld Provider 1",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-2-2"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 2",
+        "action": "SIGNED",
+        "actorUserId": "Voorbeeld Actoruserid 2",
+        "actorDisplayName": "Voorbeeld Actordisplayname 2",
+        "timestamp": "2026-03-02T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 2",
+        "signatureLevel": "AdES",
+        "provider": "Voorbeeld Provider 2",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-3-3"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 3",
+        "action": "DECLINED",
+        "actorUserId": "Voorbeeld Actoruserid 3",
+        "actorDisplayName": "Voorbeeld Actordisplayname 3",
+        "timestamp": "2026-03-03T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 3",
+        "signatureLevel": "QES",
+        "provider": "Voorbeeld Provider 3",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-1-1"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 1",
+        "documentName": "Voorbeeld Documentname 1",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 1",
+        "signatureLevel": "SES",
+        "signingMode": "sequential",
+        "status": "DRAFT",
+        "provider": "native",
+        "deadline": "2026-03-01T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 1"
+        ]
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-2-2"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 2",
+        "documentName": "Voorbeeld Documentname 2",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 2",
+        "signatureLevel": "AdES",
+        "signingMode": "parallel",
+        "status": "PENDING",
+        "provider": "validsign",
+        "deadline": "2026-03-02T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 2"
+        ]
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-3-3"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 3",
+        "documentName": "Voorbeeld Documentname 3",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 3",
+        "signatureLevel": "QES",
+        "signingMode": "sequential",
+        "status": "IN_PROGRESS",
+        "provider": "docusign",
+        "deadline": "2026-03-03T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 3"
+        ]
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-1-1"
+        },
+        "externalId": "Voorbeeld Externalid 1",
+        "documentPath": "Voorbeeld Documentpath 1",
+        "documentName": "Voorbeeld Documentname 1",
+        "status": "pending",
+        "signers": [
+          "Voorbeeld Signers 1"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 1"
+        ],
+        "createdAt": "2026-03-01T09:00:00+00:00",
+        "completedAt": "2026-03-01T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 1",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-2-2"
+        },
+        "externalId": "Voorbeeld Externalid 2",
+        "documentPath": "Voorbeeld Documentpath 2",
+        "documentName": "Voorbeeld Documentname 2",
+        "status": "in_progress",
+        "signers": [
+          "Voorbeeld Signers 2"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 2"
+        ],
+        "createdAt": "2026-03-02T09:00:00+00:00",
+        "completedAt": "2026-03-02T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 2",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-3-3"
+        },
+        "externalId": "Voorbeeld Externalid 3",
+        "documentPath": "Voorbeeld Documentpath 3",
+        "documentName": "Voorbeeld Documentname 3",
+        "status": "completed",
+        "signers": [
+          "Voorbeeld Signers 3"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 3"
+        ],
+        "createdAt": "2026-03-03T09:00:00+00:00",
+        "completedAt": "2026-03-03T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 3",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "content": "Voorbeeld html 0",
+        "namespace": "Voorbeeld Namespace 1",
+        "description": "Voorbeeld Description 1",
+        "format": "A4",
+        "orientation": "P",
+        "category": "Voorbeeld Category 1",
+        "tags": [
+          "Voorbeeld Tags 1"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 1",
+        "lockedAt": "2026-03-01T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "content": "Voorbeeld html 1",
+        "namespace": "Voorbeeld Namespace 2",
+        "description": "Voorbeeld Description 2",
+        "format": "A3",
+        "orientation": "L",
+        "category": "Voorbeeld Category 2",
+        "tags": [
+          "Voorbeeld Tags 2"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 2",
+        "lockedAt": "2026-03-02T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "content": "Voorbeeld html 2",
+        "namespace": "Voorbeeld Namespace 3",
+        "description": "Voorbeeld Description 3",
+        "format": "Letter",
+        "orientation": "P",
+        "category": "Voorbeeld Category 3",
+        "tags": [
+          "Voorbeeld Tags 3"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 3",
+        "lockedAt": "2026-03-03T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "version": 1,
+        "content": "Voorbeeld html 0",
+        "editor": "Voorbeeld Editor 1",
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 1"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "version": 2,
+        "content": "Voorbeeld html 1",
+        "editor": "Voorbeeld Editor 2",
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 2"
+      },
+      {
+        "@self": {
+          "register": "templates",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "version": 3,
+        "content": "Voorbeeld html 2",
+        "editor": "Voorbeeld Editor 3",
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 3"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-1-1"
+        },
+        "sourceFileId": 1,
+        "anonymizedFileId": 1,
+        "sourceFileName": "Voorbeeld Sourcefilename 1",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 1",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 1",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 1",
+        "outputFormat": "pdf",
+        "status": "anonymized",
+        "replacementCount": 1,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-01T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 1"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-2-2"
+        },
+        "sourceFileId": 2,
+        "anonymizedFileId": 2,
+        "sourceFileName": "Voorbeeld Sourcefilename 2",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 2",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 2",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 2",
+        "outputFormat": "docx",
+        "status": "anonymized",
+        "replacementCount": 2,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-02T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 2"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-3-3"
+        },
+        "sourceFileId": 3,
+        "anonymizedFileId": 3,
+        "sourceFileName": "Voorbeeld Sourcefilename 3",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 3",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 3",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 3",
+        "outputFormat": "odt",
+        "status": "anonymized",
+        "replacementCount": 3,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-03T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 3"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "recipientCount": 1,
+        "status": "pending",
+        "initiatedBy": "Voorbeeld Initiatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "completedCount": 1,
+        "errorCount": 1,
+        "startedAt": "2026-03-01T09:00:00+00:00",
+        "completedAt": "2026-03-01T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "recipientCount": 2,
+        "status": "processing",
+        "initiatedBy": "Voorbeeld Initiatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "completedCount": 2,
+        "errorCount": 2,
+        "startedAt": "2026-03-02T09:00:00+00:00",
+        "completedAt": "2026-03-02T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "recipientCount": 3,
+        "status": "success",
+        "initiatedBy": "Voorbeeld Initiatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "completedCount": 3,
+        "errorCount": 3,
+        "startedAt": "2026-03-03T09:00:00+00:00",
+        "completedAt": "2026-03-03T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "recipientId": "Voorbeeld Recipientid 1",
+        "generatedAt": "2026-03-01T09:00:00+00:00",
+        "format": "pdf",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "recipientType": "PERSON",
+        "caseReference": "Voorbeeld Casereference 1",
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "recipientId": "Voorbeeld Recipientid 2",
+        "generatedAt": "2026-03-02T09:00:00+00:00",
+        "format": "docx",
+        "status": "failed",
+        "generatedBy": "Voorbeeld Generatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "recipientType": "ORGANIZATION",
+        "caseReference": "Voorbeeld Casereference 2",
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "recipientId": "Voorbeeld Recipientid 3",
+        "generatedAt": "2026-03-03T09:00:00+00:00",
+        "format": "html",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "recipientType": "PERSON",
+        "caseReference": "Voorbeeld Casereference 3",
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1",
+        "bases": [
+          "Voorbeeld Bases 1"
+        ],
+        "checkedOn": "2026-03-01T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2",
+        "bases": [
+          "Voorbeeld Bases 2"
+        ],
+        "checkedOn": "2026-03-02T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3",
+        "bases": [
+          "Voorbeeld Bases 3"
+        ],
+        "checkedOn": "2026-03-03T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "templateVersion": 1,
+        "generatedAt": "2026-03-01T09:00:00+00:00",
+        "format": "pdf",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "dataRefs": [
+          "Voorbeeld Datarefs 1"
+        ],
+        "zaakId": "Voorbeeld Zaakid 1",
+        "warnings": [
+          "Voorbeeld Warnings 1"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "templateVersion": 2,
+        "generatedAt": "2026-03-02T09:00:00+00:00",
+        "format": "odf",
+        "status": "failed",
+        "generatedBy": "Voorbeeld Generatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "dataRefs": [
+          "Voorbeeld Datarefs 2"
+        ],
+        "zaakId": "Voorbeeld Zaakid 2",
+        "warnings": [
+          "Voorbeeld Warnings 2"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "templateVersion": 3,
+        "generatedAt": "2026-03-03T09:00:00+00:00",
+        "format": "html",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "dataRefs": [
+          "Voorbeeld Datarefs 3"
+        ],
+        "zaakId": "Voorbeeld Zaakid 3",
+        "warnings": [
+          "Voorbeeld Warnings 3"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "logo": "Voorbeeld Logo 1",
+        "primaryColor": "Voorbeeld Primarycolor 1",
+        "headerHtml": "Voorbeeld html 0",
+        "footerHtml": "Voorbeeld html 0",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "logo": "Voorbeeld Logo 2",
+        "primaryColor": "Voorbeeld Primarycolor 2",
+        "headerHtml": "Voorbeeld html 1",
+        "footerHtml": "Voorbeeld html 1",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "logo": "Voorbeeld Logo 3",
+        "primaryColor": "Voorbeeld Primarycolor 3",
+        "headerHtml": "Voorbeeld html 2",
+        "footerHtml": "Voorbeeld html 2",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-1-1"
+        },
+        "documentId": "Voorbeeld Documentid 1",
+        "entityType": "PERSON",
+        "entityText": "Voorbeeld Entitytext 1",
+        "scope": "document",
+        "entityKey": "Voorbeeld Entitykey 1",
+        "contactEmail": "voorbeeld0@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 1",
+        "contactRef": "https://example.invalid/resource/0",
+        "notificationStatus": "pending",
+        "notificationSentAt": "2026-03-01T09:00:00+00:00",
+        "consentStatus": "pending",
+        "objectionDeadline": "2026-03-01T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-01T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 0",
+        "publicationDecision": "pending",
+        "legalBasis": "Voorbeeld Legalbasis 1",
+        "notes": "Voorbeeld markdown 0",
+        "matchRules": [
+          {
+            "type": "exact",
+            "value": "Voorbeeld Value 1"
+          }
+        ],
+        "validFrom": "2026-03-01T09:00:00+00:00",
+        "validUntil": "2026-03-01T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "paper",
+        "consentDocument": "https://example.invalid/resource/0",
+        "consentScope": "Voorbeeld Consentscope 1"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-2-2"
+        },
+        "documentId": "Voorbeeld Documentid 2",
+        "entityType": "ORGANIZATION",
+        "entityText": "Voorbeeld Entitytext 2",
+        "scope": "entity",
+        "entityKey": "Voorbeeld Entitykey 2",
+        "contactEmail": "voorbeeld1@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 2",
+        "contactRef": "https://example.invalid/resource/1",
+        "notificationStatus": "sent",
+        "notificationSentAt": "2026-03-02T09:00:00+00:00",
+        "consentStatus": "consent_given",
+        "objectionDeadline": "2026-03-02T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-02T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 1",
+        "publicationDecision": "anonymize",
+        "legalBasis": "Voorbeeld Legalbasis 2",
+        "notes": "Voorbeeld markdown 1",
+        "matchRules": [
+          {
+            "type": "normalized",
+            "value": "Voorbeeld Value 2"
+          }
+        ],
+        "validFrom": "2026-03-02T09:00:00+00:00",
+        "validUntil": "2026-03-02T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "digital_signature",
+        "consentDocument": "https://example.invalid/resource/1",
+        "consentScope": "Voorbeeld Consentscope 2"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-3-3"
+        },
+        "documentId": "Voorbeeld Documentid 3",
+        "entityType": "PERSON",
+        "entityText": "Voorbeeld Entitytext 3",
+        "scope": "document",
+        "entityKey": "Voorbeeld Entitykey 3",
+        "contactEmail": "voorbeeld2@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 3",
+        "contactRef": "https://example.invalid/resource/2",
+        "notificationStatus": "delivered",
+        "notificationSentAt": "2026-03-03T09:00:00+00:00",
+        "consentStatus": "objection_received",
+        "objectionDeadline": "2026-03-03T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-03T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 2",
+        "publicationDecision": "publish_with_consent",
+        "legalBasis": "Voorbeeld Legalbasis 3",
+        "notes": "Voorbeeld markdown 2",
+        "matchRules": [
+          {
+            "type": "bsn",
+            "value": "Voorbeeld Value 3"
+          }
+        ],
+        "validFrom": "2026-03-03T09:00:00+00:00",
+        "validUntil": "2026-03-03T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "verbal_recorded",
+        "consentDocument": "https://example.invalid/resource/2",
+        "consentScope": "Voorbeeld Consentscope 3"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-1-1"
+        },
+        "primaryName": "Voorbeeld Primaryname 1",
+        "entityType": "PERSON",
+        "matchRules": [
+          {
+            "type": "exact",
+            "value": "Voorbeeld Value 1"
+          }
+        ],
+        "reason": "Voorbeeld Reason 1",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 1",
+        "caseReference": "Voorbeeld Casereference 1",
+        "severity": "critical",
+        "jurisdiction": "Voorbeeld Jurisdiction 1",
+        "addedBy": "Voorbeeld Addedby 1",
+        "validFrom": "2026-03-01T09:00:00+00:00",
+        "validUntil": "2026-03-01T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 1"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-2-2"
+        },
+        "primaryName": "Voorbeeld Primaryname 2",
+        "entityType": "ORGANIZATION",
+        "matchRules": [
+          {
+            "type": "normalized",
+            "value": "Voorbeeld Value 2"
+          }
+        ],
+        "reason": "Voorbeeld Reason 2",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 2",
+        "caseReference": "Voorbeeld Casereference 2",
+        "severity": "high",
+        "jurisdiction": "Voorbeeld Jurisdiction 2",
+        "addedBy": "Voorbeeld Addedby 2",
+        "validFrom": "2026-03-02T09:00:00+00:00",
+        "validUntil": "2026-03-02T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 2"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-3-3"
+        },
+        "primaryName": "Voorbeeld Primaryname 3",
+        "entityType": "OTHER",
+        "matchRules": [
+          {
+            "type": "bsn",
+            "value": "Voorbeeld Value 3"
+          }
+        ],
+        "reason": "Voorbeeld Reason 3",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 3",
+        "caseReference": "Voorbeeld Casereference 3",
+        "severity": "normal",
+        "jurisdiction": "Voorbeeld Jurisdiction 3",
+        "addedBy": "Voorbeeld Addedby 3",
+        "validFrom": "2026-03-03T09:00:00+00:00",
+        "validUntil": "2026-03-03T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 3"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-1-1"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 1",
+        "userId": "Voorbeeld Userid 1",
+        "displayName": "Voorbeeld Displayname 1",
+        "status": "PENDING",
+        "email": "voorbeeld0@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-01T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 1",
+        "ipAddress": "Voorbeeld Ipaddress 1",
+        "signatureData": "Voorbeeld Signaturedata 1"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-2-2"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 2",
+        "userId": "Voorbeeld Userid 2",
+        "displayName": "Voorbeeld Displayname 2",
+        "status": "SIGNED",
+        "email": "voorbeeld1@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-02T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 2",
+        "ipAddress": "Voorbeeld Ipaddress 2",
+        "signatureData": "Voorbeeld Signaturedata 2"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-3-3"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 3",
+        "userId": "Voorbeeld Userid 3",
+        "displayName": "Voorbeeld Displayname 3",
+        "status": "DECLINED",
+        "email": "voorbeeld2@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-03T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 3",
+        "ipAddress": "Voorbeeld Ipaddress 3",
+        "signatureData": "Voorbeeld Signaturedata 3"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-1-1"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 1",
+        "action": "CREATED",
+        "actorUserId": "Voorbeeld Actoruserid 1",
+        "actorDisplayName": "Voorbeeld Actordisplayname 1",
+        "timestamp": "2026-03-01T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 1",
+        "signatureLevel": "SES",
+        "provider": "Voorbeeld Provider 1",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-2-2"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 2",
+        "action": "SIGNED",
+        "actorUserId": "Voorbeeld Actoruserid 2",
+        "actorDisplayName": "Voorbeeld Actordisplayname 2",
+        "timestamp": "2026-03-02T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 2",
+        "signatureLevel": "AdES",
+        "provider": "Voorbeeld Provider 2",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-3-3"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 3",
+        "action": "DECLINED",
+        "actorUserId": "Voorbeeld Actoruserid 3",
+        "actorDisplayName": "Voorbeeld Actordisplayname 3",
+        "timestamp": "2026-03-03T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 3",
+        "signatureLevel": "QES",
+        "provider": "Voorbeeld Provider 3",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-1-1"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 1",
+        "documentName": "Voorbeeld Documentname 1",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 1",
+        "signatureLevel": "SES",
+        "signingMode": "sequential",
+        "status": "DRAFT",
+        "provider": "native",
+        "deadline": "2026-03-01T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 1"
+        ]
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-2-2"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 2",
+        "documentName": "Voorbeeld Documentname 2",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 2",
+        "signatureLevel": "AdES",
+        "signingMode": "parallel",
+        "status": "PENDING",
+        "provider": "validsign",
+        "deadline": "2026-03-02T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 2"
+        ]
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-3-3"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 3",
+        "documentName": "Voorbeeld Documentname 3",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 3",
+        "signatureLevel": "QES",
+        "signingMode": "sequential",
+        "status": "IN_PROGRESS",
+        "provider": "docusign",
+        "deadline": "2026-03-03T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 3"
+        ]
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-1-1"
+        },
+        "externalId": "Voorbeeld Externalid 1",
+        "documentPath": "Voorbeeld Documentpath 1",
+        "documentName": "Voorbeeld Documentname 1",
+        "status": "pending",
+        "signers": [
+          "Voorbeeld Signers 1"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 1"
+        ],
+        "createdAt": "2026-03-01T09:00:00+00:00",
+        "completedAt": "2026-03-01T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 1",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-2-2"
+        },
+        "externalId": "Voorbeeld Externalid 2",
+        "documentPath": "Voorbeeld Documentpath 2",
+        "documentName": "Voorbeeld Documentname 2",
+        "status": "in_progress",
+        "signers": [
+          "Voorbeeld Signers 2"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 2"
+        ],
+        "createdAt": "2026-03-02T09:00:00+00:00",
+        "completedAt": "2026-03-02T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 2",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-3-3"
+        },
+        "externalId": "Voorbeeld Externalid 3",
+        "documentPath": "Voorbeeld Documentpath 3",
+        "documentName": "Voorbeeld Documentname 3",
+        "status": "completed",
+        "signers": [
+          "Voorbeeld Signers 3"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 3"
+        ],
+        "createdAt": "2026-03-03T09:00:00+00:00",
+        "completedAt": "2026-03-03T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 3",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "content": "Voorbeeld html 0",
+        "namespace": "Voorbeeld Namespace 1",
+        "description": "Voorbeeld Description 1",
+        "format": "A4",
+        "orientation": "P",
+        "category": "Voorbeeld Category 1",
+        "tags": [
+          "Voorbeeld Tags 1"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 1",
+        "lockedAt": "2026-03-01T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "content": "Voorbeeld html 1",
+        "namespace": "Voorbeeld Namespace 2",
+        "description": "Voorbeeld Description 2",
+        "format": "A3",
+        "orientation": "L",
+        "category": "Voorbeeld Category 2",
+        "tags": [
+          "Voorbeeld Tags 2"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 2",
+        "lockedAt": "2026-03-02T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "content": "Voorbeeld html 2",
+        "namespace": "Voorbeeld Namespace 3",
+        "description": "Voorbeeld Description 3",
+        "format": "Letter",
+        "orientation": "P",
+        "category": "Voorbeeld Category 3",
+        "tags": [
+          "Voorbeeld Tags 3"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 3",
+        "lockedAt": "2026-03-03T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "version": 1,
+        "content": "Voorbeeld html 0",
+        "editor": "Voorbeeld Editor 1",
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 1"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "version": 2,
+        "content": "Voorbeeld html 1",
+        "editor": "Voorbeeld Editor 2",
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 2"
+      },
+      {
+        "@self": {
+          "register": "document",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "version": 3,
+        "content": "Voorbeeld html 2",
+        "editor": "Voorbeeld Editor 3",
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 3"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-1-1"
+        },
+        "sourceFileId": 1,
+        "anonymizedFileId": 1,
+        "sourceFileName": "Voorbeeld Sourcefilename 1",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 1",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 1",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 1",
+        "outputFormat": "pdf",
+        "status": "anonymized",
+        "replacementCount": 1,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-01T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 1"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-2-2"
+        },
+        "sourceFileId": 2,
+        "anonymizedFileId": 2,
+        "sourceFileName": "Voorbeeld Sourcefilename 2",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 2",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 2",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 2",
+        "outputFormat": "docx",
+        "status": "anonymized",
+        "replacementCount": 2,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-02T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 2"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-3-3"
+        },
+        "sourceFileId": 3,
+        "anonymizedFileId": 3,
+        "sourceFileName": "Voorbeeld Sourcefilename 3",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 3",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 3",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 3",
+        "outputFormat": "odt",
+        "status": "anonymized",
+        "replacementCount": 3,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-03T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 3"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "recipientCount": 1,
+        "status": "pending",
+        "initiatedBy": "Voorbeeld Initiatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "completedCount": 1,
+        "errorCount": 1,
+        "startedAt": "2026-03-01T09:00:00+00:00",
+        "completedAt": "2026-03-01T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "recipientCount": 2,
+        "status": "processing",
+        "initiatedBy": "Voorbeeld Initiatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "completedCount": 2,
+        "errorCount": 2,
+        "startedAt": "2026-03-02T09:00:00+00:00",
+        "completedAt": "2026-03-02T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "recipientCount": 3,
+        "status": "success",
+        "initiatedBy": "Voorbeeld Initiatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "completedCount": 3,
+        "errorCount": 3,
+        "startedAt": "2026-03-03T09:00:00+00:00",
+        "completedAt": "2026-03-03T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "recipientId": "Voorbeeld Recipientid 1",
+        "generatedAt": "2026-03-01T09:00:00+00:00",
+        "format": "pdf",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "recipientType": "PERSON",
+        "caseReference": "Voorbeeld Casereference 1",
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "recipientId": "Voorbeeld Recipientid 2",
+        "generatedAt": "2026-03-02T09:00:00+00:00",
+        "format": "docx",
+        "status": "failed",
+        "generatedBy": "Voorbeeld Generatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "recipientType": "ORGANIZATION",
+        "caseReference": "Voorbeeld Casereference 2",
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "recipientId": "Voorbeeld Recipientid 3",
+        "generatedAt": "2026-03-03T09:00:00+00:00",
+        "format": "html",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "recipientType": "PERSON",
+        "caseReference": "Voorbeeld Casereference 3",
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1",
+        "bases": [
+          "Voorbeeld Bases 1"
+        ],
+        "checkedOn": "2026-03-01T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2",
+        "bases": [
+          "Voorbeeld Bases 2"
+        ],
+        "checkedOn": "2026-03-02T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3",
+        "bases": [
+          "Voorbeeld Bases 3"
+        ],
+        "checkedOn": "2026-03-03T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "templateVersion": 1,
+        "generatedAt": "2026-03-01T09:00:00+00:00",
+        "format": "pdf",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "dataRefs": [
+          "Voorbeeld Datarefs 1"
+        ],
+        "zaakId": "Voorbeeld Zaakid 1",
+        "warnings": [
+          "Voorbeeld Warnings 1"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "templateVersion": 2,
+        "generatedAt": "2026-03-02T09:00:00+00:00",
+        "format": "odf",
+        "status": "failed",
+        "generatedBy": "Voorbeeld Generatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "dataRefs": [
+          "Voorbeeld Datarefs 2"
+        ],
+        "zaakId": "Voorbeeld Zaakid 2",
+        "warnings": [
+          "Voorbeeld Warnings 2"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "templateVersion": 3,
+        "generatedAt": "2026-03-03T09:00:00+00:00",
+        "format": "html",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "dataRefs": [
+          "Voorbeeld Datarefs 3"
+        ],
+        "zaakId": "Voorbeeld Zaakid 3",
+        "warnings": [
+          "Voorbeeld Warnings 3"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "logo": "Voorbeeld Logo 1",
+        "primaryColor": "Voorbeeld Primarycolor 1",
+        "headerHtml": "Voorbeeld html 0",
+        "footerHtml": "Voorbeeld html 0",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "logo": "Voorbeeld Logo 2",
+        "primaryColor": "Voorbeeld Primarycolor 2",
+        "headerHtml": "Voorbeeld html 1",
+        "footerHtml": "Voorbeeld html 1",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "logo": "Voorbeeld Logo 3",
+        "primaryColor": "Voorbeeld Primarycolor 3",
+        "headerHtml": "Voorbeeld html 2",
+        "footerHtml": "Voorbeeld html 2",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-1-1"
+        },
+        "documentId": "Voorbeeld Documentid 1",
+        "entityType": "PERSON",
+        "entityText": "Voorbeeld Entitytext 1",
+        "scope": "document",
+        "entityKey": "Voorbeeld Entitykey 1",
+        "contactEmail": "voorbeeld0@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 1",
+        "contactRef": "https://example.invalid/resource/0",
+        "notificationStatus": "pending",
+        "notificationSentAt": "2026-03-01T09:00:00+00:00",
+        "consentStatus": "pending",
+        "objectionDeadline": "2026-03-01T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-01T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 0",
+        "publicationDecision": "pending",
+        "legalBasis": "Voorbeeld Legalbasis 1",
+        "notes": "Voorbeeld markdown 0",
+        "matchRules": [
+          {
+            "type": "exact",
+            "value": "Voorbeeld Value 1"
+          }
+        ],
+        "validFrom": "2026-03-01T09:00:00+00:00",
+        "validUntil": "2026-03-01T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "paper",
+        "consentDocument": "https://example.invalid/resource/0",
+        "consentScope": "Voorbeeld Consentscope 1"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-2-2"
+        },
+        "documentId": "Voorbeeld Documentid 2",
+        "entityType": "ORGANIZATION",
+        "entityText": "Voorbeeld Entitytext 2",
+        "scope": "entity",
+        "entityKey": "Voorbeeld Entitykey 2",
+        "contactEmail": "voorbeeld1@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 2",
+        "contactRef": "https://example.invalid/resource/1",
+        "notificationStatus": "sent",
+        "notificationSentAt": "2026-03-02T09:00:00+00:00",
+        "consentStatus": "consent_given",
+        "objectionDeadline": "2026-03-02T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-02T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 1",
+        "publicationDecision": "anonymize",
+        "legalBasis": "Voorbeeld Legalbasis 2",
+        "notes": "Voorbeeld markdown 1",
+        "matchRules": [
+          {
+            "type": "normalized",
+            "value": "Voorbeeld Value 2"
+          }
+        ],
+        "validFrom": "2026-03-02T09:00:00+00:00",
+        "validUntil": "2026-03-02T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "digital_signature",
+        "consentDocument": "https://example.invalid/resource/1",
+        "consentScope": "Voorbeeld Consentscope 2"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-3-3"
+        },
+        "documentId": "Voorbeeld Documentid 3",
+        "entityType": "PERSON",
+        "entityText": "Voorbeeld Entitytext 3",
+        "scope": "document",
+        "entityKey": "Voorbeeld Entitykey 3",
+        "contactEmail": "voorbeeld2@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 3",
+        "contactRef": "https://example.invalid/resource/2",
+        "notificationStatus": "delivered",
+        "notificationSentAt": "2026-03-03T09:00:00+00:00",
+        "consentStatus": "objection_received",
+        "objectionDeadline": "2026-03-03T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-03T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 2",
+        "publicationDecision": "publish_with_consent",
+        "legalBasis": "Voorbeeld Legalbasis 3",
+        "notes": "Voorbeeld markdown 2",
+        "matchRules": [
+          {
+            "type": "bsn",
+            "value": "Voorbeeld Value 3"
+          }
+        ],
+        "validFrom": "2026-03-03T09:00:00+00:00",
+        "validUntil": "2026-03-03T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "verbal_recorded",
+        "consentDocument": "https://example.invalid/resource/2",
+        "consentScope": "Voorbeeld Consentscope 3"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-1-1"
+        },
+        "primaryName": "Voorbeeld Primaryname 1",
+        "entityType": "PERSON",
+        "matchRules": [
+          {
+            "type": "exact",
+            "value": "Voorbeeld Value 1"
+          }
+        ],
+        "reason": "Voorbeeld Reason 1",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 1",
+        "caseReference": "Voorbeeld Casereference 1",
+        "severity": "critical",
+        "jurisdiction": "Voorbeeld Jurisdiction 1",
+        "addedBy": "Voorbeeld Addedby 1",
+        "validFrom": "2026-03-01T09:00:00+00:00",
+        "validUntil": "2026-03-01T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 1"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-2-2"
+        },
+        "primaryName": "Voorbeeld Primaryname 2",
+        "entityType": "ORGANIZATION",
+        "matchRules": [
+          {
+            "type": "normalized",
+            "value": "Voorbeeld Value 2"
+          }
+        ],
+        "reason": "Voorbeeld Reason 2",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 2",
+        "caseReference": "Voorbeeld Casereference 2",
+        "severity": "high",
+        "jurisdiction": "Voorbeeld Jurisdiction 2",
+        "addedBy": "Voorbeeld Addedby 2",
+        "validFrom": "2026-03-02T09:00:00+00:00",
+        "validUntil": "2026-03-02T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 2"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-3-3"
+        },
+        "primaryName": "Voorbeeld Primaryname 3",
+        "entityType": "OTHER",
+        "matchRules": [
+          {
+            "type": "bsn",
+            "value": "Voorbeeld Value 3"
+          }
+        ],
+        "reason": "Voorbeeld Reason 3",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 3",
+        "caseReference": "Voorbeeld Casereference 3",
+        "severity": "normal",
+        "jurisdiction": "Voorbeeld Jurisdiction 3",
+        "addedBy": "Voorbeeld Addedby 3",
+        "validFrom": "2026-03-03T09:00:00+00:00",
+        "validUntil": "2026-03-03T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 3"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-1-1"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 1",
+        "userId": "Voorbeeld Userid 1",
+        "displayName": "Voorbeeld Displayname 1",
+        "status": "PENDING",
+        "email": "voorbeeld0@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-01T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 1",
+        "ipAddress": "Voorbeeld Ipaddress 1",
+        "signatureData": "Voorbeeld Signaturedata 1"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-2-2"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 2",
+        "userId": "Voorbeeld Userid 2",
+        "displayName": "Voorbeeld Displayname 2",
+        "status": "SIGNED",
+        "email": "voorbeeld1@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-02T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 2",
+        "ipAddress": "Voorbeeld Ipaddress 2",
+        "signatureData": "Voorbeeld Signaturedata 2"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-3-3"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 3",
+        "userId": "Voorbeeld Userid 3",
+        "displayName": "Voorbeeld Displayname 3",
+        "status": "DECLINED",
+        "email": "voorbeeld2@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-03T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 3",
+        "ipAddress": "Voorbeeld Ipaddress 3",
+        "signatureData": "Voorbeeld Signaturedata 3"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-1-1"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 1",
+        "action": "CREATED",
+        "actorUserId": "Voorbeeld Actoruserid 1",
+        "actorDisplayName": "Voorbeeld Actordisplayname 1",
+        "timestamp": "2026-03-01T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 1",
+        "signatureLevel": "SES",
+        "provider": "Voorbeeld Provider 1",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-2-2"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 2",
+        "action": "SIGNED",
+        "actorUserId": "Voorbeeld Actoruserid 2",
+        "actorDisplayName": "Voorbeeld Actordisplayname 2",
+        "timestamp": "2026-03-02T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 2",
+        "signatureLevel": "AdES",
+        "provider": "Voorbeeld Provider 2",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-3-3"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 3",
+        "action": "DECLINED",
+        "actorUserId": "Voorbeeld Actoruserid 3",
+        "actorDisplayName": "Voorbeeld Actordisplayname 3",
+        "timestamp": "2026-03-03T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 3",
+        "signatureLevel": "QES",
+        "provider": "Voorbeeld Provider 3",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-1-1"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 1",
+        "documentName": "Voorbeeld Documentname 1",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 1",
+        "signatureLevel": "SES",
+        "signingMode": "sequential",
+        "status": "DRAFT",
+        "provider": "native",
+        "deadline": "2026-03-01T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 1"
+        ]
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-2-2"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 2",
+        "documentName": "Voorbeeld Documentname 2",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 2",
+        "signatureLevel": "AdES",
+        "signingMode": "parallel",
+        "status": "PENDING",
+        "provider": "validsign",
+        "deadline": "2026-03-02T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 2"
+        ]
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-3-3"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 3",
+        "documentName": "Voorbeeld Documentname 3",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 3",
+        "signatureLevel": "QES",
+        "signingMode": "sequential",
+        "status": "IN_PROGRESS",
+        "provider": "docusign",
+        "deadline": "2026-03-03T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 3"
+        ]
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-1-1"
+        },
+        "externalId": "Voorbeeld Externalid 1",
+        "documentPath": "Voorbeeld Documentpath 1",
+        "documentName": "Voorbeeld Documentname 1",
+        "status": "pending",
+        "signers": [
+          "Voorbeeld Signers 1"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 1"
+        ],
+        "createdAt": "2026-03-01T09:00:00+00:00",
+        "completedAt": "2026-03-01T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 1",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-2-2"
+        },
+        "externalId": "Voorbeeld Externalid 2",
+        "documentPath": "Voorbeeld Documentpath 2",
+        "documentName": "Voorbeeld Documentname 2",
+        "status": "in_progress",
+        "signers": [
+          "Voorbeeld Signers 2"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 2"
+        ],
+        "createdAt": "2026-03-02T09:00:00+00:00",
+        "completedAt": "2026-03-02T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 2",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-3-3"
+        },
+        "externalId": "Voorbeeld Externalid 3",
+        "documentPath": "Voorbeeld Documentpath 3",
+        "documentName": "Voorbeeld Documentname 3",
+        "status": "completed",
+        "signers": [
+          "Voorbeeld Signers 3"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 3"
+        ],
+        "createdAt": "2026-03-03T09:00:00+00:00",
+        "completedAt": "2026-03-03T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 3",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "content": "Voorbeeld html 0",
+        "namespace": "Voorbeeld Namespace 1",
+        "description": "Voorbeeld Description 1",
+        "format": "A4",
+        "orientation": "P",
+        "category": "Voorbeeld Category 1",
+        "tags": [
+          "Voorbeeld Tags 1"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 1",
+        "lockedAt": "2026-03-01T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "content": "Voorbeeld html 1",
+        "namespace": "Voorbeeld Namespace 2",
+        "description": "Voorbeeld Description 2",
+        "format": "A3",
+        "orientation": "L",
+        "category": "Voorbeeld Category 2",
+        "tags": [
+          "Voorbeeld Tags 2"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 2",
+        "lockedAt": "2026-03-02T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "content": "Voorbeeld html 2",
+        "namespace": "Voorbeeld Namespace 3",
+        "description": "Voorbeeld Description 3",
+        "format": "Letter",
+        "orientation": "P",
+        "category": "Voorbeeld Category 3",
+        "tags": [
+          "Voorbeeld Tags 3"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 3",
+        "lockedAt": "2026-03-03T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "version": 1,
+        "content": "Voorbeeld html 0",
+        "editor": "Voorbeeld Editor 1",
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 1"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "version": 2,
+        "content": "Voorbeeld html 1",
+        "editor": "Voorbeeld Editor 2",
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 2"
+      },
+      {
+        "@self": {
+          "register": "dossier",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "version": 3,
+        "content": "Voorbeeld html 2",
+        "editor": "Voorbeeld Editor 3",
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 3"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Implements **ADR-111 rules 1–2** (ConductionNL/hydra, merged). Enforcement is [ConductionNL/.github#590](https://github.com/ConductionNL/.github/pull/590).

## Why

This app declares schemas and shipped no demo data, so it opened on an empty list. The person evaluating it had to author objects by hand — against a schema they don't know yet. Fleet-wide, **562 of 598 schemas** were in that state.

## 🔴 Generated, not written

Every value is derived from the schema that will validate it: `enum` picks from the enum, `pattern` is satisfied, `format` drives the shape, `minimum`/`maxLength` are honoured, `required` is always populated.

Hand-written demo data is wrong in a way nobody sees until the demo — a status outside its own enum, a required field omitted — and it fails **at import**, in front of whoever asked for the demo.

Produced and validated by the single file gate-99 also runs: `vendor/conduction/hydra-gates/scripts/lib/generate_mock_register.py`. Regenerate with `--keep` to preserve any curated objects and top up only what is short.

## 🔴 It does not install itself

`x-openregister.type: mock` is imported **on demand** (ADR-111 rule 3). Sample data appearing on a production instance because somebody upgraded is a data-integrity incident, not a convenience.

```bash
occ openregister:descriptors:list --app=<app> --import=<register>
```

The setup-wizard step that offers this during first-run (ADR-111 rule 4) follows once OpenRegister's shared installer lands — deliberately not twenty-one copies of the same logic.

## Verification

`--check` re-validates every object against its own schema with `jsonschema`, and reports **zero findings**.

Rolling this out across five apps found five defects in the generator, every one caught by that check — including a cross-product that paired every register with every schema in a file, and a validator bug that flagged `nullable: true` (OpenAPI) as invalid, which would have had someone "fix" data that was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
