### PR TITLE
feat(demo): generated demo data for every schema (ADR-111)

### DIFF
--- a/lib/Settings/docudesk_mock_register.json
+++ b/lib/Settings/docudesk_mock_register.json
@@ -1,0 +1,5233 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "docudesk demo data",
+    "version": "1.0.0",
+    "description": "Demo data covering every schema this app supplies, offered as the first step of the app's setup walkthrough. Generated from the schemas themselves, so every object satisfies the schema that will validate it."
+  },
+  "x-openregister": {
+    "type": "mock",
+    "app": "docudesk",
+    "description": "Demo data for docudesk. NOT installed automatically — a mock register is imported on demand, from the setup walkthrough or `occ openregister:descriptors:list --app=docudesk --import=<slug>`."
+  },
+  "paths": {},
+  "components": {
+    "registers": {
+      "filinq": {
+        "slug": "filinq",
+        "title": "Filinq Register (demo)",
+        "version": "1.0.0",
+        "description": "Demo data for Filinq Register. Generated from the register's own schemas — see hydra-gates/scripts/lib/generate_mock_register.py."
+      }
+    },
+    "schemas": {
+      "anonymizationBatch": {
+        "uri": null,
+        "slug": "anonymizationBatch",
+        "title": "Anonymisation Batch",
+        "description": "State of one multi-file anonymisation run: which documents it covers, how far each of them got, and which phase the batch as a whole is in. The batch flow spans several HTTP requests (create -> extract -> review -> anonymise -> report), so this record is what carries it between them. It was previously held only in Nextcloud's distributed cache, which degrades to a NullCache on any instance without `memcache.local` configured — the record was discarded on write and every follow-up call on the batch answered 404. Written and read exclusively by BatchStateRepository, keyed by the batch UUID (the object UUID is the batchId). Ownership is enforced in BatchStateService::getBatch(), which refuses a batch belonging to another non-admin user.",
+        "version": "1.0.0",
+        "summary": "",
+        "icon": "FileDocumentMultipleOutline",
+        "required": [
+          "batchId",
+          "userId"
+        ],
+        "properties": {
+          "batchId": {
+            "description": "Batch identifier. Mirrors the object UUID so the record is self-describing when inspected in OpenRegister.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Batch ID",
+            "maxLength": 64
+          },
+          "userId": {
+            "description": "Nextcloud user ID that owns the batch. BatchStateService refuses a read by any other non-admin user. maxLength is 255, not 64: measured on the dev instance, OpenRegister enforces `required`, `enum` and property constraints EVEN WHEN `hardValidation` is false, so a long externally-provisioned uid over the limit would fail the batch write closed — the exact failure mode this schema exists to remove.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Owner",
+            "maxLength": 255
+          },
+          "status": {
+            "description": "Phase the batch as a whole is in.",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 3,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "uploading",
+              "extracting",
+              "review",
+              "anonymizing",
+              "completed",
+              "error"
+            ],
+            "default": "uploading"
+          },
+          "sourceType": {
+            "description": "How the batch was created: from an uploaded set of files, or by adopting an existing Nextcloud folder.",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 4,
+            "facetable": true,
+            "title": "Source type",
+            "enum": [
+              "upload",
+              "folder"
+            ]
+          },
+          "folderId": {
+            "description": "Node ID of the adopted folder, for a folder-sourced batch.",
+            "type": "integer",
+            "required": false,
+            "visible": true,
+            "order": 5,
+            "facetable": true,
+            "title": "Folder ID"
+          },
+          "folderPath": {
+            "description": "Path of the adopted folder relative to the owner's root, for a folder-sourced batch.",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Folder path",
+            "maxLength": 4096
+          },
+          "createdAt": {
+            "description": "Unix timestamp of batch creation.",
+            "type": "integer",
+            "required": false,
+            "visible": true,
+            "order": 7,
+            "facetable": false,
+            "title": "Created at"
+          },
+          "documents": {
+            "description": "Per-document progress entries {fileId, fileName, status, entityCount, replacementCount, error, prohibitedEntries}. Named `documents` rather than `files` because `files` is an ObjectEntity column surfaced under `@self.files` for attachments, and a data property that shadows a `@self` key is a collision waiting to happen; BatchStateRepository maps it back to `files` for the rest of the app.",
+            "type": "array",
+            "required": false,
+            "visible": true,
+            "order": 8,
+            "facetable": false,
+            "title": "Documents"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-08-16T00:00:00+00:00",
+        "created": "2026-08-16T00:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "docudesk-policy-admins"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-policy-admins"
+          ],
+          "delete": [
+            "docudesk-policy-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "batchId",
+          "objectDescriptionField": "status",
+          "autoPublish": false
+        },
+        "searchable": false
+      },
+      "anonymizationLink": {
+        "x-openregister-processing": {
+          "code": "docudesk-anonymisation",
+          "naam": "Anonymisation of documents",
+          "doelbinding": "Pseudonymise / redact personal data detected in documents so they can be shared or published under the Wet Open Overheid without disclosing identifiable persons.",
+          "rechtsgrond": "public-task",
+          "grondslagSource": "EntityRelation.bases",
+          "dataCategories": [
+            "PERSON",
+            "LOCATION",
+            "ORGANIZATION",
+            "IBAN",
+            "EMAIL",
+            "PHONE_NUMBER",
+            "BSN"
+          ],
+          "backend": "filinq.anonymiser",
+          "retentionReference": "anonymizationLink/x-openregister-archival (P7Y; selectielijst category to be confirmed)",
+          "lifecycle": "draft",
+          "logReads": true,
+          "attribution": {
+            "default": "docudesk-anonymisation"
+          },
+          "subjectIdFields": {}
+        },
+        "uri": null,
+        "slug": "anonymizationLink",
+        "title": "Anonymisation Link",
+        "description": "Koppeling tussen een bronbestand (niet-geanonimiseerd) en zijn geanonimiseerde tegenhanger. Eén record per bronbestand (idempotent op sourceFileId); her-anonimisering werkt hetzelfde record bij. Zowel sourceFileId als anonymizedFileId zijn facetable zodat de OpenRegister zoek-API de koppeling in beide richtingen oplost.",
+        "version": "1.0.0",
+        "summary": "",
+        "icon": "FileLinkOutline",
+        "required": [
+          "sourceFileId",
+          "anonymizedFileId"
+        ],
+        "properties": {
+          "sourceFileId": {
+            "description": "Nextcloud bestands-ID van het originele (niet-geanonimiseerde) document — idempotentiesleutel",
+            "type": "integer",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Source file ID"
+          },
+          "sourceFileName": {
+            "description": "Bestandsnaam van het brondocument",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Source file name",
+            "maxLength": 255
+          },
+          "sourceFilePath": {
+            "description": "Volledig pad van het brondocument binnen Nextcloud",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Source path",
+            "maxLength": 4096
+          },
+          "anonymizedFileId": {
+            "description": "Nextcloud bestands-ID van het geanonimiseerde resultaat — sleutel voor de omgekeerde zoekopdracht",
+            "type": "integer",
+            "required": true,
+            "visible": true,
+            "order": 4,
+            "facetable": true,
+            "title": "Anonymized file ID"
+          },
+          "anonymizedFileName": {
+            "description": "Bestandsnaam van het geanonimiseerde resultaat",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 5,
+            "facetable": true,
+            "title": "Anonymized file name",
+            "maxLength": 255
+          },
+          "anonymizedFilePath": {
+            "description": "Volledig (stabiel) pad van het geanonimiseerde resultaat binnen Nextcloud",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Anonymized path",
+            "maxLength": 4096
+          },
+          "outputFormat": {
+            "description": "Uitvoerformaat van het geanonimiseerde document",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Format",
+            "enum": [
+              "pdf",
+              "docx",
+              "odt",
+              "txt",
+              "html"
+            ]
+          },
+          "status": {
+            "description": "Uitkomst van de anonimiseringsrun. Alleen succesvolle runs worden vastgelegd, dus de waarde is altijd 'anonymized'.",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "anonymized"
+            ],
+            "default": "anonymized"
+          },
+          "replacementCount": {
+            "description": "Aantal toegepaste entiteitsvervangingen in deze run",
+            "type": "integer",
+            "required": false,
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Replacements"
+          },
+          "runCount": {
+            "description": "Hoe vaak dit bronbestand is geanonimiseerd (opgehoogd bij elke her-anonimisering)",
+            "type": "integer",
+            "required": false,
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Run count",
+            "default": 1
+          },
+          "anonymizedAt": {
+            "description": "Datum/tijd van de anonimiseringsrun (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 11,
+            "facetable": false,
+            "title": "Anonymized at"
+          },
+          "anonymizedBy": {
+            "description": "Nextcloud gebruikers-ID dat de anonimisering heeft gestart",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 12,
+            "facetable": true,
+            "title": "Anonymized by",
+            "maxLength": 64
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-06-09T00:00:00+00:00",
+        "created": "2026-06-09T00:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "authenticated"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-policy-admins"
+          ],
+          "delete": [
+            "docudesk-policy-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "sourceFileName",
+          "objectDescriptionField": "status",
+          "autoPublish": false
+        },
+        "searchable": false,
+        "x-openregister-archival": {
+          "retention": {
+            "default": "P7Y"
+          },
+          "category": "TODO: confirm Archiefwet 1995 selectielijst category with selectielijst manager",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        }
+      },
+      "base": {
+        "x-openregister-processing": {
+          "code": "docudesk-metadata-enrichment",
+          "naam": "Document metadata enrichment",
+          "doelbinding": "Automatically enrich documents with language detection, keyword extraction, and topic classification to support findability and records management.",
+          "rechtsgrond": "public-task",
+          "grondslagSource": "EntityRelation.bases",
+          "dataCategories": [
+            "PERSON",
+            "LOCATION",
+            "ORGANIZATION"
+          ],
+          "backend": "filinq.metadata.enricher",
+          "retentionReference": "not declared (base carries no x-openregister-archival annotation)",
+          "lifecycle": "draft",
+          "logReads": true,
+          "attribution": {
+            "default": "docudesk-metadata-enrichment"
+          },
+          "subjectIdFields": {}
+        },
+        "uri": null,
+        "slug": "base",
+        "title": "Legal Basis",
+        "description": "Een Woo Art. 5 uitzonderingsgrond waaronder gegevens geanonimiseerd worden voordat een document wordt gepubliceerd. OpenRegister bewaart de UUID's; de Woo Art. 5 uitzonderingsgronden (legenda A–S) worden meegeleverd als seed-data.",
+        "x-schema-org": "schema:DefinedTerm",
+        "version": "1.2.0",
+        "summary": "Legal basis (grondslag) for anonymisation under Woo Art. 5",
+        "icon": "Gavel",
+        "required": [
+          "name",
+          "description"
+        ],
+        "properties": {
+          "name": {
+            "title": "Name",
+            "description": "Korte Nederlandstalige naam van de grondslag (zichtbaar in de operator-UI).",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "maxLength": 100,
+            "translatable": true
+          },
+          "description": {
+            "title": "Description",
+            "description": "Toelichting op de grondslag, met verwijzing naar Woo Art. 5 en waar relevant AVG-artikelen.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "maxLength": 1000,
+            "translatable": true
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-05-12T12:00:00+00:00",
+        "created": "2026-05-12T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "authenticated"
+          ],
+          "create": [
+            "docudesk-policy-admins"
+          ],
+          "update": [
+            "docudesk-policy-admins"
+          ],
+          "delete": [
+            "docudesk-policy-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "name",
+          "objectDescriptionField": "description",
+          "autoPublish": false,
+          "x-openregister-mcp": {
+            "enabled": true,
+            "tools": {
+              "search": {
+                "description": "Search Woo Article 5 legal bases — the grounds under which data is anonymised before a document is published.",
+                "scope": "read",
+                "readOnlyHint": true,
+                "filters": [
+                  "name"
+                ]
+              },
+              "get": {
+                "description": "Get a single legal basis by id, including its explanation and statutory reference.",
+                "scope": "read",
+                "readOnlyHint": true
+              }
+            }
+          }
+        },
+        "searchable": false
+      },
+      "batchCorrespondenceJob": {
+        "uri": null,
+        "slug": "batchCorrespondenceJob",
+        "title": "Batch Correspondence Job",
+        "description": "Bijhouding van een batch-correspondentieopdracht. Vervangt IAppConfig-gebaseerde statusopslag. Lifecycle-transitiebeheer via x-openregister-lifecycle.",
+        "x-schema-org": "schema:SendAction",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "EmailMultipleOutline",
+        "required": [
+          "templateId",
+          "recipientCount",
+          "status",
+          "initiatedBy"
+        ],
+        "properties": {
+          "templateId": {
+            "description": "UUID van het gebruikte template",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Template"
+          },
+          "templateName": {
+            "description": "Naam van het template (denormalized)",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Template name",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "recipientCount": {
+            "description": "Totaal aantal ontvangers in de batch",
+            "type": "integer",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Recipients"
+          },
+          "completedCount": {
+            "description": "Aantal succesvol gegenereerde brieven",
+            "type": "integer",
+            "required": false,
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Succeeded"
+          },
+          "errorCount": {
+            "description": "Aantal mislukte generaties",
+            "type": "integer",
+            "required": false,
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Failed"
+          },
+          "status": {
+            "description": "Batchstatus",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "pending",
+              "processing",
+              "success",
+              "error",
+              "completed"
+            ],
+            "default": "pending"
+          },
+          "initiatedBy": {
+            "description": "Nextcloud gebruiker die de batch heeft gestart",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Started by",
+            "maxLength": 64
+          },
+          "startedAt": {
+            "description": "Start van verwerking (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 8,
+            "facetable": false,
+            "title": "Started"
+          },
+          "completedAt": {
+            "description": "Voltooiing (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Completed"
+          },
+          "errorMessage": {
+            "description": "Foutmelding bij volledig mislukte batch",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Error message",
+            "maxLength": 2000
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-06-01T00:00:00+00:00",
+        "created": "2026-06-01T00:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "authenticated"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "authenticated"
+          ],
+          "delete": [
+            "docudesk-template-editors"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "templateName",
+          "objectDescriptionField": "status",
+          "autoPublish": false,
+          "x-openregister-mcp": {
+            "enabled": true,
+            "tools": {
+              "search": {
+                "description": "Search batch correspondence jobs — answers 'did the mail-merge finish?'. Read-only: an agent can report on a batch but can never start one.",
+                "scope": "read",
+                "readOnlyHint": true,
+                "filters": [
+                  "templateId",
+                  "status",
+                  "initiatedBy"
+                ]
+              },
+              "get": {
+                "description": "Get a single batch correspondence job by id, including completed and error counts.",
+                "scope": "read",
+                "readOnlyHint": true
+              }
+            }
+          }
+        },
+        "searchable": false,
+        "x-openregister-archival": {
+          "retention": {
+            "default": "P1Y"
+          },
+          "category": "Archiefwet 1995 selectielijst — cat. 1.2: operationele verwerkingslogboeken, korte bewaarplicht",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        },
+        "x-openregister-lifecycle": {
+          "field": "status",
+          "initial": "pending",
+          "states": {
+            "pending": {
+              "label": "Wachtend",
+              "terminal": false
+            },
+            "processing": {
+              "label": "Verwerken",
+              "terminal": false
+            },
+            "success": {
+              "label": "Geslaagd",
+              "terminal": true
+            },
+            "error": {
+              "label": "Mislukt",
+              "terminal": true
+            },
+            "completed": {
+              "label": "Voltooid",
+              "terminal": true
+            }
+          },
+          "transitions": {
+            "start": {
+              "from": "pending",
+              "to": "processing",
+              "label": "Start verwerking",
+              "requiresRole": "system",
+              "description": "BatchCorrespondenceJob::run() begint."
+            },
+            "succeed": {
+              "from": "processing",
+              "to": "success",
+              "label": "Geslaagd",
+              "requiresRole": "system",
+              "description": "Alle ontvangers verwerkt zonder fouten."
+            },
+            "fail": {
+              "from": "processing",
+              "to": "error",
+              "label": "Mislukt",
+              "requiresRole": "system",
+              "description": "Fatale fout, batch afgebroken."
+            },
+            "complete": {
+              "from": [
+                "success",
+                "error"
+              ],
+              "to": "completed",
+              "label": "Afronden",
+              "requiresRole": "system",
+              "description": "Definitieve afsluiting na verwerking."
+            }
+          }
+        },
+        "x-openregister-notifications": {
+          "batchCompleted": {
+            "trigger": {
+              "type": "lifecycle",
+              "transition": "complete"
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "field",
+                "field": "initiatedBy"
+              }
+            ],
+            "subject": {
+              "nl": "Batchcorrespondentie voltooid: {{templateName}}",
+              "en": "Batch correspondence completed: {{templateName}}"
+            },
+            "body": {
+              "nl": "{{completedCount}} van {{recipientCount}} brieven gegenereerd. Fouten: {{errorCount}}.",
+              "en": "{{completedCount}} of {{recipientCount}} letters generated. Errors: {{errorCount}}."
+            }
+          },
+          "batchFailed": {
+            "trigger": {
+              "type": "lifecycle",
+              "transition": "fail"
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "field",
+                "field": "initiatedBy"
+              }
+            ],
+            "subject": {
+              "nl": "Batchcorrespondentie mislukt: {{templateName}}",
+              "en": "Batch correspondence failed: {{templateName}}"
+            }
+          }
+        },
+        "x-openregister-calculations": {
+          "errorRate": {
+            "expression": "errorCount / recipientCount",
+            "type": "number",
+            "format": "float",
+            "description": "Ratio of failed generations over total recipients (0.0 – 1.0)",
+            "readOnly": true
+          },
+          "successRate": {
+            "expression": "completedCount / recipientCount",
+            "type": "number",
+            "format": "float",
+            "description": "Ratio of successfully generated letters over total recipients",
+            "readOnly": true
+          }
+        }
+      },
+      "correspondence": {
+        "x-openregister-notifications": {
+          "correspondenceFailed": {
+            "trigger": {
+              "type": "created"
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "field",
+                "field": "generatedBy"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "docudesk-woo-officers"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Documentgeneratie mislukt: {{templateName}}",
+              "en": "Document generation failed: {{templateName}}"
+            }
+          }
+        },
+        "uri": null,
+        "slug": "correspondence",
+        "title": "Correspondence",
+        "description": "Audit log voor gegenereerde correspondentie. Bevat metadata over welk template is gebruikt, voor welke ontvanger, en het resultaat.",
+        "x-schema-org": "schema:Message",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "EmailOutline",
+        "required": [
+          "templateId",
+          "recipientId",
+          "generatedAt",
+          "format",
+          "status",
+          "generatedBy"
+        ],
+        "properties": {
+          "templateId": {
+            "description": "UUID van het gebruikte template",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Template ID"
+          },
+          "templateName": {
+            "description": "Naam van het gebruikte template",
+            "type": "string",
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Template name",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "recipientId": {
+            "description": "UUID van het ontvangerobject in OpenRegister",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Recipient ID"
+          },
+          "recipientType": {
+            "description": "Type ontvanger",
+            "type": "string",
+            "visible": true,
+            "order": 4,
+            "facetable": true,
+            "title": "Recipient type",
+            "enum": [
+              "PERSON",
+              "ORGANIZATION"
+            ]
+          },
+          "caseReference": {
+            "description": "UUID of the source Zaak (case) in Procest. Cross-app reference: the target schema lives in Procest's register, not Filinq's, so this is a plain identifier rather than an OpenRegister relation — see x-external-register.",
+            "type": "string",
+            "format": "uuid",
+            "x-external-register": "procest",
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Case reference"
+          },
+          "generatedAt": {
+            "description": "Datum/tijd van generatie (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Generated at"
+          },
+          "format": {
+            "description": "Uitvoerformaat van het document",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Format",
+            "enum": [
+              "pdf",
+              "docx",
+              "html",
+              "email"
+            ]
+          },
+          "status": {
+            "description": "Status van de generatie",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "generated",
+              "failed"
+            ]
+          },
+          "generatedBy": {
+            "description": "Nextcloud gebruikers-ID die de generatie heeft gestart",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 9,
+            "facetable": true,
+            "title": "Generated by",
+            "maxLength": 64
+          },
+          "errorMessage": {
+            "description": "Foutmelding bij mislukte generatie",
+            "type": "string",
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Error message",
+            "maxLength": 2000
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-03-22T12:00:00+00:00",
+        "created": "2026-03-22T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "authenticated"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-template-editors"
+          ],
+          "delete": [
+            "docudesk-template-editors"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "templateName",
+          "objectDescriptionField": "status",
+          "autoPublish": false,
+          "x-openregister-mcp": {
+            "enabled": true,
+            "tools": {
+              "search": {
+                "description": "Search the correspondence audit log — which letters were generated, from which template, for which recipient, and whether generation succeeded. This is the record of what was produced, not the produced document.",
+                "scope": "read",
+                "readOnlyHint": true,
+                "filters": [
+                  "templateId",
+                  "recipientId",
+                  "recipientType",
+                  "caseReference",
+                  "status",
+                  "format",
+                  "generatedBy"
+                ]
+              },
+              "get": {
+                "description": "Get a single correspondence audit record by id, including its status and any error message.",
+                "scope": "read",
+                "readOnlyHint": true
+              }
+            }
+          }
+        },
+        "searchable": false,
+        "x-openregister-archival": {
+          "retention": {
+            "default": "P7Y"
+          },
+          "category": "Archiefwet 1995 selectielijst — cat. 3.2: zakelijke correspondentie voor organisatorische continuïteit",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        }
+      },
+      "customDictionary": {
+        "uri": null,
+        "slug": "customDictionary",
+        "title": "Custom Dictionary",
+        "description": "Organisatie-beheerde woordenlijst die als extra herkenner naast Presidio/regex werkt. Termen in deze lijst worden tegen documenttekst gematcht volgens de gekozen matchmodus; matches worden als CUSTOM_DICTIONARY entiteiten weggeschreven in OpenRegister's gedeelde entiteitencatalogus. Eigenaarschap wordt bijgehouden via @self.organisation; lezen/schrijven is fail-closed org-gated door CustomDictionaryController.",
+        "version": "1.0.0",
+        "summary": "",
+        "icon": "BookAlphabet",
+        "required": [
+          "label"
+        ],
+        "properties": {
+          "label": {
+            "description": "Naam van de woordenlijst, getoond in de admin-UI en als badge bij elke match in de review-workbench.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Label",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "description": {
+            "description": "Toelichting op het doel van deze woordenlijst.",
+            "type": "string",
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "title": "Description",
+            "translatable": true
+          },
+          "colour": {
+            "description": "Hex-kleurcode waarmee matches uit deze woordenlijst gemarkeerd worden in de review-workbench.",
+            "type": "string",
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Colour",
+            "pattern": "^#[0-9A-Fa-f]{6}$",
+            "default": "#0082C9"
+          },
+          "matchMode": {
+            "description": "Matching-strategie: `exact` (hoofdlettergevoelig, byte-voor-byte), `caseInsensitive` (hoofdletterongevoelig, standaard) of `wordBoundary` (hoofdletterongevoelig, alleen op woordgrenzen zodat een term niet binnen een langer woord matcht).",
+            "type": "string",
+            "enum": [
+              "exact",
+              "caseInsensitive",
+              "wordBoundary"
+            ],
+            "visible": true,
+            "order": 4,
+            "facetable": true,
+            "title": "Match mode",
+            "default": "caseInsensitive"
+          },
+          "fuzzy": {
+            "description": "Geaccepteerd maar genegeerd in deze versie — benaderend (fuzzy) matchen is uitgesteld naar een toekomstige versie (zie design.md Open Questions).",
+            "type": "boolean",
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Fuzzy matching (not yet active)",
+            "default": false
+          },
+          "active": {
+            "description": "Of deze woordenlijst wordt meegenomen in automatische detectie. Uitgeschakelde woordenlijsten blijven beheerbaar maar detecteren niet automatisch.",
+            "type": "boolean",
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Active",
+            "default": true
+          },
+          "termCount": {
+            "description": "Aantal termen in deze woordenlijst. Server-berekend door CustomDictionaryService bij elke list/get-aanroep (ADR-022 term-count enrichment); niet clientseitig instelbaar en niet persistent opgeslagen als schema-property.",
+            "type": "integer",
+            "required": false,
+            "visible": true,
+            "order": 7,
+            "facetable": false,
+            "title": "Term count",
+            "readOnly": true,
+            "default": 0
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-07-23T00:00:00+00:00",
+        "created": "2026-07-23T00:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "authenticated"
+          ],
+          "create": [
+            "docudesk-policy-admins"
+          ],
+          "update": [
+            "docudesk-policy-admins"
+          ],
+          "delete": [
+            "docudesk-policy-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "label",
+          "objectDescriptionField": "description",
+          "autoPublish": false
+        },
+        "searchable": false
+      },
+      "customDictionaryTerm": {
+        "uri": null,
+        "slug": "customDictionaryTerm",
+        "title": "Custom Dictionary Term",
+        "description": "Eén term binnen een organisatie-woordenlijst (customDictionary). `value` is de exacte zoekterm die CustomDictionaryMatchService tegen geëxtraheerde documenttekst matcht.",
+        "version": "1.0.0",
+        "summary": "",
+        "icon": "FormatListBulleted",
+        "required": [
+          "value",
+          "dictionary"
+        ],
+        "properties": {
+          "value": {
+            "description": "De term die gezocht wordt (bijv. een projectcodenaam, straatnaam of dossierkenmerk). Dit is de zoekterm zelf, geen weergavetekst — niet vertaalbaar.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Value",
+            "maxLength": 512
+          },
+          "label": {
+            "description": "Optioneel leesbaar label voor deze term, getoond in de review-workbench. Valt terug op het label van de woordenlijst wanneer leeg.",
+            "type": "string",
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "title": "Label",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "dictionary": {
+            "description": "Slug of UUID van de customDictionary waartoe deze term behoort. Consumer-side resolution door CustomDictionaryService (zelfde conventie als `dossier.bases`).",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": true,
+            "title": "Dictionary"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-07-23T00:00:00+00:00",
+        "created": "2026-07-23T00:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "authenticated"
+          ],
+          "create": [
+            "docudesk-policy-admins"
+          ],
+          "update": [
+            "docudesk-policy-admins"
+          ],
+          "delete": [
+            "docudesk-policy-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "value",
+          "objectDescriptionField": "label",
+          "autoPublish": false
+        },
+        "searchable": false
+      },
+      "dossier": {
+        "uri": null,
+        "slug": "dossier",
+        "title": "Dossier",
+        "description": "Een dossier representeert een Nextcloud-map (`@self.folder`) waarvan de inhoud onder één of meer Woo Art. 5 grondslagen geanonimiseerd wordt. Het dossier registreert wie het heeft beoordeeld (`checkedOn`) en welke grondslagen van toepassing zijn (`bases[]`).",
+        "x-schema-org": "schema:Collection",
+        "version": "1.1.0",
+        "summary": "Anonymisation dossier — folder + grondslagen + review timestamp",
+        "icon": "FolderAccount",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "title": "Name",
+            "description": "Naam van het dossier — komt overeen met de naam van de gekoppelde Nextcloud-map op het moment van aanmaken.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "maxLength": 200,
+            "translatable": true
+          },
+          "description": {
+            "title": "Description",
+            "description": "Vrije tekst die het doel van het dossier toelicht (bijv. \"Woo-verzoek Subsidietoekenningen cultuur\").",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "maxLength": 1000,
+            "translatable": true
+          },
+          "bases": {
+            "title": "Bases",
+            "description": "Array van slugs die verwijzen naar `base`-objecten — de Woo Art. 5 uitzonderingsgronden op basis waarvan het dossier geanonimiseerd wordt. Consumer-side resolution (Filinq's anonymisation-grondslagen-summary) zoekt de slug op in het `base`-register.",
+            "type": "array",
+            "required": false,
+            "visible": true,
+            "order": 3,
+            "facetable": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "checkedOn": {
+            "title": "Checked on",
+            "description": "Tijdstempel waarop het dossier door een operator is beoordeeld; lege waarde betekent nog niet beoordeeld.",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 4,
+            "facetable": true
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-05-12T12:00:00+00:00",
+        "created": "2026-05-12T12:00:00+00:00",
+        "maxDepth": 1,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "authenticated"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-policy-admins"
+          ],
+          "delete": [
+            "docudesk-policy-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "name",
+          "objectDescriptionField": "description",
+          "autoPublish": false,
+          "x-openregister-mcp": {
+            "enabled": true,
+            "tools": {
+              "search": {
+                "description": "Search dossiers — Nextcloud folders whose contents fall under one or more Woo Article 5 legal bases.",
+                "scope": "read",
+                "readOnlyHint": true,
+                "filters": [
+                  "name"
+                ]
+              },
+              "get": {
+                "description": "Get a single dossier by id, including the legal bases it is filed under and when it was last reviewed.",
+                "scope": "read",
+                "readOnlyHint": true
+              }
+            }
+          }
+        },
+        "searchable": false
+      },
+      "financialExtraction": {
+        "uri": null,
+        "slug": "financialExtraction",
+        "title": "Financial Extraction",
+        "description": "Structured financial field-extraction result for a receipt or supplier-invoice document (scan-en-herken): supplier/IBAN/KvK/BTW, invoice number, dates, currency, totals + VAT breakdown, line items, per-field confidence, and an additive corrections[] tuning corpus. Canonical home of the nl.conduction.filinq.extraction.completed event payload shape.",
+        "version": "1.0.0",
+        "summary": "",
+        "icon": "FileDocumentCheck",
+        "x-schema-org": "schema:Invoice",
+        "required": [
+          "documentUri",
+          "docType",
+          "requestedBy",
+          "sourceApp",
+          "fields",
+          "fieldConfidence",
+          "overallConfidence"
+        ],
+        "properties": {
+          "documentUri": {
+            "description": "URI van het bronbestand/-document waarop de extractie is uitgevoerd",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Document URI",
+            "maxLength": 2048
+          },
+          "docType": {
+            "description": "Type brondocument",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Document type",
+            "enum": [
+              "receipt",
+              "supplier-invoice"
+            ]
+          },
+          "requestedBy": {
+            "description": "Nextcloud gebruikers-ID dat de extractie heeft aangevraagd",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": true,
+            "title": "Requested by",
+            "maxLength": 64
+          },
+          "sourceApp": {
+            "description": "App-ID van de aanvragende consumer (bijv. 'shillinq')",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 4,
+            "facetable": true,
+            "title": "Source app",
+            "maxLength": 64
+          },
+          "fields": {
+            "description": "Geëxtraheerde velden: supplierName, supplierIban, supplierKvk, supplierVatId, invoiceNumber, issueDate, dueDate, currency, totalExcl, totalVat, totalIncl, vatBreakdown[], lines[]. Onbepaalde velden zijn null, nooit weggelaten.",
+            "type": "object",
+            "required": true,
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Fields"
+          },
+          "fieldConfidence": {
+            "description": "Betrouwbaarheidsscore (0..1) per geëxtraheerd veld",
+            "type": "object",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Field confidence"
+          },
+          "overallConfidence": {
+            "description": "Geaggregeerde betrouwbaarheidsscore (0..1) over alle ingevulde velden",
+            "type": "number",
+            "required": true,
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Overall confidence"
+          },
+          "corrections": {
+            "description": "Additieve lijst van door mensen gecorrigeerde veldwaarden (field, original, corrected, correctedBy, correctedAt), gekoppeld aan de oorspronkelijke extractie voor toekomstige model-tuning. De oorspronkelijke extractie blijft ongewijzigd.",
+            "type": "array",
+            "visible": true,
+            "order": 8,
+            "facetable": false,
+            "title": "Corrections",
+            "default": []
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-07-12T00:00:00+00:00",
+        "created": "2026-07-12T00:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "docudesk-financial-admins"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-financial-admins"
+          ],
+          "delete": [
+            "docudesk-financial-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "documentUri",
+          "objectDescriptionField": "docType",
+          "autoPublish": false
+        },
+        "searchable": false,
+        "x-openregister-archival": {
+          "retention": {
+            "default": "P7Y"
+          },
+          "category": "TODO: confirm Archiefwet 1995 selectielijst category with selectielijst manager",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        }
+      },
+      "generatedDocument": {
+        "x-openregister-processing": {
+          "code": "docudesk-ocr",
+          "naam": "OCR text extraction",
+          "doelbinding": "Extract machine-readable text from scanned documents and images (Tesseract OCR) for downstream metadata enrichment, search, and anonymisation.",
+          "rechtsgrond": "public-task",
+          "grondslagSource": "EntityRelation.bases",
+          "dataCategories": [
+            "PERSON",
+            "LOCATION",
+            "ORGANIZATION",
+            "EMAIL",
+            "PHONE_NUMBER"
+          ],
+          "backend": "filinq.ocr.tesseract",
+          "retentionReference": "not declared (generatedDocument carries no x-openregister-archival annotation)",
+          "lifecycle": "draft",
+          "logReads": true,
+          "attribution": {
+            "default": "docudesk-ocr"
+          },
+          "subjectIdFields": {}
+        },
+        "x-openregister-calculations": {
+          "validationStatus": {
+            "backend": "filinq.validation",
+            "type": "string",
+            "enum": [
+              "passed",
+              "warnings",
+              "failed"
+            ],
+            "description": "Document quality-control verdict computed by DocumentValidationService (passed | warnings | failed). Absent until the document is validated.",
+            "readOnly": true
+          },
+          "validationFindings": {
+            "backend": "filinq.validation",
+            "type": "array",
+            "description": "Per-check findings (checkId, severity, message, optional field, optional suggestedAction) computed by DocumentValidationService. Never embeds document content.",
+            "readOnly": true
+          }
+        },
+        "uri": null,
+        "slug": "generatedDocument",
+        "title": "Generated Document",
+        "description": "Audit trail voor documenten gegenereerd via DocumentService. Bevat metadata inclusief template UUID, versie, databronnen en resultaat, plus (optioneel) het Nextcloud bestand-ID en -pad wanneer het document is opgeslagen in Files.",
+        "x-schema-org": "schema:DigitalDocument",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "FileDocument",
+        "required": [
+          "templateId",
+          "templateVersion",
+          "generatedAt",
+          "format",
+          "status",
+          "generatedBy"
+        ],
+        "properties": {
+          "templateId": {
+            "description": "UUID van het gebruikte template",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Template ID"
+          },
+          "templateVersion": {
+            "description": "Versienummer van het gebruikte template (DCS-051)",
+            "type": "integer",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Template version"
+          },
+          "templateName": {
+            "description": "Naam van het gebruikte template",
+            "type": "string",
+            "visible": true,
+            "order": 3,
+            "facetable": true,
+            "title": "Template name",
+            "maxLength": 255
+          },
+          "dataRefs": {
+            "description": "Databronnen gebruikt voor het genereren van het document",
+            "type": "array",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Data sources"
+          },
+          "format": {
+            "description": "Uitvoerformaat van het document",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 5,
+            "facetable": true,
+            "title": "Format",
+            "enum": [
+              "pdf",
+              "odf",
+              "html",
+              "docx"
+            ]
+          },
+          "status": {
+            "description": "Status van de documentgeneratie",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "generated",
+              "failed"
+            ]
+          },
+          "generatedAt": {
+            "description": "Datum/tijd van generatie (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": true,
+            "visible": true,
+            "order": 7,
+            "facetable": false,
+            "title": "Generated at"
+          },
+          "generatedBy": {
+            "description": "Nextcloud gebruikers-ID die de generatie heeft gestart",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Generated by",
+            "maxLength": 64
+          },
+          "caseId": {
+            "description": "UUID of the linked Zaak (case) in Procest (optional). Cross-app reference: the target schema lives in Procest's register, not Filinq's, so this is a plain identifier rather than an OpenRegister relation — see x-external-register.",
+            "type": "string",
+            "format": "uuid",
+            "x-external-register": "procest",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Case ID"
+          },
+          "warnings": {
+            "description": "Waarschuwingen opgetreden tijdens generatie",
+            "type": "array",
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Warnings"
+          },
+          "errorMessage": {
+            "description": "Foutmelding bij mislukte generatie",
+            "type": "string",
+            "visible": true,
+            "order": 11,
+            "facetable": false,
+            "title": "Error message",
+            "maxLength": 2000
+          },
+          "fileId": {
+            "description": "Nextcloud bestand-ID van het opgeslagen document in Files, indien options.output.mode 'files' of 'both' was en de opslag geslaagd is (document-output-destinations-and-bulk-retention). Null wanneer niet opgeslagen.",
+            "type": "integer",
+            "required": false,
+            "visible": true,
+            "order": 12,
+            "facetable": false,
+            "title": "File ID"
+          },
+          "filePath": {
+            "description": "Pad van het opgeslagen document in Files, indien opgeslagen (document-output-destinations-and-bulk-retention). Null wanneer niet opgeslagen.",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 13,
+            "facetable": false,
+            "title": "File path",
+            "maxLength": 2048
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-07-24T00:00:00+00:00",
+        "created": "2026-06-01T00:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "authenticated"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-template-editors"
+          ],
+          "delete": [
+            "docudesk-template-editors"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "templateName",
+          "objectDescriptionField": "status",
+          "autoPublish": false,
+          "x-openregister-mcp": {
+            "enabled": true,
+            "tools": {
+              "search": {
+                "description": "Search generated documents — the audit trail of every document Filinq produced, including the Nextcloud file id and path where it was stored. Use to find the artefact an earlier generation, conversion or agent edit produced.",
+                "scope": "read",
+                "readOnlyHint": true,
+                "filters": [
+                  "templateId",
+                  "templateVersion",
+                  "status",
+                  "format",
+                  "caseId",
+                  "generatedBy",
+                  "fileId"
+                ]
+              },
+              "get": {
+                "description": "Get a single generated-document record by id, including its file id, path, warnings and error message.",
+                "scope": "read",
+                "readOnlyHint": true
+              }
+            }
+          }
+        },
+        "searchable": false
+      },
+      "glAccountBooking": {
+        "uri": null,
+        "slug": "glAccountBooking",
+        "title": "GL Account Booking",
+        "description": "Eén opgeslagen boeking van een leverancier-identiteit naar een grootboekrekening-code, gevoed door de correctie-feedback van een financiële extractie. De rekeningcode/-label zijn ondoorzichtige strings die de consumer-app aanlevert — Filinq kent en valideert geen rekeningschema (bijv. RGS). Vormt samen de geschiedenis waarop ai-gl-account-suggestion rangschikt.",
+        "version": "1.0.0",
+        "summary": "",
+        "icon": "BookOpenVariant",
+        "required": [
+          "supplierIdentity",
+          "identityType",
+          "accountCode",
+          "bookedAt",
+          "source"
+        ],
+        "properties": {
+          "supplierIdentity": {
+            "description": "Opgeloste leverancier-identiteit (KvK, IBAN, of genormaliseerde naam) waarop geschiedenis gegroepeerd wordt",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Supplier identity",
+            "maxLength": 255
+          },
+          "identityType": {
+            "description": "Type van de opgeloste leverancier-identiteit",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Identity type",
+            "enum": [
+              "kvk",
+              "iban",
+              "name"
+            ]
+          },
+          "accountCode": {
+            "description": "Ondoorzichtige grootboekrekening-code zoals aangeleverd door de consumer-app (Filinq interpreteert of valideert deze niet)",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": true,
+            "title": "Account code",
+            "maxLength": 64
+          },
+          "accountLabel": {
+            "description": "Optioneel leesbaar label bij de rekeningcode, eveneens ondoorzichtig aangeleverd door de consumer-app",
+            "type": "string",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Account label",
+            "maxLength": 255
+          },
+          "bookedAt": {
+            "description": "Tijdstip waarop deze boeking is vastgelegd",
+            "type": "string",
+            "format": "date-time",
+            "required": true,
+            "visible": true,
+            "order": 5,
+            "facetable": true,
+            "title": "Booked at"
+          },
+          "source": {
+            "description": "Herkomst van deze boeking",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Source",
+            "enum": [
+              "correction",
+              "suggestion-accepted"
+            ]
+          },
+          "extractionId": {
+            "description": "ID van de financialExtraction waaruit deze boeking voortkomt",
+            "type": "string",
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Extraction ID",
+            "maxLength": 255
+          },
+          "sourceApp": {
+            "description": "App-ID van de aanleverende consumer (bijv. 'shillinq')",
+            "type": "string",
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Source app",
+            "maxLength": 64
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-07-13T00:00:00+00:00",
+        "created": "2026-07-13T00:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "docudesk-financial-admins"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-financial-admins"
+          ],
+          "delete": [
+            "docudesk-financial-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "supplierIdentity",
+          "objectDescriptionField": "accountCode",
+          "autoPublish": false
+        },
+        "searchable": false
+      },
+      "glAccountMappingRule": {
+        "uri": null,
+        "slug": "glAccountMappingRule",
+        "title": "GL Account Mapping Rule",
+        "description": "Door de tenant-beheerder onderhouden trefwoord/categorie → grootboekrekening regel, gebruikt als cold-start fallback wanneer een leverancier nog geen boekingsgeschiedenis heeft. Filinq levert geen vooraf ingevulde regels — de tabel start leeg; er wordt geen rekeningschema (bijv. RGS) meegeleverd.",
+        "version": "1.0.0",
+        "summary": "",
+        "icon": "TagMultiple",
+        "required": [
+          "keywords",
+          "accountCode"
+        ],
+        "properties": {
+          "keywords": {
+            "description": "Trefwoorden die, indien gevonden in de leveranciersnaam/documenttekst, deze regel doen matchen",
+            "type": "array",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Keywords",
+            "items": {
+              "type": "string"
+            }
+          },
+          "accountCode": {
+            "description": "Ondoorzichtige grootboekrekening-code die bij een match wordt voorgesteld (Filinq interpreteert of valideert deze niet)",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Account code",
+            "maxLength": 64
+          },
+          "accountLabel": {
+            "description": "Optioneel leesbaar label bij de rekeningcode",
+            "type": "string",
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Account label",
+            "maxLength": 255
+          },
+          "priority": {
+            "description": "Voorrang bij meerdere matchende regels (hoger = eerder toegepast)",
+            "type": "number",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Priority",
+            "default": 0
+          },
+          "enabled": {
+            "description": "Of deze regel actief is",
+            "type": "boolean",
+            "visible": true,
+            "order": 5,
+            "facetable": true,
+            "title": "Active",
+            "default": true
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-07-13T00:00:00+00:00",
+        "created": "2026-07-13T00:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "authenticated"
+          ],
+          "create": [
+            "docudesk-financial-admins"
+          ],
+          "update": [
+            "docudesk-financial-admins"
+          ],
+          "delete": [
+            "docudesk-financial-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "accountCode",
+          "objectDescriptionField": "accountLabel",
+          "autoPublish": false
+        },
+        "searchable": false
+      },
+      "huisstijl": {
+        "uri": null,
+        "slug": "huisstijl",
+        "title": "Branding Configuration",
+        "description": "Configuratie voor organisatie huisstijl: logo, kleuren, kop-/voetteksten en standaard marges voor correspondentie.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "Palette",
+        "required": [],
+        "properties": {
+          "name": {
+            "description": "Naam van de huisstijl configuratie",
+            "type": "string",
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Name",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "logo": {
+            "description": "Logo als base64-gecodeerde string of bestandsreferentie",
+            "type": "string",
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "title": "Logo"
+          },
+          "primaryColor": {
+            "description": "Primaire kleur in CSS-formaat (bijv. #154273)",
+            "type": "string",
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Primary color",
+            "maxLength": 25
+          },
+          "headerHtml": {
+            "description": "Twig template voor de paginakoptekst",
+            "type": "string",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Header HTML",
+            "format": "html"
+          },
+          "footerHtml": {
+            "description": "Twig template voor de paginavoettekst",
+            "type": "string",
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Footer HTML",
+            "format": "html"
+          },
+          "defaultMargins": {
+            "description": "Standaard marges in mm (object met top, right, bottom, left)",
+            "type": "object",
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Default margins"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-03-22T12:00:00+00:00",
+        "created": "2026-03-22T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "authenticated"
+          ],
+          "create": [
+            "docudesk-template-editors"
+          ],
+          "update": [
+            "docudesk-template-editors"
+          ],
+          "delete": [
+            "docudesk-template-editors"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "name",
+          "objectDescriptionField": "primaryColor",
+          "autoPublish": false,
+          "x-openregister-mcp": {
+            "enabled": true,
+            "tools": {
+              "search": {
+                "description": "Search branding (huisstijl) configurations — the organisation letterheads, colours and margins available when generating correspondence.",
+                "scope": "read",
+                "readOnlyHint": true,
+                "filters": [
+                  "name"
+                ]
+              },
+              "get": {
+                "description": "Get a single branding configuration by id, including its header and footer templates and default margins.",
+                "scope": "read",
+                "readOnlyHint": true
+              }
+            }
+          }
+        },
+        "searchable": false
+      },
+      "product": {
+        "uri": null,
+        "slug": "product",
+        "title": "Product or Service",
+        "description": "Priced products and services with their unit rate — the rate card a quotation is built from. Exists so an agent asked to quote \"5 hours of dev work\" resolves a real rate instead of supplying a plausible-sounding one: an hourly rate is exactly the fact a model will invent unprompted, and on a quotation that is the failure that costs money. Read-only to agents; writing the rate card is a commercial act, not an agent one.",
+        "version": "1.0.0",
+        "summary": "",
+        "icon": "Cash",
+        "required": [
+          "name",
+          "unit",
+          "unitPrice"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Short commercial name of the product or service, as it should appear on a quotation line."
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "description": "What the client is buying. Written to be pasted onto a quotation without rewriting."
+          },
+          "unit": {
+            "type": "string",
+            "title": "Unit",
+            "description": "The unit the price is per.",
+            "enum": [
+              "hour",
+              "day",
+              "piece",
+              "month"
+            ],
+            "default": "hour"
+          },
+          "unitPrice": {
+            "type": "number",
+            "title": "Unit price",
+            "description": "Price per unit, excluding VAT, in the currency below."
+          },
+          "currency": {
+            "type": "string",
+            "title": "Currency",
+            "description": "ISO 4217 currency code.",
+            "default": "EUR"
+          },
+          "category": {
+            "type": "string",
+            "title": "Category",
+            "description": "Grouping used to narrow a search, e.g. development, design, advies."
+          },
+          "active": {
+            "type": "boolean",
+            "title": "Active",
+            "description": "Whether this may still be quoted. Inactive rows are kept for historical quotations.",
+            "default": true
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-08-17T12:00:00+00:00",
+        "created": "2026-08-17T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "authenticated"
+          ],
+          "create": [
+            "docudesk-template-editors"
+          ],
+          "update": [
+            "docudesk-template-editors"
+          ],
+          "delete": [
+            "docudesk-template-editors"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "name",
+          "objectDescriptionField": "description",
+          "autoPublish": false,
+          "x-openregister-mcp": {
+            "enabled": true,
+            "tools": {
+              "search": {
+                "description": "Search the rate card for priced products and services. Use this BEFORE quoting any amount. Returns ALL candidates with their unit and unit price — it does not choose for you: \"dev work\" may match several roles at different rates, and picking one silently is how a quotation goes out at the wrong price. If it returns nothing, ASK THE USER for the rate. Never estimate a price.",
+                "scope": "read",
+                "readOnlyHint": true,
+                "filters": [
+                  "name",
+                  "category",
+                  "unit",
+                  "active"
+                ]
+              },
+              "get": {
+                "description": "Get one product or service from the rate card by id, including its description, unit and unit price.",
+                "scope": "read",
+                "readOnlyHint": true
+              }
+            }
+          }
+        },
+        "searchable": false
+      },
+      "prohibitionOverrideAudit": {
+        "uri": null,
+        "slug": "prohibitionOverrideAudit",
+        "title": "Prohibition Override Audit",
+        "description": "Records why an operator released a low-confidence publication-prohibition match from anonymisation. Written by ProhibitionOverrideCommitter BEFORE the OpenRegister EntityRelation is PATCHed with skipAnonymization=true, so an override can never reach OpenRegister unrecorded on the Filinq side. Carries the operator commentary that OpenRegister's own audit trail does not (its PATCH whitelist is decision-only).",
+        "version": "1.0.0",
+        "summary": "",
+        "icon": "ClipboardCheckOutline",
+        "required": [
+          "ruleId",
+          "fileId",
+          "reason",
+          "acknowledgedBy",
+          "acknowledgedAt"
+        ],
+        "properties": {
+          "ruleId": {
+            "description": "Identifier of the publication-prohibition rule whose match was released.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Rule ID",
+            "maxLength": 255
+          },
+          "entityRelationId": {
+            "description": "OpenRegister EntityRelation row that was flagged skipAnonymization=true. Zero when the released match carried no relation id.",
+            "type": "integer",
+            "required": false,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Entity relation ID"
+          },
+          "fileId": {
+            "description": "Nextcloud file ID the anonymisation request was made against.",
+            "type": "integer",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": true,
+            "title": "File ID"
+          },
+          "reason": {
+            "description": "Operator's stated justification for releasing the flagged entity from redaction.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Reason",
+            "maxLength": 1024,
+            "translatable": true
+          },
+          "acknowledgedBy": {
+            "description": "Nextcloud UID of the user who acknowledged the override.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 5,
+            "facetable": true,
+            "title": "Acknowledged by",
+            "maxLength": 64
+          },
+          "acknowledgedAt": {
+            "description": "Moment the override was acknowledged (ISO 8601).",
+            "type": "string",
+            "format": "date-time",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Acknowledged at"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": true,
+        "immutable": false,
+        "updated": "2026-08-11T00:00:00+00:00",
+        "created": "2026-08-11T00:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "ruleId",
+          "objectDescriptionField": "reason",
+          "autoPublish": false
+        },
+        "searchable": false,
+        "x-openregister-archival": {
+          "retention": {
+            "default": "P10Y"
+          },
+          "reason": "An override audit entry is the only record of a deliberate decision NOT to redact a legally protected entity; it must outlive the prohibition it released, which is itself retained P10Y.",
+          "category": "TODO: confirm Archiefwet 1995 selectielijst category with selectielijst manager",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        },
+        "authorization": {
+          "read": [
+            "docudesk-policy-admins"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-policy-admins"
+          ],
+          "delete": [
+            "docudesk-policy-admins"
+          ]
+        }
+      },
+      "publicationConsent": {
+        "x-openregister-notifications": {
+          "objectionDeadline": {
+            "trigger": {
+              "type": "scheduled",
+              "intervalSec": 86400,
+              "filter": {
+                "consentStatus": "pending"
+              }
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "groups",
+                "groups": [
+                  "docudesk-woo-officers"
+                ]
+              },
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              }
+            ],
+            "subject": {
+              "nl": "Bezwaartermijn verloopt binnenkort voor een publicatie",
+              "en": "Objection deadline is approaching for a publication"
+            }
+          }
+        },
+        "uri": null,
+        "slug": "publicationConsent",
+        "title": "Publication Consent",
+        "description": "Schema voor het beheren van publicatie toestemmingen volgens GDPR en Nederlandse Wet Open Overheid. Bevat informatie over entiteiten (personen/organisaties) die geïnformeerd moeten worden voordat een document wordt gepubliceerd, en hun reactie daarop.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "AccountCheck",
+        "required": [
+          "entityType",
+          "entityText"
+        ],
+        "properties": {
+          "scope": {
+            "description": "Discriminator: `document` = per-document/per-entity consent in the WOO workflow; `entity` = standing consent for a recurring entity (mayor, council member, etc.). Default `document` preserves backward compatibility — existing rows automatically load as `document`.",
+            "type": "string",
+            "enum": [
+              "document",
+              "entity"
+            ],
+            "required": false,
+            "visible": true,
+            "order": 0,
+            "facetable": true,
+            "title": "Scope",
+            "default": "document"
+          },
+          "documentId": {
+            "description": "Verwijzing naar het document dat gepubliceerd moet worden. Verplicht voor scope=document, VERBODEN voor scope=entity (standing consent) — die conditie is per record en wordt afgedwongen door ConsentScopeValidator, niet door dit schema. Zie openspec/specs/consent-management/spec.md: \"documentId MUST be required only for scope=document records\".",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Document ID"
+          },
+          "entityType": {
+            "description": "Type entiteit (PERSON, ORGANIZATION of OTHER). OTHER maakt een standing-consent type-agnostisch: de regel matcht ongeacht welk type de detectie toekent (bijv. generieke termen die als PERSON of LOCATION herkend kunnen worden). Legacy/fallback: populated denormalised when no contactRef is set; once contactRef is linked, the contacts-leaf vCard is the source of truth for this field.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Entity type",
+            "enum": [
+              "PERSON",
+              "ORGANIZATION",
+              "OTHER"
+            ]
+          },
+          "entityText": {
+            "description": "Tekst van de gedetecteerde entiteit (Legacy/fallback: populated denormalised when no contactRef is set; once contactRef is linked, the contacts-leaf vCard is the source of truth for this field.)",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Entity text",
+            "maxLength": 500
+          },
+          "entityKey": {
+            "description": "Unieke key van de entiteit (gebruikt voor anonymisatie)",
+            "type": "string",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Entity key",
+            "maxLength": 50
+          },
+          "contactEmail": {
+            "description": "E-mailadres voor notificatie (indien bekend) (Legacy/fallback: populated denormalised when no contactRef is set; once contactRef is linked, the contacts-leaf vCard is the source of truth for this field.)",
+            "type": "string",
+            "format": "email",
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Contact e-mail",
+            "maxLength": 255
+          },
+          "contactAddress": {
+            "description": "Postadres voor notificatie (indien bekend) (Legacy/fallback: populated denormalised when no contactRef is set; once contactRef is linked, the contacts-leaf vCard is the source of truth for this field.)",
+            "type": "string",
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Contact address",
+            "maxLength": 500
+          },
+          "contactRef": {
+            "description": "Linkage pointer to the canonical NC Contact record for this affected entity. When set, the contacts-leaf link table on the publicationConsent object is the source of truth for identity + channel; entityType/entityText/contactEmail/contactAddress are legacy/fallback denormalised copies used when no contact is linked.",
+            "type": "string",
+            "format": "uri",
+            "required": false,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Contact reference"
+          },
+          "notificationStatus": {
+            "description": "Status van de notificatie",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Notification status",
+            "enum": [
+              "pending",
+              "sent",
+              "delivered",
+              "failed",
+              "skipped"
+            ],
+            "default": "pending"
+          },
+          "notificationSentAt": {
+            "description": "Datum/tijd waarop de notificatie is verzonden",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 8,
+            "facetable": false,
+            "title": "Notification sent at"
+          },
+          "consentStatus": {
+            "description": "Status van de toestemming/bezwaar",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 9,
+            "facetable": true,
+            "title": "Consent status",
+            "enum": [
+              "pending",
+              "consent_given",
+              "objection_received",
+              "no_response",
+              "anonymized"
+            ],
+            "default": "pending"
+          },
+          "objectionDeadline": {
+            "description": "Deadline voor bezwaar indienen (volgens Wet Open Overheid: minimaal 4 weken)",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Objection deadline"
+          },
+          "objectionReceivedAt": {
+            "description": "Datum/tijd waarop bezwaar is ontvangen",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 11,
+            "facetable": false,
+            "title": "Objection received at"
+          },
+          "objectionReason": {
+            "description": "Reden voor bezwaar (indien ingediend)",
+            "type": "string",
+            "format": "markdown",
+            "visible": true,
+            "order": 12,
+            "facetable": false,
+            "title": "Objection reason",
+            "maxLength": 2000,
+            "translatable": true
+          },
+          "publicationDecision": {
+            "description": "Beslissing over publicatie",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 13,
+            "facetable": true,
+            "title": "Publication decision",
+            "enum": [
+              "pending",
+              "anonymize",
+              "publish_with_consent",
+              "publish_anonymized",
+              "reject"
+            ],
+            "default": "pending",
+            "translatable": true
+          },
+          "legalBasis": {
+            "description": "Juridische grondslag voor publicatie (bijv. Wet Open Overheid, AVG artikel 6)",
+            "type": "string",
+            "visible": true,
+            "order": 14,
+            "facetable": true,
+            "title": "Legal basis",
+            "maxLength": 500,
+            "example": "Wet Open Overheid art. 3.1"
+          },
+          "notes": {
+            "description": "Interne notities over het proces",
+            "type": "string",
+            "format": "markdown",
+            "visible": true,
+            "order": 15,
+            "facetable": false,
+            "title": "Notes",
+            "maxLength": 2000,
+            "translatable": true
+          },
+          "matchRules": {
+            "description": "Array of `{type, value}` entries (same enum as `publicationProhibition`: `exact` / `normalized` / `bsn` / `kvk`). Only used on `scope=entity` records; service-level validation rejects `scope=entity` writes without at least one matchRule.",
+            "type": "array",
+            "required": false,
+            "visible": true,
+            "order": 100,
+            "items": {
+              "type": "object",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "title": "Match Type",
+                  "description": "The matching algorithm to apply: exact (literal), normalized (case- and accent-insensitive), bsn (Burgerservicenummer), or kvk (KvK registration number).",
+                  "type": "string",
+                  "enum": [
+                    "exact",
+                    "normalized",
+                    "bsn",
+                    "kvk"
+                  ]
+                },
+                "value": {
+                  "title": "Match Value",
+                  "description": "The identifier or name string to match against, interpreted according to the selected match type.",
+                  "type": "string",
+                  "maxLength": 255
+                }
+              }
+            },
+            "title": "Match rules"
+          },
+          "validFrom": {
+            "description": "Standing-consent validity start (inclusive). Only honoured on `scope=entity` records.",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 101,
+            "facetable": true,
+            "title": "Valid from"
+          },
+          "validUntil": {
+            "description": "Standing-consent validity end (inclusive); `null` means open-ended. Service-level validation surfaces a non-blocking warning when blank.",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 102,
+            "facetable": true,
+            "title": "Valid until"
+          },
+          "active": {
+            "description": "Master kill-switch on standing consents (`scope=entity`). Only `active=true` records participate in matching.",
+            "type": "boolean",
+            "required": false,
+            "visible": true,
+            "order": 103,
+            "facetable": true,
+            "title": "Active",
+            "default": true
+          },
+          "consentMethod": {
+            "description": "How consent was captured. Required at service-level on `scope=entity` writes.",
+            "type": "string",
+            "enum": [
+              "paper",
+              "digital_signature",
+              "verbal_recorded",
+              "opt_in_form"
+            ],
+            "required": false,
+            "visible": true,
+            "order": 104,
+            "facetable": true,
+            "title": "Consent method"
+          },
+          "consentDocument": {
+            "description": "Reference to the captured consent document (signed PDF / form upload).",
+            "type": "string",
+            "format": "uri",
+            "required": false,
+            "visible": true,
+            "order": 105,
+            "facetable": true,
+            "title": "Consent document"
+          },
+          "consentScope": {
+            "description": "Free-text limitation describing the scope of the standing consent (e.g. 'all publications referencing the position of burgemeester').",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 106,
+            "title": "Consent scope",
+            "maxLength": 1024
+          },
+          "policyMatch": {
+            "description": "Polymorphic reference: when set on a `scope=document` record, points to the `publicationProhibition` UUID (prohibition pre-emption) OR to a `publicationConsent` UUID with `scope=entity` (standing-consent match). Service-level validation rejects polymorphic violations and rejects `policyMatch` on `scope=entity` records.",
+            "type": "string",
+            "format": "uri",
+            "required": false,
+            "visible": true,
+            "order": 107,
+            "facetable": true,
+            "title": "Policy match",
+            "x-openregister-handling": "related-object"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2025-12-08T12:00:00+00:00",
+        "created": "2025-12-08T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "docudesk-policy-admins"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-policy-admins"
+          ],
+          "delete": [
+            "docudesk-policy-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "entityText",
+          "objectDescriptionField": "consentStatus",
+          "autoPublish": false
+        },
+        "searchable": false
+      },
+      "publicationProhibition": {
+        "uri": null,
+        "slug": "publicationProhibition",
+        "title": "Publication Prohibition",
+        "description": "Court order, minor-protection, undercover-officer or categorical privacy-board prohibition on publishing personally-identifying information. When an active rule matches, the WOO objection workflow is pre-empted and the affected entity is forcibly anonymised. Time-bound (validFrom / validUntil) and rule-typed (exact / normalized / bsn / kvk) so the cache can resolve a match in O(1) per entity.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "ShieldLockOutline",
+        "required": [
+          "primaryName",
+          "entityType",
+          "matchRules",
+          "reason",
+          "active"
+        ],
+        "properties": {
+          "primaryName": {
+            "description": "Human-readable primary identifier — the name on the court order or the categorical exemption title.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Primary name",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "entityType": {
+            "description": "Entity category the rule applies to.",
+            "type": "string",
+            "enum": [
+              "PERSON",
+              "ORGANIZATION",
+              "OTHER"
+            ],
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Entity type"
+          },
+          "matchRules": {
+            "description": "Array of {type, value} entries; type is one of `exact` (literal), `normalized` (case+accent strip), `bsn` (BSN identifier), `kvk` (KvK identifier).",
+            "type": "array",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "items": {
+              "type": "object",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "title": "Match Type",
+                  "description": "The matching algorithm to apply: exact (literal), normalized (case- and accent-insensitive), bsn (Burgerservicenummer), or kvk (KvK registration number).",
+                  "type": "string",
+                  "enum": [
+                    "exact",
+                    "normalized",
+                    "bsn",
+                    "kvk"
+                  ]
+                },
+                "value": {
+                  "title": "Match Value",
+                  "description": "The identifier or name string to match against the entity, interpreted according to the selected match type.",
+                  "type": "string",
+                  "maxLength": 255
+                }
+              }
+            },
+            "title": "Match rules"
+          },
+          "reason": {
+            "description": "Short justification — gerechtelijk bevel, minderjarige bescherming, undercover, categorical privacy-board.",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 4,
+            "title": "Reason",
+            "maxLength": 1024,
+            "translatable": true
+          },
+          "legalAuthority": {
+            "description": "Wettelijke grondslag of besluitnummer (e.g. AVG art. 17, Rechtbank Den Haag KG ZA 24/123).",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 5,
+            "title": "Legal basis",
+            "maxLength": 512
+          },
+          "caseReference": {
+            "description": "Zaaknummer / dossiernummer voor traceability.",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Case reference",
+            "maxLength": 128
+          },
+          "severity": {
+            "description": "Urgentieklasse: critical (per direct effectief), high, normal.",
+            "type": "string",
+            "enum": [
+              "critical",
+              "high",
+              "normal"
+            ],
+            "required": false,
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Severity",
+            "default": "normal"
+          },
+          "jurisdiction": {
+            "description": "Geografische/juridische scope (e.g. NL, EU, gemeente-specifiek).",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Jurisdiction",
+            "maxLength": 128
+          },
+          "addedBy": {
+            "description": "Nextcloud user die de regel heeft toegevoegd (UUID/UID).",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 9,
+            "facetable": true,
+            "title": "Added by",
+            "maxLength": 255
+          },
+          "validFrom": {
+            "description": "Begindatum (inclusief) waarop de regel matched.",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 10,
+            "facetable": true,
+            "title": "Valid from"
+          },
+          "validUntil": {
+            "description": "Einddatum (inclusief) waarop de regel matched; null = onbeperkt.",
+            "type": "string",
+            "format": "date-time",
+            "required": false,
+            "visible": true,
+            "order": 11,
+            "facetable": true,
+            "title": "Valid until"
+          },
+          "active": {
+            "description": "Master kill-switch; alleen `active: true` regels matchen.",
+            "type": "boolean",
+            "required": true,
+            "visible": true,
+            "order": 12,
+            "facetable": true,
+            "title": "Active",
+            "default": true
+          },
+          "notes": {
+            "description": "Markdown-vrije tekst voor extra context.",
+            "type": "string",
+            "required": false,
+            "visible": true,
+            "order": 13,
+            "title": "Notes",
+            "translatable": true
+          }
+        },
+        "x-openregister-archival": {
+          "retention": {
+            "default": "P10Y"
+          },
+          "reason": "Privacy-prohibitions are court-order-backed; retain at least 10 years for audit + appeal per Archiefwet selectielijst."
+        },
+        "authorization": {
+          "read": [
+            "consent"
+          ],
+          "create": [
+            "docudesk-policy-admins"
+          ],
+          "update": [
+            "docudesk-policy-admins"
+          ],
+          "delete": [
+            "docudesk-policy-admins"
+          ]
+        }
+      },
+      "signerRecord": {
+        "x-openregister-notifications": {
+          "signingRequested": {
+            "trigger": {
+              "type": "created"
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "field",
+                "field": "userId"
+              }
+            ],
+            "subject": {
+              "nl": "Je moet een document ondertekenen",
+              "en": "You have a document to sign"
+            }
+          },
+          "signingDeadline": {
+            "trigger": {
+              "type": "scheduled",
+              "intervalSec": 86400,
+              "filter": {
+                "status": "PENDING"
+              }
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "field",
+                "field": "userId"
+              }
+            ],
+            "subject": {
+              "nl": "Herinnering: een document wacht op je handtekening",
+              "en": "Reminder: a document is awaiting your signature"
+            }
+          }
+        },
+        "uri": null,
+        "slug": "signerRecord",
+        "title": "Signer Record",
+        "description": "Individueel ondertekeningsrecord",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "AccountEdit",
+        "required": [
+          "signingRequestId",
+          "userId",
+          "displayName",
+          "status"
+        ],
+        "properties": {
+          "signingRequestId": {
+            "description": "Ondertekeningsverzoek UUID",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Request ID"
+          },
+          "userId": {
+            "description": "Gebruikers-ID",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "User"
+          },
+          "displayName": {
+            "description": "Weergavenaam",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Name",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "email": {
+            "description": "E-mailadres",
+            "type": "string",
+            "format": "email",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Email",
+            "maxLength": 255
+          },
+          "order": {
+            "description": "Volgorde",
+            "type": "integer",
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Order",
+            "default": 0
+          },
+          "status": {
+            "description": "Status",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "PENDING",
+              "SIGNED",
+              "DECLINED",
+              "EXPIRED",
+              "CANCELLED"
+            ],
+            "default": "PENDING"
+          },
+          "signedAt": {
+            "description": "Datum ondertekening",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 7,
+            "facetable": false,
+            "title": "Signed at"
+          },
+          "declineReason": {
+            "description": "Reden weigering",
+            "type": "string",
+            "visible": true,
+            "order": 8,
+            "facetable": false,
+            "title": "Decline reason",
+            "maxLength": 2000,
+            "translatable": true
+          },
+          "ipAddress": {
+            "description": "IP-adres",
+            "type": "string",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "IP address",
+            "maxLength": 45
+          },
+          "signatureData": {
+            "description": "Handtekeninggegevens (base64)",
+            "type": "string",
+            "visible": false,
+            "order": 10,
+            "facetable": false,
+            "title": "Signature data"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-03-22T12:00:00+00:00",
+        "created": "2026-03-22T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "docudesk-signing-admins"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-signing-admins"
+          ],
+          "delete": [
+            "docudesk-signing-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "displayName",
+          "objectDescriptionField": "status",
+          "autoPublish": false
+        },
+        "searchable": false,
+        "x-openregister-archival": {
+          "retention": {
+            "default": "P10Y"
+          },
+          "category": "Archiefwet 1995 selectielijst — cat. 5.1.3: ondertekeningsbewijsmiddelen",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        }
+      },
+      "signingAuditEntry": {
+        "x-openregister-processing": {
+          "code": "docudesk-signing",
+          "naam": "Digital document signing",
+          "doelbinding": "Create and maintain a tamper-evident audit trail of electronic signing activities (eIDAS SES/AdES/QES) as legal evidence.",
+          "rechtsgrond": "legal-obligation",
+          "grondslagSource": "EntityRelation.bases",
+          "dataCategories": [
+            "PERSON",
+            "EMAIL",
+            "IP_ADDRESS"
+          ],
+          "backend": "filinq.signing",
+          "retentionReference": "signingAuditEntry/x-openregister-archival (P10Y; Archiefwet 1995 selectielijst cat. 5.1.3)",
+          "lifecycle": "draft",
+          "logReads": true,
+          "attribution": {
+            "default": "docudesk-signing"
+          },
+          "subjectIdFields": {
+            "ncUserId": "actorUserId"
+          }
+        },
+        "uri": null,
+        "slug": "signingAuditEntry",
+        "title": "Signing Audit Entry",
+        "description": "DEPRECATED as of migrate-signing-audit-to-or-audit: new events are routed to OR audit trail (filinq.signing.*). Existing records remain readable read-only for one major release. Onveranderbaar auditlogrecord voor digitale ondertekeningsacties. Retentie gedeclareerd via x-openregister-archival (P10Y).",
+        "deprecated": true,
+        "x-deprecated-since": "migrate-signing-audit-to-or-audit",
+        "x-sunset": "one major release after migrate-signing-audit-to-or-audit",
+        "version": "1.0.0",
+        "summary": "",
+        "icon": "ShieldCheck",
+        "required": [
+          "signingRequestId",
+          "action",
+          "actorUserId",
+          "actorDisplayName",
+          "timestamp"
+        ],
+        "properties": {
+          "signingRequestId": {
+            "description": "Ondertekeningsverzoek UUID",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Request ID"
+          },
+          "action": {
+            "description": "Actie",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": true,
+            "title": "Action",
+            "enum": [
+              "CREATED",
+              "SIGNED",
+              "DECLINED",
+              "CANCELLED",
+              "EXPIRED",
+              "COMPLETED",
+              "VIEWED"
+            ]
+          },
+          "actorUserId": {
+            "description": "Actor gebruikers-ID",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": true,
+            "title": "Actor"
+          },
+          "actorDisplayName": {
+            "description": "Actornaam",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Actor name",
+            "maxLength": 255
+          },
+          "timestamp": {
+            "description": "Tijdstip (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": true,
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Timestamp"
+          },
+          "ipAddress": {
+            "description": "IP-adres",
+            "type": "string",
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "IP address",
+            "maxLength": 45
+          },
+          "signatureLevel": {
+            "description": "eIDAS niveau",
+            "type": "string",
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Level",
+            "enum": [
+              "SES",
+              "AdES",
+              "QES"
+            ]
+          },
+          "provider": {
+            "description": "Provider",
+            "type": "string",
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Provider"
+          },
+          "metadata": {
+            "description": "Metadata (JSON)",
+            "type": "object",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Metadata"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": true,
+        "appendOnly": true,
+        "updated": "2026-03-22T12:00:00+00:00",
+        "created": "2026-03-22T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "docudesk-signing-admins"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-signing-admins"
+          ],
+          "delete": [
+            "docudesk-signing-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "action",
+          "objectDescriptionField": "actorDisplayName",
+          "autoPublish": false
+        },
+        "searchable": false,
+        "x-openregister-archival": {
+          "retention": {
+            "default": "P10Y"
+          },
+          "category": "Archiefwet 1995 selectielijst — cat. 5.1.3: ondertekeningsauditverslagen als juridisch bewijsmiddel",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        }
+      },
+      "signingRequest": {
+        "deprecated": true,
+        "deprecatedSince": "5.6.0",
+        "deprecationNote": "The bespoke signing approval-chain (signingRequest + signerRecord step state) is being migrated to OpenRegister's canonical ApprovalChain / ApprovalStep abstraction per openspec/changes/migrate-signing-to-or-approval-workflow. Existing rows remain readable for the transition window; new sign-requests go through OR's ApprovalService and react to ApprovalStep*Event via lib/EventListener/ApprovalStepListener.php. Do not introduce new write-path callers — extend the ApprovalChain side instead.",
+        "x-openregister-notifications": {
+          "signingCompleted": {
+            "trigger": {
+              "type": "scheduled",
+              "intervalSec": 86400,
+              "filter": {
+                "status": "COMPLETED"
+              }
+            },
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "field",
+                "field": "initiatorUserId"
+              }
+            ],
+            "subject": {
+              "nl": "Ondertekeningsverzoek '{{documentName}}' is voltooid",
+              "en": "Signing request '{{documentName}}' is complete"
+            }
+          }
+        },
+        "uri": null,
+        "slug": "signingRequest",
+        "title": "Signing Request",
+        "description": "Ondertekeningsverzoek voor een document. DEPRECATED v1.2.0: bespoke signing approval-chain superseded by OR ApprovalChain/Step abstractions per openspec/changes/migrate-signing-to-or-approval-workflow.",
+        "version": "1.2.0",
+        "summary": "",
+        "icon": "FileSign",
+        "required": [
+          "documentFileId",
+          "documentName",
+          "initiatorUserId",
+          "signatureLevel",
+          "signingMode",
+          "status",
+          "provider"
+        ],
+        "properties": {
+          "documentFileId": {
+            "description": "Nextcloud bestand-ID",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Document ID"
+          },
+          "documentName": {
+            "description": "Naam document",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "title": "Document name",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "initiatorUserId": {
+            "description": "Initiator gebruikers-ID",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": true,
+            "title": "Initiator"
+          },
+          "signatureLevel": {
+            "description": "eIDAS niveau",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 4,
+            "facetable": true,
+            "title": "Level",
+            "enum": [
+              "SES",
+              "AdES",
+              "QES"
+            ],
+            "default": "SES"
+          },
+          "signingMode": {
+            "description": "Ondertekeningsvolgorde",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 5,
+            "facetable": true,
+            "title": "Mode",
+            "enum": [
+              "sequential",
+              "parallel"
+            ],
+            "default": "sequential"
+          },
+          "status": {
+            "description": "Status",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "DRAFT",
+              "PENDING",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "DECLINED",
+              "EXPIRED",
+              "CANCELLED"
+            ],
+            "default": "DRAFT"
+          },
+          "provider": {
+            "description": "Provider",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Provider",
+            "enum": [
+              "native",
+              "validsign",
+              "docusign",
+              "adobesign",
+              "libresign"
+            ],
+            "default": "native"
+          },
+          "deadline": {
+            "description": "Deadline (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 8,
+            "facetable": false,
+            "title": "Deadline"
+          },
+          "signerIds": {
+            "description": "SignerRecord UUID's",
+            "type": "array",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Signers"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-03-22T12:00:00+00:00",
+        "created": "2026-03-22T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "docudesk-signing-admins"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-signing-admins"
+          ],
+          "delete": [
+            "docudesk-signing-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "documentName",
+          "objectDescriptionField": "status",
+          "autoPublish": false,
+          "x-openregister-mcp": {
+            "enabled": true,
+            "tools": {
+              "search": {
+                "description": "Search signing requests — answers 'has that contract been signed yet?'. Read-only: an agent can report on a signature process but can never start, advance or sign one.",
+                "scope": "read",
+                "readOnlyHint": true,
+                "filters": [
+                  "documentFileId",
+                  "initiatorUserId",
+                  "signatureLevel",
+                  "signingMode",
+                  "status",
+                  "provider"
+                ]
+              },
+              "get": {
+                "description": "Get a single signing request by id, including its status, eIDAS level and deadline. Returns no signature material.",
+                "scope": "read",
+                "readOnlyHint": true
+              }
+            }
+          }
+        },
+        "searchable": true,
+        "x-openregister-lifecycle": {
+          "field": "status",
+          "initialState": "DRAFT",
+          "states": {
+            "DRAFT": {
+              "label": "Draft",
+              "description": "Signing request is being assembled by the initiator; not yet sent to signers."
+            },
+            "PENDING": {
+              "label": "Pending",
+              "description": "Request has been sent and is awaiting signer action."
+            },
+            "IN_PROGRESS": {
+              "label": "In progress",
+              "description": "At least one signer has started; the request is being signed."
+            },
+            "COMPLETED": {
+              "label": "Completed",
+              "description": "All signers have signed. Terminal state."
+            },
+            "DECLINED": {
+              "label": "Declined",
+              "description": "A signer declined; the request is terminated. Terminal."
+            },
+            "EXPIRED": {
+              "label": "Expired",
+              "description": "The deadline passed before completion. Terminal."
+            },
+            "CANCELLED": {
+              "label": "Cancelled",
+              "description": "The initiator cancelled the request. Terminal."
+            }
+          },
+          "transitions": {
+            "send": {
+              "from": "DRAFT",
+              "to": "PENDING",
+              "label": "Send for signing",
+              "description": "Notify the configured signers and start collecting signatures."
+            },
+            "start": {
+              "from": "PENDING",
+              "to": "IN_PROGRESS",
+              "label": "Start signing",
+              "description": "A signer has opened the request; mark the request as in progress."
+            },
+            "complete": {
+              "from": "IN_PROGRESS",
+              "to": "COMPLETED",
+              "label": "Complete signing",
+              "description": "All signers have signed; finalise the request. Terminal."
+            },
+            "decline": {
+              "from": "IN_PROGRESS",
+              "to": "DECLINED",
+              "label": "Decline",
+              "description": "A signer declined; terminate the request. Terminal."
+            },
+            "expire": {
+              "from": "PENDING",
+              "to": "EXPIRED",
+              "label": "Expire",
+              "description": "Deadline passed before completion. Terminal."
+            },
+            "cancel": {
+              "from": "PENDING",
+              "to": "CANCELLED",
+              "label": "Cancel",
+              "description": "Initiator cancels the request before completion. Terminal."
+            }
+          }
+        },
+        "x-openregister-archival": {
+          "retention": {
+            "default": "P10Y"
+          },
+          "category": "Archiefwet 1995 selectielijst — cat. 5.1.3: ondertekeningsverzoeken als juridisch bewijsmiddel",
+          "action": "destroy",
+          "responsibleParty": "docudesk-privacy-officer"
+        }
+      },
+      "signingSession": {
+        "uri": null,
+        "slug": "signingSession",
+        "title": "Signing Session",
+        "description": "Persistente sessie voor de native SES signing-provider. Houdt de status van een ondertekeningssessie tussen HTTP-requests bij (issue #287). Wordt geschreven door NativeSigningProvider via OpenRegister zodat checkStatus/cancel/download na een fresh request de sessie kunnen terugvinden.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "FileSign",
+        "required": [
+          "externalId",
+          "documentPath",
+          "documentName",
+          "status"
+        ],
+        "properties": {
+          "externalId": {
+            "description": "Identifier van de signing-sessie (natuurlijke sleutel binnen de native provider)",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Session ID",
+            "maxLength": 128
+          },
+          "documentPath": {
+            "description": "Pad naar het bron-document binnen Nextcloud",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "title": "Document path",
+            "maxLength": 4000
+          },
+          "documentName": {
+            "description": "Naam van het document",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Document name",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "signers": {
+            "description": "Array van ondertekenaars die in deze sessie betrokken zijn",
+            "type": "array",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Signers"
+          },
+          "level": {
+            "description": "Handtekeningsniveau (alleen SES voor de native provider)",
+            "type": "string",
+            "visible": true,
+            "order": 5,
+            "facetable": true,
+            "title": "Level",
+            "enum": [
+              "SES"
+            ],
+            "default": "SES"
+          },
+          "status": {
+            "description": "Sessie-status",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 6,
+            "facetable": true,
+            "title": "Status",
+            "enum": [
+              "pending",
+              "in_progress",
+              "completed",
+              "cancelled",
+              "expired"
+            ],
+            "default": "pending"
+          },
+          "signatures": {
+            "description": "Lijst van toegevoegde handtekeningen",
+            "type": "array",
+            "visible": true,
+            "order": 7,
+            "facetable": false,
+            "title": "Signatures"
+          },
+          "createdAt": {
+            "description": "Aangemaakt (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 8,
+            "facetable": false,
+            "title": "Created"
+          },
+          "completedAt": {
+            "description": "Afgerond (ISO 8601), null tot completion",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Completed"
+          },
+          "signedDocumentPath": {
+            "description": "Pad naar het ondertekende document (kan gelijk zijn aan documentPath totdat SES-marker geschreven is)",
+            "type": "string",
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Signed path",
+            "maxLength": 4000
+          },
+          "markerEmbedded": {
+            "description": "Of de SES-marker (HMAC-blob) in het document is geschreven",
+            "type": "boolean",
+            "visible": true,
+            "order": 11,
+            "facetable": true,
+            "title": "Marker embedded",
+            "default": false
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-05-27T12:00:00+00:00",
+        "created": "2026-05-27T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "docudesk-signing-admins"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "authenticated"
+          ],
+          "delete": [
+            "docudesk-signing-admins"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "documentName",
+          "objectDescriptionField": "status",
+          "autoPublish": false
+        },
+        "searchable": false,
+        "x-openregister-lifecycle": {
+          "field": "status",
+          "initial": "pending",
+          "states": {
+            "pending": {
+              "label": "Wachtend",
+              "terminal": false
+            },
+            "in_progress": {
+              "label": "Bezig",
+              "terminal": false
+            },
+            "completed": {
+              "label": "Voltooid",
+              "terminal": true
+            },
+            "cancelled": {
+              "label": "Geannuleerd",
+              "terminal": true
+            },
+            "expired": {
+              "label": "Verlopen",
+              "terminal": true
+            }
+          },
+          "transitions": {
+            "start": {
+              "from": "pending",
+              "to": "in_progress",
+              "label": "Start sessie",
+              "description": "Eerste signer heeft de sessie geopend."
+            },
+            "complete": {
+              "from": "in_progress",
+              "to": "completed",
+              "label": "Voltooi sessie",
+              "description": "Alle handtekeningen zijn verzameld. Terminal."
+            },
+            "cancel": {
+              "from": [
+                "pending",
+                "in_progress"
+              ],
+              "to": "cancelled",
+              "label": "Annuleer sessie",
+              "description": "Sessie geannuleerd door initiator of provider."
+            },
+            "expire": {
+              "from": [
+                "pending",
+                "in_progress"
+              ],
+              "to": "expired",
+              "label": "Sessie verlopen",
+              "description": "TTL verstreken — sessie automatisch verlopen."
+            }
+          }
+        }
+      },
+      "template": {
+        "uri": null,
+        "slug": "template",
+        "title": "Document Template",
+        "description": "Herbruikbare Twig/HTML templates voor PDF-generatie. Templates zijn gescoped per app via het namespace-veld.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "FileDocument",
+        "required": [
+          "name",
+          "content",
+          "namespace"
+        ],
+        "properties": {
+          "name": {
+            "description": "Naam van het template",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": false,
+            "title": "Name",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "description": {
+            "description": "Beschrijving van het doel van het template",
+            "type": "string",
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "title": "Description",
+            "maxLength": 2000,
+            "translatable": true
+          },
+          "content": {
+            "description": "Twig/HTML template content voor PDF-rendering",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 3,
+            "facetable": false,
+            "title": "Template content",
+            "format": "html",
+            "translatable": true
+          },
+          "namespace": {
+            "description": "App-identifier die eigenaar is van dit template (bijv. larpingapp, opencatalogi)",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 4,
+            "facetable": true,
+            "title": "Namespace",
+            "maxLength": 64
+          },
+          "format": {
+            "description": "Standaard paginaformaat voor PDF-uitvoer",
+            "type": "string",
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Page format",
+            "default": "A4",
+            "enum": [
+              "A4",
+              "A3",
+              "Letter",
+              "Legal"
+            ]
+          },
+          "orientation": {
+            "description": "Standaard pagina-oriëntatie",
+            "type": "string",
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Orientation",
+            "default": "P",
+            "enum": [
+              "P",
+              "L"
+            ]
+          },
+          "category": {
+            "description": "Categorie van het template (bijv. beschikkingen, brieven, notities)",
+            "type": "string",
+            "visible": true,
+            "order": 7,
+            "facetable": true,
+            "title": "Category",
+            "maxLength": 128,
+            "translatable": true
+          },
+          "tags": {
+            "description": "Vrije tags voor zoeken en filteren",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 64
+            },
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Tags"
+          },
+          "lockedBy": {
+            "description": "Nextcloud gebruikers-ID van de gebruiker die het template momenteel bewerkt",
+            "type": "string",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Locked by",
+            "maxLength": 64
+          },
+          "lockedAt": {
+            "description": "Tijdstip waarop de bewerkvergrendeling is verkregen (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "visible": true,
+            "order": 10,
+            "facetable": false,
+            "title": "Locked at"
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": false,
+        "updated": "2026-05-18T12:00:00+00:00",
+        "created": "2026-03-01T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "authenticated"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-template-editors"
+          ],
+          "delete": [
+            "docudesk-template-editors"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "name",
+          "objectDescriptionField": "description",
+          "autoPublish": false,
+          "x-openregister-mcp": {
+            "enabled": true,
+            "tools": {
+              "search": {
+                "description": "Search Filinq document templates. Use to answer 'which letter template do we have for X?' before generating correspondence. Returns template metadata only, never rendered document content.",
+                "scope": "read",
+                "readOnlyHint": true,
+                "filters": [
+                  "name",
+                  "namespace",
+                  "category",
+                  "format",
+                  "orientation"
+                ]
+              },
+              "get": {
+                "description": "Get a single document template by id, including its category, page format and owning app namespace.",
+                "scope": "read",
+                "readOnlyHint": true
+              }
+            }
+          }
+        },
+        "searchable": true
+      },
+      "templateVersion": {
+        "uri": null,
+        "slug": "templateVersion",
+        "title": "Template Version",
+        "description": "Historische versie van een template. Wordt aangemaakt bij elke bewerking als snapshot van de vorige staat.",
+        "version": "1.1.0",
+        "summary": "",
+        "icon": "History",
+        "required": [
+          "templateId",
+          "version",
+          "content",
+          "editor"
+        ],
+        "properties": {
+          "templateId": {
+            "description": "UUID van het bovenliggende template",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 1,
+            "facetable": true,
+            "title": "Template ID"
+          },
+          "version": {
+            "description": "Volgnummer van de versie (oplopend)",
+            "type": "integer",
+            "required": true,
+            "visible": true,
+            "order": 2,
+            "facetable": false,
+            "title": "Version number"
+          },
+          "content": {
+            "description": "HTML/Twig templateinhoud op het moment van de snapshot",
+            "type": "string",
+            "required": true,
+            "visible": false,
+            "order": 3,
+            "facetable": false,
+            "title": "Content",
+            "format": "html"
+          },
+          "name": {
+            "description": "Naam van het template op het moment van de snapshot",
+            "type": "string",
+            "visible": true,
+            "order": 4,
+            "facetable": false,
+            "title": "Name",
+            "maxLength": 255,
+            "translatable": true
+          },
+          "description": {
+            "description": "Beschrijving van het template op het moment van de snapshot",
+            "type": "string",
+            "visible": true,
+            "order": 5,
+            "facetable": false,
+            "title": "Description",
+            "maxLength": 2000,
+            "translatable": true
+          },
+          "format": {
+            "description": "Paginaformaat op het moment van de snapshot",
+            "type": "string",
+            "visible": true,
+            "order": 6,
+            "facetable": false,
+            "title": "Format",
+            "default": "A4"
+          },
+          "orientation": {
+            "description": "Pagina-oriëntatie op het moment van de snapshot",
+            "type": "string",
+            "visible": true,
+            "order": 7,
+            "facetable": false,
+            "title": "Orientation",
+            "default": "P"
+          },
+          "editor": {
+            "description": "Nextcloud gebruikers-ID van de gebruiker die de bewerking uitvoerde",
+            "type": "string",
+            "required": true,
+            "visible": true,
+            "order": 8,
+            "facetable": true,
+            "title": "Editor",
+            "maxLength": 64
+          },
+          "changelog": {
+            "description": "Optionele notitie met beschrijving van de wijziging",
+            "type": "string",
+            "visible": true,
+            "order": 9,
+            "facetable": false,
+            "title": "Changelog note",
+            "maxLength": 2000,
+            "translatable": true
+          }
+        },
+        "archive": [],
+        "source": "internal",
+        "hardValidation": false,
+        "immutable": true,
+        "updated": "2026-05-18T12:00:00+00:00",
+        "created": "2026-05-18T12:00:00+00:00",
+        "maxDepth": 0,
+        "owner": null,
+        "application": null,
+        "organisation": null,
+        "groups": null,
+        "authorization": {
+          "read": [
+            "authenticated"
+          ],
+          "create": [
+            "authenticated"
+          ],
+          "update": [
+            "docudesk-template-editors"
+          ],
+          "delete": [
+            "docudesk-template-editors"
+          ]
+        },
+        "deleted": null,
+        "configuration": {
+          "objectNameField": "name",
+          "objectDescriptionField": "changelog",
+          "autoPublish": false
+        },
+        "searchable": false
+      }
+    },
+    "objects": [
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "anonymizationBatch",
+          "slug": "anonymizationbatch-anonymizationbatch-1-1"
+        },
+        "batchId": "Voorbeeld Batchid 1",
+        "userId": "Voorbeeld Userid 1",
+        "status": "uploading",
+        "sourceType": "upload",
+        "folderId": 1,
+        "folderPath": "Voorbeeld Folderpath 1",
+        "createdAt": 1,
+        "documents": [
+          "Voorbeeld Documents 1"
+        ]
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "anonymizationBatch",
+          "slug": "anonymizationbatch-anonymizationbatch-2-2"
+        },
+        "batchId": "Voorbeeld Batchid 2",
+        "userId": "Voorbeeld Userid 2",
+        "status": "extracting",
+        "sourceType": "folder",
+        "folderId": 2,
+        "folderPath": "Voorbeeld Folderpath 2",
+        "createdAt": 2,
+        "documents": [
+          "Voorbeeld Documents 2"
+        ]
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "anonymizationBatch",
+          "slug": "anonymizationbatch-anonymizationbatch-3-3"
+        },
+        "batchId": "Voorbeeld Batchid 3",
+        "userId": "Voorbeeld Userid 3",
+        "status": "review",
+        "sourceType": "upload",
+        "folderId": 3,
+        "folderPath": "Voorbeeld Folderpath 3",
+        "createdAt": 3,
+        "documents": [
+          "Voorbeeld Documents 3"
+        ]
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-1-1"
+        },
+        "sourceFileId": 1,
+        "anonymizedFileId": 1,
+        "sourceFileName": "Voorbeeld Sourcefilename 1",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 1",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 1",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 1",
+        "outputFormat": "pdf",
+        "status": "anonymized",
+        "replacementCount": 1,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-01T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 1"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-2-2"
+        },
+        "sourceFileId": 2,
+        "anonymizedFileId": 2,
+        "sourceFileName": "Voorbeeld Sourcefilename 2",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 2",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 2",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 2",
+        "outputFormat": "docx",
+        "status": "anonymized",
+        "replacementCount": 2,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-02T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 2"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "anonymizationLink",
+          "slug": "anonymizationlink-anonymizationlink-3-3"
+        },
+        "sourceFileId": 3,
+        "anonymizedFileId": 3,
+        "sourceFileName": "Voorbeeld Sourcefilename 3",
+        "sourceFilePath": "Voorbeeld Sourcefilepath 3",
+        "anonymizedFileName": "Voorbeeld Anonymizedfilename 3",
+        "anonymizedFilePath": "Voorbeeld Anonymizedfilepath 3",
+        "outputFormat": "odt",
+        "status": "anonymized",
+        "replacementCount": 3,
+        "runCount": 1,
+        "anonymizedAt": "2026-03-03T09:00:00+00:00",
+        "anonymizedBy": "Voorbeeld Anonymizedby 3"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "base",
+          "slug": "base-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "recipientCount": 1,
+        "status": "pending",
+        "initiatedBy": "Voorbeeld Initiatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "completedCount": 1,
+        "errorCount": 1,
+        "startedAt": "2026-03-01T09:00:00+00:00",
+        "completedAt": "2026-03-01T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "recipientCount": 2,
+        "status": "processing",
+        "initiatedBy": "Voorbeeld Initiatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "completedCount": 2,
+        "errorCount": 2,
+        "startedAt": "2026-03-02T09:00:00+00:00",
+        "completedAt": "2026-03-02T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "batchCorrespondenceJob",
+          "slug": "batchcorrespondencejob-batchcorrespondencejob-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "recipientCount": 3,
+        "status": "success",
+        "initiatedBy": "Voorbeeld Initiatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "completedCount": 3,
+        "errorCount": 3,
+        "startedAt": "2026-03-03T09:00:00+00:00",
+        "completedAt": "2026-03-03T09:00:00+00:00",
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "recipientId": "Voorbeeld Recipientid 1",
+        "generatedAt": "2026-03-01T09:00:00+00:00",
+        "format": "pdf",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "recipientType": "PERSON",
+        "caseReference": "00000000-0000-4000-8000-000000000000",
+        "errorMessage": "Voorbeeld Errormessage 1"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "recipientId": "Voorbeeld Recipientid 2",
+        "generatedAt": "2026-03-02T09:00:00+00:00",
+        "format": "docx",
+        "status": "failed",
+        "generatedBy": "Voorbeeld Generatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "recipientType": "ORGANIZATION",
+        "caseReference": "00000000-0000-4000-8000-000000000001",
+        "errorMessage": "Voorbeeld Errormessage 2"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "correspondence",
+          "slug": "correspondence-correspondence-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "recipientId": "Voorbeeld Recipientid 3",
+        "generatedAt": "2026-03-03T09:00:00+00:00",
+        "format": "html",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "recipientType": "PERSON",
+        "caseReference": "00000000-0000-4000-8000-000000000002",
+        "errorMessage": "Voorbeeld Errormessage 3"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "customDictionary",
+          "slug": "customdictionary-customdictionary-1-1"
+        },
+        "label": "Voorbeeld Label 1",
+        "description": "Voorbeeld Description 1",
+        "colour": "#0082C9",
+        "matchMode": "exact",
+        "fuzzy": false,
+        "active": true,
+        "termCount": 0
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "customDictionary",
+          "slug": "customdictionary-customdictionary-2-2"
+        },
+        "label": "Voorbeeld Label 2",
+        "description": "Voorbeeld Description 2",
+        "colour": "#0082C9",
+        "matchMode": "caseInsensitive",
+        "fuzzy": false,
+        "active": true,
+        "termCount": 0
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "customDictionary",
+          "slug": "customdictionary-customdictionary-3-3"
+        },
+        "label": "Voorbeeld Label 3",
+        "description": "Voorbeeld Description 3",
+        "colour": "#0082C9",
+        "matchMode": "wordBoundary",
+        "fuzzy": false,
+        "active": true,
+        "termCount": 0
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "customDictionaryTerm",
+          "slug": "customdictionaryterm-customdictionaryterm-1-1"
+        },
+        "value": "Voorbeeld Value 1",
+        "dictionary": "Voorbeeld Dictionary 1",
+        "label": "Voorbeeld Label 1"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "customDictionaryTerm",
+          "slug": "customdictionaryterm-customdictionaryterm-2-2"
+        },
+        "value": "Voorbeeld Value 2",
+        "dictionary": "Voorbeeld Dictionary 2",
+        "label": "Voorbeeld Label 2"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "customDictionaryTerm",
+          "slug": "customdictionaryterm-customdictionaryterm-3-3"
+        },
+        "value": "Voorbeeld Value 3",
+        "dictionary": "Voorbeeld Dictionary 3",
+        "label": "Voorbeeld Label 3"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1",
+        "bases": [
+          "Voorbeeld Bases 1"
+        ],
+        "checkedOn": "2026-03-01T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2",
+        "bases": [
+          "Voorbeeld Bases 2"
+        ],
+        "checkedOn": "2026-03-02T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "dossier",
+          "slug": "dossier-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3",
+        "bases": [
+          "Voorbeeld Bases 3"
+        ],
+        "checkedOn": "2026-03-03T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "financialExtraction",
+          "slug": "financialextraction-financialextraction-1-1"
+        },
+        "documentUri": "Voorbeeld Documenturi 1",
+        "docType": "receipt",
+        "requestedBy": "Voorbeeld Requestedby 1",
+        "sourceApp": "Voorbeeld Sourceapp 1",
+        "fields": {},
+        "fieldConfidence": {},
+        "overallConfidence": 1.0,
+        "corrections": []
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "financialExtraction",
+          "slug": "financialextraction-financialextraction-2-2"
+        },
+        "documentUri": "Voorbeeld Documenturi 2",
+        "docType": "supplier-invoice",
+        "requestedBy": "Voorbeeld Requestedby 2",
+        "sourceApp": "Voorbeeld Sourceapp 2",
+        "fields": {},
+        "fieldConfidence": {},
+        "overallConfidence": 2.0,
+        "corrections": []
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "financialExtraction",
+          "slug": "financialextraction-financialextraction-3-3"
+        },
+        "documentUri": "Voorbeeld Documenturi 3",
+        "docType": "receipt",
+        "requestedBy": "Voorbeeld Requestedby 3",
+        "sourceApp": "Voorbeeld Sourceapp 3",
+        "fields": {},
+        "fieldConfidence": {},
+        "overallConfidence": 3.0,
+        "corrections": []
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "templateVersion": 1,
+        "generatedAt": "2026-03-01T09:00:00+00:00",
+        "format": "pdf",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 1",
+        "templateName": "Voorbeeld Templatename 1",
+        "dataRefs": [
+          "Voorbeeld Datarefs 1"
+        ],
+        "caseId": "00000000-0000-4000-8000-000000000000",
+        "warnings": [
+          "Voorbeeld Warnings 1"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 1",
+        "fileId": 1,
+        "filePath": "Voorbeeld Filepath 1"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "templateVersion": 2,
+        "generatedAt": "2026-03-02T09:00:00+00:00",
+        "format": "odf",
+        "status": "failed",
+        "generatedBy": "Voorbeeld Generatedby 2",
+        "templateName": "Voorbeeld Templatename 2",
+        "dataRefs": [
+          "Voorbeeld Datarefs 2"
+        ],
+        "caseId": "00000000-0000-4000-8000-000000000001",
+        "warnings": [
+          "Voorbeeld Warnings 2"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 2",
+        "fileId": 2,
+        "filePath": "Voorbeeld Filepath 2"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "generatedDocument",
+          "slug": "generateddocument-generateddocument-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "templateVersion": 3,
+        "generatedAt": "2026-03-03T09:00:00+00:00",
+        "format": "html",
+        "status": "generated",
+        "generatedBy": "Voorbeeld Generatedby 3",
+        "templateName": "Voorbeeld Templatename 3",
+        "dataRefs": [
+          "Voorbeeld Datarefs 3"
+        ],
+        "caseId": "00000000-0000-4000-8000-000000000002",
+        "warnings": [
+          "Voorbeeld Warnings 3"
+        ],
+        "errorMessage": "Voorbeeld Errormessage 3",
+        "fileId": 3,
+        "filePath": "Voorbeeld Filepath 3"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "glAccountBooking",
+          "slug": "glaccountbooking-glaccountbooking-1-1"
+        },
+        "supplierIdentity": "Voorbeeld Supplieridentity 1",
+        "identityType": "kvk",
+        "accountCode": "Voorbeeld Accountcode 1",
+        "bookedAt": "2026-03-01T09:00:00+00:00",
+        "source": "correction",
+        "accountLabel": "Voorbeeld Accountlabel 1",
+        "extractionId": "Voorbeeld Extractionid 1",
+        "sourceApp": "Voorbeeld Sourceapp 1"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "glAccountBooking",
+          "slug": "glaccountbooking-glaccountbooking-2-2"
+        },
+        "supplierIdentity": "Voorbeeld Supplieridentity 2",
+        "identityType": "iban",
+        "accountCode": "Voorbeeld Accountcode 2",
+        "bookedAt": "2026-03-02T09:00:00+00:00",
+        "source": "suggestion-accepted",
+        "accountLabel": "Voorbeeld Accountlabel 2",
+        "extractionId": "Voorbeeld Extractionid 2",
+        "sourceApp": "Voorbeeld Sourceapp 2"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "glAccountBooking",
+          "slug": "glaccountbooking-glaccountbooking-3-3"
+        },
+        "supplierIdentity": "Voorbeeld Supplieridentity 3",
+        "identityType": "name",
+        "accountCode": "Voorbeeld Accountcode 3",
+        "bookedAt": "2026-03-03T09:00:00+00:00",
+        "source": "correction",
+        "accountLabel": "Voorbeeld Accountlabel 3",
+        "extractionId": "Voorbeeld Extractionid 3",
+        "sourceApp": "Voorbeeld Sourceapp 3"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "glAccountMappingRule",
+          "slug": "glaccountmappingrule-glaccountmappingrule-1-1"
+        },
+        "keywords": [
+          "Voorbeeld Keywords 1"
+        ],
+        "accountCode": "Voorbeeld Accountcode 1",
+        "accountLabel": "Voorbeeld Accountlabel 1",
+        "priority": 0,
+        "enabled": true
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "glAccountMappingRule",
+          "slug": "glaccountmappingrule-glaccountmappingrule-2-2"
+        },
+        "keywords": [
+          "Voorbeeld Keywords 2"
+        ],
+        "accountCode": "Voorbeeld Accountcode 2",
+        "accountLabel": "Voorbeeld Accountlabel 2",
+        "priority": 0,
+        "enabled": true
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "glAccountMappingRule",
+          "slug": "glaccountmappingrule-glaccountmappingrule-3-3"
+        },
+        "keywords": [
+          "Voorbeeld Keywords 3"
+        ],
+        "accountCode": "Voorbeeld Accountcode 3",
+        "accountLabel": "Voorbeeld Accountlabel 3",
+        "priority": 0,
+        "enabled": true
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "logo": "Voorbeeld Logo 1",
+        "primaryColor": "Voorbeeld Primarycolor 1",
+        "headerHtml": "Voorbeeld html 0",
+        "footerHtml": "Voorbeeld html 0",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "logo": "Voorbeeld Logo 2",
+        "primaryColor": "Voorbeeld Primarycolor 2",
+        "headerHtml": "Voorbeeld html 1",
+        "footerHtml": "Voorbeeld html 1",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "huisstijl",
+          "slug": "huisstijl-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "logo": "Voorbeeld Logo 3",
+        "primaryColor": "Voorbeeld Primarycolor 3",
+        "headerHtml": "Voorbeeld html 2",
+        "footerHtml": "Voorbeeld html 2",
+        "defaultMargins": {}
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "product",
+          "slug": "product-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "unit": "hour",
+        "unitPrice": 1.0,
+        "description": "Voorbeeld Description 1",
+        "currency": "EUR",
+        "category": "Voorbeeld Category 1",
+        "active": true
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "product",
+          "slug": "product-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "unit": "day",
+        "unitPrice": 2.0,
+        "description": "Voorbeeld Description 2",
+        "currency": "EUR",
+        "category": "Voorbeeld Category 2",
+        "active": true
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "product",
+          "slug": "product-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "unit": "piece",
+        "unitPrice": 3.0,
+        "description": "Voorbeeld Description 3",
+        "currency": "EUR",
+        "category": "Voorbeeld Category 3",
+        "active": true
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "prohibitionOverrideAudit",
+          "slug": "prohibitionoverrideaudit-prohibitionoverrideaudit-1-1"
+        },
+        "ruleId": "Voorbeeld Ruleid 1",
+        "fileId": 1,
+        "reason": "Voorbeeld Reason 1",
+        "acknowledgedBy": "Voorbeeld Acknowledgedby 1",
+        "acknowledgedAt": "2026-03-01T09:00:00+00:00",
+        "entityRelationId": 1
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "prohibitionOverrideAudit",
+          "slug": "prohibitionoverrideaudit-prohibitionoverrideaudit-2-2"
+        },
+        "ruleId": "Voorbeeld Ruleid 2",
+        "fileId": 2,
+        "reason": "Voorbeeld Reason 2",
+        "acknowledgedBy": "Voorbeeld Acknowledgedby 2",
+        "acknowledgedAt": "2026-03-02T09:00:00+00:00",
+        "entityRelationId": 2
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "prohibitionOverrideAudit",
+          "slug": "prohibitionoverrideaudit-prohibitionoverrideaudit-3-3"
+        },
+        "ruleId": "Voorbeeld Ruleid 3",
+        "fileId": 3,
+        "reason": "Voorbeeld Reason 3",
+        "acknowledgedBy": "Voorbeeld Acknowledgedby 3",
+        "acknowledgedAt": "2026-03-03T09:00:00+00:00",
+        "entityRelationId": 3
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-1-1"
+        },
+        "entityType": "PERSON",
+        "entityText": "Voorbeeld Entitytext 1",
+        "scope": "document",
+        "documentId": "Voorbeeld Documentid 1",
+        "entityKey": "Voorbeeld Entitykey 1",
+        "contactEmail": "voorbeeld0@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 1",
+        "contactRef": "https://example.invalid/resource/0",
+        "notificationStatus": "pending",
+        "notificationSentAt": "2026-03-01T09:00:00+00:00",
+        "consentStatus": "pending",
+        "objectionDeadline": "2026-03-01T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-01T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 0",
+        "publicationDecision": "pending",
+        "legalBasis": "Voorbeeld Legalbasis 1",
+        "notes": "Voorbeeld markdown 0",
+        "matchRules": [
+          {
+            "type": "exact",
+            "value": "Voorbeeld Value 1"
+          }
+        ],
+        "validFrom": "2026-03-01T09:00:00+00:00",
+        "validUntil": "2026-03-01T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "paper",
+        "consentDocument": "https://example.invalid/resource/0",
+        "consentScope": "Voorbeeld Consentscope 1"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-2-2"
+        },
+        "entityType": "ORGANIZATION",
+        "entityText": "Voorbeeld Entitytext 2",
+        "scope": "entity",
+        "documentId": "Voorbeeld Documentid 2",
+        "entityKey": "Voorbeeld Entitykey 2",
+        "contactEmail": "voorbeeld1@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 2",
+        "contactRef": "https://example.invalid/resource/1",
+        "notificationStatus": "sent",
+        "notificationSentAt": "2026-03-02T09:00:00+00:00",
+        "consentStatus": "consent_given",
+        "objectionDeadline": "2026-03-02T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-02T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 1",
+        "publicationDecision": "anonymize",
+        "legalBasis": "Voorbeeld Legalbasis 2",
+        "notes": "Voorbeeld markdown 1",
+        "matchRules": [
+          {
+            "type": "normalized",
+            "value": "Voorbeeld Value 2"
+          }
+        ],
+        "validFrom": "2026-03-02T09:00:00+00:00",
+        "validUntil": "2026-03-02T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "digital_signature",
+        "consentDocument": "https://example.invalid/resource/1",
+        "consentScope": "Voorbeeld Consentscope 2"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "publicationConsent",
+          "slug": "publicationconsent-publicationconsent-3-3"
+        },
+        "entityType": "OTHER",
+        "entityText": "Voorbeeld Entitytext 3",
+        "scope": "document",
+        "documentId": "Voorbeeld Documentid 3",
+        "entityKey": "Voorbeeld Entitykey 3",
+        "contactEmail": "voorbeeld2@example.invalid",
+        "contactAddress": "Voorbeeld Contactaddress 3",
+        "contactRef": "https://example.invalid/resource/2",
+        "notificationStatus": "delivered",
+        "notificationSentAt": "2026-03-03T09:00:00+00:00",
+        "consentStatus": "objection_received",
+        "objectionDeadline": "2026-03-03T09:00:00+00:00",
+        "objectionReceivedAt": "2026-03-03T09:00:00+00:00",
+        "objectionReason": "Voorbeeld markdown 2",
+        "publicationDecision": "publish_with_consent",
+        "legalBasis": "Voorbeeld Legalbasis 3",
+        "notes": "Voorbeeld markdown 2",
+        "matchRules": [
+          {
+            "type": "bsn",
+            "value": "Voorbeeld Value 3"
+          }
+        ],
+        "validFrom": "2026-03-03T09:00:00+00:00",
+        "validUntil": "2026-03-03T09:00:00+00:00",
+        "active": true,
+        "consentMethod": "verbal_recorded",
+        "consentDocument": "https://example.invalid/resource/2",
+        "consentScope": "Voorbeeld Consentscope 3"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-1-1"
+        },
+        "primaryName": "Voorbeeld Primaryname 1",
+        "entityType": "PERSON",
+        "matchRules": [
+          {
+            "type": "exact",
+            "value": "Voorbeeld Value 1"
+          }
+        ],
+        "reason": "Voorbeeld Reason 1",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 1",
+        "caseReference": "Voorbeeld Casereference 1",
+        "severity": "critical",
+        "jurisdiction": "Voorbeeld Jurisdiction 1",
+        "addedBy": "Voorbeeld Addedby 1",
+        "validFrom": "2026-03-01T09:00:00+00:00",
+        "validUntil": "2026-03-01T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 1"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-2-2"
+        },
+        "primaryName": "Voorbeeld Primaryname 2",
+        "entityType": "ORGANIZATION",
+        "matchRules": [
+          {
+            "type": "normalized",
+            "value": "Voorbeeld Value 2"
+          }
+        ],
+        "reason": "Voorbeeld Reason 2",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 2",
+        "caseReference": "Voorbeeld Casereference 2",
+        "severity": "high",
+        "jurisdiction": "Voorbeeld Jurisdiction 2",
+        "addedBy": "Voorbeeld Addedby 2",
+        "validFrom": "2026-03-02T09:00:00+00:00",
+        "validUntil": "2026-03-02T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 2"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "publicationProhibition",
+          "slug": "publicationprohibition-publicationprohibition-3-3"
+        },
+        "primaryName": "Voorbeeld Primaryname 3",
+        "entityType": "OTHER",
+        "matchRules": [
+          {
+            "type": "bsn",
+            "value": "Voorbeeld Value 3"
+          }
+        ],
+        "reason": "Voorbeeld Reason 3",
+        "active": true,
+        "legalAuthority": "Voorbeeld Legalauthority 3",
+        "caseReference": "Voorbeeld Casereference 3",
+        "severity": "normal",
+        "jurisdiction": "Voorbeeld Jurisdiction 3",
+        "addedBy": "Voorbeeld Addedby 3",
+        "validFrom": "2026-03-03T09:00:00+00:00",
+        "validUntil": "2026-03-03T09:00:00+00:00",
+        "notes": "Voorbeeld Notes 3"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-1-1"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 1",
+        "userId": "Voorbeeld Userid 1",
+        "displayName": "Voorbeeld Displayname 1",
+        "status": "PENDING",
+        "email": "voorbeeld0@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-01T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 1",
+        "ipAddress": "Voorbeeld Ipaddress 1",
+        "signatureData": "Voorbeeld Signaturedata 1"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-2-2"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 2",
+        "userId": "Voorbeeld Userid 2",
+        "displayName": "Voorbeeld Displayname 2",
+        "status": "SIGNED",
+        "email": "voorbeeld1@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-02T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 2",
+        "ipAddress": "Voorbeeld Ipaddress 2",
+        "signatureData": "Voorbeeld Signaturedata 2"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "signerRecord",
+          "slug": "signerrecord-signerrecord-3-3"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 3",
+        "userId": "Voorbeeld Userid 3",
+        "displayName": "Voorbeeld Displayname 3",
+        "status": "DECLINED",
+        "email": "voorbeeld2@example.invalid",
+        "order": 0,
+        "signedAt": "2026-03-03T09:00:00+00:00",
+        "declineReason": "Voorbeeld Declinereason 3",
+        "ipAddress": "Voorbeeld Ipaddress 3",
+        "signatureData": "Voorbeeld Signaturedata 3"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-1-1"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 1",
+        "action": "CREATED",
+        "actorUserId": "Voorbeeld Actoruserid 1",
+        "actorDisplayName": "Voorbeeld Actordisplayname 1",
+        "timestamp": "2026-03-01T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 1",
+        "signatureLevel": "SES",
+        "provider": "Voorbeeld Provider 1",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-2-2"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 2",
+        "action": "SIGNED",
+        "actorUserId": "Voorbeeld Actoruserid 2",
+        "actorDisplayName": "Voorbeeld Actordisplayname 2",
+        "timestamp": "2026-03-02T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 2",
+        "signatureLevel": "AdES",
+        "provider": "Voorbeeld Provider 2",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "signingAuditEntry",
+          "slug": "signingauditentry-signingauditentry-3-3"
+        },
+        "signingRequestId": "Voorbeeld Signingrequestid 3",
+        "action": "DECLINED",
+        "actorUserId": "Voorbeeld Actoruserid 3",
+        "actorDisplayName": "Voorbeeld Actordisplayname 3",
+        "timestamp": "2026-03-03T09:00:00+00:00",
+        "ipAddress": "Voorbeeld Ipaddress 3",
+        "signatureLevel": "QES",
+        "provider": "Voorbeeld Provider 3",
+        "metadata": {}
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-1-1"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 1",
+        "documentName": "Voorbeeld Documentname 1",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 1",
+        "signatureLevel": "SES",
+        "signingMode": "sequential",
+        "status": "DRAFT",
+        "provider": "native",
+        "deadline": "2026-03-01T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 1"
+        ]
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-2-2"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 2",
+        "documentName": "Voorbeeld Documentname 2",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 2",
+        "signatureLevel": "AdES",
+        "signingMode": "parallel",
+        "status": "PENDING",
+        "provider": "validsign",
+        "deadline": "2026-03-02T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 2"
+        ]
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "signingRequest",
+          "slug": "signingrequest-signingrequest-3-3"
+        },
+        "documentFileId": "Voorbeeld Documentfileid 3",
+        "documentName": "Voorbeeld Documentname 3",
+        "initiatorUserId": "Voorbeeld Initiatoruserid 3",
+        "signatureLevel": "QES",
+        "signingMode": "sequential",
+        "status": "IN_PROGRESS",
+        "provider": "docusign",
+        "deadline": "2026-03-03T09:00:00+00:00",
+        "signerIds": [
+          "Voorbeeld Signerids 3"
+        ]
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-1-1"
+        },
+        "externalId": "Voorbeeld Externalid 1",
+        "documentPath": "Voorbeeld Documentpath 1",
+        "documentName": "Voorbeeld Documentname 1",
+        "status": "pending",
+        "signers": [
+          "Voorbeeld Signers 1"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 1"
+        ],
+        "createdAt": "2026-03-01T09:00:00+00:00",
+        "completedAt": "2026-03-01T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 1",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-2-2"
+        },
+        "externalId": "Voorbeeld Externalid 2",
+        "documentPath": "Voorbeeld Documentpath 2",
+        "documentName": "Voorbeeld Documentname 2",
+        "status": "in_progress",
+        "signers": [
+          "Voorbeeld Signers 2"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 2"
+        ],
+        "createdAt": "2026-03-02T09:00:00+00:00",
+        "completedAt": "2026-03-02T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 2",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "signingSession",
+          "slug": "signingsession-signingsession-3-3"
+        },
+        "externalId": "Voorbeeld Externalid 3",
+        "documentPath": "Voorbeeld Documentpath 3",
+        "documentName": "Voorbeeld Documentname 3",
+        "status": "completed",
+        "signers": [
+          "Voorbeeld Signers 3"
+        ],
+        "level": "SES",
+        "signatures": [
+          "Voorbeeld Signatures 3"
+        ],
+        "createdAt": "2026-03-03T09:00:00+00:00",
+        "completedAt": "2026-03-03T09:00:00+00:00",
+        "signedDocumentPath": "Voorbeeld Signeddocumentpath 3",
+        "markerEmbedded": false
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-1-1"
+        },
+        "name": "Voorbeeld Name 1",
+        "content": "Voorbeeld html 0",
+        "namespace": "Voorbeeld Namespace 1",
+        "description": "Voorbeeld Description 1",
+        "format": "A4",
+        "orientation": "P",
+        "category": "Voorbeeld Category 1",
+        "tags": [
+          "Voorbeeld Tags 1"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 1",
+        "lockedAt": "2026-03-01T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-2-2"
+        },
+        "name": "Voorbeeld Name 2",
+        "content": "Voorbeeld html 1",
+        "namespace": "Voorbeeld Namespace 2",
+        "description": "Voorbeeld Description 2",
+        "format": "A3",
+        "orientation": "L",
+        "category": "Voorbeeld Category 2",
+        "tags": [
+          "Voorbeeld Tags 2"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 2",
+        "lockedAt": "2026-03-02T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "template",
+          "slug": "template-voorbeeld-name-3-3"
+        },
+        "name": "Voorbeeld Name 3",
+        "content": "Voorbeeld html 2",
+        "namespace": "Voorbeeld Namespace 3",
+        "description": "Voorbeeld Description 3",
+        "format": "Letter",
+        "orientation": "P",
+        "category": "Voorbeeld Category 3",
+        "tags": [
+          "Voorbeeld Tags 3"
+        ],
+        "lockedBy": "Voorbeeld Lockedby 3",
+        "lockedAt": "2026-03-03T09:00:00+00:00"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-1-1"
+        },
+        "templateId": "Voorbeeld Templateid 1",
+        "version": 1,
+        "content": "Voorbeeld html 0",
+        "editor": "Voorbeeld Editor 1",
+        "name": "Voorbeeld Name 1",
+        "description": "Voorbeeld Description 1",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 1"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-2-2"
+        },
+        "templateId": "Voorbeeld Templateid 2",
+        "version": 2,
+        "content": "Voorbeeld html 1",
+        "editor": "Voorbeeld Editor 2",
+        "name": "Voorbeeld Name 2",
+        "description": "Voorbeeld Description 2",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 2"
+      },
+      {
+        "@self": {
+          "register": "filinq",
+          "schema": "templateVersion",
+          "slug": "templateversion-voorbeeld-name-3-3"
+        },
+        "templateId": "Voorbeeld Templateid 3",
+        "version": 3,
+        "content": "Voorbeeld html 2",
+        "editor": "Voorbeeld Editor 3",
+        "name": "Voorbeeld Name 3",
+        "description": "Voorbeeld Description 3",
+        "format": "A4",
+        "orientation": "P",
+        "changelog": "Voorbeeld Changelog 3"
+      }
+    ]
+  }
+}

--- a/lib/Settings/filinq_mock_register.json
+++ b/lib/Settings/filinq_mock_register.json
@@ -1,14 +1,14 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "docudesk demo data",
+    "title": "filinq demo data",
     "version": "1.0.0",
     "description": "Demo data covering every schema this app supplies, offered as the first step of the app's setup walkthrough. Generated from the schemas themselves, so every object satisfies the schema that will validate it."
   },
   "x-openregister": {
     "type": "mock",
-    "app": "docudesk",
-    "description": "Demo data for docudesk. NOT installed automatically — a mock register is imported on demand, from the setup walkthrough or `occ openregister:descriptors:list --app=docudesk --import=<slug>`."
+    "app": "filinq",
+    "description": "Demo data for filinq. NOT installed automatically — a mock register is imported on demand, from the setup walkthrough or `occ openregister:descriptors:list --app=filinq --import=<slug>`."
   },
   "paths": {},
   "components": {


### PR DESCRIPTION
Implements **ADR-111 rules 1–2** (ConductionNL/hydra, merged). Enforcement is [ConductionNL/.github#590](https://github.com/ConductionNL/.github/pull/590).

## Why

This app declares schemas and shipped no demo data, so it opened on an empty list. The person evaluating it had to author objects by hand — against a schema they don't know yet. Fleet-wide, **562 of 598 schemas** were in that state.

## 🔴 Generated, not written

Every value is derived from the schema that will validate it: `enum` picks from the enum, `pattern` is satisfied, `format` drives the shape, `minimum`/`maxLength` are honoured, `required` is always populated.

Hand-written demo data is wrong in a way nobody sees until the demo — a status outside its own enum, a required field omitted — and it fails **at import**, in front of whoever asked for the demo.

Produced and validated by the single file gate-99 also runs: `vendor/conduction/hydra-gates/scripts/lib/generate_mock_register.py`. Regenerate with `--keep` to preserve any curated objects and top up only what is short.

## 🔴 It does not install itself

`x-openregister.type: mock` is imported **on demand** (ADR-111 rule 3). Sample data appearing on a production instance because somebody upgraded is a data-integrity incident, not a convenience.

```bash
occ openregister:descriptors:list --app=<app> --import=<register>
```

The setup-wizard step that offers this during first-run (ADR-111 rule 4) follows once OpenRegister's shared installer lands — deliberately not twenty-one copies of the same logic.

## Verification

`--check` re-validates every object against its own schema with `jsonschema`, and reports **zero findings**.

Rolling this out across five apps found five defects in the generator, every one caught by that check — including a cross-product that paired every register with every schema in a file, and a validator bug that flagged `nullable: true` (OpenAPI) as invalid, which would have had someone "fix" data that was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
