### PR TITLE
docs: make the demo verification command actually pass

### DIFF
--- a/docs/Installation/demo-environment.md
+++ b/docs/Installation/demo-environment.md
@@ -78,8 +78,10 @@ A page loading is not the same as a page working. Nextcloud serves its shell bef
 Check content instead:
 
 ```bash
-# The app answers, rather than 404 or an empty shell
-curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8603/apps/filinq/"
+# The app answers. Note the credentials: an app page requires a login, so the
+# SAME request without -u returns 401, which is not a broken demo — measured
+# on a booted demo while writing this page.
+curl -s -o /dev/null -w '%{http_code}\n' -u admin:admin -L "http://localhost:8603/apps/filinq/"
 
 # OpenRegister has registers — an empty list means the configuration
 # was never imported, which is not the same as "nothing configured yet"


### PR DESCRIPTION
A follow-up to the demo-environment page, fixing two things measured against a booted demo rather than inferred.

## The verification command could not pass

The page told you to run

```bash
curl -s -o /dev/null -w '%{http_code}' "http://localhost:PORT/apps/APP/"
```

and described the result as confirmation the app answered. That request is **unauthenticated**, and a Nextcloud app page requires a login — so on a completely healthy demo it prints **401**. Someone following the page would conclude their demo was broken.

Measured on two booted demos: unauthenticated `401`, the same URL with `-u admin:admin` `200`. The command now carries the demo credentials, and says in words that a bare 401 is expected rather than a fault.

This is the shape the page itself warns about, one level up: a check whose output you have already decided the meaning of isn't a check.

## Thematiq has no app page

`/apps/thematiq/` answers **404 even authenticated** — Thematiq declares `<admin-section>theming</admin-section>` and ships no app route. Every page linked there sent the reader to a dead URL. It now opens **Settings → Administration → Theming**, which answers 200.

## Verification

Both corrected commands were run against two independently booted demos (`portaliq` on 8613, `shillinq` on 8611) and return 200.