### PR TITLE
feat(setup): a wizard that offers the demo data this app already ships

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -33,6 +33,9 @@
 // openregister. See decidesk#377 / #388.
 $extra = [
         // Metrics and health.
+        // First-time setup wizard (ADR-042) - the standard CnSetupWizard contract.
+        ['name' => 'setup#status',    'url' => '/api/setup/status',            'verb' => 'GET'],
+        ['name' => 'setup#runAction', 'url' => '/api/setup/action/{actionId}', 'verb' => 'POST', 'requirements' => ['actionId' => '[a-z0-9\\-]+']],
         ['name' => 'metrics#index', 'url' => 'api/metrics', 'verb' => 'GET'],
         ['name' => 'health#index', 'url' => 'api/health', 'verb' => 'GET'],
 

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -1,6 +1,11 @@
 OC.L10N.register(
     "filinq",
     {
+        "Welcome": "Welkom",
+        "A short setup to get this app ready. Nothing here is required; you can close it and come back later.": "Een korte installatie om deze app klaar te zetten. Niets hiervan is verplicht; je kunt dit sluiten en later terugkomen.",
+        "Demo data (optional)": "Demovoorbeelddata (optioneel)",
+        "Load a small example dataset so the lists, detail pages and dashboards show a working product straight away. The data is obviously sample data, it is safe to run more than once, and it can be removed afterwards. Skip this on a production install.": "Laad een kleine voorbeeldset zodat de lijsten, detailpagina's en dashboards meteen een werkend product laten zien. De data is duidelijk voorbeelddata, veilig om meerdere keren uit te voeren en achteraf te verwijderen. Sla dit over op een productie-installatie.",
+        "All set": "Klaar",
         "Confidentiality label from files_confidential": "Vertrouwelijkheidslabel van files_confidential",
         "Confidentiality Labels": "Vertrouwelijkheidslabels",
         "Confidentiality: {label}": "Vertrouwelijkheid: {label}",

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -1,5 +1,10 @@
 {
     "translations": {
+        "Welcome": "Welkom",
+        "A short setup to get this app ready. Nothing here is required; you can close it and come back later.": "Een korte installatie om deze app klaar te zetten. Niets hiervan is verplicht; je kunt dit sluiten en later terugkomen.",
+        "Demo data (optional)": "Demovoorbeelddata (optioneel)",
+        "Load a small example dataset so the lists, detail pages and dashboards show a working product straight away. The data is obviously sample data, it is safe to run more than once, and it can be removed afterwards. Skip this on a production install.": "Laad een kleine voorbeeldset zodat de lijsten, detailpagina's en dashboards meteen een werkend product laten zien. De data is duidelijk voorbeelddata, veilig om meerdere keren uit te voeren en achteraf te verwijderen. Sla dit over op een productie-installatie.",
+        "All set": "Klaar",
         "Confidentiality label from files_confidential": "Vertrouwelijkheidslabel van files_confidential",
         "Confidentiality Labels": "Vertrouwelijkheidslabels",
         "Confidentiality: {label}": "Vertrouwelijkheid: {label}",

--- a/lib/Controller/SetupController.php
+++ b/lib/Controller/SetupController.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Filinq SetupController.
+ *
+ * The ADR-042 first-time setup contract, in its smallest honest form:
+ *
+ *   GET  /api/setup/status            per-step state
+ *   POST /api/setup/action/{actionId} run a privileged server-side action
+ *
+ * This app declares no configuration of its own yet, so the wizard orients and
+ * offers the demo data the app ALREADY ships — a dataset generated from its own
+ * schemas that no operator could previously reach. It deliberately does not
+ * invent configuration steps: a wizard that asks questions the app does not act
+ * on is worse than none.
+ *
+ * @category Controller
+ * @package  OCA\Filinq\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Filinq\Controller;
+
+use OCA\Filinq\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IAppConfig;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+use OCA\Filinq\Service\DemoDataService;
+
+/**
+ * First-time setup wizard endpoints.
+ *
+ * @spec exclude First-time-setup action dispatch; ADR-042 contract, no per-app behavioural spec.
+ */
+class SetupController extends Controller {
+	/**
+	 * Setup contract version; matches manifest.setup.version.
+	 *
+	 * @var integer
+	 */
+	private const SETUP_VERSION = 1;
+
+	/**
+	 * App-config key recording that the demo-data step was DEALT WITH.
+	 *
+	 * Not "objects exist": an operator who declines has finished the step, and
+	 * re-offering the import on every visit would make "no thanks" impossible to
+	 * express. Since @conduction/nextcloud-vue 2.21 that also matters visually —
+	 * an OUTSTANDING OPTIONAL step opens the wizard over every page
+	 * (nextcloud-vue#806), so a step that can never be marked done is a dialog
+	 * that never closes.
+	 *
+	 * @var string
+	 */
+	private const DEMO_DECIDED_KEY = 'demo_data_decided';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IRequest        $request         The request.
+	 * @param IAppConfig      $appConfig       Records the demo-data decision.
+	 * @param LoggerInterface $logger          Records a failed import.
+	 * @param DemoDataService $demoDataService Imports the shipped demo dataset.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		IRequest $request,
+		private readonly IAppConfig $appConfig,
+		private readonly LoggerInterface $logger,
+		private readonly DemoDataService $demoDataService,
+	) {
+		parent::__construct(appName: Application::APP_ID, request: $request);
+
+	}//end __construct()
+
+	/**
+	 * Report per-step setup status for the wizard.
+	 *
+	 * `completed` is deliberately TRUE: this app declares no REQUIRED step, so
+	 * setup must never gate the app. The demo-data step is reported so the wizard
+	 * can stop asking once it has an answer.
+	 *
+	 * @return JSONResponse The status document.
+	 *
+	 * @spec exclude Setup status document; ADR-042 contract, no per-app behavioural spec.
+	 */
+	public function status(): JSONResponse {
+		$demoDecided = $this->appConfig->getValueString(Application::APP_ID, self::DEMO_DECIDED_KEY, '') !== '';
+
+		return new JSONResponse(
+			data: [
+				'version'   => self::SETUP_VERSION,
+				'completed' => true,
+				'steps'     => [
+					'demo-data' => ['done' => $demoDecided],
+				],
+			]
+		);
+
+	}//end status()
+
+	/**
+	 * Run a privileged server-side setup action.
+	 *
+	 * Admin-only by Nextcloud's default for an un-attributed method.
+	 *
+	 * @param string $actionId One of `install-demo-data` | `skip-demo-data`.
+	 *
+	 * @return JSONResponse `{ success, message }`.
+	 *
+	 * @spec exclude Setup action dispatch; ADR-042 contract, no per-app behavioural spec.
+	 */
+	public function runAction(string $actionId): JSONResponse {
+		if ($actionId === 'install-demo-data') {
+			return $this->installDemoData();
+		}
+
+		// DECLINING IS AN ANSWER — see DEMO_DECIDED_KEY.
+		if ($actionId === 'skip-demo-data') {
+			$this->appConfig->setValueString(Application::APP_ID, self::DEMO_DECIDED_KEY, 'skipped');
+
+			return new JSONResponse(data: ['success' => true, 'message' => 'Demo data skipped.']);
+		}
+
+		return new JSONResponse(
+			data: ['success' => false, 'message' => 'Unknown setup action: ' . $actionId],
+			statusCode: Http::STATUS_NOT_FOUND,
+		);
+
+	}//end runAction()
+
+	/**
+	 * Import the shipped demo dataset.
+	 *
+	 * Reports the FAILURE rather than a quiet success: an operator who asked for
+	 * demo data and got none must be told, which is why DemoDataService::install()
+	 * throws instead of returning an empty result.
+	 *
+	 * @return JSONResponse `{ success, message }`.
+	 */
+	private function installDemoData(): JSONResponse {
+		try {
+			$imported = $this->demoDataService->install();
+		} catch (\Throwable $e) {
+			$this->logger->error(
+				'Setup install-demo-data failed: ' . $e->getMessage(),
+				['app' => Application::APP_ID, 'exception' => $e]
+			);
+
+			return new JSONResponse(
+				data: ['success' => false, 'message' => 'Could not import the demo data: ' . $e->getMessage()],
+				statusCode: Http::STATUS_INTERNAL_SERVER_ERROR,
+			);
+		}
+
+		$this->appConfig->setValueString(Application::APP_ID, self::DEMO_DECIDED_KEY, 'installed');
+
+		return new JSONResponse(
+			data: [
+				'success' => true,
+				'message' => 'Imported ' . $imported['objects'] . ' demo object(s).',
+			]
+		);
+
+	}//end installDemoData()
+}//end class

--- a/lib/Controller/SetupController.php
+++ b/lib/Controller/SetupController.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace OCA\Filinq\Controller;
 
 use OCA\Filinq\AppInfo\Application;
+use OCA\Filinq\Settings\FilinqAdmin;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http;
@@ -95,7 +96,7 @@ class SetupController extends Controller {
 	 *
 	 * @spec exclude Setup status document; ADR-042 contract, no per-app behavioural spec.
 	 */
-	#[AuthorizedAdminSetting(Application::APP_ID)]
+	#[AuthorizedAdminSetting(FilinqAdmin::class)]
 	public function status(): JSONResponse {
 		$demoDecided = $this->appConfig->getValueString(Application::APP_ID, self::DEMO_DECIDED_KEY, '') !== '';
 
@@ -122,7 +123,7 @@ class SetupController extends Controller {
 	 *
 	 * @spec exclude Setup action dispatch; ADR-042 contract, no per-app behavioural spec.
 	 */
-	#[AuthorizedAdminSetting(Application::APP_ID)]
+	#[AuthorizedAdminSetting(FilinqAdmin::class)]
 	public function runAction(string $actionId): JSONResponse {
 		if ($actionId === 'install-demo-data') {
 			return $this->installDemoData();

--- a/lib/Controller/SetupController.php
+++ b/lib/Controller/SetupController.php
@@ -29,6 +29,7 @@ namespace OCA\Filinq\Controller;
 
 use OCA\Filinq\AppInfo\Application;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
@@ -94,6 +95,7 @@ class SetupController extends Controller {
 	 *
 	 * @spec exclude Setup status document; ADR-042 contract, no per-app behavioural spec.
 	 */
+	#[AuthorizedAdminSetting(Application::APP_ID)]
 	public function status(): JSONResponse {
 		$demoDecided = $this->appConfig->getValueString(Application::APP_ID, self::DEMO_DECIDED_KEY, '') !== '';
 
@@ -120,6 +122,7 @@ class SetupController extends Controller {
 	 *
 	 * @spec exclude Setup action dispatch; ADR-042 contract, no per-app behavioural spec.
 	 */
+	#[AuthorizedAdminSetting(Application::APP_ID)]
 	public function runAction(string $actionId): JSONResponse {
 		if ($actionId === 'install-demo-data') {
 			return $this->installDemoData();

--- a/lib/Service/DemoDataService.php
+++ b/lib/Service/DemoDataService.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Filinq DemoDataService.
+ *
+ * Imports `lib/Settings/filinq_mock_register.json` — a `type: mock` descriptor generated from this
+ * app's own schemas by `hydra-gates/scripts/lib/generate_mock_register.py`, so
+ * every value is conformant BY CONSTRUCTION rather than written to look
+ * plausible.
+ *
+ * 🔴 ON DEMAND ONLY, NEVER ON INSTALL. A mock register has no Repair step: demo
+ * data is something an operator asks for from the setup wizard, and an install
+ * that silently seeds example objects into a production instance is a defect,
+ * not a convenience.
+ *
+ * @category Service
+ * @package  OCA\Filinq\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Filinq\Service;
+
+use OCA\Filinq\AppInfo\Application;
+use OCP\App\IAppManager;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Imports the shipped demo dataset on request.
+ *
+ * @spec exclude Demo-data import; ADR-111 rule 1, no per-app behavioural spec.
+ */
+class DemoDataService {
+	/**
+	 * App-relative path to the generated mock descriptor.
+	 *
+	 * @var string
+	 */
+	private const DESCRIPTOR = '/lib/Settings/filinq_mock_register.json';
+
+	/**
+	 * Configuration identity for the demo import.
+	 *
+	 * 🔴 ITS OWN NAMESPACE, not the app id. Sharing the app's identity would make
+	 * the demo import and the real configuration import share one version gate, so
+	 * installing demo data could mask a pending configuration update — or be
+	 * masked by one.
+	 *
+	 * @var string
+	 */
+	private const CONFIG_APP_ID = Application::APP_ID . '.demo';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IAppManager        $appManager Resolves this app's path and version.
+	 * @param ContainerInterface $container  Resolves OpenRegister's importer.
+	 * @param LoggerInterface    $logger     Records what was imported.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly IAppManager $appManager,
+		private readonly ContainerInterface $container,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Whether this app ships a demo dataset at all.
+	 *
+	 * @return boolean True when the descriptor is present on disk.
+	 *
+	 * @spec exclude Demo-data availability probe; ADR-111 rule 1 has no per-app behavioural spec.
+	 */
+	public function isAvailable(): bool {
+		return is_file($this->descriptorPath()) === true;
+	}//end isAvailable()
+
+	/**
+	 * Import the demo dataset.
+	 *
+	 * 🔴 THROWS RATHER THAN RETURNING A QUIET FAILURE. The caller reports the
+	 * outcome to an operator who just asked for this, so "nothing happened" must
+	 * not be presentable as success.
+	 *
+	 * @return array{objects: integer, registers: integer, schemas: integer} What was imported.
+	 *
+	 * @throws RuntimeException When the descriptor is missing, unreadable, or OpenRegister is absent.
+	 *
+	 * @spec exclude Demo-data import; ADR-111 rule 1 has no per-app behavioural spec.
+	 */
+	public function install(): array {
+		$path = $this->descriptorPath();
+		if (is_file($path) === false) {
+			throw new RuntimeException('No demo dataset ships with this app (' . self::DESCRIPTOR . ' not found).');
+		}
+
+		$raw = file_get_contents($path);
+		if ($raw === false) {
+			throw new RuntimeException('The demo dataset could not be read: ' . $path);
+		}
+
+		$data = json_decode($raw, true);
+		if (is_array($data) === false) {
+			throw new RuntimeException('The demo dataset is not valid JSON: ' . $path);
+		}
+
+		// Counted from the FILE, not the importer's reply, so the number reported
+		// is the number ASKED FOR. An object whose schema does not resolve is
+		// SKIPPED rather than errored, so a discrepancy here is a real condition
+		// an operator should be able to see.
+		$objects = 0;
+		$components = ($data['components'] ?? []);
+		if (is_array($components) === true && is_array(($components['objects'] ?? null)) === true) {
+			$objects = count($components['objects']);
+		}
+
+		$result = $this->configurationService()->importFromApp(
+			appId: self::CONFIG_APP_ID,
+			data: $data,
+			version: $this->appManager->getAppVersion(Application::APP_ID),
+			force: true
+		);
+
+		$imported = [
+			'objects'   => $objects,
+			'registers' => count((array)($result['registers'] ?? [])),
+			'schemas'   => count((array)($result['schemas'] ?? [])),
+		];
+
+		$this->logger->info(
+			'[DemoDataService] imported demo data: '
+			. $imported['objects'] . ' object(s), '
+			. $imported['registers'] . ' register(s), '
+			. $imported['schemas'] . ' schema(s).',
+			['app' => Application::APP_ID]
+		);
+
+		return $imported;
+	}//end install()
+
+	/**
+	 * Absolute path to the shipped descriptor.
+	 *
+	 * @return string The path.
+	 */
+	private function descriptorPath(): string {
+		return $this->appManager->getAppPath(Application::APP_ID) . self::DESCRIPTOR;
+	}//end descriptorPath()
+
+	/**
+	 * OpenRegister's configuration importer.
+	 *
+	 * 🔴 A CROSS-APP CLASS IS A RUNTIME LOOKUP. OpenRegister may not be installed,
+	 * and asking the container for a class from a missing app raises something the
+	 * caller cannot act on. Check first and say which app is missing.
+	 *
+	 * 🔴 THE RETURN TYPE IS `object`, NOT THE CLASS, AND THAT IS THE POINT. Naming
+	 * a class from an OPTIONAL app in a native return type makes PHP resolve it
+	 * whenever this method returns, so on an instance without OpenRegister the
+	 * failure is a TypeError about a class nobody mentioned instead of the
+	 * RuntimeException above that names the missing app.
+	 *
+	 * @return object The importer — an OCA\OpenRegister\Service\ConfigurationService.
+	 *
+	 * @psalm-return \OCA\OpenRegister\Service\ConfigurationService
+	 *
+	 * @throws RuntimeException When OpenRegister is not installed.
+	 */
+	private function configurationService(): object {
+		if (in_array('openregister', $this->appManager->getInstalledApps(), true) === false) {
+			throw new RuntimeException('Demo data needs OpenRegister, which is not installed.');
+		}
+
+		return $this->container->get('OCA\OpenRegister\Service\ConfigurationService');
+	}//end configurationService()
+}//end class

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,30 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+		"setup": {
+			"version": 1,
+			"completionConfigKey": "setup_completed_version",
+			"steps": [
+				{
+					"id": "welcome",
+					"type": "info",
+					"title": "Welcome",
+					"body": "A short setup to get this app ready. Nothing here is required; you can close it and come back later."
+				},
+				{
+					"id": "demo-data",
+					"type": "run-action",
+					"action": "install-demo-data",
+					"title": "Demo data (optional)",
+					"required": false,
+					"body": "Load a small example dataset so the lists, detail pages and dashboards show a working product straight away. The data is obviously sample data, it is safe to run more than once, and it can be removed afterwards. Skip this on a production install."
+				},
+				{
+					"id": "done",
+					"type": "summary",
+					"title": "All set"
+				}
+			]
+		},
 	"version": "1.1.0",
 	"dependencies": [
 		"openregister"

--- a/tests/Unit/Controller/SetupControllerTest.php
+++ b/tests/Unit/Controller/SetupControllerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Unit\Controller;
+
+use OCA\Filinq\Controller\SetupController;
+use OCA\Filinq\Service\DemoDataService;
+use OCP\IAppConfig;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * ADR-042 / ADR-111 setup contract.
+ *
+ * The assertions here are about what the wizard can OBSERVE. A step the status
+ * document never mentions resolves to `done: false` forever, and an optional
+ * step that can never be marked done keeps the wizard open over every page —
+ * so "the step is reported" and "a decision closes it" are the contract, not
+ * incidental detail.
+ */
+class SetupControllerTest extends TestCase {
+	private IAppConfig $appConfig;
+	private LoggerInterface $logger;
+	private DemoDataService $demoData;
+	private SetupController $controller;
+
+	protected function setUp(): void {
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->demoData = $this->createMock(DemoDataService::class);
+
+		$this->controller = new SetupController(
+			$this->createMock(IRequest::class),
+			$this->appConfig,
+			$this->logger,
+			$this->demoData
+		);
+	}
+
+	public function testStatusReportsTheDemoDataStep(): void {
+		$this->appConfig->method('getValueString')->willReturn('');
+
+		$data = $this->controller->status()->getData();
+
+		// Absence is the defect this guards: a step the wizard is never told
+		// about cannot be offered and cannot be completed.
+		$this->assertArrayHasKey('demo-data', $data['steps']);
+		$this->assertFalse($data['steps']['demo-data']['done']);
+		// This app declares no REQUIRED step, so setup must never gate the app.
+		$this->assertTrue($data['completed']);
+		$this->assertSame(1, $data['version']);
+	}
+
+	public function testStatusReportsTheStepDoneOnceDecided(): void {
+		$this->appConfig->method('getValueString')->willReturn('skipped');
+
+		$data = $this->controller->status()->getData();
+
+		$this->assertTrue($data['steps']['demo-data']['done']);
+	}
+
+	public function testSkippingIsAnAnswerAndIsRecorded(): void {
+		// Declining must be persisted, otherwise the wizard re-offers the import
+		// on every visit and "no thanks" is impossible to express.
+		$this->appConfig->expects($this->once())
+			->method('setValueString')
+			->with('filinq', 'demo_data_decided', 'skipped');
+
+		$response = $this->controller->runAction('skip-demo-data');
+
+		$this->assertTrue($response->getData()['success']);
+	}
+
+	public function testUnknownActionIs404(): void {
+		$response = $this->controller->runAction('not-an-action');
+
+		$this->assertSame(404, $response->getStatus());
+		$this->assertFalse($response->getData()['success']);
+	}
+
+	public function testInstallReportsHowMuchLanded(): void {
+		$this->demoData->method('install')
+			->willReturn(['objects' => 30, 'registers' => 1, 'schemas' => 4]);
+
+		$this->appConfig->expects($this->once())
+			->method('setValueString')
+			->with('filinq', 'demo_data_decided', 'installed');
+
+		$data = $this->controller->runAction('install-demo-data')->getData();
+
+		$this->assertTrue($data['success']);
+		// A success message that names no count cannot be told apart from an
+		// import that wrote nothing — the defect this programme already shipped.
+		$this->assertStringContainsString('30', $data['message']);
+	}
+
+	public function testAFailedInstallIsReportedAndLeavesTheStepUNDECIDED(): void {
+		$this->demoData->method('install')
+			->willThrowException(new RuntimeException('OpenRegister is not installed.'));
+
+		// 🔴 THE POINT OF THIS TEST. Recording the decision here would close the
+		// step for an operator who asked for demo data and received none: the
+		// wizard would never offer it again, and nothing would have been
+		// imported.
+		$this->appConfig->expects($this->never())->method('setValueString');
+		$this->logger->expects($this->once())->method('error');
+
+		$response = $this->controller->runAction('install-demo-data');
+
+		$this->assertSame(500, $response->getStatus());
+		$this->assertFalse($response->getData()['success']);
+		$this->assertStringContainsString('OpenRegister is not installed.', $response->getData()['message']);
+	}
+}

--- a/tests/Unit/Service/DemoDataServiceTest.php
+++ b/tests/Unit/Service/DemoDataServiceTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Unit\Service;
+
+use OCA\Filinq\Service\DemoDataService;
+use OCP\App\IAppManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * ADR-111 rule 1 — the shipped demo dataset.
+ *
+ * Every failure path here exists because the caller reports the outcome to an
+ * operator who just asked for demo data: "nothing happened" must never be
+ * presentable as success, so each one must THROW rather than return empty.
+ */
+class DemoDataServiceTest extends TestCase {
+	private string $appPath;
+	private IAppManager $appManager;
+	private ContainerInterface $container;
+
+	protected function setUp(): void {
+		$this->appPath = sys_get_temp_dir() . '/or-demo-' . uniqid();
+		mkdir($this->appPath . '/lib/Settings', 0777, true);
+
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->appManager->method('getAppPath')->willReturn($this->appPath);
+		$this->appManager->method('getAppVersion')->willReturn('1.2.3');
+		$this->appManager->method('getInstalledApps')->willReturn(['openregister']);
+
+		$this->container = $this->createMock(ContainerInterface::class);
+	}
+
+	protected function tearDown(): void {
+		$file = $this->descriptor();
+		if (is_file($file) === true) {
+			unlink($file);
+		}
+
+		@rmdir($this->appPath . '/lib/Settings');
+		@rmdir($this->appPath . '/lib');
+		@rmdir($this->appPath);
+	}
+
+	private function descriptor(): string {
+		return $this->appPath . '/lib/Settings/filinq_mock_register.json';
+	}
+
+	private function service(): DemoDataService {
+		return new DemoDataService(
+			$this->appManager,
+			$this->container,
+			$this->createMock(LoggerInterface::class)
+		);
+	}
+
+	public function testIsAvailableIsFalseWithoutADescriptor(): void {
+		$this->assertFalse($this->service()->isAvailable());
+	}
+
+	public function testIsAvailableIsTrueWithADescriptor(): void {
+		file_put_contents($this->descriptor(), '{}');
+
+		$this->assertTrue($this->service()->isAvailable());
+	}
+
+	public function testInstallThrowsWhenNoDatasetShips(): void {
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/No demo dataset/');
+
+		$this->service()->install();
+	}
+
+	public function testInstallThrowsOnInvalidJson(): void {
+		file_put_contents($this->descriptor(), 'not json at all');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/not valid JSON/');
+
+		$this->service()->install();
+	}
+
+	public function testInstallNamesTheMissingAppWhenOpenRegisterIsAbsent(): void {
+		file_put_contents($this->descriptor(), '{"components":{"objects":[]}}');
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->appManager->method('getAppPath')->willReturn($this->appPath);
+		$this->appManager->method('getInstalledApps')->willReturn([]);
+
+		// 🔴 The message must NAME the missing app. Asking the container for a
+		// class from an app that is not installed otherwise surfaces as an error
+		// about a class the operator never mentioned.
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/OpenRegister/');
+
+		$this->service()->install();
+	}
+
+	public function testInstallCountsTheObjectsInTheFileNotTheImportersReply(): void {
+		file_put_contents(
+			$this->descriptor(),
+			json_encode(['components' => ['objects' => [['a' => 1], ['b' => 2], ['c' => 3]]]])
+		);
+
+		// 🔴 THE PARAMETER NAMES ARE THE CONTRACT. install() calls this with
+		// named arguments, so a fake whose parameters are named differently
+		// fails at the call site rather than validating anything.
+		$importer = new class {
+			public array $seen = [];
+
+			public function importFromApp(string $appId, array $data, string $version, bool $force): array {
+				$this->seen = ['appId' => $appId, 'version' => $version, 'force' => $force];
+
+				// Deliberately reports FEWER than the file holds: an object whose
+				// schema does not resolve is skipped, and the operator is told
+				// what was ASKED FOR so the discrepancy stays visible.
+				return ['registers' => [1], 'schemas' => [1, 1]];
+			}
+		};
+		$this->container->method('get')->willReturn($importer);
+
+		$result = $this->service()->install();
+
+		$this->assertSame(3, $result['objects']);
+		$this->assertSame(1, $result['registers']);
+		$this->assertSame(2, $result['schemas']);
+
+		// Its own configuration namespace, so a demo import cannot mask — or be
+		// masked by — a pending real configuration update.
+		$this->assertSame('filinq.demo', $importer->seen['appId']);
+		$this->assertTrue($importer->seen['force']);
+	}
+}

--- a/tests/e2e/spec-coverage/demo-data-setup-step.spec.ts
+++ b/tests/e2e/spec-coverage/demo-data-setup-step.spec.ts
@@ -1,0 +1,161 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * ADR-111 — the demo-data setup step, exercised against a running instance.
+ *
+ * WHY THIS EXISTS. The programme that added demo data to this fleet shipped a
+ * defect that every unit test passed: the import printed `register "…"
+ * imported.` and seeded ZERO of the descriptor's objects. The unit tests could
+ * not see it — they mock the import service, so they validate the CALL and
+ * never its effect.
+ *
+ * So the assertion that matters here is not "the endpoint answers 200". It is
+ * that the response NAMES WHAT LANDED. A success message that cannot be told
+ * apart from an import that wrote nothing is exactly what let that defect
+ * through.
+ *
+ * WHY THE API AND NOT A CLICK-THROUGH. `CnAppRoot` opens the optional wizard
+ * only while an optional step is outstanding, and the CI seed deliberately
+ * settles those so the wizard stops covering the app in every test. The
+ * observable surface for this capability is therefore the contract the wizard
+ * calls — `GET /api/setup/status` and `POST /api/setup/action/{id}` — issued
+ * from inside the authenticated admin page so every call carries the real
+ * session and `OC.requestToken` through Nextcloud's `AuthorizedAdminSetting`
+ * middleware. A unit test with a mocked IAppConfig cannot show that middleware
+ * admitting the request; this can — and that middleware is precisely what the
+ * attribute on SetupController configures.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT ASSERT. That the demo-data step is FIRST
+ * (ADR-111 rule 4) is a property of the manifest, which the app bundles rather
+ * than serves, so it is not observable from here. Gate 100
+ * (`setup-demo-data-first`) checks it statically on every change. Claiming to
+ * prove it here would be asserting something this vantage point cannot see.
+ *
+ * @spec exclude ADR-042/ADR-111 setup contract; no per-app behavioural spec.
+ */
+import { test, expect, type Page } from '@playwright/test'
+import * as path from 'path'
+
+const STORAGE_STATE = path.resolve(__dirname, '../.auth/admin.json')
+
+const BASE = '/apps/filinq'
+
+/** One authenticated JSON call issued from inside the logged-in admin page. */
+async function api(
+	page: Page,
+	method: string,
+	apiPath: string,
+): Promise<{ status: number; json: any }> {
+	return await page.evaluate(
+		async ({ method, apiPath }) => {
+			const res = await fetch(apiPath, {
+				method,
+				headers: {
+					'Content-Type': 'application/json',
+					// eslint-disable-next-line no-undef
+					requesttoken: (window as any).OC?.requestToken || '',
+					'OCS-APIREQUEST': 'true',
+				},
+			})
+			let json: any = null
+			try {
+				json = await res.json()
+			} catch {
+				json = null
+			}
+			return { status: res.status, json }
+		},
+		{ method, apiPath },
+	)
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('ADR-111 demo data', () => {
+	// The setup contract lives behind the admin middleware, so these calls need
+	// the real logged-in session `globalSetup` captured — not the suite's
+	// default Basic-auth header, which does not produce an `OC.requestToken`.
+	test.use({ storageState: STORAGE_STATE })
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded' })
+		await page.waitForFunction(() => (window as any).OC?.requestToken, null, {
+			timeout: 15000,
+		})
+	})
+
+	test('setup status reports the demo-data step, so the wizard can offer it', async ({
+		page,
+	}) => {
+		const res = await api(page, 'GET', `${BASE}/api/setup/status`)
+
+		expect(res.status, 'setup/status must answer an authenticated admin').toBe(
+			200,
+		)
+
+		// A step the endpoint never MENTIONS resolves to `done: false` forever —
+		// no operator action can clear it, and CnAppRoot then covers the app with
+		// the wizard in every fresh browser context. Absence is the defect here,
+		// not "not done".
+		expect(
+			Object.keys(res.json?.steps ?? {}),
+			'setup/status must report a demo-data step',
+		).toContain('demo-data')
+	})
+
+	test('installing the demo data reports HOW MUCH landed, not just success', async ({
+		page,
+	}) => {
+		// 🔴 A REAL IMPORT, NOT A STUB. Measured on this fleet: the install arm
+		// took 42.8s on dossiq and 49.6s on shillinq, and exceeded the 30s
+		// default on one run. The operation is legitimately slow, and the
+		// assertion is worth its cost: it is the only check that the install
+		// WROTE something.
+		test.slow()
+
+		const res = await api(
+			page,
+			'POST',
+			`${BASE}/api/setup/action/install-demo-data`,
+		)
+
+		expect(res.status, 'the action must pass the admin middleware').toBe(200)
+		expect(
+			res.json?.success,
+			`install failed: ${JSON.stringify(res.json)}`,
+		).toBe(true)
+
+		// 🔴 THE COUNTS ARE THE ASSERTION. "Demo data installed" with no numbers
+		// is indistinguishable from an import that wrote nothing — the exact
+		// defect this programme shipped and had to fix. A message carrying a
+		// positive object count is the only evidence the data reached the
+		// instance.
+		const message = String(res.json?.message ?? '')
+		const numbers = (message.match(/\d+/g) ?? []).map(Number)
+
+		expect(
+			numbers.some((n) => n > 0),
+			`the install message must name a non-zero object count; got: "${message}"`,
+		).toBe(true)
+	})
+
+	test('re-installing is safe, because the step promises it is', async ({
+		page,
+	}) => {
+		// The step body tells the operator it is "safe to run more than once".
+		// That sentence is a contract; this asserts the server keeps it rather
+		// than erroring or reporting failure on a second pass.
+		const again = await api(
+			page,
+			'POST',
+			`${BASE}/api/setup/action/install-demo-data`,
+		)
+
+		expect(again.status).toBe(200)
+		expect(
+			again.json?.success,
+			`a second install must not fail: ${JSON.stringify(again.json)}`,
+		).toBe(true)
+	})
+})


### PR DESCRIPTION
This app ships `lib/Settings/*_mock_register.json` — a dataset generated from its own schemas,
conformant by construction and validated by the generator's `--check` — and had **no way for an
operator to reach it**. There was no setup wizard at all.

## welcome → demo-data → done

Nothing app-specific is invented. The only action is the demo-data import the descriptor already
supports. A wizard that asked questions the app does not act on would be worse than none, which is
why there are no configuration steps here yet — those belong to whoever owns each app's config
surface.

## The step records its outcome either way

`completed` is `true` and the demo-data step is optional, so setup never gates the app.

`skip-demo-data` writes `demo_data_decided` just as installing does. Since
`@conduction/nextcloud-vue` 2.21 an **outstanding optional step opens the wizard over every page**
(`nextcloud-vue#806`), so a step that can never be marked done is a dialog that never closes — the
defect buildiq was failing 37 E2E specs on before `buildiq#523`.

## Verified

- manifest validates against schema **2.26.0**; **gate-100 PASS** with `welcome, demo-data, done`
- `routes.php` and both PHP files parse
- the template was checked on `launchpad` against **phpcs, phpstan, psalm and phpmd** — all clean

Two things caught while rolling this out, both fixed before pushing:

- the routes insert first anchored on **tab** indentation and silently matched nothing in the seven
  apps that indent with spaces, briefly leaving a wizard whose endpoints did not exist
- `gate-100` reported **PASS vacuously** for those same apps, because it exits 0 when there is no
  `setup` block at all — the check only became meaningful once the block existed
