### PR TITLE
fix(e2e): move the two fixme reasons where the gate can read them

### DIFF
--- a/tests/e2e/workflows/anonymization-workflow.spec.ts
+++ b/tests/e2e/workflows/anonymization-workflow.spec.ts
@@ -246,9 +246,13 @@ test('Anonymization extract degrades gracefully (clean JSON 200, never an HTML 5
 // above), but the regex fallback does not detect arbitrary BSN/name/email on
 // the fly, so the entities-detected outcome cannot be asserted headlessly
 // here. This flips green once the sidecar is provisioned.
-test.fixme('Folder Analysis detects entities (BSN / name / email) in the seeded document', async ({
+test('Folder Analysis detects entities (BSN / name / email) in the seeded document', async ({
 	page,
 }) => {
+	test.fixme(
+		true,
+		'environment-dependent: live NER detection of fresh PII needs the NER backend sidecar, which is absent in this dev environment. The controllers no longer 500 (see the green test above), but the regex fallback cannot detect arbitrary BSN/name/email on the fly, so the entities-detected outcome is not assertable headlessly. Flips green once the sidecar is provisioned.',
+	)
 	const token = await harvestToken(page)
 	const req = page.request
 

--- a/tests/e2e/workflows/templates-crud.spec.ts
+++ b/tests/e2e/workflows/templates-crud.spec.ts
@@ -287,9 +287,13 @@ test('Template create validation rejects missing required fields (name / content
 // create form ships on TemplateDetail.vue, this should drive name+content
 // through the UI and assert the new row appears — replacing the API-seeded
 // create leg above with a genuine UI-create journey.
-test.fixme('UI can create a template via the New-template editor form', async ({
+test('UI can create a template via the New-template editor form', async ({
 	page,
 }) => {
+	test.fixme(
+		true,
+		'product gap, not a failure: the Templates UI ships no create/edit/delete affordances. When a real create form lands on TemplateDetail.vue this should drive name+content through the UI and assert the new row appears, replacing the API-seeded create leg above with a genuine UI journey.',
+	)
 	await go(page, TemplateDetail)
 	await page.getByRole('button', { name: 'New template' }).click()
 	// TODO: fill name + content fields and save once TemplateDetail.vue is


### PR DESCRIPTION
fix(e2e): move the two fixme reasons where the gate can read them

The skip-discipline gate now runs here (hydra-gates 1.10.0, #851) and
reports two V3 findings — exclusions with no reason recorded:

    1  workflows/anonymization-workflow.spec.ts
    1  workflows/templates-crud.spec.ts

Both DO have a reason, and both are good ones. Neither is anywhere a
machine can read it — each sits in a comment above the test, and
`test.fixme(title, fn)` records no description in report.json.

  - anonymization: environment-dependent, needs the NER backend sidecar
  - templates-crud: a product gap, the Templates UI ships no create form

Each reason moves into `test.fixme(true, '<reason>')`. Nothing about what
runs changes: the same two tests stay excluded, for the same reasons,
now attributable.

Verified: npm ci rc=0, npm run lint rc=0 (0 errors), prettier clean, and
`playwright test --list` compiles all 11 tests across the two files —
with both exclusions still in place, which is the thing to check here:
converting `test.fixme(title, fn)` to `test(title, fn)` without adding
the annotation would silently START running two tests that are excluded
for good reason.

Part of ConductionNL/.github#609.
