### PR TITLE
refactor(manifest): the flow pages are an index and a flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@babel/core": "^7.29.0",
-        "@conduction/nextcloud-vue": "^2.19.0",
+        "@conduction/nextcloud-vue": "^2.21.0",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.5.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2137,9 +2137,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.19.0.tgz",
-      "integrity": "sha512-gSLl4RZ7hy1e2TBuzYZLiTLBMggRYgfuxFMva59JBhb1EP93GgvEd/HpQcg+zoBL9FJPgJw9ir2OGf9Tore7og==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.21.0.tgz",
+      "integrity": "sha512-5HjI4X8k2IYxUeBdHa2OK/MnLhOFf4HxkF5dUGl42dWmYPDaPHjvawDMZcUcyP6wsP+rk0QzmPov4FGu/4Rn7Q==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",
@@ -2201,7 +2201,7 @@
         "dompurify": "^3.0.0",
         "eslint": "^8.56.0 || ^9.0.0 || ^10.0.0",
         "eslint-plugin-vue": "^9.21.0 || ^10.0.0",
-        "gridstack": "^12.0.0",
+        "gridstack": "^12.0.0 || ^13.0.0",
         "marked": "^12.0.0",
         "pinia": "^2.0.0 || ^3.0.0",
         "vue": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@babel/core": "^7.29.0",
-    "@conduction/nextcloud-vue": "^2.19.0",
+    "@conduction/nextcloud-vue": "^2.21.0",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.5.0",
     "@nextcloud/capabilities": "^1.2.1",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -315,15 +315,15 @@
 		{
 			"id": "Flows",
 			"route": "/flows",
-			"type": "flows",
+			"type": "index",
 			"title": "Flows",
-			"config": { "app": "filinq" },
-			"_note": "ADR-110 Decision 4: a flow is app-specific, so the authoring surface lives here rather than behind a deep link to another app's list. Rendered by the shared CnFlowsPage page type over OpenRegister's one native flow store (ADR-065), scoped to this app."
+			"config": { "entitySource": "flows", "app": "filinq" },
+			"_note": "ADR-110 Decision 4: a flow is app-specific, so the authoring surface lives here rather than behind a deep link to another app's list. An ordinary index over the named `flows` source (config.entitySource) rather than the deprecated `flows` page type, reading OpenRegister's one native flow store (ADR-065), scoped to this app by config.app."
 		},
 		{
 			"id": "FlowDetail",
 			"route": "/flows/:id",
-			"type": "flow-detail",
+			"type": "flow",
 			"title": "Flow",
 			"config": { "app": "filinq" },
 			"_note": "The shared CnFlowDetail canvas over the same single engine. Controls render in the NC app sidebar so the canvas keeps full width."

--- a/tests/validate-manifest.js
+++ b/tests/validate-manifest.js
@@ -33,9 +33,21 @@ const REPO_ROOT = path.resolve(__dirname, '..')
 
 const MANIFEST_PATH = path.join(REPO_ROOT, 'src', 'manifest.json')
 
+// THE INSTALLED SCHEMA WINS OVER THE VENDORED COPY.
+//
+// It used to be the other way round, and that ordering is a drift machine: the
+// vendored copy shadows the one the shipped runtime actually enforces, so the
+// check keeps passing against a snapshot of the rules while the rules move.
+// Measured here — the vendored copy sat at 2.25.0 and rejected `type: "flow"`,
+// which the installed package's schema (2.26.0) accepts and the runtime
+// registers. The manifest was right and the check was reading an older grammar.
+//
+// A manifest has to satisfy the schema its own dependency ships. The vendored
+// copy stays as a fallback for a tree with no node_modules — a fresh checkout,
+// a CI leg that skips install — but it no longer gets to overrule what is
+// installed.
 const SCHEMA_CANDIDATES = [
 	process.env.APP_MANIFEST_SCHEMA,
-	path.join(REPO_ROOT, 'tests', 'schemas', 'app-manifest-v2.schema.json'),
 	path.join(
 		REPO_ROOT,
 		'node_modules',
@@ -45,6 +57,7 @@ const SCHEMA_CANDIDATES = [
 		'schemas',
 		'app-manifest-v2.schema.json',
 	),
+	path.join(REPO_ROOT, 'tests', 'schemas', 'app-manifest-v2.schema.json'),
 	path.join(
 		REPO_ROOT,
 		'..',


### PR DESCRIPTION
Moves this app's flow pages off the two deprecated page types. Part of the fleet-wide sweep that
removes the last custom/aliased flow surfaces (`openregister#2937`, `dossiq#1402`, `integriq#1622`).

| Page | Before | After |
|---|---|---|
| `Flows` | `type: "flows"` | `type: "index"` + `config.entitySource: "flows"` |
| `FlowDetail` | `type: "flow-detail"` | `type: "flow"` |

## Why

`flows` predates named index sources. A flow lives in OpenRegister's native flow table rather than a
register/schema pair, so an object-backed index had nothing to bind to and a flow list needed a page
type of its own. `config.entitySource` closes that gap: the index names the collection and loads it.
So the list is now an ordinary index, and only the **editor** still needs a type of its own — now
called `flow` rather than `flow-detail`.

Both old names still resolve as deprecated aliases, so this is not a fix for a broken page. It moves
the manifest onto the names that are not deprecated, and it is what lets those aliases eventually be
removed.

## The `_note` is updated in the same commit

The list page's note asserted the old rationale — that a flow "cannot be addressed" by an index, or
that this had to be a custom page. This change disproves it. A note that survives the change it
describes is worse than no note: it is documentation that actively argues against the current code.

## `config.app` is untouched

Deliberately. It is not a label — the editor stamps it onto a flow created there, and the index
filters on it. Verified before pushing that it is byte-identical to `development`.

## Verification

Every app in this sweep was checked mechanically before push:

- the text edit was compared against the **same change applied structurally**, and the two had to
  agree exactly — this caught two real bugs in the first attempt, where the naive edit matched a
  *different* page's `config` line
- the result validates against the v2 manifest schema (2.26.0) with `jsonschema`
- `config.app` unchanged, page count unchanged, no `CnFlowsPage` reference left in the note
- no test in any of the 13 apps pins these page types (checked across all `tests/**/*.{ts,js}`)

## Blocked on

- `@conduction/nextcloud-vue` **2.21** — 2.20 declares a named source's columns and create button but
  does not read them (`nextcloud-vue#810`, `#818`). The dependency bump follows the release.
- `ConductionNL/.github#602` — hydra-gates validates against its own vendored schema copy, still at
  2.25.0, which has neither `flow` nor `entitySource`.
