### PR TITLE
chore(release): raise the version line above 0.1.0-beta.3 on the App Store

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@ Create a [feature request](https://github.com/ConductionNL/filinq/issues/new)
 
 **Support:** For support, contact support@conduction.nl. For a Service Level Agreement (SLA), contact sales@conduction.nl.
     ]]></description>
-    <version>0.0.38-unstable.20260827025617</version>
+    <version>0.1.0</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Filinq</namespace>


### PR DESCRIPTION
The App Store serves **`0.1.0-beta.3`** for this app (store id `docudesk`), and the release workflow computes a beta **below** it.

The baseline comes from this repo's latest stable tag and `appinfo/info.xml`. Neither knows what was published while the fleet released from Codeberg — that line had walked up a minor, and it exists only as *prerelease* tags, which the `^v[0-9]+\.[0-9]+\.[0-9]+$` stable-tag filter cannot see.

The store has **no version ordering rule** — `_check_permission` validates existence and ownership only — so a lower version uploads with a 200 and is then never offered to anyone already on the higher one. It is not a rejection, it is a silent no-op.

**This change:** `<version>` → `0.1.0`, so the next beta is `0.1.1-beta.<ts>`, which clears the store. Minor bump only; the major is unchanged.

Nothing else is touched — `openapi.json` (where present) is re-synced to the new version by the release job itself.

Related: ConductionNL/.github#593 makes this self-correcting by reading the store directly, so the baseline cannot drift below it again.