### PR TITLE
chore(deps): @conduction/nextcloud-vue 2.21.0 -> 2.22.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@babel/core": "^7.29.0",
-        "@conduction/nextcloud-vue": "^2.21.0",
+        "@conduction/nextcloud-vue": "^2.22.1",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.5.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2137,9 +2137,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.21.0.tgz",
-      "integrity": "sha512-5HjI4X8k2IYxUeBdHa2OK/MnLhOFf4HxkF5dUGl42dWmYPDaPHjvawDMZcUcyP6wsP+rk0QzmPov4FGu/4Rn7Q==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.22.1.tgz",
+      "integrity": "sha512-Dw19XXFYkLntKjv/0Fb3N4WBw6SzYn8hG5YbjEyor3DW1E/bNCA+6PO88xknyOIklhy5urcSmouVzPQQromb5Q==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@babel/core": "^7.29.0",
-    "@conduction/nextcloud-vue": "^2.21.0",
+    "@conduction/nextcloud-vue": "^2.22.1",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.5.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
Picks up the theme app-id fix (nextcloud-vue#840), required before thematiq publishes its stable release under the renamed app id.

`CnAppRoot` calls `useScopedTheme()` with no slug, so this app resolves theme tokens, the token-set catalogue and the contrast check through a hardcoded `nldesign` id. Once a build carrying `<id>thematiq</id>` is installed those answer nothing — and every path in that composable degrades to default styling by design, so the app renders unthemed with nothing in any log. 2.22.1 resolves the id across both names.

The **lock** is what moves: `2.21.0` → `2.22.1`. A caret range alone would change nothing, since `npm ci` installs what `package-lock.json` pins.