### PR TITLE
fix(ci): a push to development must reach a verdict here too

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -113,7 +113,20 @@ concurrency:
   # A branch name is not a unique lane when two event types can each produce a
   # run for it, so the event is now always part of the key.
   group: quality-${{ github.head_ref || github.ref_name }}${{ github.event_name != 'pull_request' && format('-{0}', github.event_name) || '' }}
-  cancel-in-progress: true
+
+  # PUSH RUNS ARE NOT CANCELLED — and this has to be said HERE, not only in the
+  # shared workflow. .github#597 set `cancel-in-progress` on quality.yml itself,
+  # but a caller's own concurrency cancels the whole run before the called
+  # workflow's setting can apply, so that fix reached only the apps that declare
+  # no concurrency of their own. Measured 2026-08-28 over push runs on
+  # `development` since #597: 0 of 11 cancelled where the caller was silent, 7 of
+  # 13 (54%) cancelled where the caller still said `true`.
+  #
+  # An integration branch needs a verdict per commit: the run being cancelled is
+  # the only thing that would have said whether what just landed is sound, and
+  # its replacement is cancelled too. `pull_request` keeps cancelling, where
+  # superseding really is correct.
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 # Permission CEILING for the called quality pipeline. GitHub statically
 # validates the called workflow's declared job permissions against this


### PR DESCRIPTION
Completes ConductionNL/.github#597, which only got half the fleet.

## What #597 missed

#597 set `cancel-in-progress: ${{ github.event_name != 'push' }}` on the shared `quality.yml`. But **a caller's own `concurrency` cancels the whole run before the called workflow's setting can apply** — so the fix reached only the apps that declare no concurrency of their own.

I reported #597 as fixing the cancellation. It fixed 8 of 21.

## Measured, not assumed

Push runs on `development` created after #597 merged (2026-08-27T19:45Z), completed runs only:

| caller declares `cancel-in-progress: true` | cancelled / completed |
|---|---|
| **no** — #597 applies | **0 / 11** |
| **yes** — #597 overridden | **7 / 13 (54%)** |

A clean natural experiment: same shared workflow, same traffic, the only difference is whether the caller overrides it. This repo is in the second group.

## The change

One line, plus the comment explaining why it has to be said here and not only upstream:

```diff
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'push' }}
```

`pull_request` keeps cancelling — there only the latest head commit is meaningful. The group expression is untouched, including its `Sync to Beta` reasoning.

## Why it matters

A cancelled run is not a failure, but it is not a pass either — it is **no verdict**, and it renders as "nothing wrong here" in every summary that counts failures. Concrete casualties found today once runs started completing: learniq shipped an eslint error, dossiq shipped 15 invalid manifest actions rendering as empty clickable rows, launchpad shipped 8 untranslated strings, and openregister shipped a phpmd violation plus a broken flow-create E2E — none of them reported.

Verified: YAML parses on all 13 patched files; diff is the one line plus comment.
